### PR TITLE
Add reCAPTCHA Enterprise support for Phone Auth

### DIFF
--- a/.changeset/rare-radios-leave.md
+++ b/.changeset/rare-radios-leave.md
@@ -1,0 +1,5 @@
+---
+'@firebase/auth': minor
+---
+
+Added reCAPTCHA Enterprise support for app verification during phone authentication

--- a/.changeset/rare-radios-leave.md
+++ b/.changeset/rare-radios-leave.md
@@ -1,5 +1,0 @@
----
-'@firebase/auth': minor
----
-
-Added reCAPTCHA Enterprise support for app verification during phone authentication

--- a/.changeset/shy-bikes-explain.md
+++ b/.changeset/shy-bikes-explain.md
@@ -1,0 +1,6 @@
+---
+'@firebase/auth': minor
+'firebase': minor
+---
+
+[feature] Added reCAPTCHA Enterprise support for app verification during phone authentication.

--- a/common/api-review/auth.api.md
+++ b/common/api-review/auth.api.md
@@ -445,7 +445,7 @@ export function isSignInWithEmailLink(auth: Auth, emailLink: string): boolean;
 export function linkWithCredential(user: User, credential: AuthCredential): Promise<UserCredential>;
 
 // @public
-export function linkWithPhoneNumber(user: User, phoneNumber: string, appVerifier: ApplicationVerifier): Promise<ConfirmationResult>;
+export function linkWithPhoneNumber(user: User, phoneNumber: string, appVerifier?: ApplicationVerifier): Promise<ConfirmationResult>;
 
 // @public
 export function linkWithPopup(user: User, provider: AuthProvider, resolver?: PopupRedirectResolver): Promise<UserCredential>;
@@ -625,7 +625,7 @@ export class PhoneAuthProvider {
     static readonly PHONE_SIGN_IN_METHOD: 'phone';
     static readonly PROVIDER_ID: 'phone';
     readonly providerId: "phone";
-    verifyPhoneNumber(phoneOptions: PhoneInfoOptions | string, applicationVerifier: ApplicationVerifier): Promise<string>;
+    verifyPhoneNumber(phoneOptions: PhoneInfoOptions | string, applicationVerifier?: ApplicationVerifier): Promise<string>;
 }
 
 // @public
@@ -692,7 +692,7 @@ export interface ReactNativeAsyncStorage {
 export function reauthenticateWithCredential(user: User, credential: AuthCredential): Promise<UserCredential>;
 
 // @public
-export function reauthenticateWithPhoneNumber(user: User, phoneNumber: string, appVerifier: ApplicationVerifier): Promise<ConfirmationResult>;
+export function reauthenticateWithPhoneNumber(user: User, phoneNumber: string, appVerifier?: ApplicationVerifier): Promise<ConfirmationResult>;
 
 // @public
 export function reauthenticateWithPopup(user: User, provider: AuthProvider, resolver?: PopupRedirectResolver): Promise<UserCredential>;
@@ -778,7 +778,7 @@ export function signInWithEmailAndPassword(auth: Auth, email: string, password: 
 export function signInWithEmailLink(auth: Auth, email: string, emailLink?: string): Promise<UserCredential>;
 
 // @public
-export function signInWithPhoneNumber(auth: Auth, phoneNumber: string, appVerifier: ApplicationVerifier): Promise<ConfirmationResult>;
+export function signInWithPhoneNumber(auth: Auth, phoneNumber: string, appVerifier?: ApplicationVerifier): Promise<ConfirmationResult>;
 
 // @public
 export function signInWithPopup(auth: Auth, provider: AuthProvider, resolver?: PopupRedirectResolver): Promise<UserCredential>;

--- a/docs-devsite/auth.md
+++ b/docs-devsite/auth.md
@@ -930,7 +930,7 @@ This method does not work in a Node.js environment or with [Auth](./auth.auth.md
 <b>Signature:</b>
 
 ```typescript
-export declare function signInWithPhoneNumber(auth: Auth, phoneNumber: string, appVerifier: ApplicationVerifier): Promise<ConfirmationResult>;
+export declare function signInWithPhoneNumber(auth: Auth, phoneNumber: string, appVerifier?: ApplicationVerifier): Promise<ConfirmationResult>;
 ```
 
 #### Parameters
@@ -1304,7 +1304,7 @@ This method does not work in a Node.js environment.
 <b>Signature:</b>
 
 ```typescript
-export declare function linkWithPhoneNumber(user: User, phoneNumber: string, appVerifier: ApplicationVerifier): Promise<ConfirmationResult>;
+export declare function linkWithPhoneNumber(user: User, phoneNumber: string, appVerifier?: ApplicationVerifier): Promise<ConfirmationResult>;
 ```
 
 #### Parameters
@@ -1457,7 +1457,7 @@ This method does not work in a Node.js environment or on any [User](./auth.user.
 <b>Signature:</b>
 
 ```typescript
-export declare function reauthenticateWithPhoneNumber(user: User, phoneNumber: string, appVerifier: ApplicationVerifier): Promise<ConfirmationResult>;
+export declare function reauthenticateWithPhoneNumber(user: User, phoneNumber: string, appVerifier?: ApplicationVerifier): Promise<ConfirmationResult>;
 ```
 
 #### Parameters

--- a/docs-devsite/auth.md
+++ b/docs-devsite/auth.md
@@ -923,9 +923,9 @@ Asynchronously signs in using a phone number.
 
 This method sends a code via SMS to the given phone number, and returns a [ConfirmationResult](./auth.confirmationresult.md#confirmationresult_interface)<!-- -->. After the user provides the code sent to their phone, call [ConfirmationResult.confirm()](./auth.confirmationresult.md#confirmationresultconfirm) with the code to sign the user in.
 
-For abuse prevention with reCAPTCHA v2, this method requires a [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface)<!-- -->. This SDK includes a reCAPTCHA-v2-based implementation, [RecaptchaVerifier](./auth.recaptchaverifier.md#recaptchaverifier_class)<!-- -->. This function can work on other platforms that do not support the [RecaptchaVerifier](./auth.recaptchaverifier.md#recaptchaverifier_class) (like React Native), but you need to use a third-party [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface) implementation.
+For abuse prevention, this method requires a [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface)<!-- -->. This SDK includes an implementation based on reCAPTCHA v2, [RecaptchaVerifier](./auth.recaptchaverifier.md#recaptchaverifier_class)<!-- -->. This function can work on other platforms that do not support the [RecaptchaVerifier](./auth.recaptchaverifier.md#recaptchaverifier_class) (like React Native), but you need to use a third-party [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface) implementation.
 
-For abuse prevention with reCAPTCHA Enterprise, [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface) is required in Audit mode but not in Enforce mode.
+If you've enabled project-level reCAPTCHA Enterprise bot protection in Enforce mode, you can omit the [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface)<!-- -->.
 
 This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 

--- a/docs-devsite/auth.md
+++ b/docs-devsite/auth.md
@@ -923,7 +923,9 @@ Asynchronously signs in using a phone number.
 
 This method sends a code via SMS to the given phone number, and returns a [ConfirmationResult](./auth.confirmationresult.md#confirmationresult_interface)<!-- -->. After the user provides the code sent to their phone, call [ConfirmationResult.confirm()](./auth.confirmationresult.md#confirmationresultconfirm) with the code to sign the user in.
 
-For abuse prevention, this method also requires a [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface)<!-- -->. This SDK includes a reCAPTCHA-based implementation, [RecaptchaVerifier](./auth.recaptchaverifier.md#recaptchaverifier_class)<!-- -->. This function can work on other platforms that do not support the [RecaptchaVerifier](./auth.recaptchaverifier.md#recaptchaverifier_class) (like React Native), but you need to use a third-party [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface) implementation.
+For abuse prevention with reCAPTCHA v2, this method requires a [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface)<!-- -->. This SDK includes a reCAPTCHA-v2-based implementation, [RecaptchaVerifier](./auth.recaptchaverifier.md#recaptchaverifier_class)<!-- -->. This function can work on other platforms that do not support the [RecaptchaVerifier](./auth.recaptchaverifier.md#recaptchaverifier_class) (like React Native), but you need to use a third-party [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface) implementation.
+
+For abuse prevention with reCAPTCHA Enterprise, [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface) is required in Audit mode but not in Enforce mode.
 
 This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 

--- a/docs-devsite/auth.phoneauthprovider.md
+++ b/docs-devsite/auth.phoneauthprovider.md
@@ -217,7 +217,7 @@ verifyPhoneNumber(phoneOptions: PhoneInfoOptions | string, applicationVerifier: 
 
 Promise&lt;string&gt;
 
-A Promise for a verification ID that can be passed to [PhoneAuthProvider.credential()](./auth.phoneauthprovider.md#phoneauthprovidercredential) to identify this flow..
+A Promise for a verification ID that can be passed to [PhoneAuthProvider.credential()](./auth.phoneauthprovider.md#phoneauthprovidercredential) to identify this flow.
 
 ### Example 1
 

--- a/docs-devsite/auth.phoneauthprovider.md
+++ b/docs-devsite/auth.phoneauthprovider.md
@@ -203,7 +203,7 @@ Starts a phone number authentication flow by sending a verification code to the 
 <b>Signature:</b>
 
 ```typescript
-verifyPhoneNumber(phoneOptions: PhoneInfoOptions | string, applicationVerifier: ApplicationVerifier): Promise<string>;
+verifyPhoneNumber(phoneOptions: PhoneInfoOptions | string, applicationVerifier?: ApplicationVerifier): Promise<string>;
 ```
 
 #### Parameters

--- a/docs-devsite/auth.phoneauthprovider.md
+++ b/docs-devsite/auth.phoneauthprovider.md
@@ -211,7 +211,7 @@ verifyPhoneNumber(phoneOptions: PhoneInfoOptions | string, applicationVerifier?:
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  phoneOptions | [PhoneInfoOptions](./auth.md#phoneinfooptions) \| string |  |
-|  applicationVerifier | [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface) | For abuse prevention, this method also requires a [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface)<!-- -->. This SDK includes a reCAPTCHA-based implementation, [RecaptchaVerifier](./auth.recaptchaverifier.md#recaptchaverifier_class)<!-- -->. |
+|  applicationVerifier | [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface) | For abuse prevention with reCAPTCHA v2, this method requires a [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface)<!-- -->. This SDK includes a reCAPTCHA-v2-based implementation, [RecaptchaVerifier](./auth.recaptchaverifier.md#recaptchaverifier_class)<!-- -->. For abuse prevention with reCAPTCHA Enterprise, [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface) is required in Audit mode but not in Enforce mode. |
 
 <b>Returns:</b>
 

--- a/docs-devsite/auth.phoneauthprovider.md
+++ b/docs-devsite/auth.phoneauthprovider.md
@@ -211,7 +211,7 @@ verifyPhoneNumber(phoneOptions: PhoneInfoOptions | string, applicationVerifier?:
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  phoneOptions | [PhoneInfoOptions](./auth.md#phoneinfooptions) \| string |  |
-|  applicationVerifier | [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface) | For abuse prevention with reCAPTCHA v2, this method requires a [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface)<!-- -->. This SDK includes a reCAPTCHA-v2-based implementation, [RecaptchaVerifier](./auth.recaptchaverifier.md#recaptchaverifier_class)<!-- -->. For abuse prevention with reCAPTCHA Enterprise, [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface) is required in Audit mode but not in Enforce mode. |
+|  applicationVerifier | [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface) | An [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface)<!-- -->, which prevents requests from unauthorized clients. This SDK includes an implementation based on reCAPTCHA v2, [RecaptchaVerifier](./auth.recaptchaverifier.md#recaptchaverifier_class)<!-- -->. If you've enabled reCAPTCHA Enterprise bot protection in Enforce mode, this parameter is optional; in all other configurations, the parameter is required. |
 
 <b>Returns:</b>
 

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -54,8 +54,11 @@ firebase emulators:exec --project foo-bar --only auth "yarn test:integration:loc
 
 ### Integration testing with the production backend
 
-Currently, MFA TOTP and password policy tests only run against the production backend (since they are not supported on the emulator yet).
+Currently, MFA TOTP, password policy, and reCAPTCHA Enterprise phone verification tests only run 
+against the production backend (since they are not supported on the emulator yet).
 Running against the backend also makes it a more reliable end-to-end test.
+
+#### TOTP
 
 The TOTP tests require the following email/password combination to exist in the project, so if you are running this test against your test project, please create this user:
 
@@ -70,6 +73,8 @@ curl   -H "Authorization: Bearer $(gcloud auth print-access-token)"   -H "Conten
       "returnOobLink": true,
     }'
 ```
+
+#### Password policy
 
 The password policy tests require a tenant configured with a password policy that requires all options to exist in the project.
 
@@ -97,6 +102,32 @@ curl   -H "Authorization: Bearer $(gcloud auth print-access-token)"   -H "Conten
 ```
 
 Replace the tenant ID `passpol-tenant-d7hha` in [test/integration/flows/password_policy.test.ts](https://github.com/firebase/firebase-js-sdk/blob/main/packages/auth/test/integration/flows/password_policy.test.ts) with the ID for the newly created tenant. The tenant ID can be found at the end of the `name` property in the response and is in the format `passpol-tenant-xxxxx`.
+
+#### reCAPTCHA Enterprise phone verification
+
+The reCAPTCHA Enterprise phone verification tests require reCAPTCHA Enterprise to be enabled and
+the following fictional phone number to be configured and in the project. 
+
+If you are running this
+test against your project, please [add this test phone number](https://firebase.google.com/docs/auth/web/phone-auth#create-fictional-phone-numbers-and-verification-codes):
+
+'+1 555-555-1000', SMS code: '123456'
+
+Follow [this guide](https://cloud.google.com/identity-platform/docs/recaptcha-enterprise) to enable reCAPTCHA
+Enterprise, then use the following curl command to set reCAPTCHA Enterprise to ENFORCE for phone provider:
+
+```
+curl   -H "Authorization: Bearer $(gcloud auth print-access-token)"   -H "Content-Type: application/json"   -H "X-Goog-User-Project: $
+{PROJECT_ID}"   -X POST https://identitytoolkit.googleapis.com/v2/projects/${PROJECT_ID}/config?updateMask=recaptchaConfig.phoneEnforcementState,recaptchaConfig.useSmsBotScore,recaptchaConfig.useSmsTollFraudProtection  -d '
+{
+  "name": "projects/{PROJECT_ID}",
+  "recaptchaConfig": {
+    "phoneEnforcementState": "ENFORCE",
+    "useSmsBotScore": "true",
+    "useSmsTollFraudProtection": "true",
+  },
+}'
+```
 
 ### Selenium Webdriver tests
 

--- a/packages/auth/karma.conf.js
+++ b/packages/auth/karma.conf.js
@@ -51,7 +51,8 @@ function getTestFiles(argv) {
     if (argv.prodbackend) {
       return [
         'test/integration/flows/totp.test.ts',
-        'test/integration/flows/password_policy.test.ts'
+        'test/integration/flows/password_policy.test.ts',
+        'test/integration/flows/recaptcha_enterprise.test.ts'
       ];
     }
     return argv.local

--- a/packages/auth/src/api/account_management/mfa.test.ts
+++ b/packages/auth/src/api/account_management/mfa.test.ts
@@ -20,7 +20,12 @@ import chaiAsPromised from 'chai-as-promised';
 
 import { FirebaseError } from '@firebase/util';
 
-import { Endpoint, HttpHeader } from '../';
+import {
+  Endpoint,
+  HttpHeader,
+  RecaptchaClientType,
+  RecaptchaVersion
+} from '../';
 import { mockEndpoint } from '../../../test/helpers/api/helper';
 import { testAuth, TestAuth } from '../../../test/helpers/mock_auth';
 import * as mockFetch from '../../../test/helpers/mock_fetch';
@@ -40,7 +45,10 @@ describe('api/account_management/startEnrollPhoneMfa', () => {
     idToken: 'id-token',
     phoneEnrollmentInfo: {
       phoneNumber: 'phone-number',
-      recaptchaToken: 'captcha-token'
+      recaptchaToken: 'captcha-token',
+      captchaResponse: 'captcha-response',
+      clientType: RecaptchaClientType.WEB,
+      recaptchaVersion: RecaptchaVersion.ENTERPRISE
     }
   };
 

--- a/packages/auth/src/api/account_management/mfa.ts
+++ b/packages/auth/src/api/account_management/mfa.ts
@@ -18,6 +18,8 @@
 import {
   Endpoint,
   HttpMethod,
+  RecaptchaClientType,
+  RecaptchaVersion,
   _addTidIfNecessary,
   _performApiRequest
 } from '../index';
@@ -55,7 +57,12 @@ export interface StartPhoneMfaEnrollmentRequest {
   idToken: string;
   phoneEnrollmentInfo: {
     phoneNumber: string;
-    recaptchaToken: string;
+    // reCAPTCHA v2 token
+    recaptchaToken?: string;
+    // reCAPTCHA Enterprise token
+    captchaResponse?: string;
+    clientType?: RecaptchaClientType;
+    recaptchaVersion?: RecaptchaVersion;
   };
   tenantId?: string;
 }

--- a/packages/auth/src/api/authentication/mfa.test.ts
+++ b/packages/auth/src/api/authentication/mfa.test.ts
@@ -20,7 +20,12 @@ import chaiAsPromised from 'chai-as-promised';
 
 import { FirebaseError } from '@firebase/util';
 
-import { Endpoint, HttpHeader } from '../';
+import {
+  Endpoint,
+  HttpHeader,
+  RecaptchaClientType,
+  RecaptchaVersion
+} from '../';
 import { mockEndpoint } from '../../../test/helpers/api/helper';
 import { testAuth, TestAuth } from '../../../test/helpers/mock_auth';
 import * as mockFetch from '../../../test/helpers/mock_fetch';
@@ -34,7 +39,10 @@ describe('api/authentication/startSignInPhoneMfa', () => {
     mfaPendingCredential: 'my-creds',
     mfaEnrollmentId: 'my-enrollment-id',
     phoneSignInInfo: {
-      recaptchaToken: 'captcha-token'
+      recaptchaToken: 'captcha-token',
+      captchaResponse: 'captcha-response',
+      clientType: RecaptchaClientType.WEB,
+      recaptchaVersion: RecaptchaVersion.ENTERPRISE
     }
   };
 

--- a/packages/auth/src/api/authentication/mfa.ts
+++ b/packages/auth/src/api/authentication/mfa.ts
@@ -19,6 +19,8 @@ import {
   _performApiRequest,
   Endpoint,
   HttpMethod,
+  RecaptchaClientType,
+  RecaptchaVersion,
   _addTidIfNecessary
 } from '../index';
 import { Auth } from '../../model/public_types';
@@ -47,7 +49,12 @@ export interface StartPhoneMfaSignInRequest {
   mfaPendingCredential: string;
   mfaEnrollmentId: string;
   phoneSignInInfo: {
-    recaptchaToken: string;
+    // reCAPTCHA v2 token
+    recaptchaToken?: string;
+    // reCAPTCHA Enterprise token
+    captchaResponse?: string;
+    clientType?: RecaptchaClientType;
+    recaptchaVersion?: RecaptchaVersion;
   };
   tenantId?: string;
 }

--- a/packages/auth/src/api/authentication/sms.test.ts
+++ b/packages/auth/src/api/authentication/sms.test.ts
@@ -21,7 +21,12 @@ import chaiAsPromised from 'chai-as-promised';
 import { ProviderId } from '../../model/enums';
 import { FirebaseError } from '@firebase/util';
 
-import { Endpoint, HttpHeader } from '../';
+import {
+  Endpoint,
+  HttpHeader,
+  RecaptchaClientType,
+  RecaptchaVersion
+} from '../';
 import { mockEndpoint } from '../../../test/helpers/api/helper';
 import { testAuth, TestAuth } from '../../../test/helpers/mock_auth';
 import * as mockFetch from '../../../test/helpers/mock_fetch';
@@ -38,7 +43,10 @@ use(chaiAsPromised);
 describe('api/authentication/sendPhoneVerificationCode', () => {
   const request = {
     phoneNumber: '123456789',
-    recaptchaToken: 'captchad'
+    recaptchaToken: 'captchad',
+    captchaResponse: 'captcha-response',
+    clientType: RecaptchaClientType.WEB,
+    recaptchaVersion: RecaptchaVersion.ENTERPRISE
   };
 
   let auth: TestAuth;

--- a/packages/auth/src/api/authentication/sms.ts
+++ b/packages/auth/src/api/authentication/sms.ts
@@ -18,6 +18,8 @@
 import {
   Endpoint,
   HttpMethod,
+  RecaptchaClientType,
+  RecaptchaVersion,
   _addTidIfNecessary,
   _makeTaggedError,
   _performApiRequest,
@@ -30,8 +32,13 @@ import { Auth } from '../../model/public_types';
 
 export interface SendPhoneVerificationCodeRequest {
   phoneNumber: string;
-  recaptchaToken: string;
+  // reCAPTCHA v2 token
+  recaptchaToken?: string;
   tenantId?: string;
+  // reCAPTCHA Enterprise token
+  captchaResponse?: string;
+  clientType?: RecaptchaClientType;
+  recaptchaVersion?: RecaptchaVersion;
 }
 
 export interface SendPhoneVerificationCodeResponse {

--- a/packages/auth/src/api/index.ts
+++ b/packages/auth/src/api/index.ts
@@ -86,7 +86,10 @@ export const enum RecaptchaVersion {
 export const enum RecaptchaActionName {
   SIGN_IN_WITH_PASSWORD = 'signInWithPassword',
   GET_OOB_CODE = 'getOobCode',
-  SIGN_UP_PASSWORD = 'signUpPassword'
+  SIGN_UP_PASSWORD = 'signUpPassword',
+  SEND_VERIFICATION_CODE = 'sendVerificationCode',
+  MFA_SMS_ENROLLMENT = 'mfaSmsEnrollment',
+  MFA_SMS_SIGNIN = 'mfaSmsSignin'
 }
 
 export const enum EnforcementState {
@@ -98,7 +101,8 @@ export const enum EnforcementState {
 
 // Providers that have reCAPTCHA Enterprise support.
 export const enum RecaptchaProvider {
-  EMAIL_PASSWORD_PROVIDER = 'EMAIL_PASSWORD_PROVIDER'
+  EMAIL_PASSWORD_PROVIDER = 'EMAIL_PASSWORD_PROVIDER',
+  PHONE_PROVIDER = 'PHONE_PROVIDER'
 }
 
 export const DEFAULT_API_TIMEOUT_MS = new Delay(30_000, 60_000);

--- a/packages/auth/src/api/index.ts
+++ b/packages/auth/src/api/index.ts
@@ -100,7 +100,7 @@ export const enum EnforcementState {
 }
 
 // Providers that have reCAPTCHA Enterprise support.
-export const enum RecaptchaProvider {
+export const enum RecaptchaAuthProvider {
   EMAIL_PASSWORD_PROVIDER = 'EMAIL_PASSWORD_PROVIDER',
   PHONE_PROVIDER = 'PHONE_PROVIDER'
 }

--- a/packages/auth/src/api/index.ts
+++ b/packages/auth/src/api/index.ts
@@ -89,7 +89,7 @@ export const enum RecaptchaActionName {
   SIGN_UP_PASSWORD = 'signUpPassword',
   SEND_VERIFICATION_CODE = 'sendVerificationCode',
   MFA_SMS_ENROLLMENT = 'mfaSmsEnrollment',
-  MFA_SMS_SIGNIN = 'mfaSmsSignin'
+  MFA_SMS_SIGNIN = 'mfaSmsSignIn'
 }
 
 export const enum EnforcementState {

--- a/packages/auth/src/core/credentials/email.test.ts
+++ b/packages/auth/src/core/credentials/email.test.ts
@@ -137,6 +137,7 @@ describe('core/credentials/email', () => {
 
   beforeEach(async () => {
     auth = await testAuth();
+    auth.settings.appVerificationDisabledForTesting = false;
   });
 
   context('email & password', () => {

--- a/packages/auth/src/core/credentials/email.ts
+++ b/packages/auth/src/core/credentials/email.ts
@@ -32,7 +32,11 @@ import { AuthErrorCode } from '../errors';
 import { _fail } from '../util/assert';
 import { AuthCredential } from './auth_credential';
 import { handleRecaptchaFlow } from '../../platform_browser/recaptcha/recaptcha_enterprise_verifier';
-import { RecaptchaActionName, RecaptchaClientType } from '../../api';
+import {
+  RecaptchaActionName,
+  RecaptchaClientType,
+  RecaptchaAuthProvider
+} from '../../api';
 import { SignUpRequest } from '../../api/authentication/sign_up';
 /**
  * Interface that represents the credentials returned by {@link EmailAuthProvider} for
@@ -128,7 +132,8 @@ export class EmailAuthCredential extends AuthCredential {
           auth,
           request,
           RecaptchaActionName.SIGN_IN_WITH_PASSWORD,
-          signInWithPassword
+          signInWithPassword,
+          RecaptchaAuthProvider.EMAIL_PASSWORD_PROVIDER
         );
       case SignInMethod.EMAIL_LINK:
         return signInWithEmailLink(auth, {
@@ -158,7 +163,8 @@ export class EmailAuthCredential extends AuthCredential {
           auth,
           request,
           RecaptchaActionName.SIGN_UP_PASSWORD,
-          linkEmailPassword
+          linkEmailPassword,
+          RecaptchaAuthProvider.EMAIL_PASSWORD_PROVIDER
         );
       case SignInMethod.EMAIL_LINK:
         return signInWithEmailLinkForLinking(auth, {

--- a/packages/auth/src/core/strategies/email_and_password.test.ts
+++ b/packages/auth/src/core/strategies/email_and_password.test.ts
@@ -74,6 +74,7 @@ describe('core/strategies/sendPasswordResetEmail', () => {
 
   beforeEach(async () => {
     auth = await testAuth();
+    auth.settings.appVerificationDisabledForTesting = false;
     mockFetch.setUp();
   });
 

--- a/packages/auth/src/core/strategies/email_and_password.ts
+++ b/packages/auth/src/core/strategies/email_and_password.ts
@@ -41,7 +41,11 @@ import { getModularInstance } from '@firebase/util';
 import { OperationType } from '../../model/enums';
 import { handleRecaptchaFlow } from '../../platform_browser/recaptcha/recaptcha_enterprise_verifier';
 import { IdTokenResponse } from '../../model/id_token';
-import { RecaptchaActionName, RecaptchaClientType } from '../../api';
+import {
+  RecaptchaActionName,
+  RecaptchaClientType,
+  RecaptchaAuthProvider
+} from '../../api';
 import { _isFirebaseServerApp } from '@firebase/app';
 
 /**
@@ -117,7 +121,8 @@ export async function sendPasswordResetEmail(
     authInternal,
     request,
     RecaptchaActionName.GET_OOB_CODE,
-    authentication.sendPasswordResetEmail
+    authentication.sendPasswordResetEmail,
+    RecaptchaAuthProvider.EMAIL_PASSWORD_PROVIDER
   );
 }
 
@@ -291,7 +296,8 @@ export async function createUserWithEmailAndPassword(
     authInternal,
     request,
     RecaptchaActionName.SIGN_UP_PASSWORD,
-    signUp
+    signUp,
+    RecaptchaAuthProvider.EMAIL_PASSWORD_PROVIDER
   );
   const response = await signUpResponse.catch(error => {
     if (

--- a/packages/auth/src/core/strategies/email_link.test.ts
+++ b/packages/auth/src/core/strategies/email_link.test.ts
@@ -58,6 +58,7 @@ describe('core/strategies/sendSignInLinkToEmail', () => {
 
   beforeEach(async () => {
     auth = await testAuth();
+    auth.settings.appVerificationDisabledForTesting = false;
     mockFetch.setUp();
   });
 

--- a/packages/auth/src/core/strategies/email_link.ts
+++ b/packages/auth/src/core/strategies/email_link.ts
@@ -33,7 +33,11 @@ import { _assert } from '../util/assert';
 import { getModularInstance } from '@firebase/util';
 import { _castAuth } from '../auth/auth_impl';
 import { handleRecaptchaFlow } from '../../platform_browser/recaptcha/recaptcha_enterprise_verifier';
-import { RecaptchaActionName, RecaptchaClientType } from '../../api';
+import {
+  RecaptchaActionName,
+  RecaptchaClientType,
+  RecaptchaAuthProvider
+} from '../../api';
 import { _isFirebaseServerApp } from '@firebase/app';
 import { _serverAppCurrentUserOperationNotSupportedError } from '../../core/util/assert';
 
@@ -108,7 +112,8 @@ export async function sendSignInLinkToEmail(
     authInternal,
     request,
     RecaptchaActionName.GET_OOB_CODE,
-    api.sendSignInLinkToEmail
+    api.sendSignInLinkToEmail,
+    RecaptchaAuthProvider.EMAIL_PASSWORD_PROVIDER
   );
 }
 

--- a/packages/auth/src/platform_browser/providers/phone.test.ts
+++ b/packages/auth/src/platform_browser/providers/phone.test.ts
@@ -64,7 +64,7 @@ describe('platform_browser/providers/phone', () => {
   context('#verifyPhoneNumber', () => {
     it('calls verify on the appVerifier and then calls the server when recaptcha enterprise is disabled', async () => {
       const recaptchaConfigResponseOff = {
-        recaptchaKey: 'foo/bar/to/site-key',
+        // no recaptcha key if no rCE provider is enabled
         recaptchaEnforcementState: [
           {
             provider: RecaptchaAuthProvider.PHONE_PROVIDER,
@@ -111,7 +111,7 @@ describe('platform_browser/providers/phone', () => {
 
     it('throws an error if verify without appVerifier when recaptcha enterprise is disabled', async () => {
       const recaptchaConfigResponseOff = {
-        recaptchaKey: 'foo/bar/to/site-key',
+        // no recaptcha key if no rCE provider is enabled
         recaptchaEnforcementState: [
           {
             provider: RecaptchaAuthProvider.PHONE_PROVIDER,

--- a/packages/auth/src/platform_browser/providers/phone.test.ts
+++ b/packages/auth/src/platform_browser/providers/phone.test.ts
@@ -18,19 +18,37 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 
-import { mockEndpoint } from '../../../test/helpers/api/helper';
+import {
+  mockEndpoint,
+  mockEndpointWithParams
+} from '../../../test/helpers/api/helper';
 import { testAuth, TestAuth } from '../../../test/helpers/mock_auth';
 import * as fetch from '../../../test/helpers/mock_fetch';
-import { Endpoint } from '../../api';
+import {
+  Endpoint,
+  RecaptchaClientType,
+  RecaptchaVersion,
+  RecaptchaAuthProvider,
+  EnforcementState
+} from '../../api';
 import { RecaptchaVerifier } from '../../platform_browser/recaptcha/recaptcha_verifier';
 import { PhoneAuthProvider } from './phone';
+import { FAKE_TOKEN } from '../recaptcha/recaptcha_enterprise_verifier';
+import { MockGreCAPTCHATopLevel } from '../recaptcha/recaptcha_mock';
+import { ApplicationVerifierInternal } from '../../model/application_verifier';
 
 describe('platform_browser/providers/phone', () => {
   let auth: TestAuth;
+  let v2Verifier: ApplicationVerifierInternal;
 
   beforeEach(async () => {
     fetch.setUp();
     auth = await testAuth();
+    auth.settings.appVerificationDisabledForTesting = false;
+    v2Verifier = new RecaptchaVerifier(auth, document.createElement('div'), {});
+    sinon
+      .stub(v2Verifier, 'verify')
+      .returns(Promise.resolve('verification-code'));
   });
 
   afterEach(() => {
@@ -39,26 +57,96 @@ describe('platform_browser/providers/phone', () => {
   });
 
   context('#verifyPhoneNumber', () => {
-    it('calls verify on the appVerifier and then calls the server', async () => {
+    it('calls verify on the appVerifier and then calls the server when recaptcha enterprise is disabled', async () => {
+      const recaptchaConfigResponseOff = {
+        recaptchaKey: 'foo/bar/to/site-key',
+        recaptchaEnforcementState: [
+          {
+            provider: RecaptchaAuthProvider.PHONE_PROVIDER,
+            enforcementState: EnforcementState.OFF
+          }
+        ]
+      };
+      const recaptcha = new MockGreCAPTCHATopLevel();
+      if (typeof window === 'undefined') {
+        return;
+      }
+      window.grecaptcha = recaptcha;
+      sinon
+        .stub(recaptcha.enterprise, 'execute')
+        .returns(Promise.resolve('enterprise-token'));
+
+      mockEndpointWithParams(
+        Endpoint.GET_RECAPTCHA_CONFIG,
+        {
+          clientType: RecaptchaClientType.WEB,
+          version: RecaptchaVersion.ENTERPRISE
+        },
+        recaptchaConfigResponseOff
+      );
+
       const route = mockEndpoint(Endpoint.SEND_VERIFICATION_CODE, {
         sessionInfo: 'verification-id'
       });
 
-      const verifier = new RecaptchaVerifier(
-        auth,
-        document.createElement('div'),
-        {}
-      );
-      sinon
-        .stub(verifier, 'verify')
-        .returns(Promise.resolve('verification-code'));
-
       const provider = new PhoneAuthProvider(auth);
-      const result = await provider.verifyPhoneNumber('+15105550000', verifier);
+      const result = await provider.verifyPhoneNumber(
+        '+15105550000',
+        v2Verifier
+      );
       expect(result).to.eq('verification-id');
       expect(route.calls[0].request).to.eql({
         phoneNumber: '+15105550000',
-        recaptchaToken: 'verification-code'
+        recaptchaToken: 'verification-code',
+        captchaResponse: FAKE_TOKEN,
+        clientType: RecaptchaClientType.WEB,
+        recaptchaVersion: RecaptchaVersion.ENTERPRISE
+      });
+    });
+
+    it('calls the server when recaptcha enterprise is enabled', async () => {
+      const recaptchaConfigResponseEnforce = {
+        recaptchaKey: 'foo/bar/to/site-key',
+        recaptchaEnforcementState: [
+          {
+            provider: RecaptchaAuthProvider.PHONE_PROVIDER,
+            enforcementState: EnforcementState.ENFORCE
+          }
+        ]
+      };
+      const recaptcha = new MockGreCAPTCHATopLevel();
+      if (typeof window === 'undefined') {
+        return;
+      }
+      window.grecaptcha = recaptcha;
+      sinon
+        .stub(recaptcha.enterprise, 'execute')
+        .returns(Promise.resolve('enterprise-token'));
+
+      mockEndpointWithParams(
+        Endpoint.GET_RECAPTCHA_CONFIG,
+        {
+          clientType: RecaptchaClientType.WEB,
+          version: RecaptchaVersion.ENTERPRISE
+        },
+        recaptchaConfigResponseEnforce
+      );
+
+      const route = mockEndpoint(Endpoint.SEND_VERIFICATION_CODE, {
+        sessionInfo: 'verification-id'
+      });
+
+      const provider = new PhoneAuthProvider(auth);
+      const result = await provider.verifyPhoneNumber(
+        '+15105550000',
+        v2Verifier
+      );
+      expect(result).to.eq('verification-id');
+      expect(route.calls[0].request).to.eql({
+        phoneNumber: '+15105550000',
+        captchaResponse: 'enterprise-token',
+        clientType: RecaptchaClientType.WEB,
+        recaptchaVersion: RecaptchaVersion.ENTERPRISE
       });
     });
   });

--- a/packages/auth/src/platform_browser/providers/phone.ts
+++ b/packages/auth/src/platform_browser/providers/phone.ts
@@ -104,7 +104,7 @@ export class PhoneAuthProvider {
    */
   verifyPhoneNumber(
     phoneOptions: PhoneInfoOptions | string,
-    applicationVerifier: ApplicationVerifier
+    applicationVerifier?: ApplicationVerifier
   ): Promise<string> {
     return _verifyPhoneNumber(
       this.auth,

--- a/packages/auth/src/platform_browser/providers/phone.ts
+++ b/packages/auth/src/platform_browser/providers/phone.ts
@@ -95,9 +95,10 @@ export class PhoneAuthProvider {
    *
    * @param phoneInfoOptions - The user's {@link PhoneInfoOptions}. The phone number should be in
    * E.164 format (e.g. +16505550101).
-   * @param applicationVerifier - For abuse prevention, this method also requires a
-   * {@link ApplicationVerifier}. This SDK includes a reCAPTCHA-based implementation,
-   * {@link RecaptchaVerifier}.
+   * @param applicationVerifier - For abuse prevention with reCAPTCHA v2, this method requires a
+   * {@link ApplicationVerifier}. This SDK includes a reCAPTCHA-v2-based implementation,
+   * {@link RecaptchaVerifier}. For abuse prevention with reCAPTCHA Enterprise,
+   * {@link ApplicationVerifier} is required in Audit mode but not in Enforce mode.
    *
    * @returns A Promise for a verification ID that can be passed to
    * {@link PhoneAuthProvider.credential} to identify this flow.

--- a/packages/auth/src/platform_browser/providers/phone.ts
+++ b/packages/auth/src/platform_browser/providers/phone.ts
@@ -95,10 +95,11 @@ export class PhoneAuthProvider {
    *
    * @param phoneInfoOptions - The user's {@link PhoneInfoOptions}. The phone number should be in
    * E.164 format (e.g. +16505550101).
-   * @param applicationVerifier - For abuse prevention with reCAPTCHA v2, this method requires a
-   * {@link ApplicationVerifier}. This SDK includes a reCAPTCHA-v2-based implementation,
-   * {@link RecaptchaVerifier}. For abuse prevention with reCAPTCHA Enterprise,
-   * {@link ApplicationVerifier} is required in Audit mode but not in Enforce mode.
+   * @param applicationVerifier - An {@link ApplicationVerifier}, which prevents
+   * requests from unauthorized clients. This SDK includes an implementation
+   * based on reCAPTCHA v2, {@link RecaptchaVerifier}. If you've enabled
+   * reCAPTCHA Enterprise bot protection in Enforce mode, this parameter is
+   * optional; in all other configurations, the parameter is required.
    *
    * @returns A Promise for a verification ID that can be passed to
    * {@link PhoneAuthProvider.credential} to identify this flow.

--- a/packages/auth/src/platform_browser/providers/phone.ts
+++ b/packages/auth/src/platform_browser/providers/phone.ts
@@ -100,7 +100,7 @@ export class PhoneAuthProvider {
    * {@link RecaptchaVerifier}.
    *
    * @returns A Promise for a verification ID that can be passed to
-   * {@link PhoneAuthProvider.credential} to identify this flow..
+   * {@link PhoneAuthProvider.credential} to identify this flow.
    */
   verifyPhoneNumber(
     phoneOptions: PhoneInfoOptions | string,

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha.test.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha.test.ts
@@ -29,7 +29,7 @@ import {
 
 import { isV2, isEnterprise, RecaptchaConfig } from './recaptcha';
 import { GetRecaptchaConfigResponse } from '../../api/authentication/recaptcha';
-import { EnforcementState, RecaptchaProvider } from '../../api/index';
+import { EnforcementState, RecaptchaAuthProvider } from '../../api/index';
 
 use(chaiAsPromised);
 use(sinonChai);
@@ -46,11 +46,11 @@ describe('platform_browser/recaptcha/recaptcha', () => {
     recaptchaKey: 'projects/testproj/keys/' + TEST_SITE_KEY,
     recaptchaEnforcementState: [
       {
-        provider: RecaptchaProvider.EMAIL_PASSWORD_PROVIDER,
+        provider: RecaptchaAuthProvider.EMAIL_PASSWORD_PROVIDER,
         enforcementState: EnforcementState.ENFORCE
       },
       {
-        provider: RecaptchaProvider.PHONE_PROVIDER,
+        provider: RecaptchaAuthProvider.PHONE_PROVIDER,
         enforcementState: EnforcementState.AUDIT
       }
     ]
@@ -60,11 +60,11 @@ describe('platform_browser/recaptcha/recaptcha', () => {
     recaptchaKey: 'projects/testproj/keys/' + TEST_SITE_KEY,
     recaptchaEnforcementState: [
       {
-        provider: RecaptchaProvider.EMAIL_PASSWORD_PROVIDER,
+        provider: RecaptchaAuthProvider.EMAIL_PASSWORD_PROVIDER,
         enforcementState: EnforcementState.OFF
       },
       {
-        provider: RecaptchaProvider.PHONE_PROVIDER,
+        provider: RecaptchaAuthProvider.PHONE_PROVIDER,
         enforcementState: EnforcementState.OFF
       }
     ]
@@ -75,11 +75,11 @@ describe('platform_browser/recaptcha/recaptcha', () => {
       recaptchaKey: 'projects/testproj/keys/' + TEST_SITE_KEY,
       recaptchaEnforcementState: [
         {
-          provider: RecaptchaProvider.EMAIL_PASSWORD_PROVIDER,
+          provider: RecaptchaAuthProvider.EMAIL_PASSWORD_PROVIDER,
           enforcementState: EnforcementState.ENFORCE
         },
         {
-          provider: RecaptchaProvider.PHONE_PROVIDER,
+          provider: RecaptchaAuthProvider.PHONE_PROVIDER,
           enforcementState: EnforcementState.OFF
         }
       ]
@@ -120,15 +120,15 @@ describe('platform_browser/recaptcha/recaptcha', () => {
     it('should construct the recaptcha config from the backend response', () => {
       expect(recaptchaConfig.siteKey).to.eq(TEST_SITE_KEY);
       expect(recaptchaConfig.recaptchaEnforcementState[0]).to.eql({
-        provider: RecaptchaProvider.EMAIL_PASSWORD_PROVIDER,
+        provider: RecaptchaAuthProvider.EMAIL_PASSWORD_PROVIDER,
         enforcementState: EnforcementState.ENFORCE
       });
       expect(recaptchaConfig.recaptchaEnforcementState[1]).to.eql({
-        provider: RecaptchaProvider.PHONE_PROVIDER,
+        provider: RecaptchaAuthProvider.PHONE_PROVIDER,
         enforcementState: EnforcementState.AUDIT
       });
       expect(recaptchaConfigEnforceAndOff.recaptchaEnforcementState[1]).to.eql({
-        provider: RecaptchaProvider.PHONE_PROVIDER,
+        provider: RecaptchaAuthProvider.PHONE_PROVIDER,
         enforcementState: EnforcementState.OFF
       });
     });
@@ -136,17 +136,17 @@ describe('platform_browser/recaptcha/recaptcha', () => {
     it('#getProviderEnforcementState should return the correct enforcement state of the provider', () => {
       expect(
         recaptchaConfig.getProviderEnforcementState(
-          RecaptchaProvider.EMAIL_PASSWORD_PROVIDER
+          RecaptchaAuthProvider.EMAIL_PASSWORD_PROVIDER
         )
       ).to.eq(EnforcementState.ENFORCE);
       expect(
         recaptchaConfig.getProviderEnforcementState(
-          RecaptchaProvider.PHONE_PROVIDER
+          RecaptchaAuthProvider.PHONE_PROVIDER
         )
       ).to.eq(EnforcementState.AUDIT);
       expect(
         recaptchaConfigEnforceAndOff.getProviderEnforcementState(
-          RecaptchaProvider.PHONE_PROVIDER
+          RecaptchaAuthProvider.PHONE_PROVIDER
         )
       ).to.eq(EnforcementState.OFF);
       expect(recaptchaConfig.getProviderEnforcementState('invalid-provider')).to
@@ -156,15 +156,15 @@ describe('platform_browser/recaptcha/recaptcha', () => {
     it('#isProviderEnabled should return the enablement state of the provider', () => {
       expect(
         recaptchaConfig.isProviderEnabled(
-          RecaptchaProvider.EMAIL_PASSWORD_PROVIDER
+          RecaptchaAuthProvider.EMAIL_PASSWORD_PROVIDER
         )
       ).to.be.true;
       expect(
-        recaptchaConfig.isProviderEnabled(RecaptchaProvider.PHONE_PROVIDER)
+        recaptchaConfig.isProviderEnabled(RecaptchaAuthProvider.PHONE_PROVIDER)
       ).to.be.true;
       expect(
         recaptchaConfigEnforceAndOff.isProviderEnabled(
-          RecaptchaProvider.PHONE_PROVIDER
+          RecaptchaAuthProvider.PHONE_PROVIDER
         )
       ).to.be.false;
       expect(recaptchaConfig.isProviderEnabled('invalid-provider')).to.be.false;

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha.ts
@@ -20,7 +20,11 @@ import {
   GetRecaptchaConfigResponse,
   RecaptchaEnforcementProviderState
 } from '../../api/authentication/recaptcha';
-import { EnforcementState, _parseEnforcementState } from '../../api/index';
+import {
+  EnforcementState,
+  RecaptchaProvider,
+  _parseEnforcementState
+} from '../../api/index';
 
 // reCAPTCHA v2 interface
 export interface Recaptcha {
@@ -133,6 +137,19 @@ export class RecaptchaConfig {
       this.getProviderEnforcementState(providerStr) ===
         EnforcementState.ENFORCE ||
       this.getProviderEnforcementState(providerStr) === EnforcementState.AUDIT
+    );
+  }
+
+  /**
+   * Returns true if reCAPTCHA Enterprise protection is enabled in at least one provider, otherwise
+   * returns false.
+   *
+   * @returns Whether or not reCAPTCHA Enterprise protection is enabled for at least one provider.
+   */
+  isAnyProviderEnabled(): boolean {
+    return (
+      this.isProviderEnabled(RecaptchaProvider.EMAIL_PASSWORD_PROVIDER) ||
+      this.isProviderEnabled(RecaptchaProvider.PHONE_PROVIDER)
     );
   }
 }

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha.ts
@@ -22,7 +22,7 @@ import {
 } from '../../api/authentication/recaptcha';
 import {
   EnforcementState,
-  RecaptchaProvider,
+  RecaptchaAuthProvider,
   _parseEnforcementState
 } from '../../api/index';
 
@@ -148,8 +148,8 @@ export class RecaptchaConfig {
    */
   isAnyProviderEnabled(): boolean {
     return (
-      this.isProviderEnabled(RecaptchaProvider.EMAIL_PASSWORD_PROVIDER) ||
-      this.isProviderEnabled(RecaptchaProvider.PHONE_PROVIDER)
+      this.isProviderEnabled(RecaptchaAuthProvider.EMAIL_PASSWORD_PROVIDER) ||
+      this.isProviderEnabled(RecaptchaAuthProvider.PHONE_PROVIDER)
     );
   }
 }

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
@@ -22,7 +22,8 @@ import {
   RecaptchaClientType,
   RecaptchaVersion,
   RecaptchaActionName,
-  RecaptchaProvider
+  RecaptchaAuthProvider,
+  EnforcementState
 } from '../../api';
 
 import { Auth } from '../../model/public_types';
@@ -32,6 +33,7 @@ import * as jsHelpers from '../load_js';
 import { AuthErrorCode } from '../../core/errors';
 import { StartPhoneMfaEnrollmentRequest } from '../../api/account_management/mfa';
 import { StartPhoneMfaSignInRequest } from '../../api/authentication/mfa';
+import { MockGreCAPTCHATopLevel } from './recaptcha_mock';
 
 export const RECAPTCHA_ENTERPRISE_VERIFIER_TYPE = 'recaptcha-enterprise';
 export const FAKE_TOKEN = 'NO_RECAPTCHA';
@@ -119,6 +121,12 @@ export class RecaptchaEnterpriseVerifier {
       } else {
         reject(Error('No reCAPTCHA enterprise script loaded.'));
       }
+    }
+
+    // Returns Promise for a mock token when appVerificationDisabledForTesting is true.
+    if (this.auth.settings.appVerificationDisabledForTesting) {
+      const mockRecaptcha = new MockGreCAPTCHATopLevel();
+      return mockRecaptcha.execute('siteKey', { action: 'verify' });
     }
 
     return new Promise<string>((resolve, reject) => {
@@ -226,7 +234,7 @@ export async function injectRecaptchaFields<T>(
 }
 
 type ActionMethod<TRequest, TResponse> = (
-  auth: Auth,
+  auth: AuthInternal,
   request: TRequest
 ) => Promise<TResponse>;
 
@@ -234,37 +242,104 @@ export async function handleRecaptchaFlow<TRequest, TResponse>(
   authInstance: AuthInternal,
   request: TRequest,
   actionName: RecaptchaActionName,
-  actionMethod: ActionMethod<TRequest, TResponse>
+  actionMethod: ActionMethod<TRequest, TResponse>,
+  recaptchaAuthProvider: RecaptchaAuthProvider
 ): Promise<TResponse> {
-  if (
-    authInstance
-      ._getRecaptchaConfig()
-      ?.isProviderEnabled(RecaptchaProvider.EMAIL_PASSWORD_PROVIDER)
-  ) {
-    const requestWithRecaptcha = await injectRecaptchaFields(
-      authInstance,
-      request,
-      actionName,
-      actionName === RecaptchaActionName.GET_OOB_CODE
-    );
-    return actionMethod(authInstance, requestWithRecaptcha);
+  if (recaptchaAuthProvider === RecaptchaAuthProvider.EMAIL_PASSWORD_PROVIDER) {
+    if (
+      authInstance
+        ._getRecaptchaConfig()
+        ?.isProviderEnabled(RecaptchaAuthProvider.EMAIL_PASSWORD_PROVIDER)
+    ) {
+      const requestWithRecaptcha = await injectRecaptchaFields(
+        authInstance,
+        request,
+        actionName,
+        actionName === RecaptchaActionName.GET_OOB_CODE
+      );
+      return actionMethod(authInstance, requestWithRecaptcha);
+    } else {
+      return actionMethod(authInstance, request).catch(async error => {
+        if (error.code === `auth/${AuthErrorCode.MISSING_RECAPTCHA_TOKEN}`) {
+          console.log(
+            `${actionName} is protected by reCAPTCHA Enterprise for this project. Automatically triggering the reCAPTCHA flow and restarting the flow.`
+          );
+          const requestWithRecaptcha = await injectRecaptchaFields(
+            authInstance,
+            request,
+            actionName,
+            actionName === RecaptchaActionName.GET_OOB_CODE
+          );
+          return actionMethod(authInstance, requestWithRecaptcha);
+        } else {
+          return Promise.reject(error);
+        }
+      });
+    }
+  } else if (recaptchaAuthProvider === RecaptchaAuthProvider.PHONE_PROVIDER) {
+    if (
+      authInstance
+        ._getRecaptchaConfig()
+        ?.isProviderEnabled(RecaptchaAuthProvider.PHONE_PROVIDER)
+    ) {
+      const requestWithRecaptcha = await injectRecaptchaFields(
+        authInstance,
+        request,
+        actionName
+      );
+
+      return actionMethod(authInstance, requestWithRecaptcha).catch(
+        async error => {
+          if (
+            authInstance
+              ._getRecaptchaConfig()
+              ?.getProviderEnforcementState(
+                RecaptchaAuthProvider.PHONE_PROVIDER
+              ) === EnforcementState.AUDIT
+          ) {
+            // AUDIT mode
+            if (
+              error.code === `auth/${AuthErrorCode.MISSING_RECAPTCHA_TOKEN}` ||
+              error.code === `auth/${AuthErrorCode.INVALID_APP_CREDENTIAL}`
+            ) {
+              console.log(
+                `Failed to verify with reCAPTCHA Enterprise. Automatically triggering the reCAPTCHA v2 flow to complete the ${actionName} flow.`
+              );
+              // reCAPTCHA Enterprise token is missing or reCAPTCHA Enterprise token
+              // check fails.
+              // Fallback to reCAPTCHA v2 flow.
+              const requestWithRecaptchaFields = await injectRecaptchaFields(
+                authInstance,
+                request,
+                actionName,
+                false, // isCaptchaResp
+                true // isFakeToken
+              );
+              // This will call the PhoneApiCaller to fetch and inject reCAPTCHA v2 token.
+              return actionMethod(authInstance, requestWithRecaptchaFields);
+            }
+          }
+          // ENFORCE mode or AUDIT mode with any other error.
+          return Promise.reject(error);
+        }
+      );
+    } else {
+      // Do reCAPTCHA v2 flow.
+      const requestWithRecaptchaFields = await injectRecaptchaFields(
+        authInstance,
+        request,
+        actionName,
+        false, // isCaptchaResp
+        true // isFakeToken
+      );
+
+      // This will call the PhoneApiCaller to fetch and inject v2 token.
+      return actionMethod(authInstance, requestWithRecaptchaFields);
+    }
   } else {
-    return actionMethod(authInstance, request).catch(async error => {
-      if (error.code === `auth/${AuthErrorCode.MISSING_RECAPTCHA_TOKEN}`) {
-        console.log(
-          `${actionName} is protected by reCAPTCHA Enterprise for this project. Automatically triggering the reCAPTCHA flow and restarting the flow.`
-        );
-        const requestWithRecaptcha = await injectRecaptchaFields(
-          authInstance,
-          request,
-          actionName,
-          actionName === RecaptchaActionName.GET_OOB_CODE
-        );
-        return actionMethod(authInstance, requestWithRecaptcha);
-      } else {
-        return Promise.reject(error);
-      }
-    });
+    return Promise.reject(
+      recaptchaAuthProvider + ' provider is not supported.'
+    );
   }
 }
 

--- a/packages/auth/src/platform_browser/strategies/phone.test.ts
+++ b/packages/auth/src/platform_browser/strategies/phone.test.ts
@@ -23,11 +23,21 @@ import sinonChai from 'sinon-chai';
 import { OperationType, ProviderId } from '../../model/enums';
 import { FirebaseError } from '@firebase/util';
 
-import { mockEndpoint } from '../../../test/helpers/api/helper';
+import {
+  mockEndpoint,
+  mockEndpointWithParams
+} from '../../../test/helpers/api/helper';
 import { makeJWT } from '../../../test/helpers/jwt';
 import { testAuth, testUser, TestAuth } from '../../../test/helpers/mock_auth';
 import * as fetch from '../../../test/helpers/mock_fetch';
-import { Endpoint } from '../../api';
+import { ServerError } from '../../api/errors';
+import {
+  Endpoint,
+  RecaptchaClientType,
+  RecaptchaVersion,
+  RecaptchaAuthProvider,
+  EnforcementState
+} from '../../api';
 import { MultiFactorInfoImpl } from '../../mfa/mfa_info';
 import { MultiFactorSessionImpl } from '../../mfa/mfa_session';
 import { multiFactor, MultiFactorUserImpl } from '../../mfa/mfa_user';
@@ -36,32 +46,103 @@ import { IdTokenResponse, IdTokenResponseKind } from '../../model/id_token';
 import { UserInternal } from '../../model/user';
 import { RecaptchaVerifier } from '../../platform_browser/recaptcha/recaptcha_verifier';
 import { PhoneAuthCredential } from '../../core/credentials/phone';
+import { FAKE_TOKEN } from '../recaptcha/recaptcha_enterprise_verifier';
+import { MockGreCAPTCHATopLevel } from '../../platform_browser/recaptcha/recaptcha_mock';
+
 import {
   _verifyPhoneNumber,
   linkWithPhoneNumber,
   reauthenticateWithPhoneNumber,
   signInWithPhoneNumber,
-  updatePhoneNumber
+  updatePhoneNumber,
+  injectRecaptchaV2Token
 } from './phone';
 
 use(chaiAsPromised);
 use(sinonChai);
 
+const RECAPTCHA_V2_TOKEN = 'v2-token';
+const RECAPTCHA_ENTERPRISE_TOKEN = 'enterprise-token';
+
+const recaptchaConfigResponseEnforce = {
+  recaptchaKey: 'foo/bar/to/site-key',
+  recaptchaEnforcementState: [
+    {
+      provider: RecaptchaAuthProvider.PHONE_PROVIDER,
+      enforcementState: EnforcementState.ENFORCE
+    }
+  ]
+};
+const recaptchaConfigResponseAudit = {
+  recaptchaKey: 'foo/bar/to/site-key',
+  recaptchaEnforcementState: [
+    {
+      provider: RecaptchaAuthProvider.PHONE_PROVIDER,
+      enforcementState: EnforcementState.AUDIT
+    }
+  ]
+};
+const recaptchaConfigResponseOff = {
+  recaptchaKey: 'foo/bar/to/site-key',
+  recaptchaEnforcementState: [
+    {
+      provider: RecaptchaAuthProvider.PHONE_PROVIDER,
+      enforcementState: EnforcementState.OFF
+    }
+  ]
+};
+
+function mockRecaptchaEnterpriseEnablement(
+  enablementState: EnforcementState
+): fetch.Route | undefined {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  let recaptchaConfigResponse = {};
+  if (enablementState === EnforcementState.ENFORCE) {
+    recaptchaConfigResponse = recaptchaConfigResponseEnforce;
+  } else if (enablementState === EnforcementState.AUDIT) {
+    recaptchaConfigResponse = recaptchaConfigResponseAudit;
+  } else {
+    recaptchaConfigResponse = recaptchaConfigResponseOff;
+  }
+
+  const recaptcha = new MockGreCAPTCHATopLevel();
+  window.grecaptcha = recaptcha;
+  sinon
+    .stub(recaptcha.enterprise, 'execute')
+    .returns(Promise.resolve(RECAPTCHA_ENTERPRISE_TOKEN));
+
+  return mockEndpointWithParams(
+    Endpoint.GET_RECAPTCHA_CONFIG,
+    {
+      clientType: RecaptchaClientType.WEB,
+      version: RecaptchaVersion.ENTERPRISE
+    },
+    recaptchaConfigResponse
+  );
+}
+
 describe('platform_browser/strategies/phone', () => {
   let auth: TestAuth;
-  let verifier: ApplicationVerifierInternal;
+  let v2Verifier: ApplicationVerifierInternal;
   let sendCodeEndpoint: fetch.Route;
 
   beforeEach(async () => {
     auth = await testAuth();
+    auth.settings.appVerificationDisabledForTesting = false;
     fetch.setUp();
 
     sendCodeEndpoint = mockEndpoint(Endpoint.SEND_VERIFICATION_CODE, {
       sessionInfo: 'session-info'
     });
 
-    verifier = new RecaptchaVerifier(auth, document.createElement('div'), {});
-    sinon.stub(verifier, 'verify').returns(Promise.resolve('recaptcha-token'));
+    v2Verifier = new RecaptchaVerifier(auth, document.createElement('div'), {});
+    sinon
+      .stub(v2Verifier, 'verify')
+      .returns(Promise.resolve(RECAPTCHA_V2_TOKEN));
+    mockRecaptchaEnterpriseEnablement(EnforcementState.OFF);
   });
 
   afterEach(() => {
@@ -70,22 +151,49 @@ describe('platform_browser/strategies/phone', () => {
   });
 
   describe('signInWithPhoneNumber', () => {
-    it('calls verify phone number', async () => {
-      await signInWithPhoneNumber(auth, '+15105550000', verifier);
+    it('calls verify phone number when recaptcha enterprise is disabled', async () => {
+      if (typeof window === 'undefined') {
+        return;
+      }
+      await signInWithPhoneNumber(auth, '+15105550000', v2Verifier);
 
       expect(sendCodeEndpoint.calls[0].request).to.eql({
-        recaptchaToken: 'recaptcha-token',
-        phoneNumber: '+15105550000'
+        recaptchaToken: RECAPTCHA_V2_TOKEN,
+        phoneNumber: '+15105550000',
+        captchaResponse: FAKE_TOKEN,
+        clientType: RecaptchaClientType.WEB,
+        recaptchaVersion: RecaptchaVersion.ENTERPRISE
+      });
+    });
+
+    it('calls verify phone number when recaptcha enterprise is enabled', async () => {
+      if (typeof window === 'undefined') {
+        return;
+      }
+      mockRecaptchaEnterpriseEnablement(EnforcementState.ENFORCE);
+      await signInWithPhoneNumber(auth, '+15105550000', v2Verifier);
+
+      expect(sendCodeEndpoint.calls[0].request).to.eql({
+        phoneNumber: '+15105550000',
+        captchaResponse: RECAPTCHA_ENTERPRISE_TOKEN,
+        clientType: RecaptchaClientType.WEB,
+        recaptchaVersion: RecaptchaVersion.ENTERPRISE
       });
     });
 
     context('ConfirmationResult', () => {
       it('result contains verification id baked in', async () => {
-        const result = await signInWithPhoneNumber(auth, 'number', verifier);
+        if (typeof window === 'undefined') {
+          return;
+        }
+        const result = await signInWithPhoneNumber(auth, 'number', v2Verifier);
         expect(result.verificationId).to.eq('session-info');
       });
 
       it('calling #confirm finishes the sign in flow', async () => {
+        if (typeof window === 'undefined') {
+          return;
+        }
         const idTokenResponse: IdTokenResponse = {
           idToken: 'my-id-token',
           refreshToken: 'my-refresh-token',
@@ -104,7 +212,7 @@ describe('platform_browser/strategies/phone', () => {
           users: [{ localId: 'uid' }]
         });
 
-        const result = await signInWithPhoneNumber(auth, 'number', verifier);
+        const result = await signInWithPhoneNumber(auth, 'number', v2Verifier);
         const userCred = await result.confirm('6789');
         expect(userCred.user.uid).to.eq('uid');
         expect(userCred.operationType).to.eq(OperationType.SIGN_IN);
@@ -129,6 +237,9 @@ describe('platform_browser/strategies/phone', () => {
     });
 
     it('rejects if a phone provider is already linked', async () => {
+      if (typeof window === 'undefined') {
+        return;
+      }
       getAccountInfoEndpoint.response = {
         users: [
           {
@@ -139,29 +250,56 @@ describe('platform_browser/strategies/phone', () => {
       };
 
       await expect(
-        linkWithPhoneNumber(user, 'number', verifier)
+        linkWithPhoneNumber(user, 'number', v2Verifier)
       ).to.be.rejectedWith(
         FirebaseError,
         'Firebase: User can only be linked to one identity for the given provider. (auth/provider-already-linked).'
       );
     });
 
-    it('calls verify phone number', async () => {
-      await linkWithPhoneNumber(user, '+15105550000', verifier);
+    it('calls verify phone number when recaptcha enterprise is disabled', async () => {
+      if (typeof window === 'undefined') {
+        return;
+      }
+      await linkWithPhoneNumber(user, '+15105550000', v2Verifier);
 
       expect(sendCodeEndpoint.calls[0].request).to.eql({
-        recaptchaToken: 'recaptcha-token',
-        phoneNumber: '+15105550000'
+        recaptchaToken: RECAPTCHA_V2_TOKEN,
+        phoneNumber: '+15105550000',
+        captchaResponse: FAKE_TOKEN,
+        clientType: RecaptchaClientType.WEB,
+        recaptchaVersion: RecaptchaVersion.ENTERPRISE
+      });
+    });
+
+    it('calls verify phone number when recaptcha enterprise is enabled', async () => {
+      if (typeof window === 'undefined') {
+        return;
+      }
+      mockRecaptchaEnterpriseEnablement(EnforcementState.ENFORCE);
+      await linkWithPhoneNumber(user, '+15105550000', v2Verifier);
+
+      expect(sendCodeEndpoint.calls[0].request).to.eql({
+        phoneNumber: '+15105550000',
+        captchaResponse: RECAPTCHA_ENTERPRISE_TOKEN,
+        clientType: RecaptchaClientType.WEB,
+        recaptchaVersion: RecaptchaVersion.ENTERPRISE
       });
     });
 
     context('ConfirmationResult', () => {
       it('result contains verification id baked in', async () => {
-        const result = await linkWithPhoneNumber(user, 'number', verifier);
+        if (typeof window === 'undefined') {
+          return;
+        }
+        const result = await linkWithPhoneNumber(user, 'number', v2Verifier);
         expect(result.verificationId).to.eq('session-info');
       });
 
       it('calling #confirm finishes the sign in flow', async () => {
+        if (typeof window === 'undefined') {
+          return;
+        }
         const idTokenResponse: IdTokenResponse = {
           idToken: 'my-id-token',
           refreshToken: 'my-refresh-token',
@@ -182,7 +320,7 @@ describe('platform_browser/strategies/phone', () => {
 
         const initialIdToken = await user.getIdToken();
 
-        const result = await linkWithPhoneNumber(user, 'number', verifier);
+        const result = await linkWithPhoneNumber(user, 'number', v2Verifier);
         const userCred = await result.confirm('6789');
         expect(userCred.user.uid).to.eq('uid');
         expect(userCred.operationType).to.eq(OperationType.LINK);
@@ -206,26 +344,53 @@ describe('platform_browser/strategies/phone', () => {
       user = testUser(auth, 'uid', 'email', true);
     });
 
-    it('calls verify phone number', async () => {
-      await reauthenticateWithPhoneNumber(user, '+15105550000', verifier);
+    it('calls verify phone number when recaptcha enterprise is disabled', async () => {
+      if (typeof window === 'undefined') {
+        return;
+      }
+      await reauthenticateWithPhoneNumber(user, '+15105550000', v2Verifier);
 
       expect(sendCodeEndpoint.calls[0].request).to.eql({
-        recaptchaToken: 'recaptcha-token',
-        phoneNumber: '+15105550000'
+        recaptchaToken: RECAPTCHA_V2_TOKEN,
+        phoneNumber: '+15105550000',
+        captchaResponse: FAKE_TOKEN,
+        clientType: RecaptchaClientType.WEB,
+        recaptchaVersion: RecaptchaVersion.ENTERPRISE
+      });
+    });
+
+    it('calls verify phone number when recaptcha enterprise is enabled', async () => {
+      if (typeof window === 'undefined') {
+        return;
+      }
+      mockRecaptchaEnterpriseEnablement(EnforcementState.ENFORCE);
+      await reauthenticateWithPhoneNumber(user, '+15105550000', v2Verifier);
+
+      expect(sendCodeEndpoint.calls[0].request).to.eql({
+        phoneNumber: '+15105550000',
+        captchaResponse: RECAPTCHA_ENTERPRISE_TOKEN,
+        clientType: RecaptchaClientType.WEB,
+        recaptchaVersion: RecaptchaVersion.ENTERPRISE
       });
     });
 
     context('ConfirmationResult', () => {
       it('result contains verification id baked in', async () => {
+        if (typeof window === 'undefined') {
+          return;
+        }
         const result = await reauthenticateWithPhoneNumber(
           user,
           'number',
-          verifier
+          v2Verifier
         );
         expect(result.verificationId).to.eq('session-info');
       });
 
       it('calling #confirm finishes the sign in flow', async () => {
+        if (typeof window === 'undefined') {
+          return;
+        }
         const idTokenResponse: IdTokenResponse = {
           idToken: makeJWT({ 'sub': 'uid' }),
           refreshToken: 'my-refresh-token',
@@ -247,7 +412,7 @@ describe('platform_browser/strategies/phone', () => {
         const result = await reauthenticateWithPhoneNumber(
           user,
           'number',
-          verifier
+          v2Verifier
         );
         const userCred = await result.confirm('6789');
         expect(userCred.user.uid).to.eq('uid');
@@ -260,6 +425,9 @@ describe('platform_browser/strategies/phone', () => {
       });
 
       it('rejects if the uid mismatches', async () => {
+        if (typeof window === 'undefined') {
+          return;
+        }
         const idTokenResponse: IdTokenResponse = {
           idToken: makeJWT({ 'sub': 'different-uid' }),
           refreshToken: 'my-refresh-token',
@@ -274,7 +442,7 @@ describe('platform_browser/strategies/phone', () => {
         const result = await reauthenticateWithPhoneNumber(
           user,
           'number',
-          verifier
+          v2Verifier
         );
         await expect(result.confirm('code')).to.be.rejectedWith(
           FirebaseError,
@@ -286,27 +454,161 @@ describe('platform_browser/strategies/phone', () => {
 
   describe('_verifyPhoneNumber', () => {
     it('works with a string phone number', async () => {
-      const sessionInfo = await _verifyPhoneNumber(auth, 'number', verifier);
+      if (typeof window === 'undefined') {
+        return;
+      }
+      const sessionInfo = await _verifyPhoneNumber(auth, 'number', v2Verifier);
       expect(sessionInfo).to.eq('session-info');
       expect(sendCodeEndpoint.calls[0].request).to.eql({
-        recaptchaToken: 'recaptcha-token',
-        phoneNumber: 'number'
+        recaptchaToken: RECAPTCHA_V2_TOKEN,
+        phoneNumber: 'number',
+        captchaResponse: FAKE_TOKEN,
+        clientType: RecaptchaClientType.WEB,
+        recaptchaVersion: RecaptchaVersion.ENTERPRISE
       });
     });
 
     it('works with an options object', async () => {
+      if (typeof window === 'undefined') {
+        return;
+      }
       const sessionInfo = await _verifyPhoneNumber(
         auth,
         {
           phoneNumber: 'number'
         },
-        verifier
+        v2Verifier
       );
       expect(sessionInfo).to.eq('session-info');
       expect(sendCodeEndpoint.calls[0].request).to.eql({
-        recaptchaToken: 'recaptcha-token',
-        phoneNumber: 'number'
+        recaptchaToken: RECAPTCHA_V2_TOKEN,
+        phoneNumber: 'number',
+        captchaResponse: FAKE_TOKEN,
+        clientType: RecaptchaClientType.WEB,
+        recaptchaVersion: RecaptchaVersion.ENTERPRISE
       });
+    });
+
+    it('works when recaptcha enterprise is enabled', async () => {
+      if (typeof window === 'undefined') {
+        return;
+      }
+      mockRecaptchaEnterpriseEnablement(EnforcementState.AUDIT);
+      const sessionInfo = await _verifyPhoneNumber(auth, 'number', v2Verifier);
+      expect(sessionInfo).to.eq('session-info');
+      expect(sendCodeEndpoint.calls[0].request).to.eql({
+        phoneNumber: 'number',
+        captchaResponse: RECAPTCHA_ENTERPRISE_TOKEN,
+        clientType: RecaptchaClientType.WEB,
+        recaptchaVersion: RecaptchaVersion.ENTERPRISE
+      });
+    });
+
+    it('calls fallback to recaptcha v2 flow when receiving MISSING_RECAPTCHA_TOKEN error in recaptcha enterprise audit mode', async () => {
+      if (typeof window === 'undefined') {
+        return;
+      }
+      mockRecaptchaEnterpriseEnablement(EnforcementState.AUDIT);
+      const failureMock = mockEndpoint(
+        Endpoint.SEND_VERIFICATION_CODE,
+        {
+          error: {
+            code: 400,
+            message: ServerError.MISSING_RECAPTCHA_TOKEN
+          }
+        },
+        400
+      );
+      await expect(
+        _verifyPhoneNumber(auth, 'number', v2Verifier)
+      ).to.be.rejectedWith(
+        'Firebase: The reCAPTCHA token is missing when sending request to the backend. (auth/missing-recaptcha-token).'
+      );
+      expect(failureMock.calls.length).to.eq(2);
+      // First call should have a recaptcha enterprise token
+      expect(failureMock.calls[0].request).to.eql({
+        phoneNumber: 'number',
+        captchaResponse: RECAPTCHA_ENTERPRISE_TOKEN,
+        clientType: RecaptchaClientType.WEB,
+        recaptchaVersion: RecaptchaVersion.ENTERPRISE
+      });
+      // Second call should have a recaptcha v2 token
+      expect(failureMock.calls[1].request).to.eql({
+        recaptchaToken: RECAPTCHA_V2_TOKEN,
+        phoneNumber: 'number',
+        captchaResponse: FAKE_TOKEN,
+        clientType: RecaptchaClientType.WEB,
+        recaptchaVersion: RecaptchaVersion.ENTERPRISE
+      });
+    });
+
+    it('calls fallback to recaptcha v2 flow when receiving INVALID_APP_CREDENTIAL error in recaptcha enterprise audit mode', async () => {
+      if (typeof window === 'undefined') {
+        return;
+      }
+      mockRecaptchaEnterpriseEnablement(EnforcementState.AUDIT);
+      const failureMock = mockEndpoint(
+        Endpoint.SEND_VERIFICATION_CODE,
+        {
+          error: {
+            code: 400,
+            message: ServerError.INVALID_APP_CREDENTIAL
+          }
+        },
+        400
+      );
+      await expect(
+        _verifyPhoneNumber(auth, 'number', v2Verifier)
+      ).to.be.rejectedWith(
+        'Firebase: The phone verification request contains an invalid application verifier. The reCAPTCHA token response is either invalid or expired. (auth/invalid-app-credential).'
+      );
+      expect(failureMock.calls.length).to.eq(2);
+      // First call should have a recaptcha enterprise token
+      expect(failureMock.calls[0].request).to.eql({
+        phoneNumber: 'number',
+        captchaResponse: RECAPTCHA_ENTERPRISE_TOKEN,
+        clientType: RecaptchaClientType.WEB,
+        recaptchaVersion: RecaptchaVersion.ENTERPRISE
+      });
+      // Second call should have a recaptcha v2 token
+      expect(failureMock.calls[1].request).to.eql({
+        recaptchaToken: RECAPTCHA_V2_TOKEN,
+        phoneNumber: 'number',
+        captchaResponse: FAKE_TOKEN,
+        clientType: RecaptchaClientType.WEB,
+        recaptchaVersion: RecaptchaVersion.ENTERPRISE
+      });
+    });
+
+    it('does not call fallback to recaptcha v2 flow when receiving other errors in recaptcha enterprise audit mode', async () => {
+      if (typeof window === 'undefined') {
+        return;
+      }
+      mockRecaptchaEnterpriseEnablement(EnforcementState.AUDIT);
+      const failureMock = mockEndpoint(
+        Endpoint.SEND_VERIFICATION_CODE,
+        {
+          error: {
+            code: 400,
+            message: ServerError.INVALID_RECAPTCHA_TOKEN
+          }
+        },
+        400
+      );
+      await expect(
+        _verifyPhoneNumber(auth, 'number', v2Verifier)
+      ).to.be.rejectedWith(
+        'Firebase: The reCAPTCHA token is invalid when sending request to the backend. (auth/invalid-recaptcha-token).'
+      );
+      // First call should have a recaptcha enterprise token
+      expect(failureMock.calls[0].request).to.eql({
+        phoneNumber: 'number',
+        captchaResponse: RECAPTCHA_ENTERPRISE_TOKEN,
+        clientType: RecaptchaClientType.WEB,
+        recaptchaVersion: RecaptchaVersion.ENTERPRISE
+      });
+      // No fallback to recaptcha v2 flow
+      expect(failureMock.calls.length).to.eq(1);
     });
 
     context('MFA', () => {
@@ -322,7 +624,10 @@ describe('platform_browser/strategies/phone', () => {
         mfaUser = multiFactor(user) as MultiFactorUserImpl;
       });
 
-      it('works with an enrollment flow', async () => {
+      it('works with an enrollment flow when recaptcha enterprise is disabled', async () => {
+        if (typeof window === 'undefined') {
+          return;
+        }
         const endpoint = mockEndpoint(Endpoint.START_MFA_ENROLLMENT, {
           phoneSessionInfo: {
             sessionInfo: 'session-info'
@@ -332,19 +637,53 @@ describe('platform_browser/strategies/phone', () => {
         const sessionInfo = await _verifyPhoneNumber(
           auth,
           { phoneNumber: 'number', session },
-          verifier
+          v2Verifier
         );
         expect(sessionInfo).to.eq('session-info');
         expect(endpoint.calls[0].request).to.eql({
           idToken: session.credential,
           phoneEnrollmentInfo: {
             phoneNumber: 'number',
-            recaptchaToken: 'recaptcha-token'
+            recaptchaToken: RECAPTCHA_V2_TOKEN,
+            captchaResponse: FAKE_TOKEN,
+            clientType: RecaptchaClientType.WEB,
+            recaptchaVersion: RecaptchaVersion.ENTERPRISE
           }
         });
       });
 
-      it('works when completing the sign in flow', async () => {
+      it('works with an enrollment flow when recaptcha enterprise is enabled', async () => {
+        if (typeof window === 'undefined') {
+          return;
+        }
+        mockRecaptchaEnterpriseEnablement(EnforcementState.ENFORCE);
+        const endpoint = mockEndpoint(Endpoint.START_MFA_ENROLLMENT, {
+          phoneSessionInfo: {
+            sessionInfo: 'session-info'
+          }
+        });
+        const session = (await mfaUser.getSession()) as MultiFactorSessionImpl;
+        const sessionInfo = await _verifyPhoneNumber(
+          auth,
+          { phoneNumber: 'number', session },
+          v2Verifier
+        );
+        expect(sessionInfo).to.eq('session-info');
+        expect(endpoint.calls[0].request).to.eql({
+          idToken: session.credential,
+          phoneEnrollmentInfo: {
+            phoneNumber: 'number',
+            captchaResponse: RECAPTCHA_ENTERPRISE_TOKEN,
+            clientType: RecaptchaClientType.WEB,
+            recaptchaVersion: RecaptchaVersion.ENTERPRISE
+          }
+        });
+      });
+
+      it('works when completing the sign in flow and recaptcha enterprise is disabled', async () => {
+        if (typeof window === 'undefined') {
+          return;
+        }
         const endpoint = mockEndpoint(Endpoint.START_MFA_SIGN_IN, {
           phoneResponseInfo: {
             sessionInfo: 'session-info'
@@ -364,30 +703,77 @@ describe('platform_browser/strategies/phone', () => {
             session,
             multiFactorHint: mfaInfo
           },
-          verifier
+          v2Verifier
         );
         expect(sessionInfo).to.eq('session-info');
         expect(endpoint.calls[0].request).to.eql({
           mfaPendingCredential: 'mfa-pending-credential',
           mfaEnrollmentId: 'mfa-enrollment-id',
           phoneSignInInfo: {
-            recaptchaToken: 'recaptcha-token'
+            recaptchaToken: RECAPTCHA_V2_TOKEN,
+            captchaResponse: FAKE_TOKEN,
+            clientType: RecaptchaClientType.WEB,
+            recaptchaVersion: RecaptchaVersion.ENTERPRISE
+          }
+        });
+      });
+
+      it('works when completing the sign in flow and recaptcha enterprise is enabled', async () => {
+        if (typeof window === 'undefined') {
+          return;
+        }
+        mockRecaptchaEnterpriseEnablement(EnforcementState.ENFORCE);
+        const endpoint = mockEndpoint(Endpoint.START_MFA_SIGN_IN, {
+          phoneResponseInfo: {
+            sessionInfo: 'session-info'
+          }
+        });
+        const session = MultiFactorSessionImpl._fromMfaPendingCredential(
+          'mfa-pending-credential'
+        );
+        const mfaInfo = MultiFactorInfoImpl._fromServerResponse(auth, {
+          mfaEnrollmentId: 'mfa-enrollment-id',
+          enrolledAt: Date.now(),
+          phoneInfo: 'phone-number-from-enrollment'
+        });
+        const sessionInfo = await _verifyPhoneNumber(
+          auth,
+          {
+            session,
+            multiFactorHint: mfaInfo
+          },
+          v2Verifier
+        );
+        expect(sessionInfo).to.eq('session-info');
+        expect(endpoint.calls[0].request).to.eql({
+          mfaPendingCredential: 'mfa-pending-credential',
+          mfaEnrollmentId: 'mfa-enrollment-id',
+          phoneSignInInfo: {
+            captchaResponse: RECAPTCHA_ENTERPRISE_TOKEN,
+            clientType: RecaptchaClientType.WEB,
+            recaptchaVersion: RecaptchaVersion.ENTERPRISE
           }
         });
       });
     });
 
-    it('throws if the verifier does not return a string', async () => {
-      (verifier.verify as sinon.SinonStub).returns(Promise.resolve(123));
+    it('throws if the v2Verifier does not return a string', async () => {
+      if (typeof window === 'undefined') {
+        return;
+      }
+      (v2Verifier.verify as sinon.SinonStub).returns(Promise.resolve(123));
       await expect(
-        _verifyPhoneNumber(auth, 'number', verifier)
+        _verifyPhoneNumber(auth, 'number', v2Verifier)
       ).to.be.rejectedWith(FirebaseError, 'auth/argument-error');
     });
 
-    it('throws if the verifier type is not recaptcha', async () => {
+    it('throws if the v2Verifier type is not recaptcha', async () => {
+      if (typeof window === 'undefined') {
+        return;
+      }
       const mutVerifier: {
         -readonly [K in keyof ApplicationVerifierInternal]: ApplicationVerifierInternal[K];
-      } = verifier;
+      } = v2Verifier;
       mutVerifier.type = 'not-recaptcha-thats-for-sure';
       await expect(
         _verifyPhoneNumber(auth, 'number', mutVerifier)
@@ -395,19 +781,26 @@ describe('platform_browser/strategies/phone', () => {
     });
 
     it('resets the verifier after successful verification', async () => {
-      sinon.spy(verifier, '_reset');
-      expect(await _verifyPhoneNumber(auth, 'number', verifier)).to.eq(
+      if (typeof window === 'undefined') {
+        return;
+      }
+      sinon.spy(v2Verifier, '_reset');
+      expect(await _verifyPhoneNumber(auth, 'number', v2Verifier)).to.eq(
         'session-info'
       );
-      expect(verifier._reset).to.have.been.called;
+      expect(v2Verifier._reset).to.have.been.called;
     });
 
     it('resets the verifier after a failed verification', async () => {
-      sinon.spy(verifier, '_reset');
-      (verifier.verify as sinon.SinonStub).returns(Promise.resolve(123));
+      if (typeof window === 'undefined') {
+        return;
+      }
+      sinon.spy(v2Verifier, '_reset');
+      (v2Verifier.verify as sinon.SinonStub).returns(Promise.resolve(123));
 
-      await expect(_verifyPhoneNumber(auth, 'number', verifier)).to.be.rejected;
-      expect(verifier._reset).to.have.been.called;
+      await expect(_verifyPhoneNumber(auth, 'number', v2Verifier)).to.be
+        .rejected;
+      expect(v2Verifier._reset).to.have.been.called;
     });
   });
 
@@ -453,6 +846,92 @@ describe('platform_browser/strategies/phone', () => {
     it('should reload the user', async () => {
       await updatePhoneNumber(user, credential);
       expect(reloadMock.calls.length).to.eq(1);
+    });
+  });
+
+  describe('#injectRecaptchaV2Token', () => {
+    it('injects recaptcha v2 token into SendPhoneVerificationCode request', async () => {
+      const request = {
+        phoneNumber: '123456',
+        clientType: RecaptchaClientType.WEB,
+        captchaResponse: RECAPTCHA_ENTERPRISE_TOKEN,
+        recaptchaVersion: RecaptchaVersion.ENTERPRISE
+      };
+
+      const requestWithV2Token = await injectRecaptchaV2Token(
+        auth,
+        request,
+        v2Verifier
+      );
+
+      const expectedRequest = {
+        phoneNumber: '123456',
+        recaptchaToken: RECAPTCHA_V2_TOKEN,
+        clientType: RecaptchaClientType.WEB,
+        captchaResponse: RECAPTCHA_ENTERPRISE_TOKEN,
+        recaptchaVersion: RecaptchaVersion.ENTERPRISE
+      };
+      expect(requestWithV2Token).to.eql(expectedRequest);
+    });
+
+    it('injects recaptcha v2 token into StartPhoneMfaEnrollment request', async () => {
+      const request = {
+        idToken: 'idToken',
+        phoneEnrollmentInfo: {
+          phoneNumber: '123456',
+          captchaResponse: RECAPTCHA_ENTERPRISE_TOKEN,
+          clientType: RecaptchaClientType.WEB,
+          recaptchaVersion: RecaptchaVersion.ENTERPRISE
+        }
+      };
+
+      const requestWithRecaptcha = await injectRecaptchaV2Token(
+        auth,
+        request,
+        v2Verifier
+      );
+
+      const expectedRequest = {
+        idToken: 'idToken',
+        phoneEnrollmentInfo: {
+          phoneNumber: '123456',
+          recaptchaToken: RECAPTCHA_V2_TOKEN,
+          captchaResponse: RECAPTCHA_ENTERPRISE_TOKEN,
+          clientType: RecaptchaClientType.WEB,
+          recaptchaVersion: RecaptchaVersion.ENTERPRISE
+        }
+      };
+      expect(requestWithRecaptcha).to.eql(expectedRequest);
+    });
+
+    it('injects recaptcha enterprise fields into StartPhoneMfaSignInRequest request', async () => {
+      const request = {
+        mfaPendingCredential: 'mfaPendingCredential',
+        mfaEnrollmentId: 'mfaEnrollmentId',
+        phoneSignInInfo: {
+          captchaResponse: RECAPTCHA_ENTERPRISE_TOKEN,
+          clientType: RecaptchaClientType.WEB,
+          recaptchaVersion: RecaptchaVersion.ENTERPRISE
+        }
+      };
+
+      const requestWithRecaptcha = await injectRecaptchaV2Token(
+        auth,
+        request,
+        v2Verifier
+      );
+
+      const expectedRequest = {
+        mfaPendingCredential: 'mfaPendingCredential',
+        mfaEnrollmentId: 'mfaEnrollmentId',
+        phoneSignInInfo: {
+          recaptchaToken: RECAPTCHA_V2_TOKEN,
+          captchaResponse: RECAPTCHA_ENTERPRISE_TOKEN,
+          clientType: RecaptchaClientType.WEB,
+          recaptchaVersion: RecaptchaVersion.ENTERPRISE
+        }
+      };
+      expect(requestWithRecaptcha).to.eql(expectedRequest);
     });
   });
 });

--- a/packages/auth/src/platform_browser/strategies/phone.test.ts
+++ b/packages/auth/src/platform_browser/strategies/phone.test.ts
@@ -83,7 +83,7 @@ const recaptchaConfigResponseAudit = {
   ]
 };
 const recaptchaConfigResponseOff = {
-  recaptchaKey: 'foo/bar/to/site-key',
+  // no recaptcha key if no rCE provider is enabled
   recaptchaEnforcementState: [
     {
       provider: RecaptchaAuthProvider.PHONE_PROVIDER,

--- a/packages/auth/src/platform_browser/strategies/phone.ts
+++ b/packages/auth/src/platform_browser/strategies/phone.ts
@@ -267,12 +267,8 @@ export async function _verifyPhoneNumber(
           authInstance: AuthInternal,
           request: StartPhoneMfaEnrollmentRequest
         ) => {
-          // If reCAPTCHA Enterprise token is empty or "NO_RECAPTCHA", fetch reCAPTCHA v2 token and inject into request.
-          if (
-            !request.phoneEnrollmentInfo.captchaResponse ||
-            request.phoneEnrollmentInfo.captchaResponse.length === 0 ||
-            request.phoneEnrollmentInfo.captchaResponse === FAKE_TOKEN
-          ) {
+          // If reCAPTCHA Enterprise token is FAKE_TOKEN, fetch reCAPTCHA v2 token and inject into request.
+          if (request.phoneEnrollmentInfo.captchaResponse === FAKE_TOKEN) {
             _assert(
               verifier?.type === RECAPTCHA_VERIFIER_TYPE,
               authInstance,
@@ -329,12 +325,8 @@ export async function _verifyPhoneNumber(
           authInstance: AuthInternal,
           request: StartPhoneMfaSignInRequest
         ) => {
-          // If reCAPTCHA Enterprise token is empty or "NO_RECAPTCHA", fetch reCAPTCHA v2 token and inject into request.
-          if (
-            !request.phoneSignInInfo.captchaResponse ||
-            request.phoneSignInInfo.captchaResponse.length === 0 ||
-            request.phoneSignInInfo.captchaResponse === FAKE_TOKEN
-          ) {
+          // If reCAPTCHA Enterprise token is FAKE_TOKEN, fetch reCAPTCHA v2 token and inject into request.
+          if (request.phoneSignInInfo.captchaResponse === FAKE_TOKEN) {
             _assert(
               verifier?.type === RECAPTCHA_VERIFIER_TYPE,
               authInstance,
@@ -380,12 +372,8 @@ export async function _verifyPhoneNumber(
         authInstance: AuthInternal,
         request: SendPhoneVerificationCodeRequest
       ) => {
-        // If reCAPTCHA Enterprise token is empty or "NO_RECAPTCHA", fetch reCAPTCHA v2 token and inject into request.
-        if (
-          !request.captchaResponse ||
-          request.captchaResponse.length === 0 ||
-          request.captchaResponse === FAKE_TOKEN
-        ) {
+        // If reCAPTCHA Enterprise token is FAKE_TOKEN, fetch reCAPTCHA v2 token and inject into request.
+        if (request.captchaResponse === FAKE_TOKEN) {
           _assert(
             verifier?.type === RECAPTCHA_VERIFIER_TYPE,
             authInstance,

--- a/packages/auth/src/platform_browser/strategies/phone.ts
+++ b/packages/auth/src/platform_browser/strategies/phone.ts
@@ -24,9 +24,26 @@ import {
   UserCredential
 } from '../../model/public_types';
 
-import { startEnrollPhoneMfa } from '../../api/account_management/mfa';
-import { startSignInPhoneMfa } from '../../api/authentication/mfa';
-import { sendPhoneVerificationCode } from '../../api/authentication/sms';
+import {
+  startEnrollPhoneMfa,
+  StartPhoneMfaEnrollmentRequest,
+  StartPhoneMfaEnrollmentResponse
+} from '../../api/account_management/mfa';
+import {
+  startSignInPhoneMfa,
+  StartPhoneMfaSignInRequest,
+  StartPhoneMfaSignInResponse
+} from '../../api/authentication/mfa';
+import {
+  sendPhoneVerificationCode,
+  SendPhoneVerificationCodeRequest,
+  SendPhoneVerificationCodeResponse
+} from '../../api/authentication/sms';
+import {
+  RecaptchaActionName,
+  RecaptchaClientType,
+  RecaptchaAuthProvider
+} from '../../api';
 import { ApplicationVerifierInternal } from '../../model/application_verifier';
 import { PhoneAuthCredential } from '../../core/credentials/phone';
 import { AuthErrorCode } from '../../core/errors';
@@ -50,6 +67,11 @@ import { RECAPTCHA_VERIFIER_TYPE } from '../recaptcha/recaptcha_verifier';
 import { _castAuth } from '../../core/auth/auth_impl';
 import { getModularInstance } from '@firebase/util';
 import { ProviderId } from '../../model/enums';
+import {
+  RecaptchaEnterpriseVerifier,
+  FAKE_TOKEN,
+  handleRecaptchaFlow
+} from '../recaptcha/recaptcha_enterprise_verifier';
 import { _isFirebaseServerApp } from '@firebase/app';
 
 interface OnConfirmationCallback {
@@ -190,6 +212,11 @@ export async function reauthenticateWithPhoneNumber(
   );
 }
 
+type PhoneApiCaller<TRequest, TResponse> = (
+  auth: AuthInternal,
+  request: TRequest
+) => Promise<TResponse>;
+
 /**
  * Returns a verification ID to be used in conjunction with the SMS code that is sent.
  *
@@ -199,20 +226,12 @@ export async function _verifyPhoneNumber(
   options: PhoneInfoOptions | string,
   verifier: ApplicationVerifierInternal
 ): Promise<string> {
-  const recaptchaToken = await verifier.verify();
+  if (!auth._getRecaptchaConfig()) {
+    const enterpriseVerifier = new RecaptchaEnterpriseVerifier(auth);
+    await enterpriseVerifier.verify();
+  }
 
   try {
-    _assert(
-      typeof recaptchaToken === 'string',
-      auth,
-      AuthErrorCode.ARGUMENT_ERROR
-    );
-    _assert(
-      verifier.type === RECAPTCHA_VERIFIER_TYPE,
-      auth,
-      AuthErrorCode.ARGUMENT_ERROR
-    );
-
     let phoneInfoOptions: PhoneInfoOptions;
 
     if (typeof options === 'string') {
@@ -232,13 +251,57 @@ export async function _verifyPhoneNumber(
           auth,
           AuthErrorCode.INTERNAL_ERROR
         );
-        const response = await startEnrollPhoneMfa(auth, {
+
+        const startPhoneMfaEnrollmentRequest: StartPhoneMfaEnrollmentRequest = {
           idToken: session.credential,
           phoneEnrollmentInfo: {
             phoneNumber: phoneInfoOptions.phoneNumber,
-            recaptchaToken
+            clientType: RecaptchaClientType.WEB
           }
+        };
+
+        const startEnrollPhoneMfaActionCallback: PhoneApiCaller<
+          StartPhoneMfaEnrollmentRequest,
+          StartPhoneMfaEnrollmentResponse
+        > = async (
+          authInstance: AuthInternal,
+          request: StartPhoneMfaEnrollmentRequest
+        ) => {
+          // If reCAPTCHA Enterprise token is empty or "NO_RECAPTCHA", fetch reCAPTCHA v2 token and inject into request.
+          if (
+            !request.phoneEnrollmentInfo.captchaResponse ||
+            request.phoneEnrollmentInfo.captchaResponse.length === 0 ||
+            request.phoneEnrollmentInfo.captchaResponse === FAKE_TOKEN
+          ) {
+            _assert(
+              verifier.type === RECAPTCHA_VERIFIER_TYPE,
+              authInstance,
+              AuthErrorCode.ARGUMENT_ERROR
+            );
+
+            const requestWithRecaptchaV2 = await injectRecaptchaV2Token(
+              authInstance,
+              request,
+              verifier
+            );
+            return startEnrollPhoneMfa(authInstance, requestWithRecaptchaV2);
+          }
+          return startEnrollPhoneMfa(authInstance, request);
+        };
+
+        const startPhoneMfaEnrollmentResponse: Promise<StartPhoneMfaEnrollmentResponse> =
+          handleRecaptchaFlow(
+            auth,
+            startPhoneMfaEnrollmentRequest,
+            RecaptchaActionName.MFA_SMS_ENROLLMENT,
+            startEnrollPhoneMfaActionCallback,
+            RecaptchaAuthProvider.PHONE_PROVIDER
+          );
+
+        const response = await startPhoneMfaEnrollmentResponse.catch(error => {
+          return Promise.reject(error);
         });
+
         return response.phoneSessionInfo.sessionInfo;
       } else {
         _assert(
@@ -250,21 +313,112 @@ export async function _verifyPhoneNumber(
           phoneInfoOptions.multiFactorHint?.uid ||
           phoneInfoOptions.multiFactorUid;
         _assert(mfaEnrollmentId, auth, AuthErrorCode.MISSING_MFA_INFO);
-        const response = await startSignInPhoneMfa(auth, {
+
+        const startPhoneMfaSignInRequest: StartPhoneMfaSignInRequest = {
           mfaPendingCredential: session.credential,
           mfaEnrollmentId,
           phoneSignInInfo: {
-            recaptchaToken
+            clientType: RecaptchaClientType.WEB
           }
+        };
+
+        const startSignInPhoneMfaActionCallback: PhoneApiCaller<
+          StartPhoneMfaSignInRequest,
+          StartPhoneMfaSignInResponse
+        > = async (
+          authInstance: AuthInternal,
+          request: StartPhoneMfaSignInRequest
+        ) => {
+          // If reCAPTCHA Enterprise token is empty or "NO_RECAPTCHA", fetch v2 token and inject into request.
+          if (
+            !request.phoneSignInInfo.captchaResponse ||
+            request.phoneSignInInfo.captchaResponse.length === 0 ||
+            request.phoneSignInInfo.captchaResponse === FAKE_TOKEN
+          ) {
+            _assert(
+              verifier.type === RECAPTCHA_VERIFIER_TYPE,
+              authInstance,
+              AuthErrorCode.ARGUMENT_ERROR
+            );
+
+            const requestWithRecaptchaV2 = await injectRecaptchaV2Token(
+              authInstance,
+              request,
+              verifier
+            );
+            return startSignInPhoneMfa(authInstance, requestWithRecaptchaV2);
+          }
+          return startSignInPhoneMfa(authInstance, request);
+        };
+
+        const startPhoneMfaSignInResponse: Promise<StartPhoneMfaSignInResponse> =
+          handleRecaptchaFlow(
+            auth,
+            startPhoneMfaSignInRequest,
+            RecaptchaActionName.MFA_SMS_SIGNIN,
+            startSignInPhoneMfaActionCallback,
+            RecaptchaAuthProvider.PHONE_PROVIDER
+          );
+
+        const response = await startPhoneMfaSignInResponse.catch(error => {
+          return Promise.reject(error);
         });
+
         return response.phoneResponseInfo.sessionInfo;
       }
     } else {
-      const { sessionInfo } = await sendPhoneVerificationCode(auth, {
-        phoneNumber: phoneInfoOptions.phoneNumber,
-        recaptchaToken
+      const sendPhoneVerificationCodeRequest: SendPhoneVerificationCodeRequest =
+        {
+          phoneNumber: phoneInfoOptions.phoneNumber,
+          clientType: RecaptchaClientType.WEB
+        };
+
+      const sendPhoneVerificationCodeActionCallback: PhoneApiCaller<
+        SendPhoneVerificationCodeRequest,
+        SendPhoneVerificationCodeResponse
+      > = async (
+        authInstance: AuthInternal,
+        request: SendPhoneVerificationCodeRequest
+      ) => {
+        // If reCAPTCHA Enterprise token is empty or "NO_RECAPTCHA", fetch v2 token and inject into request.
+        if (
+          !request.captchaResponse ||
+          request.captchaResponse.length === 0 ||
+          request.captchaResponse === FAKE_TOKEN
+        ) {
+          _assert(
+            verifier.type === RECAPTCHA_VERIFIER_TYPE,
+            authInstance,
+            AuthErrorCode.ARGUMENT_ERROR
+          );
+
+          const requestWithRecaptchaV2 = await injectRecaptchaV2Token(
+            authInstance,
+            request,
+            verifier
+          );
+          return sendPhoneVerificationCode(
+            authInstance,
+            requestWithRecaptchaV2
+          );
+        }
+        return sendPhoneVerificationCode(authInstance, request);
+      };
+
+      const sendPhoneVerificationCodeResponse: Promise<SendPhoneVerificationCodeResponse> =
+        handleRecaptchaFlow(
+          auth,
+          sendPhoneVerificationCodeRequest,
+          RecaptchaActionName.SEND_VERIFICATION_CODE,
+          sendPhoneVerificationCodeActionCallback,
+          RecaptchaAuthProvider.PHONE_PROVIDER
+        );
+
+      const response = await sendPhoneVerificationCodeResponse.catch(error => {
+        return Promise.reject(error);
       });
-      return sessionInfo;
+
+      return response.sessionInfo;
     }
   } finally {
     verifier._reset();
@@ -305,4 +459,76 @@ export async function updatePhoneNumber(
     );
   }
   await _link(userInternal, credential);
+}
+
+// Helper function that fetches and injects a reCAPTCHA v2 token into the request.
+export async function injectRecaptchaV2Token<T>(
+  auth: AuthInternal,
+  request: T,
+  recaptchaV2Verifier: ApplicationVerifierInternal
+): Promise<T> {
+  _assert(
+    recaptchaV2Verifier.type === RECAPTCHA_VERIFIER_TYPE,
+    auth,
+    AuthErrorCode.ARGUMENT_ERROR
+  );
+
+  const recaptchaV2Token = await recaptchaV2Verifier.verify();
+
+  _assert(
+    typeof recaptchaV2Token === 'string',
+    auth,
+    AuthErrorCode.ARGUMENT_ERROR
+  );
+
+  const newRequest = { ...request };
+
+  if ('phoneEnrollmentInfo' in newRequest) {
+    const phoneNumber = (
+      newRequest as unknown as StartPhoneMfaEnrollmentRequest
+    ).phoneEnrollmentInfo.phoneNumber;
+    const captchaResponse = (
+      newRequest as unknown as StartPhoneMfaEnrollmentRequest
+    ).phoneEnrollmentInfo.captchaResponse;
+    const clientType = (newRequest as unknown as StartPhoneMfaEnrollmentRequest)
+      .phoneEnrollmentInfo.clientType;
+    const recaptchaVersion = (
+      newRequest as unknown as StartPhoneMfaEnrollmentRequest
+    ).phoneEnrollmentInfo.recaptchaVersion;
+
+    Object.assign(newRequest, {
+      'phoneEnrollmentInfo': {
+        phoneNumber,
+        recaptchaToken: recaptchaV2Token,
+        captchaResponse,
+        clientType,
+        recaptchaVersion
+      }
+    });
+
+    return newRequest;
+  } else if ('phoneSignInInfo' in newRequest) {
+    const captchaResponse = (
+      newRequest as unknown as StartPhoneMfaSignInRequest
+    ).phoneSignInInfo.captchaResponse;
+    const clientType = (newRequest as unknown as StartPhoneMfaSignInRequest)
+      .phoneSignInInfo.clientType;
+    const recaptchaVersion = (
+      newRequest as unknown as StartPhoneMfaSignInRequest
+    ).phoneSignInInfo.recaptchaVersion;
+
+    Object.assign(newRequest, {
+      'phoneSignInInfo': {
+        recaptchaToken: recaptchaV2Token,
+        captchaResponse,
+        clientType,
+        recaptchaVersion
+      }
+    });
+
+    return newRequest;
+  } else {
+    Object.assign(newRequest, { 'recaptchaToken': recaptchaV2Token });
+    return newRequest;
+  }
 }

--- a/packages/auth/src/platform_browser/strategies/phone.ts
+++ b/packages/auth/src/platform_browser/strategies/phone.ts
@@ -102,14 +102,14 @@ class ConfirmationResultImpl implements ConfirmationResult {
  * provides the code sent to their phone, call {@link ConfirmationResult.confirm}
  * with the code to sign the user in.
  *
- * For abuse prevention with reCAPTCHA v2, this method requires a {@link ApplicationVerifier}.
- * This SDK includes a reCAPTCHA-v2-based implementation, {@link RecaptchaVerifier}.
+ * For abuse prevention, this method requires a {@link ApplicationVerifier}.
+ * This SDK includes an implementation based on reCAPTCHA v2, {@link RecaptchaVerifier}.
  * This function can work on other platforms that do not support the
  * {@link RecaptchaVerifier} (like React Native), but you need to use a
  * third-party {@link ApplicationVerifier} implementation.
  *
- * For abuse prevention with reCAPTCHA Enterprise, {@link ApplicationVerifier} is required in Audit
- * mode but not in Enforce mode.
+ * If you've enabled project-level reCAPTCHA Enterprise bot protection in
+ * Enforce mode, you can omit the {@link ApplicationVerifier}.
  *
  * This method does not work in a Node.js environment or with {@link Auth} instances created with a
  * {@link @firebase/app#FirebaseServerApp}.

--- a/packages/auth/src/platform_browser/strategies/phone.ts
+++ b/packages/auth/src/platform_browser/strategies/phone.ts
@@ -102,11 +102,14 @@ class ConfirmationResultImpl implements ConfirmationResult {
  * provides the code sent to their phone, call {@link ConfirmationResult.confirm}
  * with the code to sign the user in.
  *
- * For abuse prevention, this method also requires a {@link ApplicationVerifier}.
- * This SDK includes a reCAPTCHA-based implementation, {@link RecaptchaVerifier}.
+ * For abuse prevention with reCAPTCHA v2, this method requires a {@link ApplicationVerifier}.
+ * This SDK includes a reCAPTCHA-v2-based implementation, {@link RecaptchaVerifier}.
  * This function can work on other platforms that do not support the
  * {@link RecaptchaVerifier} (like React Native), but you need to use a
  * third-party {@link ApplicationVerifier} implementation.
+ *
+ * For abuse prevention with reCAPTCHA Enterprise, {@link ApplicationVerifier} is required in Audit
+ * mode but not in Enforce mode.
  *
  * This method does not work in a Node.js environment or with {@link Auth} instances created with a
  * {@link @firebase/app#FirebaseServerApp}.

--- a/packages/auth/src/platform_browser/strategies/phone.ts
+++ b/packages/auth/src/platform_browser/strategies/phone.ts
@@ -68,9 +68,9 @@ import { _castAuth } from '../../core/auth/auth_impl';
 import { getModularInstance } from '@firebase/util';
 import { ProviderId } from '../../model/enums';
 import {
-  RecaptchaEnterpriseVerifier,
   FAKE_TOKEN,
-  handleRecaptchaFlow
+  handleRecaptchaFlow,
+  _initializeRecaptchaConfig
 } from '../recaptcha/recaptcha_enterprise_verifier';
 import { _isFirebaseServerApp } from '@firebase/app';
 
@@ -227,8 +227,17 @@ export async function _verifyPhoneNumber(
   verifier?: ApplicationVerifierInternal
 ): Promise<string> {
   if (!auth._getRecaptchaConfig()) {
-    const enterpriseVerifier = new RecaptchaEnterpriseVerifier(auth);
-    await enterpriseVerifier.verify();
+    try {
+      await _initializeRecaptchaConfig(auth);
+    } catch (error) {
+      // If an error occurs while fetching the config, there is no way to know the enablement state
+      // of Phone provider, so we proceed with recaptcha V2 verification.
+      // The error is likely "recaptchaKey undefined", as reCAPTCHA Enterprise is not
+      // enabled for any provider.
+      console.log(
+        'Failed to initialize reCAPTCHA Enterprise config. Triggering the reCAPTCHA v2 verification.'
+      );
+    }
   }
 
   try {

--- a/packages/auth/src/platform_browser/strategies/phone.ts
+++ b/packages/auth/src/platform_browser/strategies/phone.ts
@@ -129,7 +129,7 @@ class ConfirmationResultImpl implements ConfirmationResult {
 export async function signInWithPhoneNumber(
   auth: Auth,
   phoneNumber: string,
-  appVerifier: ApplicationVerifier
+  appVerifier?: ApplicationVerifier
 ): Promise<ConfirmationResult> {
   if (_isFirebaseServerApp(auth.app)) {
     return Promise.reject(
@@ -162,7 +162,7 @@ export async function signInWithPhoneNumber(
 export async function linkWithPhoneNumber(
   user: User,
   phoneNumber: string,
-  appVerifier: ApplicationVerifier
+  appVerifier?: ApplicationVerifier
 ): Promise<ConfirmationResult> {
   const userInternal = getModularInstance(user) as UserInternal;
   await _assertLinkedStatus(false, userInternal, ProviderId.PHONE);
@@ -194,7 +194,7 @@ export async function linkWithPhoneNumber(
 export async function reauthenticateWithPhoneNumber(
   user: User,
   phoneNumber: string,
-  appVerifier: ApplicationVerifier
+  appVerifier?: ApplicationVerifier
 ): Promise<ConfirmationResult> {
   const userInternal = getModularInstance(user) as UserInternal;
   if (_isFirebaseServerApp(userInternal.auth.app)) {
@@ -224,7 +224,7 @@ type PhoneApiCaller<TRequest, TResponse> = (
 export async function _verifyPhoneNumber(
   auth: AuthInternal,
   options: PhoneInfoOptions | string,
-  verifier: ApplicationVerifierInternal
+  verifier?: ApplicationVerifierInternal
 ): Promise<string> {
   if (!auth._getRecaptchaConfig()) {
     const enterpriseVerifier = new RecaptchaEnterpriseVerifier(auth);
@@ -274,7 +274,7 @@ export async function _verifyPhoneNumber(
             request.phoneEnrollmentInfo.captchaResponse === FAKE_TOKEN
           ) {
             _assert(
-              verifier.type === RECAPTCHA_VERIFIER_TYPE,
+              verifier?.type === RECAPTCHA_VERIFIER_TYPE,
               authInstance,
               AuthErrorCode.ARGUMENT_ERROR
             );
@@ -329,14 +329,14 @@ export async function _verifyPhoneNumber(
           authInstance: AuthInternal,
           request: StartPhoneMfaSignInRequest
         ) => {
-          // If reCAPTCHA Enterprise token is empty or "NO_RECAPTCHA", fetch v2 token and inject into request.
+          // If reCAPTCHA Enterprise token is empty or "NO_RECAPTCHA", fetch reCAPTCHA v2 token and inject into request.
           if (
             !request.phoneSignInInfo.captchaResponse ||
             request.phoneSignInInfo.captchaResponse.length === 0 ||
             request.phoneSignInInfo.captchaResponse === FAKE_TOKEN
           ) {
             _assert(
-              verifier.type === RECAPTCHA_VERIFIER_TYPE,
+              verifier?.type === RECAPTCHA_VERIFIER_TYPE,
               authInstance,
               AuthErrorCode.ARGUMENT_ERROR
             );
@@ -380,14 +380,14 @@ export async function _verifyPhoneNumber(
         authInstance: AuthInternal,
         request: SendPhoneVerificationCodeRequest
       ) => {
-        // If reCAPTCHA Enterprise token is empty or "NO_RECAPTCHA", fetch v2 token and inject into request.
+        // If reCAPTCHA Enterprise token is empty or "NO_RECAPTCHA", fetch reCAPTCHA v2 token and inject into request.
         if (
           !request.captchaResponse ||
           request.captchaResponse.length === 0 ||
           request.captchaResponse === FAKE_TOKEN
         ) {
           _assert(
-            verifier.type === RECAPTCHA_VERIFIER_TYPE,
+            verifier?.type === RECAPTCHA_VERIFIER_TYPE,
             authInstance,
             AuthErrorCode.ARGUMENT_ERROR
           );
@@ -421,7 +421,7 @@ export async function _verifyPhoneNumber(
       return response.sessionInfo;
     }
   } finally {
-    verifier._reset();
+    verifier?._reset();
   }
 }
 

--- a/packages/auth/test/integration/flows/recaptcha_enterprise.test.ts
+++ b/packages/auth/test/integration/flows/recaptcha_enterprise.test.ts
@@ -1,0 +1,198 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinonChai from 'sinon-chai';
+import {
+  linkWithPhoneNumber,
+  PhoneAuthProvider,
+  reauthenticateWithPhoneNumber,
+  signInAnonymously,
+  signInWithPhoneNumber,
+  unlink,
+  updatePhoneNumber,
+  Auth,
+  OperationType,
+  ProviderId
+} from '@firebase/auth';
+import {
+  cleanUpTestInstance,
+  getTestInstance
+} from '../../helpers/integration/helpers';
+
+import { getEmulatorUrl } from '../../helpers/integration/settings';
+
+use(chaiAsPromised);
+use(sinonChai);
+
+let auth: Auth;
+let emulatorUrl: string | null;
+
+// NOTE: These happy test cases don't use a real phone number. In order to run these tests
+// you must allowlist the following phone number as "testing" numbers in the Auth console.
+// https://console.firebase.google.com/u/0/project/_/authentication/providers
+//   • +1 (555) 555-1000, SMS code 123456
+
+const FICTIONAL_PHONE = {
+  phoneNumber: '+15555551000',
+  code: '123456'
+};
+
+// This phone number is not allowlisted. It is used in error test cases to catch errors, as
+// using fictional phone number always receives success response from the server.
+// Note: Don't use this for happy cases because we want to avoid sending actual SMS message.
+const NONFICTIONAL_PHONE = {
+  phoneNumber: '+15555553000'
+};
+
+// These tests are written when reCAPTCHA Enterprise is set to ENFORCE. In order to run these tests
+// you must enable reCAPTCHA Enterprise in Cloud Console and set enforcement state for PHONE_PROVIDER
+// to ENFORCE.
+// The CI project has reCAPTCHA bot-score and toll fraud protection enabled.
+describe('Integration test: phone auth with reCAPTCHA Enterprise ENFORCE mode', () => {
+  beforeEach(() => {
+    emulatorUrl = getEmulatorUrl();
+    if (!emulatorUrl) {
+      auth = getTestInstance();
+      // Sets to false to generate the real reCAPTCHA Enterprise token
+      auth.settings.appVerificationDisabledForTesting = false;
+    }
+  });
+
+  afterEach(async () => {
+    if (!emulatorUrl) {
+      await cleanUpTestInstance(auth);
+    }
+  });
+
+  it('allows user to sign in with phone number', async function () {
+    if (emulatorUrl) {
+      this.skip();
+    }
+
+    // This generates real recaptcha token and use it for verification
+    const confirmationResult = await signInWithPhoneNumber(
+      auth,
+      FICTIONAL_PHONE.phoneNumber
+    );
+    expect(confirmationResult.verificationId).not.to.be.null;
+
+    const userCred = await confirmationResult.confirm('123456');
+    expect(auth.currentUser).to.eq(userCred.user);
+    expect(userCred.operationType).to.eq(OperationType.SIGN_IN);
+
+    const user = userCred.user;
+    expect(user.isAnonymous).to.be.false;
+    expect(user.uid).to.be.a('string');
+    expect(user.phoneNumber).to.eq(FICTIONAL_PHONE.phoneNumber);
+  });
+
+  it('throws error if recaptcha token is invalid', async function () {
+    if (emulatorUrl) {
+      this.skip();
+    }
+    // Simulates a fake token by setting this to true
+    auth.settings.appVerificationDisabledForTesting = true;
+
+    // Use unallowlisted phone number to trigger real reCAPTCHA Enterprise verification
+    // Since it will throw an error, no SMS will be sent.
+    await expect(
+      signInWithPhoneNumber(auth, NONFICTIONAL_PHONE.phoneNumber)
+    ).to.be.rejectedWith('auth/invalid-recaptcha-token');
+  });
+
+  it('anonymous users can upgrade using phone number', async function () {
+    if (emulatorUrl) {
+      this.skip();
+    }
+    const { user } = await signInAnonymously(auth);
+    const { uid: anonId } = user;
+
+    const provider = new PhoneAuthProvider(auth);
+    const verificationId = await provider.verifyPhoneNumber(
+      FICTIONAL_PHONE.phoneNumber
+    );
+
+    await updatePhoneNumber(
+      user,
+      PhoneAuthProvider.credential(verificationId, FICTIONAL_PHONE.code)
+    );
+    expect(user.phoneNumber).to.eq(FICTIONAL_PHONE.phoneNumber);
+
+    await auth.signOut();
+
+    const cr = await signInWithPhoneNumber(auth, FICTIONAL_PHONE.phoneNumber);
+    const { user: secondSignIn } = await cr.confirm(FICTIONAL_PHONE.code);
+
+    expect(secondSignIn.uid).to.eq(anonId);
+    expect(secondSignIn.isAnonymous).to.be.false;
+    expect(secondSignIn.providerData[0].phoneNumber).to.eq(
+      FICTIONAL_PHONE.phoneNumber
+    );
+    expect(secondSignIn.providerData[0].providerId).to.eq('phone');
+  });
+
+  it('anonymous users can link (and unlink) phone number', async function () {
+    if (emulatorUrl) {
+      this.skip();
+    }
+    const { user } = await signInAnonymously(auth);
+    const { uid: anonId } = user;
+
+    const confirmationResult = await linkWithPhoneNumber(
+      user,
+      FICTIONAL_PHONE.phoneNumber
+    );
+    const linkResult = await confirmationResult.confirm(FICTIONAL_PHONE.code);
+    expect(linkResult.operationType).to.eq(OperationType.LINK);
+    expect(linkResult.user.uid).to.eq(user.uid);
+    expect(linkResult.user.phoneNumber).to.eq(FICTIONAL_PHONE.phoneNumber);
+
+    await unlink(user, ProviderId.PHONE);
+    expect(auth.currentUser!.uid).to.eq(anonId);
+    // Is anonymous stays false even after unlinking
+    expect(auth.currentUser!.isAnonymous).to.be.false;
+    expect(auth.currentUser!.phoneNumber).to.be.null;
+  });
+
+  it('allows the user to reauthenticate with phone number', async function () {
+    if (emulatorUrl) {
+      this.skip();
+    }
+    // Create a phone user first
+    let confirmationResult = await signInWithPhoneNumber(
+      auth,
+      FICTIONAL_PHONE.phoneNumber
+    );
+    const { user } = await confirmationResult.confirm(FICTIONAL_PHONE.code);
+    const oldToken = await user.getIdToken();
+
+    // Wait a bit to ensure the sign in time is different in the token
+    await new Promise((resolve): void => {
+      setTimeout(resolve, 1500);
+    });
+
+    confirmationResult = await reauthenticateWithPhoneNumber(
+      user,
+      FICTIONAL_PHONE.phoneNumber
+    );
+    await confirmationResult.confirm(FICTIONAL_PHONE.code);
+
+    expect(await user.getIdToken()).not.to.eq(oldToken);
+  });
+});


### PR DESCRIPTION
### Discussion

Currently, Firebase Auth Web SDK is relying on reCAPTCHA v2 to verify that the phone number verification request comes from one of the app's allowed domains to mitigate SMS abuse.

A downside of reCAPTCHA v2 is that end-users are required to solve a challenge. Therefore, we would like to give end-users a better user experience by integrating [reCAPTCHA Enterprise](https://cloud.google.com/recaptcha/docs/overview) with our phone auth flow. reCAPTCHA Enterprise is completely invisible to the user, so the phone auth flow will become seamless without user interaction.


### Testing

  * CI
  * Manual testing with test app