### PR TITLE
Exclude `.git` from archived build, instead of deleting it

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -50,12 +50,10 @@ jobs:
         yarn
     - name: yarn build
       run: yarn build
-    - name: Remove git directory
-      run: rm -rf .git
     - name: Archive build
       if: ${{ !cancelled() }}
       run: |
-        tar -cf build.tar .
+        tar -cf build.tar --exclude=.git .
         gzip build.tar
     - name: Upload build archive
       if: ${{ !cancelled() }}


### PR DESCRIPTION
Instead of having an additional step to delete the `.git` directory before archiving it, we can directly exclude it from the archived build with `--exclude`.

Firestore is already doing this here: https://github.com/firebase/firebase-js-sdk/blob/main/.github/workflows/test-changed-firestore.yml#L71