### PR TITLE
Remove data-connect es5 bundles

### DIFF
--- a/packages/data-connect/package.json
+++ b/packages/data-connect/package.json
@@ -6,7 +6,6 @@
   "main": "dist/index.node.cjs.js",
   "browser": "dist/index.esm2017.js",
   "module": "dist/index.esm2017.js",
-  "esm5": "dist/index.esm5.js",
   "exports": {
     ".": {
       "types": "./dist/public.d.ts",
@@ -14,7 +13,6 @@
         "import": "./dist/node-esm/index.node.esm.js",
         "require": "./dist/index.node.cjs.js"
       },
-      "esm5": "./dist/index.esm5.js",
       "browser": {
         "require": "./dist/index.cjs.js",
         "import": "./dist/index.esm2017.js"

--- a/packages/data-connect/rollup.config.js
+++ b/packages/data-connect/rollup.config.js
@@ -35,22 +35,9 @@ function onWarn(warning, defaultWarn) {
   defaultWarn(warning);
 }
 
-const es5BuildPlugins = [
+const buildPlugins = [
   typescriptPlugin({
     typescript,
-    abortOnError: false
-  }),
-  json()
-];
-
-const es2017BuildPlugins = [
-  typescriptPlugin({
-    typescript,
-    tsconfigOverride: {
-      compilerOptions: {
-        target: 'es2017'
-      }
-    },
     abortOnError: false
   }),
   json({ preferConst: true })
@@ -61,32 +48,13 @@ const browserBuilds = [
     input: 'src/index.ts',
     output: [
       {
-        file: pkg.esm5,
-        format: 'es',
-        sourcemap: true
-      }
-    ],
-    plugins: [
-      ...es5BuildPlugins,
-      replace(generateBuildTargetReplaceConfig('esm', 5))
-    ],
-    treeshake: {
-      moduleSideEffects: false
-    },
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`)),
-    onwarn: onWarn
-  },
-  {
-    input: 'src/index.ts',
-    output: [
-      {
         file: pkg.module,
         format: 'es',
         sourcemap: true
       }
     ],
     plugins: [
-      ...es2017BuildPlugins,
+      ...buildPlugins,
       replace(generateBuildTargetReplaceConfig('esm', 2017))
     ],
     treeshake: {
@@ -97,15 +65,13 @@ const browserBuilds = [
   },
   {
     input: 'src/index.ts',
-    output: [
-      {
-        file: 'dist/index.cjs.js',
-        format: 'cjs',
-        sourcemap: true
-      }
-    ],
+    output: {
+      file: pkg.exports['.'].browser.require,
+      format: 'cjs',
+      sourcemap: true
+    },
     plugins: [
-      ...es2017BuildPlugins,
+      ...buildPlugins,
       replace(generateBuildTargetReplaceConfig('cjs', 2017))
     ],
     treeshake: {
@@ -119,10 +85,14 @@ const browserBuilds = [
 const nodeBuilds = [
   {
     input: 'src/index.node.ts',
-    output: { file: pkg.main, format: 'cjs', sourcemap: true },
+    output: {
+      file: pkg.main,
+      format: 'cjs', 
+      sourcemap: true 
+    },
     plugins: [
-      ...es5BuildPlugins,
-      replace(generateBuildTargetReplaceConfig('cjs', 5))
+      ...buildPlugins,
+      replace(generateBuildTargetReplaceConfig('cjs', 2017))
     ],
     treeshake: {
       moduleSideEffects: false
@@ -138,7 +108,7 @@ const nodeBuilds = [
       sourcemap: true
     },
     plugins: [
-      ...es2017BuildPlugins,
+      ...buildPlugins,
       replace(generateBuildTargetReplaceConfig('esm', 2017)),
       emitModulePackageFile()
     ],

--- a/packages/data-connect/rollup.config.js
+++ b/packages/data-connect/rollup.config.js
@@ -87,8 +87,8 @@ const nodeBuilds = [
     input: 'src/index.node.ts',
     output: {
       file: pkg.main,
-      format: 'cjs', 
-      sourcemap: true 
+      format: 'cjs',
+      sourcemap: true
     },
     plugins: [
       ...buildPlugins,


### PR DESCRIPTION
Follow up from #8509- this will be merged into v11 once we've rebased on top of the data connect changes.