### PR TITLE
Proceed to reCAPTCHA v2 if unable to get phone enablement state

### DIFF
--- a/packages/auth/src/platform_browser/providers/phone.test.ts
+++ b/packages/auth/src/platform_browser/providers/phone.test.ts
@@ -64,7 +64,7 @@ describe('platform_browser/providers/phone', () => {
   context('#verifyPhoneNumber', () => {
     it('calls verify on the appVerifier and then calls the server when recaptcha enterprise is disabled', async () => {
       const recaptchaConfigResponseOff = {
-        recaptchaKey: 'foo/bar/to/site-key',
+        // no recaptcha key if no rCE provider is enabled
         recaptchaEnforcementState: [
           {
             provider: RecaptchaAuthProvider.PHONE_PROVIDER,
@@ -111,7 +111,7 @@ describe('platform_browser/providers/phone', () => {
 
     it('throws an error if verify without appVerifier when recaptcha enterprise is disabled', async () => {
       const recaptchaConfigResponseOff = {
-        recaptchaKey: 'foo/bar/to/site-key',
+        // no recaptcha key if no rCE provider is enabled
         recaptchaEnforcementState: [
           {
             provider: RecaptchaAuthProvider.PHONE_PROVIDER,

--- a/packages/auth/src/platform_browser/strategies/phone.test.ts
+++ b/packages/auth/src/platform_browser/strategies/phone.test.ts
@@ -83,7 +83,7 @@ const recaptchaConfigResponseAudit = {
   ]
 };
 const recaptchaConfigResponseOff = {
-  recaptchaKey: 'foo/bar/to/site-key',
+  // no recaptcha key if no rCE provider is enabled
   recaptchaEnforcementState: [
     {
       provider: RecaptchaAuthProvider.PHONE_PROVIDER,

--- a/packages/auth/src/platform_browser/strategies/phone.ts
+++ b/packages/auth/src/platform_browser/strategies/phone.ts
@@ -235,7 +235,7 @@ export async function _verifyPhoneNumber(
       // The error is likely "recaptchaKey undefined", as reCAPTCHA Enterprise is not
       // enabled for any provider.
       console.log(
-        'Failed to initialize reCAPTCHA Enterprise config. Triggering the reCAPTCHA v2 verification'
+        'Failed to initialize reCAPTCHA Enterprise config. Triggering the reCAPTCHA v2 verification.'
       );
     }
   }


### PR DESCRIPTION
**Issue**

At the beginning of phone auth flow, we initialize the reCAPTCHA Enterprise config in order to check the enablement state. However, if rCE is not enabled for any provider (phone, email), `GetRecaptchaConfig` response will not contain a `recaptchaKey`, and [this error](https://github.com/firebase/firebase-js-sdk/blob/629919ea760e35b7d880a099edf7f42b5bcbae4b/packages/auth/src/platform_browser/recaptcha/recaptcha.ts#L91) will eventually be thrown. Therefore, phone auth flows are broken when rCE is not enabled.

This PR ignores the above error when failing to initialize rCE config and proceeds to use reCAPTCHA v2 verification.

**Test**
- CI/unit test
- Manual testing

