### PR TITLE
Update Firebase index.d.ts type definition file reference

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -69,7 +69,7 @@ packages/app-check-types @hsubox76 @firebase/jssdk-global-approvers
 packages/app-check-interop-types @hsubox76 @firebase/jssdk-global-approvers
 
 # Documentation Changes
-packages/firebase/index.d.ts @egilmorez @firebase/jssdk-global-approvers
+packages/firebase/compat/index.d.ts @egilmorez @firebase/jssdk-global-approvers
 scripts/docgen/content-sources/ @egilmorez @firebase/jssdk-global-approvers
 docs-devsite/ @firebase/firebase-techwriters
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,7 +206,7 @@ Reference docs for the Firebase [JS SDK](https://firebase.google.com/docs/refere
 [Typedoc](https://typedoc.org/).
 
 Typedoc generates this documentation from the main
-[firebase index.d.ts type definition file](packages/firebase/index.d.ts).  Any updates to
+[firebase index.d.ts type definition file](packages/firebase/compat/index.d.ts).  Any updates to
 documentation should be made in that file.
 
 If any pages are added or removed by your change (by adding or removing a class or interface), the

--- a/packages/remote-config/src/remote_config.ts
+++ b/packages/remote-config/src/remote_config.ts
@@ -32,7 +32,7 @@ const DEFAULT_CACHE_MAX_AGE_MILLIS = 12 * 60 * 60 * 1000; // Twelve hours.
 /**
  * Encapsulates business logic mapping network and storage dependencies to the public SDK API.
  *
- * See {@link https://github.com/firebase/firebase-js-sdk/blob/main/packages/firebase/index.d.ts|interface documentation} for method descriptions.
+ * See {@link https://github.com/firebase/firebase-js-sdk/blob/main/packages/firebase/compat/index.d.ts|interface documentation} for method descriptions.
  */
 export class RemoteConfig implements RemoteConfigType {
   /**


### PR DESCRIPTION
# PR Summary
Commit cdada6c68f9740d13dd6674bcb658e28e68253b6 moved the location of `packages/firebase/index.d.ts` to `packages/firebase/compat/index.d.ts`. This PR adjusts sources to changes.