### PR TITLE
Update Bug Report Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_v2.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_v2.yaml
@@ -31,7 +31,7 @@ body:
     id: operating-system
     attributes:
       label: Operating System
-      description: Describe your operating system
+      description: Describe the operating system where you are experiencing the issue.
       placeholder: ex. iOS 16.4, macOS Ventura 13.4, Windows 11
     validations:
       required: true
@@ -55,7 +55,7 @@ body:
     id: firebase-sdk-products
     attributes:
       label: Firebase SDK Product(s)
-      description: Select the Firebase product(s) relevant to your issue.
+      description: Select the Firebase product(s) relevant to your issue. You can select multiple options in the dropdown.
       multiple: true
       options:
         - Analytics

--- a/.github/ISSUE_TEMPLATE/bug_report_v2.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_v2.yaml
@@ -96,7 +96,6 @@ body:
         What were you trying to accomplish? What happened? This should include a background description, log/console output, etc.
     validations:
       required: true
-        - type: textarea
   - type: textarea
     id: reproduce-code
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report_v2.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_v2.yaml
@@ -31,7 +31,7 @@ body:
     id: operating-system
     attributes:
       label: Operating System
-      description: Describe the operating system where you are experiencing the issue.
+      description: Describe the operating system(s) where you are experiencing the issue.
       placeholder: ex. iOS 16.4, macOS Ventura 13.4, Windows 11
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report_v2.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_v2.yaml
@@ -91,7 +91,8 @@ body:
         - What you were trying to achieve.
         - What actually happened.
         - Any error messages or unexpected behavior you observed.
-        - Relevant log snippets or console output (if available).      placeholder: |
+        - Relevant log snippets or console output (if available).
+      placeholder: |
         What were you trying to accomplish? What happened? This should include a background description, log/console output, etc.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report_v2.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_v2.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 name: 🐞 Bug Report
 description: File a bug report
 title: 'Title for the bug'
-labels: 'question, new'
+labels: 'new'
 body:
   - type: markdown
     id: before-you-start
@@ -32,30 +32,30 @@ body:
     attributes:
       label: Operating System
       description: Describe your operating system
-      placeholder: ex. iOS 16.4
+      placeholder: ex. iOS 16.4, macOS Ventura 13.4, Windows 11
     validations:
       required: true
   - type: input
-    id: browser-version
+    id: environment
     attributes:
-      label: Browser Version
-      description: Describe your browser version
-      placeholder: ex. Safari/604.1
+      label: Environment (if applicable)
+      description: Describe the environment where you are experiencing the issue. This could include the browser and its version, Node.js version, or any other relevant environment details.
+      placeholder: ex. Chrome 115, Node.js v18.16.0, React Native 
     validations:
       required: true
   - type: input
     id: firebase-sdk-version
     attributes:
       label: Firebase SDK Version
-      description: Describe your Firebase SDK Version
+      description: The Firebase JS SDK version you're using.
       placeholder: ex. 9.16.0
     validations:
       required: true
   - type: dropdown
     id: firebase-sdk-products
     attributes:
-      label: 'Firebase SDK Product:'
-      description: Which Firebase Products are used in your app?
+      label: Firebase SDK Product(s)
+      description: Select the Firebase Product(s) relevant to your issue.
       multiple: true
       options:
         - Analytics
@@ -77,7 +77,7 @@ body:
   - type: textarea
     id: project-tooling
     attributes:
-      label: Describe your project's tooling
+      label: Project Tooling
       description: Describe the tooling your app is built with
       placeholder: React app with Webpack and Jest
     validations:
@@ -85,16 +85,23 @@ body:
   - type: textarea
     id: describe-your-problem
     attributes:
-      label: Describe the problem
-      description: Describe what you were trying to do and what occurred
-      placeholder: |
+      label: Detailed Problem Description
+      description: |
+        Please provide a clear and concise description of the problem. Include:
+        - What you were trying to achieve.
+        - What actually happened.
+        - Any error messages or unexpected behavior you observed.
+        - Relevant log snippets or console output (if available).      placeholder: |
         What were you trying to accomplish? What happened? This should include a background description, log/console output, etc.
     validations:
       required: true
+        - type: textarea
   - type: textarea
     id: reproduce-code
     attributes:
       label: Steps and code to reproduce issue
-      description: Please provide a description of how to replicate your issue. Copy and paste any relevant code here to reproduce the problem or links to code to reproduce it.
-    validations:
-      required: true
+      description: |
+        If possible, provide a minimal, self-contained code snippet or steps that consistently reproduce the issue. 
+        This will significantly aid in debugging.
+      validations:
+        required: true

--- a/.github/ISSUE_TEMPLATE/bug_report_v2.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_v2.yaml
@@ -21,7 +21,7 @@ body:
     id: before-you-start
     attributes:
       value: |
-        *[READ THIS]:* to evaluate if you are in the right place?
+        *[READ THIS]:* Are in the right place?
         - For issues or feature requests related to __the code in this repository__, file a GitHub issue.
         - If this is a __feature request__, make sure the issue title starts with "FR:".
         - For general technical questions, post a question on [StackOverflow](http://stackoverflow.com/) with the firebase tag.

--- a/.github/ISSUE_TEMPLATE/bug_report_v2.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_v2.yaml
@@ -15,7 +15,7 @@
 name: 🐞 Bug Report
 description: File a bug report
 title: 'Title for the bug'
-labels: 'new'
+labels: 'question', 'new'
 body:
   - type: markdown
     id: before-you-start
@@ -55,7 +55,7 @@ body:
     id: firebase-sdk-products
     attributes:
       label: Firebase SDK Product(s)
-      description: Select the Firebase Product(s) relevant to your issue.
+      description: Select the Firebase product(s) relevant to your issue.
       multiple: true
       options:
         - Analytics

--- a/.github/ISSUE_TEMPLATE/bug_report_v2.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_v2.yaml
@@ -15,7 +15,7 @@
 name: 🐞 Bug Report
 description: File a bug report
 title: 'Title for the bug'
-labels: 'question', 'new'
+labels: 'question, new'
 body:
   - type: markdown
     id: before-you-start

--- a/.github/ISSUE_TEMPLATE/bug_report_v2.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_v2.yaml
@@ -21,7 +21,7 @@ body:
     id: before-you-start
     attributes:
       value: |
-        *[READ THIS]:* Are in the right place?
+        *[READ THIS]:* Are you in the right place?
         - For issues or feature requests related to __the code in this repository__, file a GitHub issue.
         - If this is a __feature request__, make sure the issue title starts with "FR:".
         - For general technical questions, post a question on [StackOverflow](http://stackoverflow.com/) with the firebase tag.

--- a/.github/ISSUE_TEMPLATE/bug_report_v2.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_v2.yaml
@@ -103,5 +103,5 @@ body:
       description: |
         If possible, provide a minimal, self-contained code snippet or steps that consistently reproduce the issue. 
         This will significantly aid in debugging.
-      validations:
-        required: true
+    validations:
+      required: true


### PR DESCRIPTION
Our Bug report template required that the user input a browser version. This isn't applicable in cases where the bug occurs in a non-browser environment (e.g. Node, React Native).

Users usually only select one product. We should make it more clear that they can select multiple if they're relevant.