### PR TITLE
Remove modifiers from compat overloads

### DIFF
--- a/.changeset/tame-paws-nail.md
+++ b/.changeset/tame-paws-nail.md
@@ -1,0 +1,53 @@
+---
+'@firebase/analytics': patch
+'@firebase/analytics-compat': patch
+'@firebase/analytics-interop-types': patch
+'@firebase/analytics-types': patch
+'@firebase/app': patch
+'@firebase/app-check': patch
+'@firebase/app-check-compat': patch
+'@firebase/app-check-interop-types': patch
+'@firebase/app-check-types': patch
+'@firebase/app-compat': patch
+'@firebase/app-types': patch
+'@firebase/auth': patch
+'@firebase/auth-compat': patch
+'@firebase/auth-interop-types': patch
+'@firebase/auth-types': patch
+'@firebase/component': patch
+'@firebase/data-connect': patch
+'@firebase/database': patch
+'@firebase/database-compat': patch
+'@firebase/database-types': patch
+'firebase': patch
+'@firebase/firestore': patch
+'@firebase/firestore-compat': patch
+'@firebase/firestore-types': patch
+'@firebase/functions': patch
+'@firebase/functions-compat': patch
+'@firebase/functions-types': patch
+'@firebase/installations': patch
+'@firebase/installations-compat': patch
+'@firebase/installations-types': patch
+'@firebase/logger': patch
+'@firebase/messaging': patch
+'@firebase/messaging-compat': patch
+'@firebase/messaging-interop-types': patch
+'@firebase/performance': patch
+'@firebase/performance-compat': patch
+'@firebase/performance-types': patch
+'@firebase/remote-config': patch
+'@firebase/remote-config-compat': patch
+'@firebase/remote-config-types': patch
+'@firebase/rules-unit-testing': patch
+'@firebase/storage': patch
+'@firebase/storage-compat': patch
+'@firebase/storage-types': patch
+'@firebase/template': patch
+'@firebase/template-types': patch
+'@firebase/util': patch
+'@firebase/vertexai': patch
+'@firebase/webchannel-wrapper': patch
+---
+
+Upgrade to TypeScript 5.5.4

--- a/scripts/build/create-overloads.ts
+++ b/scripts/build/create-overloads.ts
@@ -178,7 +178,7 @@ function keepPublicFunctionsTransformer(
         overloads.push(
           factory.updateFunctionDeclaration(
             node,
-            ts.getModifiers(node),
+            (ts.canHaveDecorators(node) ? ts.getDecorators(node) : []),
             node.asteriskToken,
             node.name,
             node.typeParameters,

--- a/scripts/build/create-overloads.ts
+++ b/scripts/build/create-overloads.ts
@@ -178,7 +178,7 @@ function keepPublicFunctionsTransformer(
         overloads.push(
           factory.updateFunctionDeclaration(
             node,
-            (ts.canHaveDecorators(node) ? ts.getDecorators(node) : []),
+            ts.canHaveDecorators(node) ? ts.getDecorators(node) : [],
             node.asteriskToken,
             node.name,
             node.typeParameters,


### PR DESCRIPTION
Fixes issue in the e2e tests where there are `declare` statements inside of `declare` blocks: https://github.com/firebase/firebase-js-sdk/actions/runs/11518441707/job/32075789147

In #8561, this script was modified, and all modifiers were accidentally added to all function declarations. This means that the `export` and `declare` modifiers were brought over, which is what caused the issue.