### PR TITLE
Upgrade Vertex Mock Responses to V5

### DIFF
--- a/packages/vertexai/src/requests/response-helpers.ts
+++ b/packages/vertexai/src/requests/response-helpers.ts
@@ -36,6 +36,7 @@ export function createEnhancedContentResponse(
    * The Vertex AI backend omits default values.
    * This causes the `index` property to be omitted from the first candidate in the
    * response, since it has index 0, and 0 is a default value.
+   * See: https://github.com/firebase/firebase-js-sdk/issues/8566
    */
   if (response.candidates && !response.candidates[0].hasOwnProperty('index')) {
     response.candidates[0].index = 0;

--- a/packages/vertexai/src/requests/stream-reader.ts
+++ b/packages/vertexai/src/requests/stream-reader.ts
@@ -151,7 +151,9 @@ export function aggregateResponses(
   for (const response of responses) {
     if (response.candidates) {
       for (const candidate of response.candidates) {
-        const i = candidate.index;
+        // Index will be undefined if it's the first index (0), so we should use 0 if it's undefined.
+        // See: https://github.com/firebase/firebase-js-sdk/issues/8566
+        const i = candidate.index || 0;
         if (!aggregatedResponse.candidates) {
           aggregatedResponse.candidates = [];
         }

--- a/scripts/update_vertexai_responses.sh
+++ b/scripts/update_vertexai_responses.sh
@@ -17,7 +17,7 @@
 # This script replaces mock response files for Vertex AI unit tests with a fresh
 # clone of the shared repository of Vertex AI test data.
 
-RESPONSES_VERSION='v4.*' # The major version of mock responses to use
+RESPONSES_VERSION='v5.*' # The major version of mock responses to use
 REPO_NAME="vertexai-sdk-test-data"
 REPO_LINK="https://github.com/FirebaseExtended/$REPO_NAME.git"
 

--- a/scripts/update_vertexai_responses.sh
+++ b/scripts/update_vertexai_responses.sh
@@ -17,7 +17,7 @@
 # This script replaces mock response files for Vertex AI unit tests with a fresh
 # clone of the shared repository of Vertex AI test data.
 
-RESPONSES_VERSION='v3.*' # The major version of mock responses to use
+RESPONSES_VERSION='v4.*' # The major version of mock responses to use
 REPO_NAME="vertexai-sdk-test-data"
 REPO_LINK="https://github.com/FirebaseExtended/$REPO_NAME.git"
 


### PR DESCRIPTION
Upgrades the mock responses from v3 to v5.

This also includes a fix for an issue where where the first candidate's index is undefined, causing undefined to be used as the key when aggregating candidates.