### PR TITLE
Replace 'Vertex AI For Firebase' usage with 'Vertex AI in Firebase'

### DIFF
--- a/docs-devsite/index.md
+++ b/docs-devsite/index.md
@@ -27,5 +27,5 @@ https://github.com/firebase/firebase-js-sdk
 |  [@firebase/performance](./performance.md#performance_package) | The Firebase Performance Monitoring Web SDK. This SDK does not work in a Node.js environment. |
 |  [@firebase/remote-config](./remote-config.md#remote-config_package) | The Firebase Remote Config Web SDK. This SDK does not work in a Node.js environment. |
 |  [@firebase/storage](./storage.md#storage_package) | Cloud Storage for Firebase |
-|  [@firebase/vertexai-preview](./vertexai-preview.md#vertexai-preview_package) | The Vertex AI in Firebase SDK. |
+|  [@firebase/vertexai-preview](./vertexai-preview.md#vertexai-preview_package) | The Vertex AI in Firebase Web SDK. |
 

--- a/docs-devsite/index.md
+++ b/docs-devsite/index.md
@@ -27,5 +27,5 @@ https://github.com/firebase/firebase-js-sdk
 |  [@firebase/performance](./performance.md#performance_package) | The Firebase Performance Monitoring Web SDK. This SDK does not work in a Node.js environment. |
 |  [@firebase/remote-config](./remote-config.md#remote-config_package) | The Firebase Remote Config Web SDK. This SDK does not work in a Node.js environment. |
 |  [@firebase/storage](./storage.md#storage_package) | Cloud Storage for Firebase |
-|  [@firebase/vertexai-preview](./vertexai-preview.md#vertexai-preview_package) | The Vertex AI For Firebase Web SDK. |
+|  [@firebase/vertexai-preview](./vertexai-preview.md#vertexai-preview_package) | The Vertex AI in Firebase SDK. |
 

--- a/docs-devsite/vertexai-preview.md
+++ b/docs-devsite/vertexai-preview.md
@@ -10,7 +10,7 @@ https://github.com/firebase/firebase-js-sdk
 {% endcomment %}
 
 # vertexai-preview package
-The Vertex AI in Firebase SDK.
+The Vertex AI in Firebase Web SDK.
 
 ## Functions
 

--- a/docs-devsite/vertexai-preview.md
+++ b/docs-devsite/vertexai-preview.md
@@ -10,7 +10,7 @@ https://github.com/firebase/firebase-js-sdk
 {% endcomment %}
 
 # vertexai-preview package
-The Vertex AI For Firebase Web SDK.
+The Vertex AI in Firebase SDK.
 
 ## Functions
 
@@ -27,7 +27,7 @@ The Vertex AI For Firebase Web SDK.
 |  --- | --- |
 |  [ChatSession](./vertexai-preview.chatsession.md#chatsession_class) | ChatSession class that enables sending chat messages and stores history of sent and received messages so far. |
 |  [GenerativeModel](./vertexai-preview.generativemodel.md#generativemodel_class) | Class for generative model APIs. |
-|  [VertexAIError](./vertexai-preview.vertexaierror.md#vertexaierror_class) | Error class for the Vertex AI for Firebase SDK. |
+|  [VertexAIError](./vertexai-preview.vertexaierror.md#vertexaierror_class) | Error class for the Vertex AI in Firebase SDK. |
 
 ## Enumerations
 
@@ -90,8 +90,8 @@ The Vertex AI For Firebase Web SDK.
 |  [TextPart](./vertexai-preview.textpart.md#textpart_interface) | Content part interface if the part represents a text string. |
 |  [ToolConfig](./vertexai-preview.toolconfig.md#toolconfig_interface) | Tool config. This config is shared for all tools provided in the request. |
 |  [UsageMetadata](./vertexai-preview.usagemetadata.md#usagemetadata_interface) | Usage metadata about a [GenerateContentResponse](./vertexai-preview.generatecontentresponse.md#generatecontentresponse_interface)<!-- -->. |
-|  [VertexAI](./vertexai-preview.vertexai.md#vertexai_interface) | An instance of the Vertex AI for Firebase SDK. |
-|  [VertexAIOptions](./vertexai-preview.vertexaioptions.md#vertexaioptions_interface) | Options when initializing the Vertex AI for Firebase SDK. |
+|  [VertexAI](./vertexai-preview.vertexai.md#vertexai_interface) | An instance of the Vertex AI in Firebase SDK. |
+|  [VertexAIOptions](./vertexai-preview.vertexaioptions.md#vertexaioptions_interface) | Options when initializing the Vertex AI in Firebase SDK. |
 |  [VideoMetadata](./vertexai-preview.videometadata.md#videometadata_interface) | Describes the input video content. |
 |  [WebAttribution](./vertexai-preview.webattribution.md#webattribution_interface) |  |
 

--- a/docs-devsite/vertexai-preview.vertexai.md
+++ b/docs-devsite/vertexai-preview.vertexai.md
@@ -10,7 +10,7 @@ https://github.com/firebase/firebase-js-sdk
 {% endcomment %}
 
 # VertexAI interface
-An instance of the Vertex AI for Firebase SDK.
+An instance of the Vertex AI in Firebase SDK.
 
 <b>Signature:</b>
 

--- a/docs-devsite/vertexai-preview.vertexaierror.md
+++ b/docs-devsite/vertexai-preview.vertexaierror.md
@@ -10,7 +10,7 @@ https://github.com/firebase/firebase-js-sdk
 {% endcomment %}
 
 # VertexAIError class
-Error class for the Vertex AI for Firebase SDK.
+Error class for the Vertex AI in Firebase SDK.
 
 <b>Signature:</b>
 

--- a/docs-devsite/vertexai-preview.vertexaioptions.md
+++ b/docs-devsite/vertexai-preview.vertexaioptions.md
@@ -10,7 +10,7 @@ https://github.com/firebase/firebase-js-sdk
 {% endcomment %}
 
 # VertexAIOptions interface
-Options when initializing the Vertex AI for Firebase SDK.
+Options when initializing the Vertex AI in Firebase SDK.
 
 <b>Signature:</b>
 

--- a/packages/vertexai/src/errors.ts
+++ b/packages/vertexai/src/errors.ts
@@ -20,7 +20,7 @@ import { VertexAIErrorCode, CustomErrorData } from './types';
 import { VERTEX_TYPE } from './constants';
 
 /**
- * Error class for the Vertex AI for Firebase SDK.
+ * Error class for the Vertex AI in Firebase SDK.
  *
  * @public
  */

--- a/packages/vertexai/src/index.ts
+++ b/packages/vertexai/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * The Vertex AI in Firebase SDK.
+ * The Vertex AI in Firebase Web SDK.
  *
  * @packageDocumentation
  */

--- a/packages/vertexai/src/index.ts
+++ b/packages/vertexai/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * The Vertex AI For Firebase Web SDK.
+ * The Vertex AI in Firebase SDK.
  *
  * @packageDocumentation
  */

--- a/packages/vertexai/src/public-types.ts
+++ b/packages/vertexai/src/public-types.ts
@@ -20,7 +20,7 @@ import { FirebaseApp } from '@firebase/app';
 export * from './types';
 
 /**
- * An instance of the Vertex AI for Firebase SDK.
+ * An instance of the Vertex AI in Firebase SDK.
  * @public
  */
 export interface VertexAI {
@@ -32,7 +32,7 @@ export interface VertexAI {
 }
 
 /**
- * Options when initializing the Vertex AI for Firebase SDK.
+ * Options when initializing the Vertex AI in Firebase SDK.
  * @public
  */
 export interface VertexAIOptions {


### PR DESCRIPTION
Replace 'Vertex AI For Firebase' usage with 'Vertex AI in Firebase'.