### PR TITLE
Remove LocalStorage synchronization on storage events in Safari

### DIFF
--- a/.changeset/mighty-shirts-pump.md
+++ b/.changeset/mighty-shirts-pump.md
@@ -1,0 +1,5 @@
+---
+'@firebase/auth': patch
+---
+
+Remove localStorage synchronization on storage events in Safari iframes. See [GitHub PR #8408](https://github.com/firebase/firebase-js-sdk/pull/8408).

--- a/packages/auth/src/platform_browser/persistence/local_storage.ts
+++ b/packages/auth/src/platform_browser/persistence/local_storage.ts
@@ -18,9 +18,6 @@
 import { Persistence } from '../../model/public_types';
 
 import {
-  _isSafari,
-  _isIOS,
-  _isIframe,
   _isMobileBrowser,
   _isIE10
 } from '../../core/util/browser';

--- a/packages/auth/src/platform_browser/persistence/local_storage.ts
+++ b/packages/auth/src/platform_browser/persistence/local_storage.ts
@@ -17,10 +17,7 @@
 
 import { Persistence } from '../../model/public_types';
 
-import {
-  _isMobileBrowser,
-  _isIE10
-} from '../../core/util/browser';
+import { _isMobileBrowser, _isIE10 } from '../../core/util/browser';
 import {
   PersistenceInternal as InternalPersistence,
   PersistenceType,


### PR DESCRIPTION
This PR removes a localStorage synchronization fix introduced in 2016 to address an issue in Safari 9 (*Important:* [b/28330893](http://b/28330893)). The fix, while necessary at the time, is now causing several Auth tests to fail in Safari. After removing this fix, all tests pass.

The Safari tests are failing because they assume that a storage event without a change to the underlying storage will not trigger callbacks that we attach. With this fix, if we dispatch a storage event without a change to the underlying storage, a manual synchronization will take place, which will then cause the callbacks to be called.
See: [`local_storage.test.ts`](https://github.com/firebase/firebase-js-sdk/blob/main/packages/auth/src/platform_browser/persistence/local_storage.test.ts#L168-#L179).

**Testing**:
I tested localStorage behaviour in the latest Safari version with an app hosted at `127.0.0.1` that contains an iframe hosted at `localhost`. I opened the app in two tabs and triggered localStorage events by signing in with Google in a popup, and observed that changes to localStorage are synchronized correctly across the iframes in both tabs.
I created a repro with instructions to help others test this behaviour: https://github.com/dlarocque/safari-iframe-localstorage.