### PR TITLE
Tell renovate to ignore idb and remove unused dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,13 +13,12 @@
     }
   ],
   "ignoreDeps": [
-    "karma-sauce-launcher",
     "protractor",
     "long",
     "rollup-plugin-copy-assets",
-    "whatwg-fetch",
     "typedoc",
-    "@microsoft/tsdoc"
+    "@microsoft/tsdoc",
+    "idb"
   ],
   "ignorePaths": [
     "auth/demo",


### PR DESCRIPTION
We don't want to upgrade idb, since it targets `esnext`, which could introduce a burden to use latest node/browsers for our users (or transpile).

We should also remove the dependencies we don't have anymore.