### PR TITLE
rename vertexai package reference in a changeset

### DIFF
--- a/.changeset/little-cows-tie.md
+++ b/.changeset/little-cows-tie.md
@@ -25,7 +25,7 @@
 '@firebase/database': patch
 'firebase': patch
 '@firebase/template': patch
-'@firebase/vertexai-preview': patch
+'@firebase/vertexai': patch
 '@firebase/storage': patch
 '@firebase/logger': patch
 '@firebase/auth': patch


### PR DESCRIPTION
The package has been renamed with the latest Vertex merges - change to avoid breaking changesets tool.