### PR TITLE
Consolidate CI test output into a single string

### DIFF
--- a/scripts/run_tests_in_ci.js
+++ b/scripts/run_tests_in_ci.js
@@ -73,10 +73,10 @@ const argv = yargs.options({
     const testProcess = spawn('yarn', ['--cwd', dir, scriptName]);
 
     testProcess.childProcess.stdout.on('data', data => {
-      testProcessOutput += data.toString();
+      testProcessOutput += '[stdout]' + data.toString();
     });
     testProcess.childProcess.stderr.on('data', data => {
-      testProcessOutput += data.toString();
+      testProcessOutput += '[stderr]' + data.toString();
     });
 
     await testProcess;

--- a/scripts/run_tests_in_ci.js
+++ b/scripts/run_tests_in_ci.js
@@ -61,8 +61,7 @@ const argv = yargs.options({
   const dir = path.resolve(myPath);
   const { name } = require(`${dir}/package.json`);
 
-  let stdout = '';
-  let stderr = '';
+  let testProcessOutput = '';
   try {
     if (process.env?.BROWSERS) {
       for (const package in crossBrowserPackages) {
@@ -74,19 +73,18 @@ const argv = yargs.options({
     const testProcess = spawn('yarn', ['--cwd', dir, scriptName]);
 
     testProcess.childProcess.stdout.on('data', data => {
-      stdout += data.toString();
+      testProcessOutput += data.toString();
     });
     testProcess.childProcess.stderr.on('data', data => {
-      stderr += data.toString();
+      testProcessOutput += data.toString();
     });
 
     await testProcess;
     console.log('Success: ' + name);
-    writeLogs('Success', name, stdout + '\n' + stderr);
+    writeLogs('Success', name, testProcessOutput);
   } catch (e) {
     console.error('Failure: ' + name);
-    console.log(stdout);
-    console.error(stderr);
+    console.error(testProcessOutput);
 
     if (process.env.CHROME_VERSION_NOTES) {
       console.error();
@@ -94,7 +92,7 @@ const argv = yargs.options({
       console.error();
     }
 
-    writeLogs('Failure', name, stdout + '\n' + stderr);
+    writeLogs('Failure', name, testProcessOutput);
 
     process.exit(1);
   }


### PR DESCRIPTION
Having the `stdout` and `stderr` in a single string makes it easier to read when analyzing test failures. Currently if there's a test failure, we output stdout and stderr separately so we can't tell which errors were logged during which test.

For example, in https://github.com/firebase/firebase-js-sdk/actions/runs/10776099172/job/29882046607, there are tons of `FIREBASE FATAL ERROR`'s logged, but I can't tell which tests are logging these errors, or if they're even what's causing the tests to fail.