### PR TITLE
Download testing emulators using a buffer

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -14,7 +14,7 @@
 
 name: Test All Packages
 
-on: push
+on: pull_request
 
 env:
   # make chromedriver detect installed Chrome version and download the corresponding driver
@@ -92,8 +92,7 @@ jobs:
     - name: Run unit tests
       # Ignore auth and firestore since they're handled in their own separate jobs.
       run: |
-        # xvfb-run yarn lerna run --ignore '{firebase-messaging-integration-test,@firebase/auth*,@firebase/firestore*,firebase-firestore-integration-test}' test:ci
-        xvfb-run yarn lerna run --scope @firebase/data-connect test
+        xvfb-run yarn lerna run --ignore '{firebase-messaging-integration-test,@firebase/auth*,@firebase/firestore*,firebase-firestore-integration-test}' test:ci
         node scripts/print_test_logs.js
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -14,7 +14,7 @@
 
 name: Test All Packages
 
-on: pull_request
+on: push
 
 env:
   # make chromedriver detect installed Chrome version and download the corresponding driver
@@ -92,7 +92,8 @@ jobs:
     - name: Run unit tests
       # Ignore auth and firestore since they're handled in their own separate jobs.
       run: |
-        xvfb-run yarn lerna run --ignore '{firebase-messaging-integration-test,@firebase/auth*,@firebase/firestore*,firebase-firestore-integration-test}' test:ci
+        # xvfb-run yarn lerna run --ignore '{firebase-messaging-integration-test,@firebase/auth*,@firebase/firestore*,firebase-firestore-integration-test}' test:ci
+        xvfb-run yarn lerna run --scope @firebase/data-connect test
         node scripts/print_test_logs.js
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}

--- a/scripts/emulator-testing/dataconnect-test-runner.ts
+++ b/scripts/emulator-testing/dataconnect-test-runner.ts
@@ -18,6 +18,7 @@
 import { DataConnectEmulator } from './emulators/dataconnect-emulator';
 import { spawn } from 'child-process-promise';
 import * as path from 'path';
+
 function runTest(port: number) {
   console.log(
     'path: ' + path.resolve(__dirname, '../../packages/data-connect')
@@ -38,7 +39,7 @@ async function run(): Promise<void> {
     await emulator.setUp();
     await runTest(emulator.port);
   } finally {
-    await emulator.tearDown();
+    emulator.tearDown();
   }
 }
 run().catch(err => {

--- a/scripts/emulator-testing/emulators/dataconnect-emulator.ts
+++ b/scripts/emulator-testing/emulators/dataconnect-emulator.ts
@@ -21,8 +21,6 @@ import { Emulator } from './emulator';
 const DATABASE_EMULATOR_VERSION = '1.3.7';
 
 export class DataConnectEmulator extends Emulator {
-  //   namespace: string;
-
   constructor(port = 3628) {
     const os = platform();
     let urlString = '';

--- a/scripts/emulator-testing/emulators/emulator.ts
+++ b/scripts/emulator-testing/emulators/emulator.ts
@@ -57,7 +57,12 @@ export abstract class Emulator {
     const { name: tempDir } = tmp.dirSync({ unsafeCleanup: true });
     const filepath = path.resolve(tempDir, this.binaryName);
     let cur = 0;
-    let buf = new Uint8Array(2 ** 26);
+    // The emulators vary in size and are approximately 32MiB. If we define this array to be
+    // only 32MiB, there's a risk in the future that the download will suddenly fail because there
+    // was an increase in emulator size, and the buffer is no longer large enough.
+    // To prevent this, we give some room for an increase in size of the emulators
+    // and make the buffer 64MiB.
+    let buf = new Uint8Array(2 ** 26); // 64 MiB
     return new Promise<void>((resolve, reject) => {
       /**
        * Once the download is `done` in `readChunk`, we want to set `this.binaryPath` to the path of the

--- a/scripts/emulator-testing/emulators/emulator.ts
+++ b/scripts/emulator-testing/emulators/emulator.ts
@@ -97,7 +97,10 @@ export abstract class Emulator {
             // The execute permission is required for it to be able to start
             // with 'java -jar'.
             fs.chmod(filepath, 0o755, err => {
-              if (err) reject(err);
+              if (err) {
+                reject(err);
+              }
+
               console.log(`Changed emulator file permissions to 'rwxr-xr-x'.`);
               this.binaryPath = filepath;
               if (this.copyToCache()) {
@@ -121,11 +124,14 @@ export abstract class Emulator {
       }
       let promise: ChildProcessPromise<SpawnPromiseResult>;
       if (this.isDataConnect) {
-        promise = spawn(this.binaryPath, [
-          'dev',
-          '--local_connection_string',
-          "'postgresql://postgres:secretpassword@localhost:5432/postgres?sslmode=disable'"
-        ]);
+        promise = spawn(
+          this.binaryPath, 
+          [
+            'dev',
+            '--local_connection_string',
+            "'postgresql://postgres:secretpassword@localhost:5432/postgres?sslmode=disable'"
+          ]
+        );
       } else {
         promise = spawn(
           'java',
@@ -185,7 +191,7 @@ export abstract class Emulator {
 
     if (this.binaryPath) {
       console.log(`Deleting the emulator jar at ${this.binaryPath}`);
-      fs.unlinkSync(this.binaryPath);
+      // fs.unlinkSync(this.binaryPath);
     }
   }
 

--- a/scripts/emulator-testing/emulators/emulator.ts
+++ b/scripts/emulator-testing/emulators/emulator.ts
@@ -57,10 +57,10 @@ export abstract class Emulator {
     const filepath = path.resolve(tempDir, this.binaryName);
     return new Promise<void>((resolve, reject) => {
       /**
-       * Once the download is `done` in `readChunk`, we want to set `this.binaryPath` to the path of the 
+       * Once the download is `done` in `readChunk`, we want to set `this.binaryPath` to the path of the
        * downloaded emulator. Unfortunately, we can't access `this` when inside `readChunk`'s scope, since
        * it's a named function expression, and does not inherit the `this` object from it's parent.
-       * To work around this, we wrap the fetch in a promise, 
+       * To work around this, we wrap the fetch in a promise,
        * then once it's resolved we can access `this` in a callback arrow function that *does* inherit
        * `this` from the parent object, allowing us to set `this.binaryPath`.
        * Note that we can't make readChunk an arrow function, since it needs to be named so that we can


### PR DESCRIPTION
The streaming file download was failing when downloading the data connect emulator in CI only (reasons unknown). To fix the issue, we can download the file to a buffer (`Uint8Array`), then write it synchronously to disk.

We preferred the streaming approach because it meant we didn't have to store the entire emulator file in memory, but I found that this buffer approach uses roughly the same amount of memory (~195mB in total for the test process).