### PR TITLE
Remove indentation in Vertex AI API Not Enabled Error

### DIFF
--- a/.changeset/six-toys-chew.md
+++ b/.changeset/six-toys-chew.md
@@ -1,0 +1,5 @@
+---
+'@firebase/vertexai': patch
+---
+
+Remove indentation in VertexAI API Not Enabled error

--- a/packages/vertexai/src/requests/request.ts
+++ b/packages/vertexai/src/requests/request.ts
@@ -166,13 +166,13 @@ export async function makeRequest(
       ) {
         throw new VertexAIError(
           VertexAIErrorCode.API_NOT_ENABLED,
-          `The Vertex AI in Firebase SDK requires the Vertex AI in Firebase
-          API ('firebasevertexai.googleapis.com') to be enabled in your
-          Firebase project. Enable this API by visiting the Firebase Console
-          at https://console.firebase.google.com/project/${url.apiSettings.project}/genai/
-          and clicking "Get started". If you enabled this API recently,
-          wait a few minutes for the action to propagate to our systems and
-          then retry.`,
+          `The Vertex AI in Firebase SDK requires the Vertex AI in Firebase ` +
+          `API ('firebasevertexai.googleapis.com') to be enabled in your ` +
+          `Firebase project. Enable this API by visiting the Firebase Console ` +
+          `at https://console.firebase.google.com/project/${url.apiSettings.project}/genai/ ` +
+          `and clicking "Get started". If you enabled this API recently, ` +
+          `wait a few minutes for the action to propagate to our systems and ` +
+          `then retry.`,
           {
             status: response.status,
             statusText: response.statusText,

--- a/packages/vertexai/src/requests/request.ts
+++ b/packages/vertexai/src/requests/request.ts
@@ -167,12 +167,12 @@ export async function makeRequest(
         throw new VertexAIError(
           VertexAIErrorCode.API_NOT_ENABLED,
           `The Vertex AI in Firebase SDK requires the Vertex AI in Firebase ` +
-          `API ('firebasevertexai.googleapis.com') to be enabled in your ` +
-          `Firebase project. Enable this API by visiting the Firebase Console ` +
-          `at https://console.firebase.google.com/project/${url.apiSettings.project}/genai/ ` +
-          `and clicking "Get started". If you enabled this API recently, ` +
-          `wait a few minutes for the action to propagate to our systems and ` +
-          `then retry.`,
+            `API ('firebasevertexai.googleapis.com') to be enabled in your ` +
+            `Firebase project. Enable this API by visiting the Firebase Console ` +
+            `at https://console.firebase.google.com/project/${url.apiSettings.project}/genai/ ` +
+            `and clicking "Get started". If you enabled this API recently, ` +
+            `wait a few minutes for the action to propagate to our systems and ` +
+            `then retry.`,
           {
             status: response.status,
             statusText: response.statusText,


### PR DESCRIPTION
If we use a multi-line template string for the error message, the indentation will be preserved. We should instead add multiple single-line template strings.