### PR TITLE
Rollup JS files with rollup-typescript-plugin

### DIFF
--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -36,6 +36,8 @@ const typescriptPlugin = rollupTypescriptPlugin({
 
 const typescriptPluginCDN = rollupTypescriptPlugin({
   typescript,
+  allowJs: true,
+  include: ['*.ts', '**/*.ts', '*.js', '**/*.js'],
   tsconfigOverride: {
     compilerOptions: {
       declaration: false


### PR DESCRIPTION
The rollup-typescript-plugin does not transpile JS files using the TS compiler by default. This means that external dependencies that provide JS bundles will not be transpiled to the target ES version specified in the TypeScript config used by the plugin. 
In other words, if one of our dependencies has a bundle that uses newer JS features that aren't supported in all browsers, it will be included in our bundle without being translated into an older JS version that we promise our bundles are compatible with.

This resulted in one of our dependencies (https://github.com/jakearchibald/idb) being included in the CDN bundles without being transpiled to ES5 (the target ES version). Since this dependencies bundle uses ES2018 syntax (object spread operator `{ ...x }`), this upgraded our CDN bundles' minimum ES version requirement to ES2018 which isn't compatible with older browser versions. To see the ES2018 syntax in one of the CDN bundles, see https://www.gstatic.com/firebasejs/10.13.1/firebase-app.js and search for `...oldTraps`.

After enabling `allowJs` in the typescript plugin CDN config, this ES2018 code now gets transpiled into ES5 code.

I verified the bundle is now es5 compliant by using [ESLint Playground](https://eslint.org/play/#eyJ0ZXh0IjoieCA9IFsxLDIsM11cbnkgPSB7IC4uLnggfSIsIm9wdGlvbnMiOnsicnVsZXMiOnt9LCJsYW5ndWFnZU9wdGlvbnMiOnsiZWNtYVZlcnNpb24iOjUsInBhcnNlck9wdGlvbnMiOnsiZWNtYUZlYXR1cmVzIjp7fX0sInNvdXJjZVR5cGUiOiJzY3JpcHQifX19).