### PR TITLE
Update endpoint to Clearlog

### DIFF
--- a/.changeset/four-pillows-fetch.md
+++ b/.changeset/four-pillows-fetch.md
@@ -1,0 +1,5 @@
+---
+'@firebase/messaging': patch
+---
+
+The logging endpoint has been updated to ensure proper logging of WebPush entries. This resolves an issue where BigQuery logs were missing WebPush data. The payload structure has also been updated in alignment with the latest logging requirements as specified in go/firelog.

--- a/packages/messaging/src/helpers/logToFirelog.test.ts
+++ b/packages/messaging/src/helpers/logToFirelog.test.ts
@@ -31,10 +31,7 @@ import { MessagingService } from '../messaging-service';
 import { Stub } from '../testing/sinon-types';
 import { getFakeMessagingService } from '../testing/fakes/messaging-service';
 
-const FIRELOG_ENDPOINT = LogModule._mergeStrings(
-  'hts/frbslgigp.ogepscmv/ieo/eaylg',
-  'tp:/ieaeogn-agolai.o/1frlglgc/o'
-);
+const LOG_ENDPOINT = "https://play.google.com/log?format=json_proto3";
 
 const FCM_TRANSPORT_KEY = LogModule._mergeStrings(
   'AzSCbw63g1R0nCw85jG8',
@@ -68,7 +65,7 @@ describe('logToFirelog', () => {
 
       // assert
       expect(fetchStub).to.be.calledOnceWith(
-        FIRELOG_ENDPOINT.concat('?key=', FCM_TRANSPORT_KEY),
+        LOG_ENDPOINT.concat('&key=', FCM_TRANSPORT_KEY),
         {
           method: 'POST',
           body: JSON.stringify(LogModule._createLogRequest([getFakeLogEvent()]))

--- a/packages/messaging/src/helpers/logToFirelog.test.ts
+++ b/packages/messaging/src/helpers/logToFirelog.test.ts
@@ -31,7 +31,7 @@ import { MessagingService } from '../messaging-service';
 import { Stub } from '../testing/sinon-types';
 import { getFakeMessagingService } from '../testing/fakes/messaging-service';
 
-const LOG_ENDPOINT = "https://play.google.com/log?format=json_proto3";
+const LOG_ENDPOINT = 'https://play.google.com/log?format=json_proto3';
 
 const FCM_TRANSPORT_KEY = LogModule._mergeStrings(
   'AzSCbw63g1R0nCw85jG8',

--- a/packages/messaging/src/helpers/logToFirelog.ts
+++ b/packages/messaging/src/helpers/logToFirelog.ts
@@ -36,10 +36,7 @@ import {
 import { MessagePayloadInternal } from '../interfaces/internal-message-payload';
 import { MessagingService } from '../messaging-service';
 
-const FIRELOG_ENDPOINT = _mergeStrings(
-  'hts/frbslgigp.ogepscmv/ieo/eaylg',
-  'tp:/ieaeogn-agolai.o/1frlglgc/o'
-);
+const LOG_ENDPOINT = "https://play.google.com/log?format=json_proto3";
 
 const FCM_TRANSPORT_KEY = _mergeStrings(
   'AzSCbw63g1R0nCw85jG8',
@@ -97,7 +94,7 @@ export async function _dispatchLogEvents(
     do {
       try {
         response = await fetch(
-          FIRELOG_ENDPOINT.concat('?key=', FCM_TRANSPORT_KEY),
+          LOG_ENDPOINT.concat('&key=', FCM_TRANSPORT_KEY),
           {
             method: 'POST',
             body: JSON.stringify(logRequest)
@@ -216,7 +213,9 @@ function createAndEnqueueLogEvent(
 
   /* eslint-disable camelcase */
   logEvent.event_time_ms = Math.floor(Date.now()).toString();
-  logEvent.source_extension_json_proto3 = JSON.stringify(fcmEvent);
+  logEvent.source_extension_json_proto3 = JSON.stringify({
+    messaging_client_event: fcmEvent 
+  });
 
   if (!!productId) {
     logEvent.compliance_data = buildComplianceData(productId);

--- a/packages/messaging/src/helpers/logToFirelog.ts
+++ b/packages/messaging/src/helpers/logToFirelog.ts
@@ -36,7 +36,7 @@ import {
 import { MessagePayloadInternal } from '../interfaces/internal-message-payload';
 import { MessagingService } from '../messaging-service';
 
-const LOG_ENDPOINT = "https://play.google.com/log?format=json_proto3";
+const LOG_ENDPOINT = 'https://play.google.com/log?format=json_proto3';
 
 const FCM_TRANSPORT_KEY = _mergeStrings(
   'AzSCbw63g1R0nCw85jG8',
@@ -214,7 +214,7 @@ function createAndEnqueueLogEvent(
   /* eslint-disable camelcase */
   logEvent.event_time_ms = Math.floor(Date.now()).toString();
   logEvent.source_extension_json_proto3 = JSON.stringify({
-    messaging_client_event: fcmEvent 
+    messaging_client_event: fcmEvent
   });
 
   if (!!productId) {


### PR DESCRIPTION
Here’s a refined version of your GitHub PR description:

Context: The logging endpoint has been updated in accordance with [go/firelog](https://github.com/firebase/firebase-js-sdk/compare/link). We observed that BigQuery logging is missing entries for WebPush (see [b/350475783](https://github.com/firebase/firebase-js-sdk/compare/link) for reference). This PR addresses the issue by updating both the endpoint and the payload to ensure proper logging of WebPush entries.