### PR TITLE
Set `FirebaseError` name to be calling constructors name

### DIFF
--- a/.changeset/chatty-walls-wink.md
+++ b/.changeset/chatty-walls-wink.md
@@ -1,0 +1,5 @@
+---
+'@firebase/util': patch
+---
+
+Set FirebaseError names to be the calling constructors name.

--- a/common/api-review/util.api.md
+++ b/common/api-review/util.api.md
@@ -213,7 +213,6 @@ export class FirebaseError extends Error {
     customData?: Record<string, unknown> | undefined);
     readonly code: string;
     customData?: Record<string, unknown> | undefined;
-    readonly name: string;
 }
 
 // Warning: (ae-missing-release-tag) "FirebaseSignInProvider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/util/src/errors.ts
+++ b/packages/util/src/errors.ts
@@ -72,9 +72,6 @@ export interface ErrorData {
 // Based on code from:
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Custom_Error_Types
 export class FirebaseError extends Error {
-  /** The custom name for all FirebaseErrors. */
-  readonly name: string = ERROR_NAME;
-
   constructor(
     /** The error code for this error. */
     readonly code: string,
@@ -83,6 +80,9 @@ export class FirebaseError extends Error {
     public customData?: Record<string, unknown>
   ) {
     super(message);
+
+    // Set the name of the error to the name of the calling constructor.
+    this.name = this.constructor.name;
 
     // Fix For ES5
     // https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work


### PR DESCRIPTION
We currently set the error name to be `FirebaseError` and make it readonly. This means that whenever subclasses of `FirebaseError` call `super()`, the name will be locked at `FirebaseError`. This results in those errors from subclasses looking like:
```
[StorageError [FirebaseError]: Firebase Storage: An unknown error occurred, please check the error payload for server response. (storage/unknown)] {
  code: 'storage/unknown',
  customData: { serverResponse: '' },
  status_: 404,
  _baseMessage: 'Firebase Storage: An unknown error occurred, please check the error payload for server response. (storage/unknown)'
}
```

Subclasses should provide their own `name` property, so we should instead set the error name to be the name of the calling constructor. So if we do `throw new StorageError`, `name` will be `StorageError`. This makes errors look like this instead:
```
[StorageError: Firebase Storage: An unknown error occurred, please check the error payload for server response. (storage/unknown)] {
  code: 'storage/unknown',
  customData: { serverResponse: '' },
  status_: 404,
  _baseMessage: 'Firebase Storage: An unknown error occurred, please check the error payload for server response. (storage/unknown)'
}
```

This change will apply to all SDKs that have subclasses of `FirebaseError` (VertexAI, Storage, Functions, Auth).