### PR TITLE
Upgrade vertex responses to v3

### DIFF
--- a/packages/vertexai/src/requests/stream-reader.test.ts
+++ b/packages/vertexai/src/requests/stream-reader.test.ts
@@ -210,7 +210,7 @@ describe('processStream', () => {
     expect(aggregatedResponse.text()).to.include('Quantum mechanics is');
     expect(
       aggregatedResponse.candidates?.[0].citationMetadata?.citations.length
-    ).to.equal(2);
+    ).to.equal(3);
     let foundCitationMetadata = false;
     for await (const response of result.stream) {
       expect(response.text()).to.not.be.empty;

--- a/scripts/update_vertexai_responses.sh
+++ b/scripts/update_vertexai_responses.sh
@@ -17,7 +17,7 @@
 # This script replaces mock response files for Vertex AI unit tests with a fresh
 # clone of the shared repository of Vertex AI test data.
 
-RESPONSES_VERSION='v2.*' # The major version of mock responses to use
+RESPONSES_VERSION='v3.*' # The major version of mock responses to use
 REPO_NAME="vertexai-sdk-test-data"
 REPO_LINK="https://github.com/FirebaseExtended/$REPO_NAME.git"
 


### PR DESCRIPTION
Ugrades vertex mock responses from v2 to v3. 

Related: https://github.com/FirebaseExtended/vertexai-sdk-test-data/pull/15