### PR TITLE
Use ubuntu-latest for Firefox CI tests

### DIFF
--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -76,9 +76,7 @@ jobs:
     steps:
       - name: install Firefox stable
         run: |
-          sudo apt-get update
-          sudo apt-get install firefox
-          sudo apt-get install wget
+          npx @puppeteer/browsers install firefox@stable
 
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -99,8 +97,6 @@ jobs:
         run: xvfb-run yarn test:changed auth
         env:
           BROWSERS: 'Firefox'
-          SNAP_NAME: ''
-          SNAP_INSTANCE_NAME: ''
 
   test-webkit:
     name: Test Auth on Webkit if Changed

--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -70,11 +70,8 @@ jobs:
         run: xvfb-run yarn test:changed auth
   test-firefox:
     name: Test Auth on Firefox If Changed
-    # Whatever version of Firefox comes with 22.04 is causing Firefox
-    # startup to hang when launched by karma. Need to look further into
-    # why.
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: install Firefox stable

--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -75,9 +75,7 @@ jobs:
 
     steps:
       - name: install Firefox stable
-        run: |
-          npx @puppeteer/browsers install firefox@stable
-
+        run: npx @puppeteer/browsers install firefox@stable
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -99,6 +99,8 @@ jobs:
         run: xvfb-run yarn test:changed auth
         env:
           BROWSERS: 'Firefox'
+          SNAP_NAME: ''
+          SNAP_INSTANCE_NAME: ''
 
   test-webkit:
     name: Test Auth on Webkit if Changed

--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -169,10 +169,7 @@ jobs:
 
   compat-test-firefox:
     name: Test Firestore Compatible on Firefox
-    # Whatever version of Firefox comes with 22.04 is causing Firefox
-    # startup to hang when launched by karma. Need to look further into
-    # why.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: build
     if: ${{ needs.build.outputs.changed == 'true'}}
     steps:
@@ -202,10 +199,7 @@ jobs:
     strategy:
       matrix:
         test-name: ["test:browser", "test:travis", "test:lite:browser", "test:browser:prod:nameddb", "test:lite:browser:nameddb"]
-    # Whatever version of Firefox comes with 22.04 is causing Firefox
-    # startup to hang when launched by karma. Need to look further into
-    # why.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: build
     if: ${{ needs.build.outputs.changed == 'true'}}
     steps:

--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -169,7 +169,7 @@ jobs:
 
   compat-test-firefox:
     name: Test Firestore Compatible on Firefox
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     needs: build
     if: ${{ needs.build.outputs.changed == 'true'}}
     steps:
@@ -193,15 +193,13 @@ jobs:
         run: cd packages/firestore-compat && xvfb-run yarn run test:ci
         env:
           BROWSERS: 'Firefox'
-          SNAP_NAME: ''
-          SNAP_INSTANCE_NAME: ''
 
   test-firefox:
     name: Test Firestore on Firefox
     strategy:
       matrix:
         test-name: ["test:browser", "test:travis", "test:lite:browser", "test:browser:prod:nameddb", "test:lite:browser:nameddb"]
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     needs: build
     if: ${{ needs.build.outputs.changed == 'true'}}
     steps:
@@ -226,8 +224,6 @@ jobs:
         env:
           BROWSERS: 'Firefox'
           EXPERIMENTAL_MODE: true
-          SNAP_NAME: ''
-          SNAP_INSTANCE_NAME: ''
 
   compat-test-webkit:
     name: Test Firestore Compatible on Webkit

--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -193,6 +193,8 @@ jobs:
         run: cd packages/firestore-compat && xvfb-run yarn run test:ci
         env:
           BROWSERS: 'Firefox'
+          SNAP_NAME: ''
+          SNAP_INSTANCE_NAME: ''
 
   test-firefox:
     name: Test Firestore on Firefox
@@ -224,6 +226,8 @@ jobs:
         env:
           BROWSERS: 'Firefox'
           EXPERIMENTAL_MODE: true
+          SNAP_NAME: ''
+          SNAP_INSTANCE_NAME: ''
 
   compat-test-webkit:
     name: Test Firestore Compatible on Webkit

--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -169,14 +169,13 @@ jobs:
 
   compat-test-firefox:
     name: Test Firestore Compatible on Firefox
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     needs: build
     if: ${{ needs.build.outputs.changed == 'true'}}
     steps:
       - name: install Firefox stable
         run: |
-          sudo apt-get update
-          sudo apt-get install firefox
+          npx @puppeteer/browsers install firefox@stable
       - name: Set up Node (20)
         uses: actions/setup-node@v3
         with:
@@ -199,14 +198,14 @@ jobs:
     strategy:
       matrix:
         test-name: ["test:browser", "test:travis", "test:lite:browser", "test:browser:prod:nameddb", "test:lite:browser:nameddb"]
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     needs: build
     if: ${{ needs.build.outputs.changed == 'true'}}
     steps:
-      - name: install Firefox stable
-        run: |
-          sudo apt-get update
-          sudo apt-get install firefox
+      # - name: install Firefox stable
+      #   run: |
+      #     sudo apt-get update
+      #     sudo apt-get install firefox
       - name: Download build archive
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -174,8 +174,7 @@ jobs:
     if: ${{ needs.build.outputs.changed == 'true'}}
     steps:
       - name: install Firefox stable
-        run: |
-          npx @puppeteer/browsers install firefox@stable
+        run: npx @puppeteer/browsers install firefox@stable
       - name: Set up Node (20)
         uses: actions/setup-node@v3
         with:
@@ -202,10 +201,8 @@ jobs:
     needs: build
     if: ${{ needs.build.outputs.changed == 'true'}}
     steps:
-      # - name: install Firefox stable
-      #   run: |
-      #     sudo apt-get update
-      #     sudo apt-get install firefox
+      - name: install Firefox stable
+        run: npx @puppeteer/browsers install firefox@stable
       - name: Download build archive
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/test-changed.yml
+++ b/.github/workflows/test-changed.yml
@@ -75,6 +75,8 @@ jobs:
         run: xvfb-run yarn test:changed core
         env:
           BROWSERS: 'Firefox'
+          SNAP_NAME: ''
+          SNAP_INSTANCE_NAME: ''
           
           
   test-webkit:

--- a/.github/workflows/test-changed.yml
+++ b/.github/workflows/test-changed.yml
@@ -50,7 +50,7 @@ jobs:
 
   test-firefox:
     name: Test Packages With Changed Files in Firefox
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
       - name: Checkout Repo
@@ -75,8 +75,6 @@ jobs:
         run: xvfb-run yarn test:changed core
         env:
           BROWSERS: 'Firefox'
-          SNAP_NAME: ''
-          SNAP_INSTANCE_NAME: ''
           
           
   test-webkit:

--- a/.github/workflows/test-changed.yml
+++ b/.github/workflows/test-changed.yml
@@ -50,10 +50,7 @@ jobs:
 
   test-firefox:
     name: Test Packages With Changed Files in Firefox
-    # Whatever version of Firefox comes with 22.04 is causing Firefox
-    # startup to hang when launched by karma. Need to look further into
-    # why.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/test-changed.yml
+++ b/.github/workflows/test-changed.yml
@@ -61,10 +61,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 22.10.0
-      # - name: install Firefox stable
-      #   run: |
-      #     sudo apt-get update
-      #     sudo apt-get install firefox
+      - name: install Firefox stable
+        run: npx @puppeteer/browsers install firefox@stable
       - name: Test setup and yarn install
         run: |
           cp config/ci.config.json config/project.json

--- a/.github/workflows/test-changed.yml
+++ b/.github/workflows/test-changed.yml
@@ -50,7 +50,7 @@ jobs:
 
   test-firefox:
     name: Test Packages With Changed Files in Firefox
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Repo
@@ -61,10 +61,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 22.10.0
-      - name: install Firefox stable
-        run: |
-          sudo apt-get update
-          sudo apt-get install firefox
+      # - name: install Firefox stable
+      #   run: |
+      #     sudo apt-get update
+      #     sudo apt-get install firefox
       - name: Test setup and yarn install
         run: |
           cp config/ci.config.json config/project.json

--- a/config/karma.base.js
+++ b/config/karma.base.js
@@ -118,3 +118,5 @@ config.mochaReporter = {
 };
 
 module.exports = config;
+
+// FIXME: trigger all CI tests

--- a/config/karma.base.js
+++ b/config/karma.base.js
@@ -118,5 +118,3 @@ config.mochaReporter = {
 };
 
 module.exports = config;
-
-// FIXME: trigger all CI tests


### PR DESCRIPTION
We locked the ubuntu image for Firefox tests 2 years ago: https://github.com/firebase/firebase-js-sdk/pull/6833 because the new image was having issues. Hopefully that's been fixed by now, trying ubuntu-latest.

Conclusion: Firefox installed with apt-get seems to cause issues on Ubuntu 22.04, perhaps because of some conflict with Ubuntu 22.04's own pre-installed Snap version of Firefox. This can be solved either by removing the Firefox install altogether or by installing with puppeteer instead, which seems to not cause a conflict. Although removing the install and relying on the image's pre-installed Firefox works fine, and Github seems to update their Ubuntu regularly so it always has the latest version of Firefox, I prefer to use puppeteer for explicit control over the version. Maybe we want to lock it to some specific version or test with a specific version in the future, and this sets us up to easily do that.