### PR TITLE
Internalize IDB dependency

### DIFF
--- a/packages/app-compat/rollup.config.js
+++ b/packages/app-compat/rollup.config.js
@@ -17,7 +17,7 @@
 
 import typescriptPlugin from 'rollup-plugin-typescript2';
 import json from '@rollup/plugin-json';
-import resolve from '@rollup/plugin-node-resolve'
+import resolve from '@rollup/plugin-node-resolve';
 import typescript from 'typescript';
 import { emitModulePackageFile } from '../../scripts/build/rollup_emit_module_package_file';
 import pkg from './package.json';
@@ -55,7 +55,12 @@ const esmBuilds = [
     input: 'src/index.ts',
     output: { file: pkg.esm5, format: 'es', sourcemap: true },
     plugins: [...es5BuildPlugins, emitModulePackageFile()],
-    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`)))
+    external: id =>
+      deps.some(
+        dep =>
+          dep !== pkg.dependencies.idb &&
+          (id === dep || id.startsWith(`${dep}/`))
+      )
   },
   {
     input: 'src/index.lite.ts',
@@ -64,7 +69,7 @@ const esmBuilds = [
       format: 'es',
       sourcemap: true
     },
-    plugins: es5BuildPlugins,
+    plugins: es5BuildPlugins
   },
   {
     input: 'src/index.ts',
@@ -74,7 +79,12 @@ const esmBuilds = [
       sourcemap: true
     },
     plugins: [...es2017BuildPlugins, emitModulePackageFile()],
-    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`)))
+    external: id =>
+      deps.some(
+        dep =>
+          dep !== pkg.dependencies.idb &&
+          (id === dep || id.startsWith(`${dep}/`))
+      )
   },
   {
     input: 'src/index.lite.ts',
@@ -84,7 +94,12 @@ const esmBuilds = [
       sourcemap: true
     },
     plugins: es2017BuildPlugins,
-    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`)))
+    external: id =>
+      deps.some(
+        dep =>
+          dep !== pkg.dependencies.idb &&
+          (id === dep || id.startsWith(`${dep}/`))
+      )
   }
 ];
 

--- a/packages/app-compat/rollup.config.js
+++ b/packages/app-compat/rollup.config.js
@@ -17,6 +17,7 @@
 
 import typescriptPlugin from 'rollup-plugin-typescript2';
 import json from '@rollup/plugin-json';
+import resolve from '@rollup/plugin-node-resolve'
 import typescript from 'typescript';
 import { emitModulePackageFile } from '../../scripts/build/rollup_emit_module_package_file';
 import pkg from './package.json';
@@ -45,7 +46,8 @@ const es2017BuildPlugins = [
   }),
   json({
     preferConst: true
-  })
+  }),
+  resolve()
 ];
 
 const esmBuilds = [
@@ -53,7 +55,7 @@ const esmBuilds = [
     input: 'src/index.ts',
     output: { file: pkg.esm5, format: 'es', sourcemap: true },
     plugins: [...es5BuildPlugins, emitModulePackageFile()],
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`)))
   },
   {
     input: 'src/index.lite.ts',
@@ -63,7 +65,6 @@ const esmBuilds = [
       sourcemap: true
     },
     plugins: es5BuildPlugins,
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
   },
   {
     input: 'src/index.ts',
@@ -73,7 +74,7 @@ const esmBuilds = [
       sourcemap: true
     },
     plugins: [...es2017BuildPlugins, emitModulePackageFile()],
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`)))
   },
   {
     input: 'src/index.lite.ts',
@@ -83,7 +84,7 @@ const esmBuilds = [
       sourcemap: true
     },
     plugins: es2017BuildPlugins,
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`)))
   }
 ];
 

--- a/packages/app-compat/rollup.config.js
+++ b/packages/app-compat/rollup.config.js
@@ -57,9 +57,7 @@ const esmBuilds = [
     plugins: [...es5BuildPlugins, emitModulePackageFile()],
     external: id =>
       deps.some(
-        dep =>
-          dep !== 'idb' &&
-          (id === dep || id.startsWith(`${dep}/`))
+        dep => dep !== 'idb' && (id === dep || id.startsWith(`${dep}/`))
       )
   },
   {
@@ -81,9 +79,7 @@ const esmBuilds = [
     plugins: [...es2017BuildPlugins, emitModulePackageFile()],
     external: id =>
       deps.some(
-        dep =>
-          dep !== 'idb' &&
-          (id === dep || id.startsWith(`${dep}/`))
+        dep => dep !== 'idb' && (id === dep || id.startsWith(`${dep}/`))
       )
   },
   {
@@ -96,9 +92,7 @@ const esmBuilds = [
     plugins: es2017BuildPlugins,
     external: id =>
       deps.some(
-        dep =>
-          dep !== 'idb' &&
-          (id === dep || id.startsWith(`${dep}/`))
+        dep => dep !== 'idb' && (id === dep || id.startsWith(`${dep}/`))
       )
   }
 ];

--- a/packages/app-compat/rollup.config.js
+++ b/packages/app-compat/rollup.config.js
@@ -58,7 +58,7 @@ const esmBuilds = [
     external: id =>
       deps.some(
         dep =>
-          dep !== pkg.dependencies.idb &&
+          dep !== 'idb' &&
           (id === dep || id.startsWith(`${dep}/`))
       )
   },
@@ -82,7 +82,7 @@ const esmBuilds = [
     external: id =>
       deps.some(
         dep =>
-          dep !== pkg.dependencies.idb &&
+          dep !== 'idb' &&
           (id === dep || id.startsWith(`${dep}/`))
       )
   },
@@ -97,7 +97,7 @@ const esmBuilds = [
     external: id =>
       deps.some(
         dep =>
-          dep !== pkg.dependencies.idb &&
+          dep !== 'idb' &&
           (id === dep || id.startsWith(`${dep}/`))
       )
   }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -42,12 +42,12 @@
     "@firebase/util": "1.10.0",
     "@firebase/logger": "0.4.2",
     "@firebase/component": "0.6.9",
-    "idb": "7.1.1",
     "tslib": "^2.1.0"
   },
   "license": "Apache-2.0",
   "devDependencies": {
     "@rollup/plugin-json": "4.1.0",
+    "idb": "7.1.1",
     "rollup": "2.79.1",
     "rollup-plugin-replace": "2.2.0",
     "rollup-plugin-typescript2": "0.31.2",

--- a/packages/app/rollup.config.js
+++ b/packages/app/rollup.config.js
@@ -77,9 +77,7 @@ const esmBuilds = [
     },
     external: id =>
       deps.some(
-        dep =>
-          dep !== 'idb' &&
-          (id === dep || id.startsWith(`${dep}/`))
+        dep => dep !== 'idb' && (id === dep || id.startsWith(`${dep}/`))
       ),
     plugins: [
       ...es2017BuildPlugins,
@@ -98,9 +96,7 @@ const cjsBuilds = [
     output: [{ file: pkg.main, format: 'cjs', sourcemap: true }],
     external: id =>
       deps.some(
-        dep =>
-          dep !== 'idb' &&
-          (id === dep || id.startsWith(`${dep}/`))
+        dep => dep !== 'idb' && (id === dep || id.startsWith(`${dep}/`))
       ),
     plugins: [
       ...es5BuildPlugins,

--- a/packages/app/rollup.config.js
+++ b/packages/app/rollup.config.js
@@ -78,7 +78,7 @@ const esmBuilds = [
     external: id =>
       deps.some(
         dep =>
-          dep !== pkg.dependencies.idb &&
+          dep !== 'idb' &&
           (id === dep || id.startsWith(`${dep}/`))
       ),
     plugins: [
@@ -99,7 +99,7 @@ const cjsBuilds = [
     external: id =>
       deps.some(
         dep =>
-          dep !== pkg.dependencies.idb &&
+          dep !== 'idb' &&
           (id === dep || id.startsWith(`${dep}/`))
       ),
     plugins: [

--- a/packages/app/rollup.config.js
+++ b/packages/app/rollup.config.js
@@ -17,6 +17,7 @@
 
 import typescriptPlugin from 'rollup-plugin-typescript2';
 import replace from 'rollup-plugin-replace';
+import resolve from '@rollup/plugin-node-resolve'
 import typescript from 'typescript';
 import json from '@rollup/plugin-json';
 import dts from 'rollup-plugin-dts';
@@ -46,7 +47,8 @@ const es2017BuildPlugins = [
   }),
   json({
     preferConst: true
-  })
+  }),
+  resolve()
 ];
 
 const esmBuilds = [
@@ -73,7 +75,7 @@ const esmBuilds = [
       format: 'es',
       sourcemap: true
     },
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`)),
+    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`))),
     plugins: [
       ...es2017BuildPlugins,
       replace({
@@ -89,7 +91,7 @@ const cjsBuilds = [
   {
     input: 'src/index.ts',
     output: [{ file: pkg.main, format: 'cjs', sourcemap: true }],
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`)),
+    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`))),
     plugins: [
       ...es5BuildPlugins,
       replace({

--- a/packages/app/rollup.config.js
+++ b/packages/app/rollup.config.js
@@ -17,7 +17,7 @@
 
 import typescriptPlugin from 'rollup-plugin-typescript2';
 import replace from 'rollup-plugin-replace';
-import resolve from '@rollup/plugin-node-resolve'
+import resolve from '@rollup/plugin-node-resolve';
 import typescript from 'typescript';
 import json from '@rollup/plugin-json';
 import dts from 'rollup-plugin-dts';
@@ -75,7 +75,12 @@ const esmBuilds = [
       format: 'es',
       sourcemap: true
     },
-    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`))),
+    external: id =>
+      deps.some(
+        dep =>
+          dep !== pkg.dependencies.idb &&
+          (id === dep || id.startsWith(`${dep}/`))
+      ),
     plugins: [
       ...es2017BuildPlugins,
       replace({
@@ -91,7 +96,12 @@ const cjsBuilds = [
   {
     input: 'src/index.ts',
     output: [{ file: pkg.main, format: 'cjs', sourcemap: true }],
-    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`))),
+    external: id =>
+      deps.some(
+        dep =>
+          dep !== pkg.dependencies.idb &&
+          (id === dep || id.startsWith(`${dep}/`))
+      ),
     plugins: [
       ...es5BuildPlugins,
       replace({

--- a/packages/installations-compat/rollup.config.js
+++ b/packages/installations-compat/rollup.config.js
@@ -45,7 +45,7 @@ const esmBuilds = [
     external: id =>
       deps.some(
         dep =>
-          dep !== pkg.dependencies.idb &&
+          dep !== 'idb' &&
           (id === dep || id.startsWith(`${dep}/`))
       ),
     plugins: [...es5BuildPlugins, emitModulePackageFile()]
@@ -60,7 +60,7 @@ const esmBuilds = [
     external: id =>
       deps.some(
         dep =>
-          dep !== pkg.dependencies.idb &&
+          dep !== 'idb' &&
           (id === dep || id.startsWith(`${dep}/`))
       ),
     plugins: [...es2017BuildPlugins, emitModulePackageFile()]
@@ -74,7 +74,7 @@ const cjsBuilds = [
     external: id =>
       deps.some(
         dep =>
-          dep !== pkg.dependencies.idb &&
+          dep !== 'idb' &&
           (id === dep || id.startsWith(`${dep}/`))
       ),
     plugins: es5BuildPlugins

--- a/packages/installations-compat/rollup.config.js
+++ b/packages/installations-compat/rollup.config.js
@@ -17,6 +17,7 @@
 
 import json from '@rollup/plugin-json';
 import typescriptPlugin from 'rollup-plugin-typescript2';
+import resolve from '@rollup/plugin-node-resolve';
 import typescript from 'typescript';
 import pkg from './package.json';
 import { emitModulePackageFile } from '../../scripts/build/rollup_emit_module_package_file';
@@ -33,14 +34,15 @@ const es2017BuildPlugins = [
       }
     }
   }),
-  json({ preferConst: true })
+  json({ preferConst: true }),
+  resolve()
 ];
 
 const esmBuilds = [
   {
     input: 'src/index.ts',
     output: { file: pkg.esm5, format: 'es', sourcemap: true },
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`)),
+    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`))),
     plugins: [...es5BuildPlugins, emitModulePackageFile()]
   },
   {
@@ -50,7 +52,7 @@ const esmBuilds = [
       format: 'es',
       sourcemap: true
     },
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`)),
+    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`))),
     plugins: [...es2017BuildPlugins, emitModulePackageFile()]
   }
 ];
@@ -59,7 +61,7 @@ const cjsBuilds = [
   {
     input: 'src/index.ts',
     output: { file: pkg.main, format: 'cjs', sourcemap: true },
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`)),
+    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`))),
     plugins: es5BuildPlugins
   }
 ];

--- a/packages/installations-compat/rollup.config.js
+++ b/packages/installations-compat/rollup.config.js
@@ -42,7 +42,12 @@ const esmBuilds = [
   {
     input: 'src/index.ts',
     output: { file: pkg.esm5, format: 'es', sourcemap: true },
-    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`))),
+    external: id =>
+      deps.some(
+        dep =>
+          dep !== pkg.dependencies.idb &&
+          (id === dep || id.startsWith(`${dep}/`))
+      ),
     plugins: [...es5BuildPlugins, emitModulePackageFile()]
   },
   {
@@ -52,7 +57,12 @@ const esmBuilds = [
       format: 'es',
       sourcemap: true
     },
-    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`))),
+    external: id =>
+      deps.some(
+        dep =>
+          dep !== pkg.dependencies.idb &&
+          (id === dep || id.startsWith(`${dep}/`))
+      ),
     plugins: [...es2017BuildPlugins, emitModulePackageFile()]
   }
 ];
@@ -61,7 +71,12 @@ const cjsBuilds = [
   {
     input: 'src/index.ts',
     output: { file: pkg.main, format: 'cjs', sourcemap: true },
-    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`))),
+    external: id =>
+      deps.some(
+        dep =>
+          dep !== pkg.dependencies.idb &&
+          (id === dep || id.startsWith(`${dep}/`))
+      ),
     plugins: es5BuildPlugins
   }
 ];

--- a/packages/installations-compat/rollup.config.js
+++ b/packages/installations-compat/rollup.config.js
@@ -44,9 +44,7 @@ const esmBuilds = [
     output: { file: pkg.esm5, format: 'es', sourcemap: true },
     external: id =>
       deps.some(
-        dep =>
-          dep !== 'idb' &&
-          (id === dep || id.startsWith(`${dep}/`))
+        dep => dep !== 'idb' && (id === dep || id.startsWith(`${dep}/`))
       ),
     plugins: [...es5BuildPlugins, emitModulePackageFile()]
   },
@@ -59,9 +57,7 @@ const esmBuilds = [
     },
     external: id =>
       deps.some(
-        dep =>
-          dep !== 'idb' &&
-          (id === dep || id.startsWith(`${dep}/`))
+        dep => dep !== 'idb' && (id === dep || id.startsWith(`${dep}/`))
       ),
     plugins: [...es2017BuildPlugins, emitModulePackageFile()]
   }
@@ -73,9 +69,7 @@ const cjsBuilds = [
     output: { file: pkg.main, format: 'cjs', sourcemap: true },
     external: id =>
       deps.some(
-        dep =>
-          dep !== 'idb' &&
-          (id === dep || id.startsWith(`${dep}/`))
+        dep => dep !== 'idb' && (id === dep || id.startsWith(`${dep}/`))
       ),
     plugins: es5BuildPlugins
   }

--- a/packages/installations/package.json
+++ b/packages/installations/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "@firebase/app": "0.10.11",
+    "idb": "7.1.1",
     "rollup": "2.79.1",
     "@rollup/plugin-commonjs": "21.1.0",
     "@rollup/plugin-json": "4.1.0",
@@ -66,7 +67,6 @@
   "dependencies": {
     "@firebase/util": "1.10.0",
     "@firebase/component": "0.6.9",
-    "idb": "7.1.1",
     "tslib": "^2.1.0"
   }
 }

--- a/packages/installations/rollup.config.js
+++ b/packages/installations/rollup.config.js
@@ -18,7 +18,7 @@
 import json from '@rollup/plugin-json';
 import typescriptPlugin from 'rollup-plugin-typescript2';
 import replace from 'rollup-plugin-replace';
-import resolve from '@rollup/plugin-node-resolve'
+import resolve from '@rollup/plugin-node-resolve';
 import typescript from 'typescript';
 import pkg from './package.json';
 import { generateBuildTargetReplaceConfig } from '../../scripts/build/rollup_replace_build_target';
@@ -45,7 +45,12 @@ const esmBuilds = [
   {
     input: 'src/index.ts',
     output: [{ file: pkg.esm5, format: 'es', sourcemap: true }],
-    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`))),
+    external: id =>
+      deps.some(
+        dep =>
+          dep !== pkg.dependencies.idb &&
+          (id === dep || id.startsWith(`${dep}/`))
+      ),
     plugins: [
       ...es5BuildPlugins,
       replace(generateBuildTargetReplaceConfig('esm', 5)),
@@ -59,7 +64,12 @@ const esmBuilds = [
       format: 'es',
       sourcemap: true
     },
-    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`))),
+    external: id =>
+      deps.some(
+        dep =>
+          dep !== pkg.dependencies.idb &&
+          (id === dep || id.startsWith(`${dep}/`))
+      ),
     plugins: [
       ...es2017BuildPlugins,
       replace(generateBuildTargetReplaceConfig('esm', 2017)),

--- a/packages/installations/rollup.config.js
+++ b/packages/installations/rollup.config.js
@@ -18,6 +18,7 @@
 import json from '@rollup/plugin-json';
 import typescriptPlugin from 'rollup-plugin-typescript2';
 import replace from 'rollup-plugin-replace';
+import resolve from '@rollup/plugin-node-resolve'
 import typescript from 'typescript';
 import pkg from './package.json';
 import { generateBuildTargetReplaceConfig } from '../../scripts/build/rollup_replace_build_target';
@@ -36,14 +37,15 @@ const es2017BuildPlugins = [
       }
     }
   }),
-  json({ preferConst: true })
+  json({ preferConst: true }),
+  resolve()
 ];
 
 const esmBuilds = [
   {
     input: 'src/index.ts',
     output: [{ file: pkg.esm5, format: 'es', sourcemap: true }],
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`)),
+    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`))),
     plugins: [
       ...es5BuildPlugins,
       replace(generateBuildTargetReplaceConfig('esm', 5)),
@@ -57,7 +59,7 @@ const esmBuilds = [
       format: 'es',
       sourcemap: true
     },
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`)),
+    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`))),
     plugins: [
       ...es2017BuildPlugins,
       replace(generateBuildTargetReplaceConfig('esm', 2017)),

--- a/packages/installations/rollup.config.js
+++ b/packages/installations/rollup.config.js
@@ -48,7 +48,7 @@ const esmBuilds = [
     external: id =>
       deps.some(
         dep =>
-          dep !== pkg.dependencies.idb &&
+          dep !== 'idb' &&
           (id === dep || id.startsWith(`${dep}/`))
       ),
     plugins: [
@@ -67,7 +67,7 @@ const esmBuilds = [
     external: id =>
       deps.some(
         dep =>
-          dep !== pkg.dependencies.idb &&
+          dep !== 'idb' &&
           (id === dep || id.startsWith(`${dep}/`))
       ),
     plugins: [

--- a/packages/installations/rollup.config.js
+++ b/packages/installations/rollup.config.js
@@ -47,9 +47,7 @@ const esmBuilds = [
     output: [{ file: pkg.esm5, format: 'es', sourcemap: true }],
     external: id =>
       deps.some(
-        dep =>
-          dep !== 'idb' &&
-          (id === dep || id.startsWith(`${dep}/`))
+        dep => dep !== 'idb' && (id === dep || id.startsWith(`${dep}/`))
       ),
     plugins: [
       ...es5BuildPlugins,
@@ -66,9 +64,7 @@ const esmBuilds = [
     },
     external: id =>
       deps.some(
-        dep =>
-          dep !== 'idb' &&
-          (id === dep || id.startsWith(`${dep}/`))
+        dep => dep !== 'idb' && (id === dep || id.startsWith(`${dep}/`))
       ),
     plugins: [
       ...es2017BuildPlugins,

--- a/packages/messaging-compat/rollup.config.js
+++ b/packages/messaging-compat/rollup.config.js
@@ -16,6 +16,7 @@
  */
 
 import json from '@rollup/plugin-json';
+import resolve from '@rollup/plugin-node-resolve';
 import pkg from './package.json';
 import typescript from 'typescript';
 import typescriptPlugin from 'rollup-plugin-typescript2';
@@ -41,7 +42,8 @@ const es2017BuildPlugins = [
       }
     }
   }),
-  json({ preferConst: true })
+  json({ preferConst: true }),
+  resolve()
 ];
 
 const esmBuilds = [
@@ -49,7 +51,7 @@ const esmBuilds = [
     input: 'src/index.ts',
     output: { file: pkg.esm5, format: 'es', sourcemap: true },
     plugins: [...es5BuildPlugins, emitModulePackageFile()],
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`)))
   },
   {
     input: 'src/index.ts',
@@ -59,7 +61,7 @@ const esmBuilds = [
       sourcemap: true
     },
     plugins: [...es2017BuildPlugins, emitModulePackageFile()],
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`)))
   }
 ];
 
@@ -68,7 +70,7 @@ const cjsBuilds = [
     input: 'src/index.ts',
     output: { file: pkg.main, format: 'cjs', sourcemap: true },
     plugins: es5BuildPlugins,
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`)))
   }
 ];
 

--- a/packages/messaging-compat/rollup.config.js
+++ b/packages/messaging-compat/rollup.config.js
@@ -53,9 +53,7 @@ const esmBuilds = [
     plugins: [...es5BuildPlugins, emitModulePackageFile()],
     external: id =>
       deps.some(
-        dep =>
-          dep !== 'idb' &&
-          (id === dep || id.startsWith(`${dep}/`))
+        dep => dep !== 'idb' && (id === dep || id.startsWith(`${dep}/`))
       )
   },
   {
@@ -68,9 +66,7 @@ const esmBuilds = [
     plugins: [...es2017BuildPlugins, emitModulePackageFile()],
     external: id =>
       deps.some(
-        dep =>
-          dep !== 'idb' &&
-          (id === dep || id.startsWith(`${dep}/`))
+        dep => dep !== 'idb' && (id === dep || id.startsWith(`${dep}/`))
       )
   }
 ];
@@ -82,9 +78,7 @@ const cjsBuilds = [
     plugins: es5BuildPlugins,
     external: id =>
       deps.some(
-        dep =>
-          dep !== 'idb' &&
-          (id === dep || id.startsWith(`${dep}/`))
+        dep => dep !== 'idb' && (id === dep || id.startsWith(`${dep}/`))
       )
   }
 ];

--- a/packages/messaging-compat/rollup.config.js
+++ b/packages/messaging-compat/rollup.config.js
@@ -51,7 +51,12 @@ const esmBuilds = [
     input: 'src/index.ts',
     output: { file: pkg.esm5, format: 'es', sourcemap: true },
     plugins: [...es5BuildPlugins, emitModulePackageFile()],
-    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`)))
+    external: id =>
+      deps.some(
+        dep =>
+          dep !== pkg.dependencies.idb &&
+          (id === dep || id.startsWith(`${dep}/`))
+      )
   },
   {
     input: 'src/index.ts',
@@ -61,7 +66,12 @@ const esmBuilds = [
       sourcemap: true
     },
     plugins: [...es2017BuildPlugins, emitModulePackageFile()],
-    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`)))
+    external: id =>
+      deps.some(
+        dep =>
+          dep !== pkg.dependencies.idb &&
+          (id === dep || id.startsWith(`${dep}/`))
+      )
   }
 ];
 
@@ -70,7 +80,12 @@ const cjsBuilds = [
     input: 'src/index.ts',
     output: { file: pkg.main, format: 'cjs', sourcemap: true },
     plugins: es5BuildPlugins,
-    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`)))
+    external: id =>
+      deps.some(
+        dep =>
+          dep !== pkg.dependencies.idb &&
+          (id === dep || id.startsWith(`${dep}/`))
+      )
   }
 ];
 

--- a/packages/messaging-compat/rollup.config.js
+++ b/packages/messaging-compat/rollup.config.js
@@ -54,7 +54,7 @@ const esmBuilds = [
     external: id =>
       deps.some(
         dep =>
-          dep !== pkg.dependencies.idb &&
+          dep !== 'idb' &&
           (id === dep || id.startsWith(`${dep}/`))
       )
   },
@@ -69,7 +69,7 @@ const esmBuilds = [
     external: id =>
       deps.some(
         dep =>
-          dep !== pkg.dependencies.idb &&
+          dep !== 'idb' &&
           (id === dep || id.startsWith(`${dep}/`))
       )
   }
@@ -83,7 +83,7 @@ const cjsBuilds = [
     external: id =>
       deps.some(
         dep =>
-          dep !== pkg.dependencies.idb &&
+          dep !== 'idb' &&
           (id === dep || id.startsWith(`${dep}/`))
       )
   }

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -58,11 +58,11 @@
     "@firebase/messaging-interop-types": "0.2.2",
     "@firebase/util": "1.10.0",
     "@firebase/component": "0.6.9",
-    "idb": "7.1.1",
     "tslib": "^2.1.0"
   },
   "devDependencies": {
     "@firebase/app": "0.10.11",
+    "idb": "7.1.1",
     "rollup": "2.79.1",
     "rollup-plugin-typescript2": "0.31.2",
     "@rollup/plugin-json": "4.1.0",

--- a/packages/messaging/rollup.config.js
+++ b/packages/messaging/rollup.config.js
@@ -73,9 +73,7 @@ const esmBuilds = [
     ],
     external: id =>
       deps.some(
-        dep =>
-          dep !== 'idb' &&
-          (id === dep || id.startsWith(`${dep}/`))
+        dep => dep !== 'idb' && (id === dep || id.startsWith(`${dep}/`))
       )
   },
   // sw builds
@@ -85,9 +83,7 @@ const esmBuilds = [
     plugins: es2017BuildPlugins,
     external: id =>
       deps.some(
-        dep =>
-          dep !== 'idb' &&
-          (id === dep || id.startsWith(`${dep}/`))
+        dep => dep !== 'idb' && (id === dep || id.startsWith(`${dep}/`))
       )
   }
 ];
@@ -102,9 +98,7 @@ const cjsBuilds = [
     ],
     external: id =>
       deps.some(
-        dep =>
-          dep !== 'idb' &&
-          (id === dep || id.startsWith(`${dep}/`))
+        dep => dep !== 'idb' && (id === dep || id.startsWith(`${dep}/`))
       )
   },
   // sw build
@@ -121,9 +115,7 @@ const cjsBuilds = [
     ],
     external: id =>
       deps.some(
-        dep =>
-          dep !== 'idb' &&
-          (id === dep || id.startsWith(`${dep}/`))
+        dep => dep !== 'idb' && (id === dep || id.startsWith(`${dep}/`))
       )
   }
 ];

--- a/packages/messaging/rollup.config.js
+++ b/packages/messaging/rollup.config.js
@@ -16,6 +16,7 @@
  */
 
 import json from '@rollup/plugin-json';
+import resolve from "@rollup/plugin-node-resolve";
 import pkg from './package.json';
 import typescript from 'typescript';
 import replace from 'rollup-plugin-replace';
@@ -43,7 +44,8 @@ const es2017BuildPlugins = [
       }
     }
   }),
-  json({ preferConst: true })
+  json({ preferConst: true }),
+  resolve()
 ];
 
 const esmBuilds = [
@@ -69,14 +71,14 @@ const esmBuilds = [
       replace(generateBuildTargetReplaceConfig('esm', 2017)),
       emitModulePackageFile()
     ],
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`)))
   },
   // sw builds
   {
     input: 'src/index.sw.ts',
     output: { file: pkg.sw, format: 'es', sourcemap: true },
     plugins: es2017BuildPlugins,
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`)))
   }
 ];
 
@@ -88,7 +90,7 @@ const cjsBuilds = [
       ...es5BuildPlugins,
       replace(generateBuildTargetReplaceConfig('cjs', 5))
     ],
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`)))
   },
   // sw build
   // TODO: This may no longer be necessary when we can provide ESM Node
@@ -102,7 +104,7 @@ const cjsBuilds = [
       ...es5BuildPlugins,
       replace(generateBuildTargetReplaceConfig('cjs', 5))
     ],
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`)))
   }
 ];
 

--- a/packages/messaging/rollup.config.js
+++ b/packages/messaging/rollup.config.js
@@ -16,7 +16,7 @@
  */
 
 import json from '@rollup/plugin-json';
-import resolve from "@rollup/plugin-node-resolve";
+import resolve from '@rollup/plugin-node-resolve';
 import pkg from './package.json';
 import typescript from 'typescript';
 import replace from 'rollup-plugin-replace';
@@ -71,14 +71,24 @@ const esmBuilds = [
       replace(generateBuildTargetReplaceConfig('esm', 2017)),
       emitModulePackageFile()
     ],
-    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`)))
+    external: id =>
+      deps.some(
+        dep =>
+          dep !== pkg.dependencies.idb &&
+          (id === dep || id.startsWith(`${dep}/`))
+      )
   },
   // sw builds
   {
     input: 'src/index.sw.ts',
     output: { file: pkg.sw, format: 'es', sourcemap: true },
     plugins: es2017BuildPlugins,
-    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`)))
+    external: id =>
+      deps.some(
+        dep =>
+          dep !== pkg.dependencies.idb &&
+          (id === dep || id.startsWith(`${dep}/`))
+      )
   }
 ];
 
@@ -90,7 +100,12 @@ const cjsBuilds = [
       ...es5BuildPlugins,
       replace(generateBuildTargetReplaceConfig('cjs', 5))
     ],
-    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`)))
+    external: id =>
+      deps.some(
+        dep =>
+          dep !== pkg.dependencies.idb &&
+          (id === dep || id.startsWith(`${dep}/`))
+      )
   },
   // sw build
   // TODO: This may no longer be necessary when we can provide ESM Node
@@ -104,7 +119,12 @@ const cjsBuilds = [
       ...es5BuildPlugins,
       replace(generateBuildTargetReplaceConfig('cjs', 5))
     ],
-    external: id => deps.some(dep => dep !== pkg.dependencies.idb && (id === dep || id.startsWith(`${dep}/`)))
+    external: id =>
+      deps.some(
+        dep =>
+          dep !== pkg.dependencies.idb &&
+          (id === dep || id.startsWith(`${dep}/`))
+      )
   }
 ];
 

--- a/packages/messaging/rollup.config.js
+++ b/packages/messaging/rollup.config.js
@@ -74,7 +74,7 @@ const esmBuilds = [
     external: id =>
       deps.some(
         dep =>
-          dep !== pkg.dependencies.idb &&
+          dep !== 'idb' &&
           (id === dep || id.startsWith(`${dep}/`))
       )
   },
@@ -86,7 +86,7 @@ const esmBuilds = [
     external: id =>
       deps.some(
         dep =>
-          dep !== pkg.dependencies.idb &&
+          dep !== 'idb' &&
           (id === dep || id.startsWith(`${dep}/`))
       )
   }
@@ -103,7 +103,7 @@ const cjsBuilds = [
     external: id =>
       deps.some(
         dep =>
-          dep !== pkg.dependencies.idb &&
+          dep !== 'idb' &&
           (id === dep || id.startsWith(`${dep}/`))
       )
   },
@@ -122,7 +122,7 @@ const cjsBuilds = [
     external: id =>
       deps.some(
         dep =>
-          dep !== pkg.dependencies.idb &&
+          dep !== 'idb' &&
           (id === dep || id.startsWith(`${dep}/`))
       )
   }


### PR DESCRIPTION
Internalize the IDB dependency, since it uses ES2018 syntax, while our bundles use <= ES2017.