### PR TITLE
Add Installations Auth Id token to FirebaseServerApp

### DIFF
--- a/common/api-review/app.api.md
+++ b/common/api-review/app.api.md
@@ -74,9 +74,9 @@ export interface FirebaseOptions {
 // @public
 export interface FirebaseServerApp extends FirebaseApp {
     // (undocumented)
-    installationsAuthToken?: string;
+    readonly installationsAuthToken: string | null;
     // (undocumented)
-    installationsId?: string;
+    readonly installationsId: string | null;
     name: string;
     readonly settings: FirebaseServerAppSettings;
 }

--- a/common/api-review/app.api.md
+++ b/common/api-review/app.api.md
@@ -73,6 +73,10 @@ export interface FirebaseOptions {
 
 // @public
 export interface FirebaseServerApp extends FirebaseApp {
+    // (undocumented)
+    installationsAuthToken?: string;
+    // (undocumented)
+    installationsId?: string;
     name: string;
     readonly settings: FirebaseServerAppSettings;
 }
@@ -80,6 +84,7 @@ export interface FirebaseServerApp extends FirebaseApp {
 // @public
 export interface FirebaseServerAppSettings extends Omit<FirebaseAppSettings, 'name'> {
     authIdToken?: string;
+    installationsAuthToken?: string;
     releaseOnDeref?: object;
 }
 

--- a/packages/app/src/errors.ts
+++ b/packages/app/src/errors.ts
@@ -31,7 +31,8 @@ export const enum AppError {
   IDB_WRITE = 'idb-set',
   IDB_DELETE = 'idb-delete',
   FINALIZATION_REGISTRY_NOT_SUPPORTED = 'finalization-registry-not-supported',
-  INVALID_SERVER_APP_ENVIRONMENT = 'invalid-server-app-environment'
+  INVALID_SERVER_APP_ENVIRONMENT = 'invalid-server-app-environment',
+  INVALID_SERVER_APP_INSTALLATIONS_AUTH_TOKEN = 'invalid-server-installations-auth-token'
 }
 
 const ERRORS: ErrorMap<AppError> = {
@@ -61,7 +62,9 @@ const ERRORS: ErrorMap<AppError> = {
   [AppError.FINALIZATION_REGISTRY_NOT_SUPPORTED]:
     'FirebaseServerApp deleteOnDeref field defined but the JS runtime does not support FinalizationRegistry.',
   [AppError.INVALID_SERVER_APP_ENVIRONMENT]:
-    'FirebaseServerApp is not for use in browser environments.'
+    'FirebaseServerApp is not for use in browser environments.',
+  [AppError.INVALID_SERVER_APP_INSTALLATIONS_AUTH_TOKEN]:
+    'FirebaseServerApp could not initialize due to an invalid Installations auth token'
 };
 
 interface ErrorParams {

--- a/packages/app/src/firebaseServerApp.ts
+++ b/packages/app/src/firebaseServerApp.ts
@@ -30,7 +30,8 @@ import { base64Decode } from '@firebase/util';
 
 export class FirebaseServerAppImpl
   extends FirebaseAppImpl
-  implements FirebaseServerApp {
+  implements FirebaseServerApp
+{
   private readonly _serverConfig: FirebaseServerAppSettings;
   private _finalizationRegistry: FinalizationRegistry<object> | null;
   private _refCount: number;
@@ -69,17 +70,20 @@ export class FirebaseServerAppImpl
     };
 
     // Parse the installationAuthToken if provided.
+    this._installationsId = null;
     if (this._serverConfig.installationsAuthToken !== undefined) {
-      const thirdPart = this._serverConfig.installationsAuthToken.split(".")[1].split(".")[0];
-      const decodedToken = base64Decode(thirdPart);
-      const tokenJSON = JSON.parse(decodedToken ? decodedToken : "");
-      if (!decodedToken || !tokenJSON || tokenJSON.fid === undefined) {
-        throw ERROR_FACTORY.create(AppError.INVALID_SERVER_APP_INSTALLATIONS_AUTH_TOKEN);
-      } else {
+      try {
+        const decodedToken = base64Decode(
+          this._serverConfig.installationsAuthToken.split('.')[1]
+        );
+        const tokenJSON = JSON.parse(decodedToken ? decodedToken : '');
         this._installationsId = tokenJSON.fid;
+      } catch (e) {
+        console.warn(e);
       }
-    } else {
-      this._installationsId = null;
+      if (!this._installationsId) {
+        console.error('INVALID SERVER APP INSTALLATIONS AUTH TOKEN!');
+      }
     }
 
     this._finalizationRegistry = null;

--- a/packages/app/src/public-types.ts
+++ b/packages/app/src/public-types.ts
@@ -100,6 +100,9 @@ export interface FirebaseServerApp extends FirebaseApp {
    * ```
    */
   readonly settings: FirebaseServerAppSettings;
+
+  readonly installationsId : string | null;
+  readonly installationsAuthToken : string | null;
 }
 
 /**
@@ -195,6 +198,26 @@ export interface FirebaseServerAppSettings
    * operations fail.
    */
   authIdToken?: string;
+
+  /**
+   * An optional Installations Auth token which allows the use of Remote Config SDK in
+   * SSR enviornments.
+   *
+   * If provided, the `FirebaseServerApp` will attempt to parse the Installations id
+   * from the token.
+   * 
+   * If the token is deemed to be malformed then an error will be
+   * thrown during the invocation of `initializeServerApp`.
+   * 
+   * If the the Installations Id and the provided `installationsAuthToken` are successfully parsed,
+   * then they will be used by the Installations implementation when `getToken` and `getId` are
+   * invoked.
+   * 
+   * Attempting to use Remote Config without providing an `installationsAuthToken` here will cause
+   * Installations to throw errors when Remote Config attempts to query the Installations id and
+   * authToken.
+   */
+  installationsAuthToken?: string;
 
   /**
    * An optional object. If provided, the Firebase SDK uses a `FinalizationRegistry`

--- a/packages/app/src/public-types.ts
+++ b/packages/app/src/public-types.ts
@@ -101,8 +101,8 @@ export interface FirebaseServerApp extends FirebaseApp {
    */
   readonly settings: FirebaseServerAppSettings;
 
-  readonly installationsId : string | null;
-  readonly installationsAuthToken : string | null;
+  readonly installationsId: string | null;
+  readonly installationsAuthToken: string | null;
 }
 
 /**
@@ -205,14 +205,14 @@ export interface FirebaseServerAppSettings
    *
    * If provided, the `FirebaseServerApp` will attempt to parse the Installations id
    * from the token.
-   * 
+   *
    * If the token is deemed to be malformed then an error will be
    * thrown during the invocation of `initializeServerApp`.
-   * 
+   *
    * If the the Installations Id and the provided `installationsAuthToken` are successfully parsed,
    * then they will be used by the Installations implementation when `getToken` and `getId` are
    * invoked.
-   * 
+   *
    * Attempting to use Remote Config without providing an `installationsAuthToken` here will cause
    * Installations to throw errors when Remote Config attempts to query the Installations id and
    * authToken.

--- a/packages/installations/src/api/get-id.ts
+++ b/packages/installations/src/api/get-id.ts
@@ -19,6 +19,8 @@ import { getInstallationEntry } from '../helpers/get-installation-entry';
 import { refreshAuthToken } from '../helpers/refresh-auth-token';
 import { FirebaseInstallationsImpl } from '../interfaces/installation-impl';
 import { Installations } from '../interfaces/public-types';
+import { _isFirebaseServerApp } from '@firebase/app';
+import { ERROR_FACTORY, ErrorCode } from '../util/errors';
 
 /**
  * Creates a Firebase Installation if there isn't one for the app and
@@ -28,6 +30,13 @@ import { Installations } from '../interfaces/public-types';
  * @public
  */
 export async function getId(installations: Installations): Promise<string> {
+  if(_isFirebaseServerApp(installations.app)) {
+    if(!installations.app.installationsId) {
+      throw ERROR_FACTORY.create(ErrorCode.SERVER_APP_MISSING_AUTH_TOKEN);
+    } 
+    return installations.app.installationsId;
+  }
+
   const installationsImpl = installations as FirebaseInstallationsImpl;
   const { installationEntry, registrationPromise } = await getInstallationEntry(
     installationsImpl

--- a/packages/installations/src/api/get-id.ts
+++ b/packages/installations/src/api/get-id.ts
@@ -30,10 +30,10 @@ import { ERROR_FACTORY, ErrorCode } from '../util/errors';
  * @public
  */
 export async function getId(installations: Installations): Promise<string> {
-  if(_isFirebaseServerApp(installations.app)) {
-    if(!installations.app.installationsId) {
+  if (_isFirebaseServerApp(installations.app)) {
+    if (!installations.app.installationsId) {
       throw ERROR_FACTORY.create(ErrorCode.SERVER_APP_MISSING_AUTH_TOKEN);
-    } 
+    }
     return installations.app.installationsId;
   }
 

--- a/packages/installations/src/api/get-id.ts
+++ b/packages/installations/src/api/get-id.ts
@@ -32,7 +32,9 @@ import { ERROR_FACTORY, ErrorCode } from '../util/errors';
 export async function getId(installations: Installations): Promise<string> {
   if (_isFirebaseServerApp(installations.app)) {
     if (!installations.app.installationsId) {
-      throw ERROR_FACTORY.create(ErrorCode.SERVER_APP_MISSING_AUTH_TOKEN);
+      throw ERROR_FACTORY.create(
+        ErrorCode.SERVER_APP_MISSING_INSTALLATIONS_AUTH_TOKEN
+      );
     }
     return installations.app.installationsId;
   }

--- a/packages/installations/src/api/get-token.ts
+++ b/packages/installations/src/api/get-token.ts
@@ -34,10 +34,10 @@ export async function getToken(
   installations: Installations,
   forceRefresh = false
 ): Promise<string> {
-  if(_isFirebaseServerApp(installations.app)) {
-    if(installations.app.installationsAuthToken === undefined) {
+  if (_isFirebaseServerApp(installations.app)) {
+    if (installations.app.installationsAuthToken === undefined) {
       throw ERROR_FACTORY.create(ErrorCode.SERVER_APP_MISSING_AUTH_TOKEN);
-    } 
+    }
     return installations.app.installationsAuthToken;
   }
   const installationsImpl = installations as FirebaseInstallationsImpl;

--- a/packages/installations/src/api/get-token.ts
+++ b/packages/installations/src/api/get-token.ts
@@ -19,6 +19,8 @@ import { getInstallationEntry } from '../helpers/get-installation-entry';
 import { refreshAuthToken } from '../helpers/refresh-auth-token';
 import { FirebaseInstallationsImpl } from '../interfaces/installation-impl';
 import { Installations } from '../interfaces/public-types';
+import { _isFirebaseServerApp } from '@firebase/app';
+import { ERROR_FACTORY, ErrorCode } from '../util/errors';
 
 /**
  * Returns a Firebase Installations auth token, identifying the current
@@ -32,6 +34,12 @@ export async function getToken(
   installations: Installations,
   forceRefresh = false
 ): Promise<string> {
+  if(_isFirebaseServerApp(installations.app)) {
+    if(installations.app.installationsAuthToken === undefined) {
+      throw ERROR_FACTORY.create(ErrorCode.SERVER_APP_MISSING_AUTH_TOKEN);
+    } 
+    return installations.app.installationsAuthToken;
+  }
   const installationsImpl = installations as FirebaseInstallationsImpl;
   await completeInstallationRegistration(installationsImpl);
 

--- a/packages/installations/src/api/get-token.ts
+++ b/packages/installations/src/api/get-token.ts
@@ -35,8 +35,10 @@ export async function getToken(
   forceRefresh = false
 ): Promise<string> {
   if (_isFirebaseServerApp(installations.app)) {
-    if (installations.app.installationsAuthToken === undefined) {
-      throw ERROR_FACTORY.create(ErrorCode.SERVER_APP_MISSING_AUTH_TOKEN);
+    if (!installations.app.installationsAuthToken) {
+      throw ERROR_FACTORY.create(
+        ErrorCode.SERVER_APP_MISSING_INSTALLATIONS_AUTH_TOKEN
+      );
     }
     return installations.app.installationsAuthToken;
   }

--- a/packages/installations/src/util/errors.ts
+++ b/packages/installations/src/util/errors.ts
@@ -25,7 +25,7 @@ export const enum ErrorCode {
   REQUEST_FAILED = 'request-failed',
   APP_OFFLINE = 'app-offline',
   DELETE_PENDING_REGISTRATION = 'delete-pending-registration',
-  SERVER_APP_MISSING_AUTH_TOKEN = 'server-app-missing-auth-token'
+  SERVER_APP_MISSING_INSTALLATIONS_AUTH_TOKEN = 'server-app-missing-installatoins-auth-token'
 }
 
 const ERROR_DESCRIPTION_MAP: { readonly [key in ErrorCode]: string } = {
@@ -38,7 +38,7 @@ const ERROR_DESCRIPTION_MAP: { readonly [key in ErrorCode]: string } = {
   [ErrorCode.APP_OFFLINE]: 'Could not process request. Application offline.',
   [ErrorCode.DELETE_PENDING_REGISTRATION]:
     "Can't delete installation while there is a pending registration request.",
-  [ErrorCode.SERVER_APP_MISSING_AUTH_TOKEN]:
+  [ErrorCode.SERVER_APP_MISSING_INSTALLATIONS_AUTH_TOKEN]:
     'The instance of FirebaseServerApp was not initialized with a valid installationsAuthToken'
 };
 

--- a/packages/installations/src/util/errors.ts
+++ b/packages/installations/src/util/errors.ts
@@ -39,7 +39,7 @@ const ERROR_DESCRIPTION_MAP: { readonly [key in ErrorCode]: string } = {
   [ErrorCode.DELETE_PENDING_REGISTRATION]:
     "Can't delete installation while there is a pending registration request.",
   [ErrorCode.SERVER_APP_MISSING_AUTH_TOKEN]:
-    "The instance of FirebaseServerApp was not initialized with a valid installationsAuthToken"
+    'The instance of FirebaseServerApp was not initialized with a valid installationsAuthToken'
 };
 
 interface ErrorParams {

--- a/packages/installations/src/util/errors.ts
+++ b/packages/installations/src/util/errors.ts
@@ -24,7 +24,8 @@ export const enum ErrorCode {
   INSTALLATION_NOT_FOUND = 'installation-not-found',
   REQUEST_FAILED = 'request-failed',
   APP_OFFLINE = 'app-offline',
-  DELETE_PENDING_REGISTRATION = 'delete-pending-registration'
+  DELETE_PENDING_REGISTRATION = 'delete-pending-registration',
+  SERVER_APP_MISSING_AUTH_TOKEN = 'server-app-missing-auth-token'
 }
 
 const ERROR_DESCRIPTION_MAP: { readonly [key in ErrorCode]: string } = {
@@ -36,7 +37,9 @@ const ERROR_DESCRIPTION_MAP: { readonly [key in ErrorCode]: string } = {
     '{$requestName} request failed with error "{$serverCode} {$serverStatus}: {$serverMessage}"',
   [ErrorCode.APP_OFFLINE]: 'Could not process request. Application offline.',
   [ErrorCode.DELETE_PENDING_REGISTRATION]:
-    "Can't delete installation while there is a pending registration request."
+    "Can't delete installation while there is a pending registration request.",
+  [ErrorCode.SERVER_APP_MISSING_AUTH_TOKEN]:
+    "The instance of FirebaseServerApp was not initialized with a valid installationsAuthToken"
 };
 
 interface ErrorParams {


### PR DESCRIPTION
Hey there! So you want to contribute to a Firebase SDK? 
Before you file this pull request, please read these guidelines:

### Discussion

Add Installations Auth Id token as a potential parameter when initializing FirebaseServerApp instances. The token will be used by Installations in lieu of hitting local storage to determine the Installations Auth Token and Installations Id.

Do not merge this change. It will unlock product SDKs to use Installations in server enviornments, but we should wait for any product SDK changes to be scheduled before releasing this change to the public API surface.

### Testing

TBD

### API Changes

This conforms with the existing API propsal for FirebaseServerApp which included an Installations Auth token.