### PR TITLE
Only fetch reCAPTCHA v2 token when FAKE_TOKEN

### DIFF
--- a/packages/auth/src/platform_browser/strategies/phone.ts
+++ b/packages/auth/src/platform_browser/strategies/phone.ts
@@ -267,12 +267,8 @@ export async function _verifyPhoneNumber(
           authInstance: AuthInternal,
           request: StartPhoneMfaEnrollmentRequest
         ) => {
-          // If reCAPTCHA Enterprise token is empty or "NO_RECAPTCHA", fetch reCAPTCHA v2 token and inject into request.
-          if (
-            !request.phoneEnrollmentInfo.captchaResponse ||
-            request.phoneEnrollmentInfo.captchaResponse.length === 0 ||
-            request.phoneEnrollmentInfo.captchaResponse === FAKE_TOKEN
-          ) {
+          // If reCAPTCHA Enterprise token is FAKE_TOKEN, fetch reCAPTCHA v2 token and inject into request.
+          if (request.phoneEnrollmentInfo.captchaResponse === FAKE_TOKEN) {
             _assert(
               verifier?.type === RECAPTCHA_VERIFIER_TYPE,
               authInstance,
@@ -329,12 +325,8 @@ export async function _verifyPhoneNumber(
           authInstance: AuthInternal,
           request: StartPhoneMfaSignInRequest
         ) => {
-          // If reCAPTCHA Enterprise token is empty or "NO_RECAPTCHA", fetch reCAPTCHA v2 token and inject into request.
-          if (
-            !request.phoneSignInInfo.captchaResponse ||
-            request.phoneSignInInfo.captchaResponse.length === 0 ||
-            request.phoneSignInInfo.captchaResponse === FAKE_TOKEN
-          ) {
+          // If reCAPTCHA Enterprise token is FAKE_TOKEN, fetch reCAPTCHA v2 token and inject into request.
+          if (request.phoneSignInInfo.captchaResponse === FAKE_TOKEN) {
             _assert(
               verifier?.type === RECAPTCHA_VERIFIER_TYPE,
               authInstance,
@@ -380,12 +372,8 @@ export async function _verifyPhoneNumber(
         authInstance: AuthInternal,
         request: SendPhoneVerificationCodeRequest
       ) => {
-        // If reCAPTCHA Enterprise token is empty or "NO_RECAPTCHA", fetch reCAPTCHA v2 token and inject into request.
-        if (
-          !request.captchaResponse ||
-          request.captchaResponse.length === 0 ||
-          request.captchaResponse === FAKE_TOKEN
-        ) {
+        // If reCAPTCHA Enterprise token is FAKE_TOKEN, fetch reCAPTCHA v2 token and inject into request.
+        if (request.captchaResponse === FAKE_TOKEN) {
           _assert(
             verifier?.type === RECAPTCHA_VERIFIER_TYPE,
             authInstance,


### PR DESCRIPTION
**Issue** 
Currently, we show the challenge and fetch reCAPTCHA v2 token when reCAPTCHA Enterprise token is empty (token fetch fails) before making the phone auth request.

In Enforce mode, we fetch rcv2 token when rCE token is empty. This is incorrect behavior, we shouldn't fetch rcv2 token in Enforce mode. Fetching rcv2 means we will show the rcv2 challenge, which would make confuse developers as to why we show rcv2 challenge when they're in Enforce mode. 

We expect to throw MISSING_RECAPTCHA_TOKEN instead without fetching rcv2 token. This PR fixes that.

**Testing**

- CI
- Manual testing

