### PR TITLE
Major bump for database-compat for Node engines change.

### DIFF
--- a/.changeset/afraid-terms-kick.md
+++ b/.changeset/afraid-terms-kick.md
@@ -1,0 +1,5 @@
+---
+'@firebase/database-compat': major
+---
+
+Set required version of Node to >=18.


### PR DESCRIPTION
See https://github.com/firebase/firebase-js-sdk/issues/8583

In order to mark the Node `engines` requirement change with a major bump, we need to do two steps:
1. Release a new version of the Firebase JS SDK with the dependency `database-compat` bumped by a major version to 2.0.0, which contains the Node `engines` requirement of 18.0.0 to enable current web SDK users to not be disrupted by the next step
2. Release a version of just `@firebase/database-compat` within the 1.x.x version range which reverts the `engines` field change (has no engines field, as it did before 11.0.0), enabling any repos with a semver `^1.x.x` dependency on `@firebase/database-compat` to avoid receiving the `engines` field bump.