### PR TITLE
Upgrade actions from master to v4

### DIFF
--- a/.github/workflows/canary-deploy.yml
+++ b/.github/workflows/canary-deploy.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
       with:
         # Canary release script requires git history and tags.
         fetch-depth: 0

--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
       with:
         # This makes Actions fetch all Git history so check_changeset script can diff properly.
         fetch-depth: 0

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
       with:
         # get all history for the diff
         fetch-depth: 0

--- a/.github/workflows/check-pkg-paths.yml
+++ b/.github/workflows/check-pkg-paths.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
       with:
         # This makes Actions fetch all Git history so run-changed script can diff properly.
         fetch-depth: 0

--- a/.github/workflows/deploy-config.yml
+++ b/.github/workflows/deploy-config.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
       with:
         # This makes Actions fetch all Git history so run-changed script can diff properly.
         fetch-depth: 0

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
       - name: Set up Node (20)
         uses: actions/setup-node@master
         with:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
       with:
         # get all history for the diff
         fetch-depth: 0

--- a/.github/workflows/merge-release-branch.yml
+++ b/.github/workflows/merge-release-branch.yml
@@ -24,7 +24,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout Release Branch
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           ref: release
       - name: Get release version

--- a/.github/workflows/prerelease-manual-deploy.yml
+++ b/.github/workflows/prerelease-manual-deploy.yml
@@ -30,7 +30,7 @@ jobs:
     
         steps:
         - name: Checkout Repo
-          uses: actions/checkout@master
+          uses: actions/checkout@v4
           with:
             # Canary release script requires git history and tags.
             fetch-depth: 0

--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
       - name: Setup Node.js 20.x
         uses: actions/setup-node@master

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -27,7 +27,7 @@ jobs:
     if: ${{ !startsWith(github.event.head_commit.message, 'Version Packages (#') }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -37,7 +37,7 @@ jobs:
       with:
         node-version: 20.x
     - name: Checkout release branch (with history)
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
       with:
         # Release script requires git history and tags.
         fetch-depth: 0

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -63,7 +63,7 @@ jobs:
           })
           console.log(result)
     - name: Checkout current branch (with history)
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
       with:
         # Release script requires git history and tags.
         fetch-depth: 0

--- a/.github/workflows/release-tweet.yml
+++ b/.github/workflows/release-tweet.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
       - name: Setup Node.js 20.x
         uses: actions/setup-node@master
         with:

--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
          echo $CHROME_VERSION_NOTES=$CHROME_VERSION_MISMATCH_MESSAGE
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           # This makes Actions fetch all Git history so run-changed script can diff properly.
           fetch-depth: 0
@@ -84,7 +84,7 @@ jobs:
           sudo apt-get install wget
 
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           # This makes Actions fetch all Git history so run-changed script can diff properly.
           fetch-depth: 0

--- a/.github/workflows/test-changed-fcm-integration.yml
+++ b/.github/workflows/test-changed-fcm-integration.yml
@@ -34,7 +34,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install google-chrome-stable
     - name: Checkout Repo
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
       with:
         # This makes Actions fetch all Git history so run-changed script can diff properly.
         fetch-depth: 0

--- a/.github/workflows/test-changed-firestore-integration.yml
+++ b/.github/workflows/test-changed-firestore-integration.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
       with:
         # This makes Actions fetch all Git history so run-changed script can diff properly.
         fetch-depth: 0

--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           # This makes Actions fetch all Git history so run-changed script can diff properly.
           fetch-depth: 0

--- a/.github/workflows/test-changed-misc.yml
+++ b/.github/workflows/test-changed-misc.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
       with:
         # This makes Actions fetch all Git history so run-changed script can diff properly.
         fetch-depth: 0

--- a/.github/workflows/test-changed.yml
+++ b/.github/workflows/test-changed.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           # This makes Actions fetch all Git history so run-changed script can diff properly.
           fetch-depth: 0
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Node (20)

--- a/.github/workflows/test-firebase-integration.yml
+++ b/.github/workflows/test-firebase-integration.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
       with:
         # This makes Actions fetch all Git history so run-changed script can diff properly.
         fetch-depth: 0

--- a/.github/workflows/update-api-reports.yml
+++ b/.github/workflows/update-api-reports.yml
@@ -25,7 +25,7 @@ jobs:
       contents: write
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
       with:
         # checkout HEAD commit instead of merge commit
         ref: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
The `actions/checkout` was being pulled from `@master` which is still at v2, since their default branch has changed from master to main in 2020.

Previous default branch, at v2: https://github.com/actions/checkout/tree/master
New default branch, at v4: https://github.com/actions/checkout/tree/main

The v2 -> v3 bump was to drop support for Node runtimes < 16: https://github.com/actions/checkout/compare/v2.4.2...v3.0.2#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R17-R18
The v3 -> v4 bump was to drop support for Node runtimes < 20: https://github.com/actions/checkout/compare/v4.0.0...v4.1.0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R15-R17

Since we're already using Node >= 20, we can upgrade all the way to v4.
