### PR TITLE
Upgrade workflows Node version from `20.x` to `22.10.0`

### DIFF
--- a/.github/workflows/canary-deploy.yml
+++ b/.github/workflows/canary-deploy.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Node (20)
       uses: actions/setup-node@v3
       with:
-        node-version: 20.x
+        node-version: 22.10.0
     - name: Yarn install
       run: yarn
     - name: Deploy canary

--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Set up Node (20)
       uses: actions/setup-node@v3
       with:
-        node-version: 20.x
+        node-version: 22.10.0
     - name: Yarn install
       run: yarn
     - name: Run changeset script

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Node (20)
       uses: actions/setup-node@v3
       with:
-        node-version: 20.x
+        node-version: 22.10.0
     - name: Yarn install
       run: yarn
     - name: Run doc generation

--- a/.github/workflows/check-pkg-paths.yml
+++ b/.github/workflows/check-pkg-paths.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Node (20)
       uses: actions/setup-node@v3
       with:
-        node-version: 20.x
+        node-version: 22.10.0
     - name: Yarn install
       run: yarn
     - name: Yarn build

--- a/.github/workflows/deploy-config.yml
+++ b/.github/workflows/deploy-config.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Set up node (20)
       uses: actions/setup-node@v3
       with:
-        node-version: 20.x
+        node-version: 22.10.0
     - name: Yarn install
       run: yarn
     - name: Deploy project config if needed

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Node (20)
         uses: actions/setup-node@master
         with:
-          node-version: 20.x
+          node-version: 22.10.0
       - name: install Chrome stable
         run: |
           sudo apt-get update

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up node (20)
       uses: actions/setup-node@v3
       with:
-        node-version: 20.x
+        node-version: 22.10.0
     - name: Yarn install
       run: yarn
     - name: Run formatting script

--- a/.github/workflows/health-metrics-pull-request.yml
+++ b/.github/workflows/health-metrics-pull-request.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.10.0
       - uses: 'google-github-actions/auth@v0'
         with:
           credentials_json: '${{ secrets.GCP_SA_KEY }}'
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.10.0
       - uses: 'google-github-actions/auth@v0'
         with:
           credentials_json: '${{ secrets.GCP_SA_KEY }}'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up node (20)
       uses: actions/setup-node@v3
       with:
-        node-version: 20.x
+        node-version: 22.10.0
     - name: yarn install
       run: yarn
     - name: yarn lint

--- a/.github/workflows/prerelease-manual-deploy.yml
+++ b/.github/workflows/prerelease-manual-deploy.yml
@@ -37,7 +37,7 @@ jobs:
         - name: Set up node (20)
           uses: actions/setup-node@v3
           with:
-            node-version: 20.x
+            node-version: 22.10.0
         - name: Yarn install
           run: yarn
         - name: Deploy prerelease

--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js 20.x
         uses: actions/setup-node@master
         with:
-          node-version: 20.x
+          node-version: 22.10.0
 
       - name: Get PR number and send to tracker.
         run: node scripts/ci/log-changesets.js

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node.js 20.x
         uses: actions/setup-node@master
         with:
-          node-version: 20.x
+          node-version: 22.10.0
 
       - name: Install Dependencies
         run: yarn

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Set up node (20)
       uses: actions/setup-node@v3
       with:
-        node-version: 20.x
+        node-version: 22.10.0
     - name: Checkout release branch (with history)
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Set up node (20)
       uses: actions/setup-node@v3
       with:
-        node-version: 20.x
+        node-version: 22.10.0
     - name: Merge main into release
       uses: actions/github-script@v6
       with:

--- a/.github/workflows/release-tweet.yml
+++ b/.github/workflows/release-tweet.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node.js 20.x
         uses: actions/setup-node@master
         with:
-          node-version: 20.x
+          node-version: 22.10.0
       - name: Poll release notes page on devsite
         run: node scripts/ci/poll_release_notes.js
         env:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Set up Node (20)
       uses: actions/setup-node@v3
       with:
-        node-version: 20.x
+        node-version: 22.10.0
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json
@@ -82,7 +82,7 @@ jobs:
     - name: Set up Node (20)
       uses: actions/setup-node@v3
       with:
-        node-version: 20.x
+        node-version: 22.10.0
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json
@@ -133,7 +133,7 @@ jobs:
     - name: Set up Node (20)
       uses: actions/setup-node@v3
       with:
-        node-version: 20.x
+        node-version: 22.10.0
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json
@@ -173,7 +173,7 @@ jobs:
     - name: Set up Node (20)
       uses: actions/setup-node@v3
       with:
-        node-version: 20.x
+        node-version: 22.10.0
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json
@@ -217,7 +217,7 @@ jobs:
     - name: Set up Node (20)
       uses: actions/setup-node@v3
       with:
-        node-version: 20.x
+        node-version: 22.10.0
     - run: cp config/ci.config.json config/project.json
     - run: yarn
     - run: yarn build:${{ matrix.persistence }}

--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Node (20)
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.10.0
       - name: Test setup and yarn install
         run: |
           cp config/ci.config.json config/project.json
@@ -91,7 +91,7 @@ jobs:
       - name: Set up Node (20)
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.10.0
       - name: Test setup and yarn install
         run: |
           cp config/ci.config.json config/project.json
@@ -115,7 +115,7 @@ jobs:
       - name: Set up Node (20)
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.10.0
       - name: Test setup and yarn install
         run: |
           cp config/ci.config.json config/project.json

--- a/.github/workflows/test-changed-fcm-integration.yml
+++ b/.github/workflows/test-changed-fcm-integration.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Set up Node (20)
       uses: actions/setup-node@v3
       with:
-        node-version: 20.x
+        node-version: 22.10.0
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json

--- a/.github/workflows/test-changed-firestore-integration.yml
+++ b/.github/workflows/test-changed-firestore-integration.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Set up Node (20)
       uses: actions/setup-node@v3
       with:
-        node-version: 20.x
+        node-version: 22.10.0
     - name: install Chrome stable
       run: |
         sudo apt-get update

--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Node (20)
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.10.0
       - name: install Chrome stable
         run: |
           sudo apt-get update
@@ -87,7 +87,7 @@ jobs:
       - name: Set up Node (20)
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.10.0
       - name: install Chrome stable
         run: |
           sudo apt-get update
@@ -115,7 +115,7 @@ jobs:
       - name: Set up Node (20)
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.10.0
       - name: install Chrome stable
         run: |
           sudo apt-get update
@@ -145,7 +145,7 @@ jobs:
       - name: Set up Node (20)
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.10.0
       - name: install Chrome stable
         run: |
           sudo apt-get update
@@ -183,7 +183,7 @@ jobs:
       - name: Set up Node (20)
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.10.0
       - name: Download build archive
         uses: actions/download-artifact@v3
         with:
@@ -222,7 +222,7 @@ jobs:
       - name: Set up Node (20)
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.10.0
       - name: Test setup and yarn install
         run: cp config/ci.config.json config/project.json
       - name: Run tests
@@ -240,7 +240,7 @@ jobs:
       - name: Set up Node (20)
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.10.0
       - name: Download build archive
         uses: actions/download-artifact@v3
         with:
@@ -277,7 +277,7 @@ jobs:
       - name: Set up Node (20)
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.10.0
       - name: Test setup
         run: |
           cp config/ci.config.json config/project.json

--- a/.github/workflows/test-changed-misc.yml
+++ b/.github/workflows/test-changed-misc.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Node (20)
       uses: actions/setup-node@v3
       with:
-        node-version: 20.x
+        node-version: 22.10.0
     - name: install Chrome stable
       run: |
         sudo apt-get update

--- a/.github/workflows/test-changed.yml
+++ b/.github/workflows/test-changed.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Node (20)
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.10.0
       - name: install Chrome stable
         run: |
           sudo apt-get update
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Node (20)
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.10.0
       - name: install Firefox stable
         run: |
           sudo apt-get update
@@ -92,7 +92,7 @@ jobs:
       - name: Set up Node (20)
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.10.0
       - name: Test setup and yarn install
         run: |
           cp config/ci.config.json config/project.json

--- a/.github/workflows/test-firebase-integration.yml
+++ b/.github/workflows/test-firebase-integration.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Node (20)
       uses: actions/setup-node@v3
       with:
-        node-version: 20.x
+        node-version: 22.10.0
     - name: install Chrome stable
       run: |
         sudo apt-get update

--- a/.github/workflows/update-api-reports.yml
+++ b/.github/workflows/update-api-reports.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Set up node (20)
       uses: actions/setup-node@v3
       with:
-        node-version: 20.x
+        node-version: 22.10.0
     - name: Yarn install
       run: yarn
     - name: Update API reports


### PR DESCRIPTION
Node 22 enters LTS on October 29th, 2024, so we should upgrade CI to run on Node 22.

Would there be any benefits to using `22.x` instead of `22.10.0`? I specified an exact version in case it helps with reproducibility.