### PR TITLE
Fix Storage Node tests

### DIFF
--- a/packages/storage/test/integration/integration.test.ts
+++ b/packages/storage/test/integration/integration.test.ts
@@ -209,7 +209,7 @@ describe('FirebaseStorage Exp', () => {
     );
     await Promise.race([
       failureDeferred.promise,
-      new Promise(resolve => setTimeout(resolve, 4000))
+      new Promise(resolve => setTimeout(resolve, 2000))
     ]);
     task.resume();
     await task;

--- a/packages/storage/test/unit/requests.test.ts
+++ b/packages/storage/test/unit/requests.test.ts
@@ -145,19 +145,6 @@ describe('Firebase Storage > Requests', () => {
 
   const metadataContentType = 'application/json; charset=utf-8';
 
-  function readBlob(blob: Blob): Promise<string> {
-    const reader = new FileReader();
-    reader.readAsText(blob);
-    return new Promise((resolve, reject) => {
-      reader.onload = () => {
-        resolve(reader.result as string);
-      };
-      reader.onerror = () => {
-        reject(reader.error as Error);
-      };
-    });
-  }
-
   async function assertBodyEquals(
     body: Blob | string | Uint8Array | null,
     expectedStr: string
@@ -167,9 +154,11 @@ describe('Firebase Storage > Requests', () => {
     }
 
     if (typeof Blob !== 'undefined' && body instanceof Blob) {
-      return readBlob(body).then(str => {
+      return body.text().then(str => {
         assert.equal(str, expectedStr);
-      });
+      }).catch(err => {
+        return Promise.reject(err);
+      })
     } else if (body instanceof Uint8Array) {
       const str = decodeUint8Array(body);
       assert.equal(str, expectedStr);


### PR DESCRIPTION
This is a couple of fixes to the Storage Node tests that are currently failling.
1. `FileReader` was undefined in Node environments, and causing a test to fail. It turns out we don't need to use a `FileReader` to read a blob as a string anymore anyway, and can just replace it with the new [`blob.text()`](https://developer.mozilla.org/en-US/docs/Web/API/Blob/text).
2. `'can pause uploads without an error'` was failing because it was taking over 5000ms to complete. If we reduce the pause duration from 4000ms to 2000ms, the test passes in ~3000ms.