### PR TITLE
Fix changeset checker

### DIFF
--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -54,14 +54,14 @@ jobs:
     - name: Print blocking failure status
       run: echo "${{steps.check-changeset.outputs.BLOCKING_FAILURE}}"
     - name: Find Comment
-      uses: peter-evans/find-comment@v1
+      uses: peter-evans/find-comment@v3
       id: fc
       with:
         issue-number: ${{github.event.number}}
         body-includes: Changeset File Check
     - name: Create comment (missing packages)
       if: ${{!steps.fc.outputs.comment-id && steps.check-changeset.outputs.CHANGESET_ERROR_MESSAGE}}
-      uses: peter-evans/create-or-update-comment@v1
+      uses: peter-evans/create-or-update-comment@v4
       with:
         issue-number: ${{github.event.number}}
         body: |
@@ -69,7 +69,7 @@ jobs:
           ${{steps.check-changeset.outputs.CHANGESET_ERROR_MESSAGE}}
     - name: Update comment (missing packages)
       if: ${{steps.fc.outputs.comment-id}}
-      uses: peter-evans/create-or-update-comment@v1
+      uses: peter-evans/create-or-update-comment@v4
       with:
         comment-id: ${{steps.fc.outputs.comment-id}} && steps.check-changeset.outputs.CHANGESET_ERROR_MESSAGE}}
         edit-mode: replace
@@ -78,7 +78,7 @@ jobs:
           ${{steps.check-changeset.outputs.CHANGESET_ERROR_MESSAGE}}
     - name: Update comment (no missing packages)
       if: ${{steps.fc.outputs.comment-id && !steps.check-changeset.outputs.CHANGESET_ERROR_MESSAGE}}
-      uses: peter-evans/create-or-update-comment@v1
+      uses: peter-evans/create-or-update-comment@v4
       with:
         comment-id: ${{steps.fc.outputs.comment-id}}
         edit-mode: replace

--- a/packages/analytics/src/api.ts
+++ b/packages/analytics/src/api.ts
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+//fsdj
 import { _getProvider, FirebaseApp, getApp } from '@firebase/app';
 import {
   Analytics,
@@ -62,6 +62,8 @@ declare module '@firebase/component' {
     [ANALYTICS_TYPE]: AnalyticsService;
   }
 }
+
+console.log('hi');
 
 /**
  * Returns an {@link Analytics} instance for the given app.

--- a/packages/analytics/src/api.ts
+++ b/packages/analytics/src/api.ts
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-//fsdj
+
 import { _getProvider, FirebaseApp, getApp } from '@firebase/app';
 import {
   Analytics,
@@ -62,8 +62,6 @@ declare module '@firebase/component' {
     [ANALYTICS_TYPE]: AnalyticsService;
   }
 }
-
-console.log('hi');
 
 /**
  * Returns an {@link Analytics} instance for the given app.

--- a/scripts/ci/check_changeset.ts
+++ b/scripts/ci/check_changeset.ts
@@ -136,7 +136,10 @@ async function main() {
     await exec(`echo "BLOCKING_FAILURE=false" >> $GITHUB_OUTPUT`);
   } catch (e) {
     const error = e as Error;
-    if (error.message.match('No changesets present')) {
+    if (
+      error.message.match('No changesets present') ||
+      error.message.match('no changesets were found')
+    ) {
       await exec(`echo "BLOCKING_FAILURE=false" >> $GITHUB_OUTPUT`);
     } else {
       const messageLines = error.message.replace(/🦋  error /g, '').split('\n');


### PR DESCRIPTION
Our changeset_checker script's primary job is to check if any package has a minor bump and remind us to bump `firebase` to a minor if so. There's a separate changesets actions bot whose job is to check if there are any changesets at all, so our script can ignore checking for that. There seems to be another message pattern we haven't accounted for indicating that there are no changesets. Added that to the check.

This avoids false errors like the below (second message in screenshot).
![image](https://github.com/user-attachments/assets/8093ef92-f2fe-443d-9371-55618111b33a)
