### PR TITLE
Remove prototype overrides in `FirebaseError` and all subclasses

### DIFF
--- a/.changeset/hungry-glasses-drop.md
+++ b/.changeset/hungry-glasses-drop.md
@@ -1,0 +1,8 @@
+---
+'@firebase/vertexai': patch
+'@firebase/storage': patch
+'@firebase/auth': patch
+'@firebase/util': patch
+---
+
+Remove prototype overrides in `FirebaseError` and all subclasses.

--- a/packages/auth/src/mfa/mfa_error.ts
+++ b/packages/auth/src/mfa/mfa_error.ts
@@ -42,8 +42,6 @@ export class MultiFactorError
     readonly user?: UserInternal
   ) {
     super(error.code, error.message);
-    // https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
-    Object.setPrototypeOf(this, MultiFactorError.prototype);
     this.customData = {
       appName: auth.name,
       tenantId: auth.tenantId ?? undefined,

--- a/packages/storage/src/implementation/error.ts
+++ b/packages/storage/src/implementation/error.ts
@@ -42,9 +42,6 @@ export class StorageError extends FirebaseError {
       `Firebase Storage: ${message} (${prependCode(code)})`
     );
     this._baseMessage = this.message;
-    // Without this, `instanceof StorageError`, in tests for example,
-    // returns false.
-    Object.setPrototypeOf(this, StorageError.prototype);
   }
 
   get status(): number {

--- a/packages/util/src/errors.ts
+++ b/packages/util/src/errors.ts
@@ -84,12 +84,6 @@ export class FirebaseError extends Error {
   ) {
     super(message);
 
-    // Fix For ES5
-    // https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
-    // TODO(dlarocque): Replace this with `new.target`: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#support-for-newtarget
-    //                   which we can now use since we no longer target ES5.
-    Object.setPrototypeOf(this, FirebaseError.prototype);
-
     // Maintains proper stack trace for where our error was thrown.
     // Only available on V8.
     if (Error.captureStackTrace) {

--- a/packages/vertexai/src/errors.ts
+++ b/packages/vertexai/src/errors.ts
@@ -54,12 +54,6 @@ export class VertexAIError extends FirebaseError {
       Error.captureStackTrace(this, VertexAIError);
     }
 
-    // Allows instanceof VertexAIError in ES5/ES6
-    // https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
-    // TODO(dlarocque): Replace this with `new.target`: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#support-for-newtarget
-    //                   which we can now use since we no longer target ES5.
-    Object.setPrototypeOf(this, VertexAIError.prototype);
-
     // Since Error is an interface, we don't inherit toString and so we define it ourselves.
     this.toString = () => fullMessage;
   }


### PR DESCRIPTION
We override the prototype of `this` in all of the constructors for our custom error classes. This allowed us to adjust the prototype chain, so that we can perform `instanceof` checks on subclasses of `Error`.

Since ES2015, the built-in `Error` constructor uses [`new.target`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target) to adjust the prototype chain for us, so we no longer need to do it ourselves.

See https://github.com/Microsoft/TypeScript-wiki/blob/main/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work (the link doesn't work well since the linked header is hidden behind a rolled up section that can be expanded by clicking "See Changes for Older Releases" at the bottom).

Since `new.target` does not exist in ES5, the prototype chain won't be adjusted if our bundle is transpiled down to ES5.