### PR TITLE
Clear fetch abort timeout

### DIFF
--- a/.changeset/four-baboons-behave.md
+++ b/.changeset/four-baboons-behave.md
@@ -1,0 +1,5 @@
+---
+'@firebase/vertexai': patch
+---
+
+Clear fetch timeout after request completion. Fixes an issue that caused Node scripts to hang due to a pending timeout.

--- a/packages/vertexai/src/constants.ts
+++ b/packages/vertexai/src/constants.ts
@@ -28,3 +28,5 @@ export const DEFAULT_API_VERSION = 'v1beta';
 export const PACKAGE_VERSION = version;
 
 export const LANGUAGE_TAG = 'gl-js';
+
+export const DEFAULT_FETCH_TIMEOUT_MS = 180 * 1000;

--- a/packages/vertexai/src/requests/request.ts
+++ b/packages/vertexai/src/requests/request.ts
@@ -146,7 +146,7 @@ export async function makeRequest(
     );
     // Timeout is 180s by default
     const timeoutMillis =
-      requestOptions?.timeout !== undefined && requestOptions.timeout >= 0
+      requestOptions?.timeout != null && requestOptions.timeout >= 0
         ? requestOptions.timeout
         : DEFAULT_FETCH_TIMEOUT_MS;
     const abortController = new AbortController();

--- a/packages/vertexai/src/requests/request.ts
+++ b/packages/vertexai/src/requests/request.ts
@@ -21,6 +21,7 @@ import { ApiSettings } from '../types/internal';
 import {
   DEFAULT_API_VERSION,
   DEFAULT_BASE_URL,
+  DEFAULT_FETCH_TIMEOUT_MS,
   LANGUAGE_TAG,
   PACKAGE_VERSION
 } from '../constants';
@@ -145,9 +146,9 @@ export async function makeRequest(
     );
     // Timeout is 180s by default
     const timeoutMillis =
-      requestOptions?.timeout !== undefined
+      requestOptions?.timeout !== undefined && requestOptions.timeout >= 0
         ? requestOptions.timeout
-        : 180 * 1000;
+        : DEFAULT_FETCH_TIMEOUT_MS;
     const abortController = new AbortController();
     fetchTimeoutId = setTimeout(() => abortController.abort(), timeoutMillis);
     request.fetchOptions.signal = abortController.signal;


### PR DESCRIPTION
We set a timeout to abort a request after 180s by default, but we don't cancel this timeout after the request completes. We should cancel this timeout after the request completes to prevent Node scripts from hanging.

I inlined everything in `buildFetchOptions` and removed that function. Let me know if I should revert this and initialize the `AbortController` in there- but I think the timeout-related code still has to be inlined so that we can get the `timeoutId`.

I tested this in a Node script using the default timeout and a custom timeout, and they both work as expected. If the timeout is triggered before the request completes, an `AbortError` is thrown. If the request completes before the timeout is triggered, the timeout is cancelled, and the Node script is able to exit.

Fixes [b/380936830](http://b/380936830) (internal)