### PR TITLE
Rename usages of "master" branch to "main"

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -5,4 +5,4 @@ with multi-package repos, or single-package repos to help you version and publis
 find the full documentation for it [in our repository](https://github.com/changesets/changesets)
 
 We have a quick list of common questions to get you started engaging with this project in
-[our documentation](https://github.com/changesets/changesets/blob/main/docs/common-questions.md)
+[our documentation](https://github.com/changesets/changesets/blob/master/docs/common-questions.md)

--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -5,4 +5,4 @@ with multi-package repos, or single-package repos to help you version and publis
 find the full documentation for it [in our repository](https://github.com/changesets/changesets)
 
 We have a quick list of common questions to get you started engaging with this project in
-[our documentation](https://github.com/changesets/changesets/blob/master/docs/common-questions.md)
+[our documentation](https://github.com/changesets/changesets/blob/ch-branchswitch-main/docs/common-questions.md)

--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -5,4 +5,4 @@ with multi-package repos, or single-package repos to help you version and publis
 find the full documentation for it [in our repository](https://github.com/changesets/changesets)
 
 We have a quick list of common questions to get you started engaging with this project in
-[our documentation](https://github.com/changesets/changesets/blob/ch-branchswitch-main/docs/common-questions.md)
+[our documentation](https://github.com/changesets/changesets/blob/main/docs/common-questions.md)

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
   "commit": false,
   "linked": [],
   "access": "public",
-  "baseBranch": "master",
+  "baseBranch": "ch-branchswitch-main",
   "updateInternalDependencies": "patch",
   "ignore": [
     "firebase-namespace-integration-test",

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
   "commit": false,
   "linked": [],
   "access": "public",
-  "baseBranch": "ch-branchswitch-main",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [
     "firebase-namespace-integration-test",

--- a/.github/workflows/canary-deploy.yml
+++ b/.github/workflows/canary-deploy.yml
@@ -17,7 +17,7 @@ name: Canary Deploy
 on:
   push:
     branches:
-      - ch-branchswitch-main
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/canary-deploy.yml
+++ b/.github/workflows/canary-deploy.yml
@@ -17,7 +17,7 @@ name: Canary Deploy
 on:
   push:
     branches:
-      - master
+      - ch-branchswitch-main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -17,7 +17,7 @@ name: Check Changeset
 on:
   pull_request:
     branches:
-      - ch-branchswitch-main
+      - main
 
 env:
   GITHUB_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -41,9 +41,9 @@ jobs:
     - name: Yarn install
       run: yarn
     - name: Run changeset script
-      # pull ch-branchswitch-main so changeset can diff against it
+      # pull main so changeset can diff against it
       run: |
-        git pull -f --no-rebase origin ch-branchswitch-main:ch-branchswitch-main
+        git pull -f --no-rebase origin main:main
         yarn ts-node-script scripts/ci/check_changeset.ts
       id: check-changeset
     - name: Print changeset checker output

--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -17,7 +17,7 @@ name: Check Changeset
 on:
   pull_request:
     branches:
-      - master
+      - ch-branchswitch-main
 
 env:
   GITHUB_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -41,9 +41,9 @@ jobs:
     - name: Yarn install
       run: yarn
     - name: Run changeset script
-      # pull master so changeset can diff against it
+      # pull ch-branchswitch-main so changeset can diff against it
       run: |
-        git pull -f --no-rebase origin master:master
+        git pull -f --no-rebase origin ch-branchswitch-main:ch-branchswitch-main
         yarn ts-node-script scripts/ci/check_changeset.ts
       id: check-changeset
     - name: Print changeset checker output

--- a/.github/workflows/merge-release-branch.yml
+++ b/.github/workflows/merge-release-branch.yml
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Merge Release Into Master
+name: Merge Release Into Main
 
 on: workflow_dispatch
 
 jobs:
-  merge_to_master:
+  merge_to_main:
     runs-on: ubuntu-latest
     # Allow GITHUB_TOKEN to have write permissions
     permissions:
@@ -36,7 +36,7 @@ jobs:
       - name: Echo version in shell
         run: |
           echo "Merging release ${{ steps.get-version.outputs.RELEASE_VERSION }}"
-      - name: Merge to master
+      - name: Merge to main
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -44,7 +44,7 @@ jobs:
             github.rest.repos.merge({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              base: 'master',
+              base: 'ch-branchswitch-main',
               head: 'release',
               commit_message: 'Release ${{ steps.get-version.outputs.RELEASE_VERSION }}'
             })

--- a/.github/workflows/merge-release-branch.yml
+++ b/.github/workflows/merge-release-branch.yml
@@ -44,7 +44,7 @@ jobs:
             github.rest.repos.merge({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              base: 'ch-branchswitch-main',
+              base: 'main',
               head: 'release',
               commit_message: 'Release ${{ steps.get-version.outputs.RELEASE_VERSION }}'
             })

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -43,9 +43,9 @@ jobs:
       # Ensures a new @firebase/app is published with every release.
       # This keeps the SDK_VERSION variable up to date.
       - name: Add a changeset for @firebase/app
-        # pull ch-branchswitch-main so changeset can diff against it
+        # pull main so changeset can diff against it
         run: |
-          git pull -f --no-rebase origin ch-branchswitch-main:ch-branchswitch-main
+          git pull -f --no-rebase origin main:main
           yarn ts-node-script scripts/ci/add_changeset.ts
 
       - name: Create Release Pull Request

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -43,9 +43,9 @@ jobs:
       # Ensures a new @firebase/app is published with every release.
       # This keeps the SDK_VERSION variable up to date.
       - name: Add a changeset for @firebase/app
-        # pull master so changeset can diff against it
+        # pull ch-branchswitch-main so changeset can diff against it
         run: |
-          git pull -f --no-rebase origin master:master
+          git pull -f --no-rebase origin ch-branchswitch-main:ch-branchswitch-main
           yarn ts-node-script scripts/ci/add_changeset.ts
 
       - name: Create Release Pull Request

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -25,10 +25,10 @@ on:
       source-branch:
         description: 'Branch to release from'
         type: choice
-        default: 'ch-branchswitch-main'
+        default: 'main'
         required: true
         options:
-        - ch-branchswitch-main
+        - main
         - v8
       verbose:
         description: 'Enable verbose logging'
@@ -50,7 +50,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 20.x
-    - name: Merge ch-branchswitch-main into release
+    - name: Merge main into release
       uses: actions/github-script@v6
       with:
         github-token: ${{ secrets.OSS_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -25,10 +25,10 @@ on:
       source-branch:
         description: 'Branch to release from'
         type: choice
-        default: 'master'
+        default: 'ch-branchswitch-main'
         required: true
         options:
-        - master
+        - ch-branchswitch-main
         - v8
       verbose:
         description: 'Enable verbose logging'
@@ -50,7 +50,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 20.x
-    - name: Merge master into release
+    - name: Merge ch-branchswitch-main into release
       uses: actions/github-script@v6
       with:
         github-token: ${{ secrets.OSS_BOT_GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ review.
 * Make your changes in a new git branch:
 
   ```shell
-  git checkout -b my-fix-branch master
+  git checkout -b my-fix-branch ch-branchswitch-main
   ```
 
 * Create your change, **including appropriate test cases**. Changes with tests are more likely to be
@@ -144,7 +144,7 @@ entries to the `.gitignore`).
     git push origin my-fix-branch
     ```
 
-* In GitHub, create a pull request against the `firebase-js-sdk:master` branch.
+* In GitHub, create a pull request against the `firebase-js-sdk:ch-branchswitch-main` branch.
 * Add changeset. See [Adding changeset to PR](#adding-changeset-to-pr).
 * All pull requests must be reviewed by a member of the Firebase JS SDK team, who will merge it
 when/if they feel it is good to go.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ review.
 * Make your changes in a new git branch:
 
   ```shell
-  git checkout -b my-fix-branch ch-branchswitch-main
+  git checkout -b my-fix-branch main
   ```
 
 * Create your change, **including appropriate test cases**. Changes with tests are more likely to be
@@ -144,7 +144,7 @@ entries to the `.gitignore`).
     git push origin my-fix-branch
     ```
 
-* In GitHub, create a pull request against the `firebase-js-sdk:ch-branchswitch-main` branch.
+* In GitHub, create a pull request against the `firebase-js-sdk:main` branch.
 * Add changeset. See [Adding changeset to PR](#adding-changeset-to-pr).
 * All pull requests must be reviewed by a member of the Firebase JS SDK team, who will merge it
 when/if they feel it is good to go.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!-- BADGES -->
 ![Build Status](https://img.shields.io/github/actions/workflow/status/firebase/firebase-js-sdk/test-all.yml)
 [![Version](https://img.shields.io/npm/v/firebase.svg?label=version)](https://www.npmjs.com/package/firebase)
-[![Coverage Status](https://coveralls.io/repos/github/firebase/firebase-js-sdk/badge.svg?branch=ch-branchswitch-main)](https://coveralls.io/github/firebase/firebase-js-sdk?branch=ch-branchswitch-main)
+[![Coverage Status](https://coveralls.io/repos/github/firebase/firebase-js-sdk/badge.svg?branch=main)](https://coveralls.io/github/firebase/firebase-js-sdk?branch=main)
 <!-- END BADGES -->
 
 The Firebase JavaScript SDK implements the client-side libraries used by

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!-- BADGES -->
 ![Build Status](https://img.shields.io/github/actions/workflow/status/firebase/firebase-js-sdk/test-all.yml)
 [![Version](https://img.shields.io/npm/v/firebase.svg?label=version)](https://www.npmjs.com/package/firebase)
-[![Coverage Status](https://coveralls.io/repos/github/firebase/firebase-js-sdk/badge.svg?branch=master)](https://coveralls.io/github/firebase/firebase-js-sdk?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/firebase/firebase-js-sdk/badge.svg?branch=ch-branchswitch-main)](https://coveralls.io/github/firebase/firebase-js-sdk?branch=ch-branchswitch-main)
 <!-- END BADGES -->
 
 The Firebase JavaScript SDK implements the client-side libraries used by

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -96,7 +96,7 @@ curl   -H "Authorization: Bearer $(gcloud auth print-access-token)"   -H "Conten
     }'
 ```
 
-Replace the tenant ID `passpol-tenant-d7hha` in [test/integration/flows/password_policy.test.ts](https://github.com/firebase/firebase-js-sdk/blob/master/packages/auth/test/integration/flows/password_policy.test.ts) with the ID for the newly created tenant. The tenant ID can be found at the end of the `name` property in the response and is in the format `passpol-tenant-xxxxx`.
+Replace the tenant ID `passpol-tenant-d7hha` in [test/integration/flows/password_policy.test.ts](https://github.com/firebase/firebase-js-sdk/blob/ch-branchswitch-main/packages/auth/test/integration/flows/password_policy.test.ts) with the ID for the newly created tenant. The tenant ID can be found at the end of the `name` property in the response and is in the format `passpol-tenant-xxxxx`.
 
 ### Selenium Webdriver tests
 

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -96,7 +96,7 @@ curl   -H "Authorization: Bearer $(gcloud auth print-access-token)"   -H "Conten
     }'
 ```
 
-Replace the tenant ID `passpol-tenant-d7hha` in [test/integration/flows/password_policy.test.ts](https://github.com/firebase/firebase-js-sdk/blob/ch-branchswitch-main/packages/auth/test/integration/flows/password_policy.test.ts) with the ID for the newly created tenant. The tenant ID can be found at the end of the `name` property in the response and is in the format `passpol-tenant-xxxxx`.
+Replace the tenant ID `passpol-tenant-d7hha` in [test/integration/flows/password_policy.test.ts](https://github.com/firebase/firebase-js-sdk/blob/main/packages/auth/test/integration/flows/password_policy.test.ts) with the ID for the newly created tenant. The tenant ID can be found at the end of the `name` property in the response and is in the format `passpol-tenant-xxxxx`.
 
 ### Selenium Webdriver tests
 

--- a/packages/firebase/README.md
+++ b/packages/firebase/README.md
@@ -1,7 +1,7 @@
 <!-- BADGES -->
 ![Build Status](https://img.shields.io/github/workflow/status/firebase/firebase-js-sdk/Run%20All%20Tests.svg)
 [![Version](https://img.shields.io/npm/v/firebase.svg?label=version)](https://www.npmjs.com/package/firebase)
-[![Coverage Status](https://coveralls.io/repos/github/firebase/firebase-js-sdk/badge.svg?branch=ch-branchswitch-main)](https://coveralls.io/github/firebase/firebase-js-sdk?branch=ch-branchswitch-main)
+[![Coverage Status](https://coveralls.io/repos/github/firebase/firebase-js-sdk/badge.svg?branch=main)](https://coveralls.io/github/firebase/firebase-js-sdk?branch=main)
 <!-- END BADGES -->
 
 # Firebase - App success made simple

--- a/packages/firebase/README.md
+++ b/packages/firebase/README.md
@@ -1,7 +1,7 @@
 <!-- BADGES -->
 ![Build Status](https://img.shields.io/github/workflow/status/firebase/firebase-js-sdk/Run%20All%20Tests.svg)
 [![Version](https://img.shields.io/npm/v/firebase.svg?label=version)](https://www.npmjs.com/package/firebase)
-[![Coverage Status](https://coveralls.io/repos/github/firebase/firebase-js-sdk/badge.svg?branch=master)](https://coveralls.io/github/firebase/firebase-js-sdk?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/firebase/firebase-js-sdk/badge.svg?branch=ch-branchswitch-main)](https://coveralls.io/github/firebase/firebase-js-sdk?branch=ch-branchswitch-main)
 <!-- END BADGES -->
 
 # Firebase - App success made simple

--- a/packages/remote-config/src/remote_config.ts
+++ b/packages/remote-config/src/remote_config.ts
@@ -32,7 +32,7 @@ const DEFAULT_CACHE_MAX_AGE_MILLIS = 12 * 60 * 60 * 1000; // Twelve hours.
 /**
  * Encapsulates business logic mapping network and storage dependencies to the public SDK API.
  *
- * See {@link https://github.com/firebase/firebase-js-sdk/blob/ch-branchswitch-main/packages/firebase/index.d.ts|interface documentation} for method descriptions.
+ * See {@link https://github.com/firebase/firebase-js-sdk/blob/main/packages/firebase/index.d.ts|interface documentation} for method descriptions.
  */
 export class RemoteConfig implements RemoteConfigType {
   /**

--- a/packages/remote-config/src/remote_config.ts
+++ b/packages/remote-config/src/remote_config.ts
@@ -32,7 +32,7 @@ const DEFAULT_CACHE_MAX_AGE_MILLIS = 12 * 60 * 60 * 1000; // Twelve hours.
 /**
  * Encapsulates business logic mapping network and storage dependencies to the public SDK API.
  *
- * See {@link https://github.com/FirebasePrivate/firebase-js-sdk/blob/master/packages/firebase/index.d.ts|interface documentation} for method descriptions.
+ * See {@link https://github.com/firebase/firebase-js-sdk/blob/ch-branchswitch-main/packages/firebase/index.d.ts|interface documentation} for method descriptions.
  */
 export class RemoteConfig implements RemoteConfigType {
   /**

--- a/scripts/ci-test/deploy-if-needed.ts
+++ b/scripts/ci-test/deploy-if-needed.ts
@@ -52,7 +52,7 @@ async function deployIfNeeded() {
   if (!token) {
     throw new Error('No FIREBASE_CLI_TOKEN found, exiting.');
   }
-  const diff = await git.diff(['--name-only', 'origin/master...HEAD']);
+  const diff = await git.diff(['--name-only', 'origin/ch-branchswitch-main...HEAD']);
   const changedFiles = diff.split('\n');
   let flags: string[] = [];
   for (const group of projectConfigGroups) {

--- a/scripts/ci-test/deploy-if-needed.ts
+++ b/scripts/ci-test/deploy-if-needed.ts
@@ -52,7 +52,7 @@ async function deployIfNeeded() {
   if (!token) {
     throw new Error('No FIREBASE_CLI_TOKEN found, exiting.');
   }
-  const diff = await git.diff(['--name-only', 'origin/ch-branchswitch-main...HEAD']);
+  const diff = await git.diff(['--name-only', 'origin/main...HEAD']);
   const changedFiles = diff.split('\n');
   let flags: string[] = [];
   for (const group of projectConfigGroups) {

--- a/scripts/ci-test/tasks.ts
+++ b/scripts/ci-test/tasks.ts
@@ -94,7 +94,7 @@ export async function getTestTasks(): Promise<TestTask[]> {
   const depGraph: { [key: string]: any } = JSON.parse(
     (await exec('npx lerna ls --all --graph', { cwd: root })).stdout
   );
-  const diff = await git.diff(['--name-only', 'origin/master...HEAD']);
+  const diff = await git.diff(['--name-only', 'origin/ch-branchswitch-main...HEAD']);
   const changedFiles = diff.split('\n');
   let testTasks: TestTask[] = [];
   for (const filename of changedFiles) {

--- a/scripts/ci-test/tasks.ts
+++ b/scripts/ci-test/tasks.ts
@@ -94,7 +94,7 @@ export async function getTestTasks(): Promise<TestTask[]> {
   const depGraph: { [key: string]: any } = JSON.parse(
     (await exec('npx lerna ls --all --graph', { cwd: root })).stdout
   );
-  const diff = await git.diff(['--name-only', 'origin/ch-branchswitch-main...HEAD']);
+  const diff = await git.diff(['--name-only', 'origin/main...HEAD']);
   const changedFiles = diff.split('\n');
   let testTasks: TestTask[] = [];
   for (const filename of changedFiles) {

--- a/scripts/ci/add_changeset.ts
+++ b/scripts/ci/add_changeset.ts
@@ -39,8 +39,8 @@ const FILE_PATH = `${projectRoot}/.changeset/bump-sdk-version.md`;
 async function addChangeSet() {
   // check if a few firebase version is being released
   try {
-    // The way actions/checkout works, there is no local `master` branch, but it
-    // has access to the remote origin/master.
+    // The way actions/checkout works, there is no local `ch-branchswitch-main` branch, but it
+    // has access to the remote origin/ch-branchswitch-main.
     const { stdout } = await exec('yarn changeset status');
     // only add a changeset for @firebase/app if
     // 1. we are publishing a new firebase version. and

--- a/scripts/ci/add_changeset.ts
+++ b/scripts/ci/add_changeset.ts
@@ -39,8 +39,8 @@ const FILE_PATH = `${projectRoot}/.changeset/bump-sdk-version.md`;
 async function addChangeSet() {
   // check if a few firebase version is being released
   try {
-    // The way actions/checkout works, there is no local `ch-branchswitch-main` branch, but it
-    // has access to the remote origin/ch-branchswitch-main.
+    // The way actions/checkout works, there is no local `main` branch, but it
+    // has access to the remote origin/main.
     const { stdout } = await exec('yarn changeset status');
     // only add a changeset for @firebase/app if
     // 1. we are publishing a new firebase version. and

--- a/scripts/ci/check_changeset.ts
+++ b/scripts/ci/check_changeset.ts
@@ -26,7 +26,7 @@ import fs from 'mz/fs';
 const root = resolve(__dirname, '../..');
 const git = simpleGit(root);
 
-const baseRef = process.env.GITHUB_PULL_REQUEST_BASE_SHA || 'ch-branchswitch-main';
+const baseRef = process.env.GITHUB_PULL_REQUEST_BASE_SHA || 'main';
 const headRef = process.env.GITHUB_PULL_REQUEST_HEAD_SHA || 'HEAD';
 
 const githubOutputFile = (function (): string {

--- a/scripts/ci/check_changeset.ts
+++ b/scripts/ci/check_changeset.ts
@@ -26,7 +26,7 @@ import fs from 'mz/fs';
 const root = resolve(__dirname, '../..');
 const git = simpleGit(root);
 
-const baseRef = process.env.GITHUB_PULL_REQUEST_BASE_SHA || 'master';
+const baseRef = process.env.GITHUB_PULL_REQUEST_BASE_SHA || 'ch-branchswitch-main';
 const headRef = process.env.GITHUB_PULL_REQUEST_HEAD_SHA || 'HEAD';
 
 const githubOutputFile = (function (): string {

--- a/scripts/format/format.ts
+++ b/scripts/format/format.ts
@@ -42,7 +42,7 @@ const { path: targetPath, all: runOnAll } = yargs(hideBin(process.argv))
   .usage(
     `Runs prettier formatting and updates license headers. ` +
       `If no arguments are provided it will run formatting on any ` +
-      `files changed since ch-branchswitch-main.`
+      `files changed since main.`
   )
   .parseSync();
 
@@ -56,8 +56,8 @@ const format = async () => {
           glob(join(targetPath, '/**/*'), (err, res) => resolve(res));
         });
       } else {
-        // Otherwise get all files changed since ch-branchswitch-main.
-        const baseSha = process.env.GITHUB_PULL_REQUEST_BASE_SHA || 'ch-branchswitch-main';
+        // Otherwise get all files changed since main.
+        const baseSha = process.env.GITHUB_PULL_REQUEST_BASE_SHA || 'main';
         const diff = await git.diff([
           '--name-only',
           '--diff-filter=d',

--- a/scripts/format/format.ts
+++ b/scripts/format/format.ts
@@ -42,7 +42,7 @@ const { path: targetPath, all: runOnAll } = yargs(hideBin(process.argv))
   .usage(
     `Runs prettier formatting and updates license headers. ` +
       `If no arguments are provided it will run formatting on any ` +
-      `files changed since master.`
+      `files changed since ch-branchswitch-main.`
   )
   .parseSync();
 
@@ -56,8 +56,8 @@ const format = async () => {
           glob(join(targetPath, '/**/*'), (err, res) => resolve(res));
         });
       } else {
-        // Otherwise get all files changed since master.
-        const baseSha = process.env.GITHUB_PULL_REQUEST_BASE_SHA || 'master';
+        // Otherwise get all files changed since ch-branchswitch-main.
+        const baseSha = process.env.GITHUB_PULL_REQUEST_BASE_SHA || 'ch-branchswitch-main';
         const diff = await git.diff([
           '--name-only',
           '--diff-filter=d',

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -28,7 +28,7 @@ export const projectRoot = dirname(resolve(__dirname, '../package.json'));
 export async function getChangedFiles(): Promise<string[]> {
   console.log(projectRoot);
   const git = simpleGit(projectRoot);
-  const diff = await git.diff(['--name-only', 'origin/ch-branchswitch-main...HEAD']);
+  const diff = await git.diff(['--name-only', 'origin/main...HEAD']);
   const changedFiles = diff.split('\n');
 
   return changedFiles;

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -28,7 +28,7 @@ export const projectRoot = dirname(resolve(__dirname, '../package.json'));
 export async function getChangedFiles(): Promise<string[]> {
   console.log(projectRoot);
   const git = simpleGit(projectRoot);
-  const diff = await git.diff(['--name-only', 'origin/master...HEAD']);
+  const diff = await git.diff(['--name-only', 'origin/ch-branchswitch-main...HEAD']);
   const changedFiles = diff.split('\n');
 
   return changedFiles;


### PR DESCRIPTION
This is to match the coordinated effort across all Firebase platform SDKs. The change has already been made in the Apple and Android repos.