### PR TITLE
Add node engines fields specifying a minimum of 18

### DIFF
--- a/config/functions/package.json
+++ b/config/functions/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "engines": {
-    "node": "16"
+    "node": ">=18.0.0"
   }
 }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -38,5 +38,8 @@
     "webpack": "5.76.0",
     "webpack-cli": "4.10.0",
     "webpack-dev-server": "4.11.1"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/integration/compat-interop/package.json
+++ b/integration/compat-interop/package.json
@@ -25,5 +25,8 @@
   },
   "devDependencies": {
     "typescript": "4.7.4"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/integration/compat-typings/package.json
+++ b/integration/compat-typings/package.json
@@ -11,5 +11,8 @@
   },
   "devDependencies": {
     "typescript": "4.7.4"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/integration/firebase/package.json
+++ b/integration/firebase/package.json
@@ -21,5 +21,8 @@
     "mocha": "9.2.2",
     "npm-run-all": "4.1.5",
     "typescript": "4.7.4"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/integration/firestore/package.json
+++ b/integration/firestore/package.json
@@ -32,5 +32,8 @@
     "typescript": "4.2.2",
     "webpack": "5.76.0",
     "webpack-stream": "7.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/integration/messaging/package.json
+++ b/integration/messaging/package.json
@@ -17,5 +17,8 @@
     "mocha": "9.2.2",
     "undici": "6.19.7",
     "selenium-assistant": "6.1.1"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "license": "Apache-2.0",
   "engines": {
-    "node": "^8.13.0 || >=10.10.0"
+    "node": ">=18.0.0"
   },
   "homepage": "https://github.com/firebase/firebase-js-sdk",
   "keywords": [

--- a/packages/app-check-compat/package.json
+++ b/packages/app-check-compat/package.json
@@ -67,5 +67,8 @@
       ".ts"
     ],
     "reportDir": "./coverage/node"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/packages/app-check/package.json
+++ b/packages/app-check/package.json
@@ -68,5 +68,8 @@
       ".ts"
     ],
     "reportDir": "./coverage/node"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/packages/app-compat/package.json
+++ b/packages/app-compat/package.json
@@ -68,5 +68,8 @@
       ".ts"
     ],
     "reportDir": "./coverage/node"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -68,5 +68,8 @@
       ".ts"
     ],
     "reportDir": "./coverage/node"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/packages/auth-compat/package.json
+++ b/packages/auth-compat/package.json
@@ -82,5 +82,8 @@
       ".ts"
     ],
     "reportDir": "./coverage/node"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/packages/auth/internal/package.json
+++ b/packages/auth/internal/package.json
@@ -6,5 +6,8 @@
   "browser": "../dist/esm2017/internal.js",
   "esm5": "../dist/esm5/internal.js",
   "typings": "../dist/esm5/internal/index.d.ts",
-  "private": true
+  "private": true,
+  "engines": {
+    "node": ">=18.0.0"
+  }
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -161,5 +161,8 @@
       ".ts"
     ],
     "reportDir": "./coverage/node"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -56,5 +56,8 @@
       ".ts"
     ],
     "reportDir": "./coverage/node"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/packages/database-compat/package.json
+++ b/packages/database-compat/package.json
@@ -69,5 +69,8 @@
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -78,5 +78,8 @@
       ".ts"
     ],
     "reportDir": "./coverage/node"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/packages/firestore-compat/package.json
+++ b/packages/firestore-compat/package.json
@@ -74,5 +74,8 @@
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/packages/firestore/lite/package.json
+++ b/packages/firestore/lite/package.json
@@ -8,5 +8,8 @@
   "react-native": "../dist/lite/index.rn.esm2017.js",
   "esm5": "../dist/lite/index.browser.esm5.js",
   "typings": "../dist/lite/index.d.ts",
-  "private": true
+  "private": true,
+  "engines": {
+    "node": ">=18.0.0"
+  }
 }

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -2,7 +2,7 @@
   "name": "@firebase/firestore",
   "version": "4.7.0",
   "engines": {
-    "node": ">=10.10.0"
+    "node": ">=18.0.0"
   },
   "description": "The Cloud Firestore component of the Firebase JS SDK.",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",

--- a/packages/functions-compat/package.json
+++ b/packages/functions-compat/package.json
@@ -75,5 +75,8 @@
       ".ts"
     ],
     "reportDir": "./coverage/node"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -80,5 +80,8 @@
       ".ts"
     ],
     "reportDir": "./coverage/node"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -55,5 +55,8 @@
       ".ts"
     ],
     "reportDir": "./coverage/node"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/packages/rules-unit-testing/package.json
+++ b/packages/rules-unit-testing/package.json
@@ -20,7 +20,7 @@
     "./package.json": "./package.json"
   },
   "engines": {
-    "node": ">=10.10.0"
+    "node": ">=18.0.0"
   },
   "files": [
     "dist"

--- a/packages/storage-compat/package.json
+++ b/packages/storage-compat/package.json
@@ -63,5 +63,8 @@
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -73,5 +73,8 @@
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
   },
-  "typings": "dist/src/index.d.ts"
+  "typings": "dist/src/index.d.ts",
+  "engines": {
+    "node": ">=18.0.0"
+  }
 }

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -65,5 +65,8 @@
       ".ts"
     ],
     "reportDir": "./coverage/node"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/repo-scripts/api-documenter/package.json
+++ b/repo-scripts/api-documenter/package.json
@@ -34,5 +34,8 @@
     "@types/js-yaml": "4.0.9",
     "@types/resolve": "1.20.6",
     "mocha-chai-jest-snapshot": "1.1.3"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/repo-scripts/changelog-generator/package.json
+++ b/repo-scripts/changelog-generator/package.json
@@ -39,5 +39,8 @@
       ".ts"
     ],
     "reportDir": "./coverage/node"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/repo-scripts/prune-dts/package.json
+++ b/repo-scripts/prune-dts/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "^8.13.0 || >=10.10.0"
+    "node": ">=18.0.0"
   },
   "description": "A script to prune non-exported types from a d.ts.",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",

--- a/repo-scripts/size-analysis/package.json
+++ b/repo-scripts/size-analysis/package.json
@@ -57,5 +57,8 @@
       ".ts"
     ],
     "reportDir": "./coverage/node"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }


### PR DESCRIPTION
Update all appropriate `package.json` files in the repo to reflect a minimum Node `engines` version of 18.

Exceptions:
- Unpublished packages that only serve as entry points. e.g. `auth/cordova`, or `firebase/compat/storage` (the actual published package is `@firebase/storage-compat`).
- Types packages - FYI these are leftover from compat - all modular code should be using types within their own package.
- Auth demo apps - these are demo apps for auth testing and should be maintained by auth to the specification they want them at
- Packages that shouldn't be used in Node at all (Analytics, Installations, Messaging, Performance, Remote Config, Webchannel-wrapper)
- The template packages

Notes:
- Internal packages like `component`, `logger`, and `util` should be platform agnostic, but this enables us to introduce any new APIs (e.g., new cryptography API) that old versions of Node don't support, if we need to in the future
- 18 isn't necessarily the exact minimum for many of our internal tools, many of which can handle much older versions of Node, but our CI runs on 18 anyway.

See https://docs.google.com/spreadsheets/d/1TpQleZQiw1AW_E_CQE12mfW0cRNLvwIB03hDsfop7f8/edit?gid=0&resourcekey=0-k7oyij2BtGpazx4_2cexuA#gid=0 (internal link) for a breakdown of exactly which packages were included or excluded and some notes as to why.