### PR TITLE
Fix analytics test warnings

### DIFF
--- a/packages/analytics/testing/get-fake-firebase-services.ts
+++ b/packages/analytics/testing/get-fake-firebase-services.ts
@@ -15,7 +15,12 @@
  * limitations under the License.
  */
 
-import { FirebaseApp, initializeApp, _registerComponent, _addOrOverwriteComponent } from '@firebase/app';
+import {
+  FirebaseApp,
+  initializeApp,
+  _registerComponent,
+  _addOrOverwriteComponent
+} from '@firebase/app';
 import { Component, ComponentType } from '@firebase/component';
 import { _FirebaseInstallationsInternal } from '@firebase/installations';
 import { AnalyticsService } from '../src/factory';

--- a/packages/analytics/testing/get-fake-firebase-services.ts
+++ b/packages/analytics/testing/get-fake-firebase-services.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { FirebaseApp, initializeApp, _registerComponent } from '@firebase/app';
+import { FirebaseApp, initializeApp, _registerComponent, _addOrOverwriteComponent } from '@firebase/app';
 import { Component, ComponentType } from '@firebase/component';
 import { _FirebaseInstallationsInternal } from '@firebase/installations';
 import { AnalyticsService } from '../src/factory';
@@ -78,5 +78,18 @@ export function getFullApp(fakeAppParams?: {
     )
   );
   const app = initializeApp({ ...fakeConfig, ...fakeAppParams });
+  _addOrOverwriteComponent(
+    app,
+    //@ts-ignore
+    new Component(
+      'heartbeat',
+      () => {
+        return {
+          triggerHeartbeat: () => {}
+        } as any;
+      },
+      ComponentType.PUBLIC
+    )
+  );
   return app;
 }


### PR DESCRIPTION
Analytics test logs had a lot of spam with warnings that the app is already deleted. This actually didn't come from a call to deleteApp() but a reference to `app.name` (which is actually a getter function) in a heartbeatService method. This is because some of the analytics tests use a full FirebaseApp initialized with initializeApp instead of a stub, which causes heartbeatService to also be initialized and start running its lifecycle methods.

The solution is to replace the heartbeatService component in the app used for testing, a fix which was already done in AppCheck, probably for the same problem https://github.com/firebase/firebase-js-sdk/blob/main/packages/app-check/test/util.ts#L70 Analytics tests don't need to test the heartbeatService so it makes sense to stub it out.