### PR TITLE
VertexAI: use updated set of mock responses

### DIFF
--- a/packages/vertexai/src/methods/generate-content.test.ts
+++ b/packages/vertexai/src/methods/generate-content.test.ts
@@ -188,7 +188,7 @@ describe('generateContent()', () => {
     );
   });
   it('unknown enum - should ignore', async () => {
-    const mockResponse = getMockResponse('unary-success-unknown-enum.json');
+    const mockResponse = getMockResponse('unary-success-unknown-enum-safety-ratings.json');
     const makeRequestStub = stub(request, 'makeRequest').resolves(
       mockResponse as Response
     );
@@ -197,7 +197,7 @@ describe('generateContent()', () => {
       'model',
       fakeRequestParams
     );
-    expect(result.response.text()).to.include('30 minutes of brewing');
+    expect(result.response.text()).to.include('Some text');
     expect(makeRequestStub).to.be.calledWith(
       'model',
       Task.GENERATE_CONTENT,

--- a/packages/vertexai/src/methods/generate-content.test.ts
+++ b/packages/vertexai/src/methods/generate-content.test.ts
@@ -188,7 +188,9 @@ describe('generateContent()', () => {
     );
   });
   it('unknown enum - should ignore', async () => {
-    const mockResponse = getMockResponse('unary-success-unknown-enum-safety-ratings.json');
+    const mockResponse = getMockResponse(
+      'unary-success-unknown-enum-safety-ratings.json'
+    );
     const makeRequestStub = stub(request, 'makeRequest').resolves(
       mockResponse as Response
     );

--- a/packages/vertexai/src/requests/stream-reader.test.ts
+++ b/packages/vertexai/src/requests/stream-reader.test.ts
@@ -174,7 +174,7 @@ describe('processStream', () => {
   });
   it('unknown enum - should ignore', async () => {
     const fakeResponse = getMockResponseStreaming(
-      'streaming-success-unknown-enum.txt'
+      'streaming-success-unknown-safety-enum.txt'
     );
     const result = processStream(fakeResponse as Response);
     const aggregatedResponse = await result.response;

--- a/scripts/update_vertexai_responses.sh
+++ b/scripts/update_vertexai_responses.sh
@@ -17,7 +17,7 @@
 # This script replaces mock response files for Vertex AI unit tests with a fresh
 # clone of the shared repository of Vertex AI test data.
 
-RESPONSES_VERSION='v1.*' # The major version of mock responses to use
+RESPONSES_VERSION='v2.*' # The major version of mock responses to use
 REPO_NAME="vertexai-sdk-test-data"
 REPO_LINK="https://github.com/FirebaseExtended/$REPO_NAME.git"
 


### PR DESCRIPTION
The set of mock responses were updated to reduce some more duplication: https://github.com/FirebaseExtended/vertexai-sdk-test-data/pull/12

This updates the test code to use the updated version.