### PR TITLE
Abort Firestore listeners on terminate.

### DIFF
--- a/packages/firestore/src/core/component_provider.ts
+++ b/packages/firestore/src/core/component_provider.ts
@@ -485,5 +485,6 @@ export class OnlineComponentProvider {
   async terminate(): Promise<void> {
     await remoteStoreShutdown(this.remoteStore);
     this.datastore?.terminate();
+    this.eventManager?.terminate();
   }
 }

--- a/packages/firestore/src/core/event_manager.ts
+++ b/packages/firestore/src/core/event_manager.ts
@@ -346,7 +346,10 @@ export function removeSnapshotsInSyncListener(
   eventManagerImpl.snapshotsInSyncListeners.delete(observer);
 }
 
-function errorAllTargets(eventManager: EventManager, error: FirestoreError) {
+function errorAllTargets(
+  eventManager: EventManager,
+  error: FirestoreError
+): void {
   const eventManagerImpl = debugCast(eventManager, EventManagerImpl);
   const queries = eventManagerImpl.queries;
 

--- a/packages/firestore/test/integration/api/batch_writes.test.ts
+++ b/packages/firestore/test/integration/api/batch_writes.test.ts
@@ -155,12 +155,11 @@ apiDescribe('Database batch writes', persistence => {
       );
       return accumulator
         .awaitEvent()
-        .then(initialSnap => {
+        .then(async initialSnap => {
           expect(initialSnap.docs.length).to.equal(0);
 
           // Atomically write two documents.
-          // eslint-disable-next-line @typescript-eslint/no-floating-promises
-          writeBatch(db).set(docA, { a: 1 }).set(docB, { b: 2 }).commit();
+          await writeBatch(db).set(docA, { a: 1 }).set(docB, { b: 2 }).commit();
 
           return accumulator.awaitEvent();
         })

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -63,7 +63,8 @@ import {
   FieldPath,
   newTestFirestore,
   SnapshotOptions,
-  newTestApp
+  newTestApp,
+  FirestoreError
 } from '../util/firebase_export';
 import {
   apiDescribe,
@@ -1438,6 +1439,22 @@ apiDescribe('Database', persistence => {
       // This should proceed without error.
       unsubscribe();
       // Multiple calls should proceed as well.
+      unsubscribe();
+    });
+  });
+
+  it('query listener throws error on termination', async () => {
+    return withTestDoc(persistence, async (docRef, firestore) => {
+      const deferred: Deferred<FirestoreError> = new Deferred();
+      const unsubscribe = onSnapshot(docRef, snapshot => {}, deferred.resolve);
+
+      await terminate(firestore);
+
+      await expect(deferred.promise)
+        .to.eventually.haveOwnProperty('message')
+        .equal('Firestore shutting down');
+
+      // Call should proceed without error.
       unsubscribe();
     });
   });


### PR DESCRIPTION
In preparation for clearing cache on named database reuse, listeners need to abort when FirestoreClient is terminated.
