### PR TITLE
Make VertexAIError error codes use the vertex type prefix

### DIFF
--- a/common/api-review/vertexai-preview.api.md
+++ b/common/api-review/vertexai-preview.api.md
@@ -622,15 +622,15 @@ export class VertexAIError extends FirebaseError {
 
 // @public
 export const enum VertexAIErrorCode {
-    ERROR = "error",
-    FETCH_ERROR = "fetch-error",
-    INVALID_CONTENT = "invalid-content",
-    NO_API_KEY = "no-api-key",
-    NO_MODEL = "no-model",
-    NO_PROJECT_ID = "no-project-id",
-    PARSE_FAILED = "parse-failed",
-    REQUEST_ERROR = "request-error",
-    RESPONSE_ERROR = "response-error"
+    ERROR = "vertexAI/error",
+    FETCH_ERROR = "vertexAI/fetch-error",
+    INVALID_CONTENT = "vertexAI/invalid-content",
+    NO_API_KEY = "vertexAI/no-api-key",
+    NO_MODEL = "vertexAI/no-model",
+    NO_PROJECT_ID = "vertexAI/no-project-id",
+    PARSE_FAILED = "vertexAI/parse-failed",
+    REQUEST_ERROR = "vertexAI/request-error",
+    RESPONSE_ERROR = "vertexAI/response-error"
 }
 
 // @public

--- a/packages/vertexai/src/errors.ts
+++ b/packages/vertexai/src/errors.ts
@@ -17,7 +17,6 @@
 
 import { FirebaseError } from '@firebase/util';
 import { VertexAIErrorCode, CustomErrorData } from './types';
-import { VERTEX_TYPE } from './constants';
 
 /**
  * Error class for the Vertex AI in Firebase SDK.
@@ -38,11 +37,9 @@ export class VertexAIError extends FirebaseError {
     readonly customErrorData?: CustomErrorData
   ) {
     // Match error format used by FirebaseError from ErrorFactory
-    const service = VERTEX_TYPE;
     const serviceName = 'VertexAI';
-    const fullCode = `${service}/${code}`;
-    const fullMessage = `${serviceName}: ${message} (${fullCode}).`;
-    super(fullCode, fullMessage);
+    const fullMessage = `${serviceName}: ${message} (${code}).`;
+    super(code, fullMessage);
 
     // FirebaseError initializes a stack trace, but it assumes the error is created from the error
     // factory. Since we break this assumption, we set the stack trace to be originating from this

--- a/packages/vertexai/src/types/error.ts
+++ b/packages/vertexai/src/types/error.ts
@@ -63,30 +63,33 @@ export interface CustomErrorData {
  * @public
  */
 export const enum VertexAIErrorCode {
+  // TODO (dlarocque): Initialize error codes using the `VERTEX_TYPE` constant
+  // in a computed template string literal. Can not do this until we upgrade to
+  // TS5: https://github.com/microsoft/TypeScript/issues/40793
   /** A generic error occurred. */
-  ERROR = 'error',
+  ERROR = 'vertexAI/error',
 
   /** An error occurred in a request. */
-  REQUEST_ERROR = 'request-error',
+  REQUEST_ERROR = 'vertexAI/request-error',
 
   /** An error occurred in a response. */
-  RESPONSE_ERROR = 'response-error',
+  RESPONSE_ERROR = 'vertexAI/response-error',
 
   /** An error occurred while performing a fetch. */
-  FETCH_ERROR = 'fetch-error',
+  FETCH_ERROR = 'vertexAI/fetch-error',
 
   /** An error associated with a Content object.  */
-  INVALID_CONTENT = 'invalid-content',
+  INVALID_CONTENT = 'vertexAI/invalid-content',
 
   /** An error occurred due to a missing Firebase API key. */
-  NO_API_KEY = 'no-api-key',
+  NO_API_KEY = 'vertexAI/no-api-key',
 
   /** An error occurred due to a model name not being specified during initialization. */
-  NO_MODEL = 'no-model',
+  NO_MODEL = 'vertexAI/no-model',
 
   /** An error occurred due to a missing project ID. */
-  NO_PROJECT_ID = 'no-project-id',
+  NO_PROJECT_ID = 'vertexAI/no-project-id',
 
   /** An error occurred while parsing. */
-  PARSE_FAILED = 'parse-failed'
+  PARSE_FAILED = 'vertexAI/parse-failed'
 }


### PR DESCRIPTION
Since the `code` argument being passed (e.g. `fetch-error`) was `readonly`, it was overriding the prefixed error code that is set in the super constructor (`vertexAI/fetch-error`). So the error code users would see would not be prefixed. We should include the prefix, since that's what the other products do. Instead of fixing this by just making `code` not `readonly`, we should just add the prefix directly to the enum value, so that users can check error codes more safely. Otherwise they'd have access to the non-prefixed errors, and would have to prefix it themselves if they want to actually use it- `if (err.code === 'vertexAI/${VertexAIErrorCode.FETCH_ERROR}') {...}`

For example:
```ts
try {
  // ...
} catch (err) {
  if (err instanceof VertexAIError) {
    if (err.code === VertexAIErrorCode.FETCH_ERROR) { /* ... */ }
  }
}