### PR TITLE
fix error when initializing firebase on service worker

### DIFF
--- a/.changeset/slow-emus-vanish.md
+++ b/.changeset/slow-emus-vanish.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app-compat': patch
+---
+
+Updated how app-compat checks the global scope.

--- a/packages/app-compat/src/index.ts
+++ b/packages/app-compat/src/index.ts
@@ -16,7 +16,7 @@
  */
 
 import { FirebaseNamespace } from './public-types';
-import { isBrowser, getGlobal } from '@firebase/util';
+import { getGlobal } from '@firebase/util';
 import { firebase as firebaseNamespace } from './firebaseNamespace';
 import { logger } from './logger';
 import { registerCoreComponents } from './registerCoreComponents';
@@ -39,14 +39,14 @@ try {
 
     // eslint-disable-next-line
     const sdkVersion = ((globals as any).firebase as FirebaseNamespace).SDK_VERSION;
-      if (sdkVersion && sdkVersion.indexOf('LITE') >= 0) {
-        logger.warn(`
+    if (sdkVersion && sdkVersion.indexOf('LITE') >= 0) {
+      logger.warn(`
         Warning: You are trying to load Firebase while using Firebase Performance standalone script.
         You should load Firebase Performance with this instance of Firebase to avoid loading duplicate code.
         `);
-      }
+    }
   }
-} catch{
+} catch {
   // ignore errors thrown by getGlobal
 }
 

--- a/packages/app-compat/src/index.ts
+++ b/packages/app-compat/src/index.ts
@@ -38,7 +38,8 @@ try {
     `);
 
     // eslint-disable-next-line
-    const sdkVersion = ((globals as any).firebase as FirebaseNamespace).SDK_VERSION;
+    const sdkVersion = ((globals as any).firebase as FirebaseNamespace)
+      .SDK_VERSION;
     if (sdkVersion && sdkVersion.indexOf('LITE') >= 0) {
       logger.warn(`
         Warning: You are trying to load Firebase while using Firebase Performance standalone script.

--- a/packages/app-compat/src/index.ts
+++ b/packages/app-compat/src/index.ts
@@ -16,7 +16,7 @@
  */
 
 import { FirebaseNamespace } from './public-types';
-import { isBrowser } from '@firebase/util';
+import { isBrowser, getGlobal } from '@firebase/util';
 import { firebase as firebaseNamespace } from './firebaseNamespace';
 import { logger } from './logger';
 import { registerCoreComponents } from './registerCoreComponents';
@@ -27,22 +27,27 @@ declare global {
   }
 }
 
-// Firebase Lite detection
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-if (isBrowser() && window.firebase !== undefined) {
-  logger.warn(`
-    Warning: Firebase is already defined in the global scope. Please make sure
-    Firebase library is only loaded once.
-  `);
-
-  // eslint-disable-next-line
-  const sdkVersion = (window.firebase as FirebaseNamespace).SDK_VERSION;
-  if (sdkVersion && sdkVersion.indexOf('LITE') >= 0) {
+try {
+  const globals = getGlobal();
+  // Firebase Lite detection
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if ((globals as any).firebase !== undefined) {
     logger.warn(`
-    Warning: You are trying to load Firebase while using Firebase Performance standalone script.
-    You should load Firebase Performance with this instance of Firebase to avoid loading duplicate code.
+      Warning: Firebase is already defined in the global scope. Please make sure
+      Firebase library is only loaded once.
     `);
+
+    // eslint-disable-next-line
+    const sdkVersion = ((globals as any).firebase as FirebaseNamespace).SDK_VERSION;
+      if (sdkVersion && sdkVersion.indexOf('LITE') >= 0) {
+        logger.warn(`
+        Warning: You are trying to load Firebase while using Firebase Performance standalone script.
+        You should load Firebase Performance with this instance of Firebase to avoid loading duplicate code.
+        `);
+      }
   }
+} catch{
+  // ignore errors thrown by getGlobal
 }
 
 const firebase = firebaseNamespace;


### PR DESCRIPTION
Updated how app-compat checks the global scope. The `getGlobal()` checks the existence of `self`, `window`, and also `global`.

Fixes #8409