### PR TITLE
Close emulator file after download is complete

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -93,7 +93,7 @@ jobs:
       # Ignore auth and firestore since they're handled in their own separate jobs.
       run: |
         # xvfb-run yarn lerna run --ignore '{firebase-messaging-integration-test,@firebase/auth*,@firebase/firestore*,firebase-firestore-integration-test}' test:ci
-        xvfb-run yarn lerna run --scope @firebase/data-connect
+        xvfb-run yarn lerna run --scope @firebase/data-connect test:ci
         node scripts/print_test_logs.js
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -14,7 +14,7 @@
 
 name: Test All Packages
 
-on: push
+on: pull_request
 
 env:
   # make chromedriver detect installed Chrome version and download the corresponding driver
@@ -92,8 +92,7 @@ jobs:
     - name: Run unit tests
       # Ignore auth and firestore since they're handled in their own separate jobs.
       run: |
-        # xvfb-run yarn lerna run --ignore '{firebase-messaging-integration-test,@firebase/auth*,@firebase/firestore*,firebase-firestore-integration-test}' test:ci
-        xvfb-run yarn lerna run --scope @firebase/data-connect test:ci
+        xvfb-run yarn lerna run --ignore '{firebase-messaging-integration-test,@firebase/auth*,@firebase/firestore*,firebase-firestore-integration-test}' test:ci
         node scripts/print_test_logs.js
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -14,7 +14,7 @@
 
 name: Test All Packages
 
-on: pull_request
+on: push
 
 env:
   # make chromedriver detect installed Chrome version and download the corresponding driver
@@ -92,7 +92,8 @@ jobs:
     - name: Run unit tests
       # Ignore auth and firestore since they're handled in their own separate jobs.
       run: |
-        xvfb-run yarn lerna run --ignore '{firebase-messaging-integration-test,@firebase/auth*,@firebase/firestore*,firebase-firestore-integration-test}' test:ci
+        # xvfb-run yarn lerna run --ignore '{firebase-messaging-integration-test,@firebase/auth*,@firebase/firestore*,firebase-firestore-integration-test}' test:ci
+        xvfb-run yarn lerna run --scope @firebase/data-connect
         node scripts/print_test_logs.js
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}

--- a/scripts/emulator-testing/emulators/emulator.ts
+++ b/scripts/emulator-testing/emulators/emulator.ts
@@ -75,7 +75,15 @@ export abstract class Emulator {
                   const reader = resp.body.getReader();
                   reader.read().then(function readChunk({ done, value }): any {
                     if (done) {
-                      downloadComplete();
+                      console.log('Emulator download is done.')
+                      writer.close(err => {
+                        if (err) {
+                          downloadFailed(`Failed to close the downloaded emulator file: ${err}`);
+                        }
+
+                        console.log('Closed downloaded emulator file.')
+                        downloadComplete();
+                      })
                     } else {
                       writer.write(value);
                       return reader.read().then(readChunk);
@@ -92,7 +100,6 @@ export abstract class Emulator {
 
         downloadPromise.then(
           () => {
-            console.log('Download complete');
             // Change emulator binary file permission to 'rwxr-xr-x'.
             // The execute permission is required for it to be able to start
             // with 'java -jar'.

--- a/scripts/emulator-testing/emulators/emulator.ts
+++ b/scripts/emulator-testing/emulators/emulator.ts
@@ -75,15 +75,17 @@ export abstract class Emulator {
                   const reader = resp.body.getReader();
                   reader.read().then(function readChunk({ done, value }): any {
                     if (done) {
-                      console.log('Emulator download is done.')
+                      console.log('Emulator download is done.');
                       writer.close(err => {
                         if (err) {
-                          downloadFailed(`Failed to close the downloaded emulator file: ${err}`);
+                          downloadFailed(
+                            `Failed to close the downloaded emulator file: ${err}`
+                          );
                         }
 
-                        console.log('Closed downloaded emulator file.')
+                        console.log('Closed downloaded emulator file.');
                         downloadComplete();
-                      })
+                      });
                     } else {
                       writer.write(value);
                       return reader.read().then(readChunk);


### PR DESCRIPTION
We need to close the writer after the download is complete, otherwise we get an `ETXTBSY` when trying to read a file that is busy.