### PR TITLE
fix: remove unnecessary console.log statement

### DIFF
--- a/.changeset/perfect-weeks-care.md
+++ b/.changeset/perfect-weeks-care.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app': patch
+---
+
+Removed an unnecessary console.log statement.

--- a/packages/app/src/heartbeatService.ts
+++ b/packages/app/src/heartbeatService.ts
@@ -90,7 +90,6 @@ export class HeartbeatServiceImpl implements HeartbeatService {
       // service, not the browser user agent.
       const agent = platformLogger.getPlatformInfoString();
       const date = getUTCDateString();
-      console.log('heartbeats', this._heartbeatsCache?.heartbeats);
       if (this._heartbeatsCache?.heartbeats == null) {
         this._heartbeatsCache = await this._heartbeatsCachePromise;
         // If we failed to construct a heartbeats cache, then return immediately.


### PR DESCRIPTION
Following the discussion in issue #8436, I’ve removed an unnecessary console.log statement that appears to have been inadvertently included in a recent commit