### PR TITLE
Make the `FunctionsError` class publicly exported

### DIFF
--- a/.changeset/tender-tips-hammer.md
+++ b/.changeset/tender-tips-hammer.md
@@ -1,0 +1,5 @@
+---
+'@firebase/functions': patch
+---
+
+Make the `FunctionsError` class publicly exported.

--- a/common/api-review/functions.api.md
+++ b/common/api-review/functions.api.md
@@ -19,7 +19,8 @@ export interface Functions {
 
 // @public
 export class FunctionsError extends FirebaseError {
-    constructor(code: FunctionsErrorCodeCore, message?: string,
+    constructor(
+    code: FunctionsErrorCodeCore, message?: string,
     details?: unknown);
     readonly details?: unknown;
 }

--- a/common/api-review/functions.api.md
+++ b/common/api-review/functions.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { FirebaseApp } from '@firebase/app';
+import { FirebaseError } from '@firebase/util';
 
 // @public
 export function connectFunctionsEmulator(functionsInstance: Functions, host: string, port: number): void;
@@ -14,6 +15,14 @@ export interface Functions {
     app: FirebaseApp;
     customDomain: string | null;
     region: string;
+}
+
+// @public
+export class FunctionsError extends FirebaseError {
+    constructor(
+    code: FunctionsErrorCodeCore, message?: string,
+    details?: unknown);
+    readonly details?: unknown;
 }
 
 // @public

--- a/common/api-review/functions.api.md
+++ b/common/api-review/functions.api.md
@@ -5,7 +5,6 @@
 ```ts
 
 import { FirebaseApp } from '@firebase/app';
-import { FirebaseError } from '@firebase/util';
 
 // @public
 export function connectFunctionsEmulator(functionsInstance: Functions, host: string, port: number): void;
@@ -15,12 +14,6 @@ export interface Functions {
     app: FirebaseApp;
     customDomain: string | null;
     region: string;
-}
-
-// @public
-export interface FunctionsError extends FirebaseError {
-    readonly code: FunctionsErrorCode;
-    readonly details?: unknown;
 }
 
 // @public

--- a/common/api-review/functions.api.md
+++ b/common/api-review/functions.api.md
@@ -19,8 +19,7 @@ export interface Functions {
 
 // @public
 export class FunctionsError extends FirebaseError {
-    constructor(
-    code: FunctionsErrorCodeCore, message?: string,
+    constructor(code: FunctionsErrorCodeCore, message?: string,
     details?: unknown);
     readonly details?: unknown;
 }

--- a/docs-devsite/functions.functionserror.md
+++ b/docs-devsite/functions.functionserror.md
@@ -40,7 +40,8 @@ Constructs a new instance of the `FunctionsError` class.
 <b>Signature:</b>
 
 ```typescript
-constructor(code: FunctionsErrorCode, message?: string, 
+constructor(
+    code: FunctionsErrorCode, message?: string, 
     details?: unknown);
 ```
 

--- a/docs-devsite/functions.functionserror.md
+++ b/docs-devsite/functions.functionserror.md
@@ -10,7 +10,7 @@ https://github.com/firebase/firebase-js-sdk
 {% endcomment %}
 
 # FunctionsError class
-An explicit error that can be thrown from a handler to send an error to the client that called the function.
+An error returned by the Firebase Functions client SDK.
 
 See [FunctionsErrorCode](./functions.md#functionserrorcode) for full documentation of codes.
 

--- a/docs-devsite/functions.functionserror.md
+++ b/docs-devsite/functions.functionserror.md
@@ -9,32 +9,49 @@ overwritten. Changes should be made in the source code at
 https://github.com/firebase/firebase-js-sdk
 {% endcomment %}
 
-# FunctionsError interface
-An error returned by the Firebase Functions client SDK.
+# FunctionsError class
+An explicit error that can be thrown from a handler to send an error to the client that called the function.
+
+See [FunctionsErrorCode](./functions.md#functionserrorcode) for full documentation of codes.
 
 <b>Signature:</b>
 
 ```typescript
-export interface FunctionsError extends FirebaseError 
+export declare class FunctionsError extends FirebaseError 
 ```
 <b>Extends:</b> [FirebaseError](./util.firebaseerror.md#firebaseerror_class)
 
+## Constructors
+
+|  Constructor | Modifiers | Description |
+|  --- | --- | --- |
+|  [(constructor)(code, message, details)](./functions.functionserror.md#functionserrorconstructor) |  | Constructs a new instance of the <code>FunctionsError</code> class |
+
 ## Properties
 
-|  Property | Type | Description |
-|  --- | --- | --- |
-|  [code](./functions.functionserror.md#functionserrorcode) | [FunctionsErrorCode](./functions.md#functionserrorcode) | A standard error code that will be returned to the client. This also determines the HTTP status code of the response, as defined in code.proto. |
-|  [details](./functions.functionserror.md#functionserrordetails) | unknown | Extra data to be converted to JSON and included in the error response. |
+|  Property | Modifiers | Type | Description |
+|  --- | --- | --- | --- |
+|  [details](./functions.functionserror.md#functionserrordetails) |  | unknown | Extra data to be converted to JSON and included in the error response. |
 
-## FunctionsError.code
+## FunctionsError.(constructor)
 
-A standard error code that will be returned to the client. This also determines the HTTP status code of the response, as defined in code.proto.
+Constructs a new instance of the `FunctionsError` class
 
 <b>Signature:</b>
 
 ```typescript
-readonly code: FunctionsErrorCode;
+constructor(
+    code: FunctionsErrorCode, message?: string, 
+    details?: unknown);
 ```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  code | [FunctionsErrorCode](./functions.md#functionserrorcodecore) |  |
+|  message | string |  |
+|  details | unknown |  |
 
 ## FunctionsError.details
 

--- a/docs-devsite/functions.functionserror.md
+++ b/docs-devsite/functions.functionserror.md
@@ -25,23 +25,22 @@ export declare class FunctionsError extends FirebaseError
 
 |  Constructor | Modifiers | Description |
 |  --- | --- | --- |
-|  [(constructor)(code, message, details)](./functions.functionserror.md#functionserrorconstructor) |  | Constructs a new instance of the <code>FunctionsError</code> class |
+|  [(constructor)(code, message, details)](./functions.functionserror.md#functionserrorconstructor) |  | Constructs a new instance of the <code>FunctionsError</code> class. |
 
 ## Properties
 
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
-|  [details](./functions.functionserror.md#functionserrordetails) |  | unknown | Extra data to be converted to JSON and included in the error response. |
+|  [details](./functions.functionserror.md#functionserrordetails) |  | unknown | Additional details to be converted to JSON and included in the error response. |
 
 ## FunctionsError.(constructor)
 
-Constructs a new instance of the `FunctionsError` class
+Constructs a new instance of the `FunctionsError` class.
 
 <b>Signature:</b>
 
 ```typescript
-constructor(
-    code: FunctionsErrorCode, message?: string, 
+constructor(code: FunctionsErrorCode, message?: string, 
     details?: unknown);
 ```
 
@@ -55,7 +54,7 @@ constructor(
 
 ## FunctionsError.details
 
-Extra data to be converted to JSON and included in the error response.
+Additional details to be converted to JSON and included in the error response.
 
 <b>Signature:</b>
 

--- a/docs-devsite/functions.md
+++ b/docs-devsite/functions.md
@@ -27,7 +27,7 @@ Cloud Functions for Firebase
 
 |  Class | Description |
 |  --- | --- |
-|  [FunctionsError](./functions.functionserror.md#functionserror_class) | An explicit error that can be thrown from a handler to send an error to the client that called the function.<!-- -->See [FunctionsErrorCode](./functions.md#functionserrorcode) for full documentation of codes. |
+|  [FunctionsError](./functions.functionserror.md#functionserror_class) | An error returned by the Firebase Functions client SDK.<!-- -->See [FunctionsErrorCode](./functions.md#functionserrorcode) for full documentation of codes. |
 
 ## Interfaces
 

--- a/docs-devsite/functions.md
+++ b/docs-devsite/functions.md
@@ -23,12 +23,17 @@ Cloud Functions for Firebase
 |  [httpsCallable(functionsInstance, name, options)](./functions.md#httpscallable_1dd297c) | Returns a reference to the callable HTTPS trigger with the given name. |
 |  [httpsCallableFromURL(functionsInstance, url, options)](./functions.md#httpscallablefromurl_7af6987) | Returns a reference to the callable HTTPS trigger with the specified url. |
 
+## Classes
+
+|  Class | Description |
+|  --- | --- |
+|  [FunctionsError](./functions.functionserror.md#functionserror_class) | An explicit error that can be thrown from a handler to send an error to the client that called the function.<!-- -->See [FunctionsErrorCode](./functions.md#functionserrorcode) for full documentation of codes. |
+
 ## Interfaces
 
 |  Interface | Description |
 |  --- | --- |
 |  [Functions](./functions.functions.md#functions_interface) | A <code>Functions</code> instance. |
-|  [FunctionsError](./functions.functionserror.md#functionserror_interface) | An error returned by the Firebase Functions client SDK. |
 |  [HttpsCallableOptions](./functions.httpscallableoptions.md#httpscallableoptions_interface) | An interface for metadata about how calls should be executed. |
 |  [HttpsCallableResult](./functions.httpscallableresult.md#httpscallableresult_interface) | An <code>HttpsCallableResult</code> wraps a single result from a function call. |
 

--- a/packages/functions/src/api.ts
+++ b/packages/functions/src/api.ts
@@ -32,6 +32,7 @@ import {
   getDefaultEmulatorHostnameAndPort
 } from '@firebase/util';
 
+export { FunctionsError } from './error';
 export * from './public-types';
 
 /**

--- a/packages/functions/src/callable.test.ts
+++ b/packages/functions/src/callable.test.ts
@@ -57,6 +57,7 @@ async function expectError(
     await promise;
   } catch (e) {
     failed = true;
+    expect(e).to.be.instanceOf(FunctionsError);
     const error = e as FunctionsError;
     expect(error.code).to.equal(`${FUNCTIONS_TYPE}/${code}`);
     expect(error.message).to.equal(message);

--- a/packages/functions/src/error.ts
+++ b/packages/functions/src/error.ts
@@ -49,8 +49,7 @@ const errorCodeMap: { [name: string]: FunctionsErrorCode } = {
 };
 
 /**
- * An explicit error that can be thrown from a handler to send an error to the
- * client that called the function.
+ * An error returned by the Firebase Functions client SDK.
  *
  * See {@link FunctionsErrorCode} for full documentation of codes.
  *

--- a/packages/functions/src/error.ts
+++ b/packages/functions/src/error.ts
@@ -56,15 +56,18 @@ const errorCodeMap: { [name: string]: FunctionsErrorCode } = {
  * @public
  */
 export class FunctionsError extends FirebaseError {
+  /**
+   * Constructs a new instance of the `FunctionsError` class.
+   */
   constructor(
     /**
-     * A standard error code that will be returned to the client. This also
-     * determines the HTTP status code of the response, as defined in code.proto.
-     */
+    * A standard error code that will be returned to the client. This also
+    * determines the HTTP status code of the response, as defined in code.proto.
+    */
     code: FunctionsErrorCode,
     message?: string,
     /**
-     * Extra data to be converted to JSON and included in the error response.
+     * Additional details to be converted to JSON and included in the error response.
      */
     readonly details?: unknown
   ) {

--- a/packages/functions/src/error.ts
+++ b/packages/functions/src/error.ts
@@ -66,6 +66,7 @@ export class FunctionsError extends FirebaseError {
     readonly details?: unknown
   ) {
     super(`${FUNCTIONS_TYPE}/${code}`, message || '');
+    // TODO (dlarocque): Set this to be the root of the stack trace.
   }
 }
 

--- a/packages/functions/src/error.ts
+++ b/packages/functions/src/error.ts
@@ -61,9 +61,9 @@ export class FunctionsError extends FirebaseError {
    */
   constructor(
     /**
-    * A standard error code that will be returned to the client. This also
-    * determines the HTTP status code of the response, as defined in code.proto.
-    */
+     * A standard error code that will be returned to the client. This also
+     * determines the HTTP status code of the response, as defined in code.proto.
+     */
     code: FunctionsErrorCode,
     message?: string,
     /**

--- a/packages/functions/src/error.ts
+++ b/packages/functions/src/error.ts
@@ -51,6 +51,10 @@ const errorCodeMap: { [name: string]: FunctionsErrorCode } = {
 /**
  * An explicit error that can be thrown from a handler to send an error to the
  * client that called the function.
+ *
+ * See {@link FunctionsErrorCode} for full documentation of codes.
+ *
+ * @public
  */
 export class FunctionsError extends FirebaseError {
   constructor(
@@ -66,7 +70,10 @@ export class FunctionsError extends FirebaseError {
     readonly details?: unknown
   ) {
     super(`${FUNCTIONS_TYPE}/${code}`, message || '');
-    // TODO (dlarocque): Set this to be the root of the stack trace.
+
+    // Since the FirebaseError constructor sets the prototype of `this` to FirebaseError.prototype,
+    // we also have to do it in all subclasses to allow for correct `instanceof` checks.
+    Object.setPrototypeOf(this, FunctionsError.prototype);
   }
 }
 

--- a/packages/functions/src/public-types.ts
+++ b/packages/functions/src/public-types.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 import { FirebaseApp } from '@firebase/app';
-import { FirebaseError } from '@firebase/util';
 
 /**
  * An `HttpsCallableResult` wraps a single result from a function call.
@@ -143,23 +142,6 @@ export type FunctionsErrorCodeCore =
  * @public
  */
 export type FunctionsErrorCode = `functions/${FunctionsErrorCodeCore}`;
-
-/**
- * An error returned by the Firebase Functions client SDK.
- * @public
- */
-export interface FunctionsError extends FirebaseError {
-  /**
-   * A standard error code that will be returned to the client. This also
-   * determines the HTTP status code of the response, as defined in code.proto.
-   */
-  readonly code: FunctionsErrorCode;
-
-  /**
-   * Extra data to be converted to JSON and included in the error response.
-   */
-  readonly details?: unknown;
-}
 
 declare module '@firebase/component' {
   interface NameServiceMapping {


### PR DESCRIPTION
We should export the `FunctionsError` class to users, so that they can perform instanceof checks.

Tested using:
```js
import { FirebaseError, initializeApp } from "firebase/app";
import { FunctionsError, getFunctions, httpsCallable } from "firebase/functions";

const firebaseConfig = {
  /* ... */
};

const app = initializeApp(firebaseConfig);
const functions = getFunctions(app);
(async () => {
  try {
    const addMessage = httpsCallable(functions, 'addMessage'); // Function does not exist
    await addMessage({ text: 'hello' });
  } catch (err) {
    console.log(err instanceof FirebaseError); // true
    console.log(err instanceof FunctionsError); // true
    throw err;
  }
})();

```

Also added an `expect(error).to.be.instanceOf(FunctionsError)` to all error checks in the tests.

Fixes #8511 