### PR TITLE
Fix: sort document reference by long type id

### DIFF
--- a/packages/firestore/src/local/memory_remote_document_cache.ts
+++ b/packages/firestore/src/local/memory_remote_document_cache.ts
@@ -171,7 +171,10 @@ class MemoryRemoteDocumentCacheImpl implements MemoryRemoteDocumentCache {
     // Documents are ordered by key, so we can use a prefix scan to narrow down
     // the documents we need to match the query against.
     const collectionPath = query.path;
-    const prefix = new DocumentKey(collectionPath.child(''));
+    // DocumentId can be numeric ("__id<Long>__") or a plain string. Numeric IDs ordered before strings, sorted numerically.
+    const prefix = new DocumentKey(
+      collectionPath.child('__id' + Number.MIN_SAFE_INTEGER + '__')
+    );
     const iterator = this.docs.getIteratorFrom(prefix);
     while (iterator.hasNext()) {
       const {

--- a/packages/firestore/src/local/memory_remote_document_cache.ts
+++ b/packages/firestore/src/local/memory_remote_document_cache.ts
@@ -47,6 +47,11 @@ interface MemoryRemoteDocumentCacheEntry {
   size: number;
 }
 
+/**
+ * The smallest value representable by a 64-bit signed integer (long).
+ */
+const MIN_LONG_VALUE = '-9223372036854775808';
+
 type DocumentEntryMap = SortedMap<DocumentKey, MemoryRemoteDocumentCacheEntry>;
 function documentEntryMap(): DocumentEntryMap {
   return new SortedMap<DocumentKey, MemoryRemoteDocumentCacheEntry>(
@@ -171,9 +176,11 @@ class MemoryRemoteDocumentCacheImpl implements MemoryRemoteDocumentCache {
     // Documents are ordered by key, so we can use a prefix scan to narrow down
     // the documents we need to match the query against.
     const collectionPath = query.path;
-    // DocumentId can be numeric ("__id<Long>__") or a plain string. Numeric IDs ordered before strings, sorted numerically.
+    // Document keys are ordered first by numeric value ("__id<Long>__"),
+    // then lexicographically by string value. Start the iterator at the minimum
+    // possible Document key value.
     const prefix = new DocumentKey(
-      collectionPath.child('__id' + Number.MIN_SAFE_INTEGER + '__')
+      collectionPath.child('__id' + MIN_LONG_VALUE + '__')
     );
     const iterator = this.docs.getIteratorFrom(prefix);
     while (iterator.hasNext()) {

--- a/packages/firestore/src/model/path.ts
+++ b/packages/firestore/src/model/path.ts
@@ -17,6 +17,7 @@
 
 import { debugAssert, fail } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
+import { Integer } from '@firebase/webchannel-wrapper/bloom-blob';
 
 export const DOCUMENT_KEY_NAME = '__name__';
 
@@ -194,8 +195,8 @@ abstract class BasePath<B extends BasePath<B>> {
       return 1;
     } else if (isLhsNumeric && isRhsNumeric) {
       // both numeric
-      return Math.sign(
-        BasePath.extractNumericId(lhs) - BasePath.extractNumericId(rhs)
+      return BasePath.extractNumericId(lhs).compare(
+        BasePath.extractNumericId(rhs)
       );
     } else {
       // both non-numeric
@@ -214,8 +215,8 @@ abstract class BasePath<B extends BasePath<B>> {
     return segment.startsWith('__id') && segment.endsWith('__');
   }
 
-  private static extractNumericId(segment: string): number {
-    return parseInt(segment.substring(4, segment.length - 2), 10);
+  private static extractNumericId(segment: string): Integer {
+    return Integer.fromString(segment.substring(4, segment.length - 2));
   }
 }
 

--- a/packages/firestore/src/model/path.ts
+++ b/packages/firestore/src/model/path.ts
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
+import { Integer } from '@firebase/webchannel-wrapper/bloom-blob';
+
 import { debugAssert, fail } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
-import { Integer } from '@firebase/webchannel-wrapper/bloom-blob';
 
 export const DOCUMENT_KEY_NAME = '__name__';
 

--- a/packages/firestore/src/model/path.ts
+++ b/packages/firestore/src/model/path.ts
@@ -166,7 +166,7 @@ abstract class BasePath<B extends BasePath<B>> {
   }
 
   /**
-   * Compare 2 paths compared segment by segment, prioritizing numeric IDs
+   * Compare 2 paths segment by segment, prioritizing numeric IDs
    * (e.g., "__id123__") in numeric ascending order, followed by string
    * segments in lexicographical order.
    */

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -2260,9 +2260,9 @@ apiDescribe('Database', persistence => {
         '__id-2__': { a: 1 },
         '_id1__': { a: 1 },
         '__id1_': { a: 1 },
-        // max safe integer +1, +2
-        '__id9007199254740992__': { a: 1 },
-        '__id9007199254740993__': { a: 1 },
+        // largest long numbers
+        '__id9223372036854775807__': { a: 1 },
+        '__id9223372036854775806__': { a: 1 },
         // smallest long numbers
         '__id-9223372036854775808__': { a: 1 },
         '__id-9223372036854775807__': { a: 1 }
@@ -2276,8 +2276,8 @@ apiDescribe('Database', persistence => {
           '__id-2__',
           '__id7__',
           '__id12__',
-          '__id9007199254740992__',
-          '__id9007199254740993__',
+          '__id9223372036854775806__',
+          '__id9223372036854775807__',
           '12',
           '7',
           'A',
@@ -2311,9 +2311,9 @@ apiDescribe('Database', persistence => {
         '__id-2__': { a: 1 },
         '_id1__': { a: 1 },
         '__id1_': { a: 1 },
-        // max safe integer +1, +2
-        '__id9007199254740992__': { a: 1 },
-        '__id9007199254740993__': { a: 1 },
+        // largest long numbers
+        '__id9223372036854775807__': { a: 1 },
+        '__id9223372036854775806__': { a: 1 },
         // smallest long numbers
         '__id-9223372036854775808__': { a: 1 },
         '__id-9223372036854775807__': { a: 1 }
@@ -2328,8 +2328,8 @@ apiDescribe('Database', persistence => {
         );
         const expectedDocs = [
           '__id12__',
-          '__id9007199254740992__',
-          '__id9007199254740993__',
+          '__id9223372036854775806__',
+          '__id9223372036854775807__',
           '12',
           '7',
           'A',
@@ -2361,16 +2361,16 @@ apiDescribe('Database', persistence => {
           '__id-2__': { a: 1 },
           '_id1__': { a: 1 },
           '__id1_': { a: 1 },
-          // max safe integer +1, +2
-          '__id9007199254740992__': { a: 1 },
-          '__id9007199254740993__': { a: 1 },
+          // largest long numbers
+          '__id9223372036854775807__': { a: 1 },
+          '__id9223372036854775806__': { a: 1 },
           // smallest long numbers
           '__id-9223372036854775808__': { a: 1 },
           '__id-9223372036854775807__': { a: 1 }
         };
 
         return withTestCollection(
-          persistence.toLruGc(),
+          persistence,
           testDocs,
           async collectionRef => {
             const orderedQuery = query(collectionRef, orderBy(documentId()));
@@ -2380,8 +2380,8 @@ apiDescribe('Database', persistence => {
               '__id-2__',
               '__id7__',
               '__id12__',
-              '__id9007199254740992__',
-              '__id9007199254740993__',
+              '__id9223372036854775806__',
+              '__id9223372036854775807__',
               '12',
               '7',
               'A',
@@ -2403,8 +2403,8 @@ apiDescribe('Database', persistence => {
             );
             expectedDocs = [
               '__id12__',
-              '__id9007199254740992__',
-              '__id9007199254740993__',
+              '__id9223372036854775806__',
+              '__id9223372036854775807__',
               '12',
               '7',
               'A',

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -2262,10 +2262,10 @@ apiDescribe('Database', persistence => {
         '__id1_': { a: 1 },
         // max safe integer +1, +2
         '__id9007199254740992__': { a: 1 },
-        '__id9007199254740993__': { a: 2 },
+        '__id9007199254740993__': { a: 1 },
         // smallest long numbers
-        '__id-9223372036854775808__': { a: 3 },
-        '__id-9223372036854775807__': { a: 4 }
+        '__id-9223372036854775808__': { a: 1 },
+        '__id-9223372036854775807__': { a: 1 }
       };
 
       return withTestCollection(persistence, testDocs, async collectionRef => {
@@ -2313,10 +2313,10 @@ apiDescribe('Database', persistence => {
         '__id1_': { a: 1 },
         // max safe integer +1, +2
         '__id9007199254740992__': { a: 1 },
-        '__id9007199254740993__': { a: 2 },
+        '__id9007199254740993__': { a: 1 },
         // smallest long numbers
-        '__id-9223372036854775808__': { a: 3 },
-        '__id-9223372036854775807__': { a: 4 }
+        '__id-9223372036854775808__': { a: 1 },
+        '__id-9223372036854775807__': { a: 1 }
       };
 
       return withTestCollection(persistence, testDocs, async collectionRef => {
@@ -2363,10 +2363,10 @@ apiDescribe('Database', persistence => {
           '__id1_': { a: 1 },
           // max safe integer +1, +2
           '__id9007199254740992__': { a: 1 },
-          '__id9007199254740993__': { a: 2 },
+          '__id9007199254740993__': { a: 1 },
           // smallest long numbers
-          '__id-9223372036854775808__': { a: 3 },
-          '__id-9223372036854775807__': { a: 4 }
+          '__id-9223372036854775808__': { a: 1 },
+          '__id-9223372036854775807__': { a: 1 }
         };
 
         return withTestCollection(

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -2250,13 +2250,13 @@ apiDescribe('Database', persistence => {
   describe('sort documents by DocumentId', () => {
     it('snapshot listener sorts query by DocumentId same way as get query', async () => {
       const testDocs = {
-        A: { a: 1 },
-        a: { a: 1 },
-        Aa: { a: 1 },
+        'A': { a: 1 },
+        'a': { a: 1 },
+        'Aa': { a: 1 },
         '7': { a: 1 },
-        12: { a: 1 },
+        '12': { a: 1 },
         '__id7__': { a: 1 },
-        __id12__: { a: 1 },
+        '__id12__': { a: 1 },
         '__id-2__': { a: 1 },
         '_id1__': { a: 1 },
         '__id1_': { a: 1 },
@@ -2301,13 +2301,13 @@ apiDescribe('Database', persistence => {
 
     it('snapshot listener sorts filtered query by DocumentId same way as get query', async () => {
       const testDocs = {
-        A: { a: 1 },
-        a: { a: 1 },
-        Aa: { a: 1 },
+        'A': { a: 1 },
+        'a': { a: 1 },
+        'Aa': { a: 1 },
         '7': { a: 1 },
-        12: { a: 1 },
+        '12': { a: 1 },
         '__id7__': { a: 1 },
-        __id12__: { a: 1 },
+        '__id12__': { a: 1 },
         '__id-2__': { a: 1 },
         '_id1__': { a: 1 },
         '__id1_': { a: 1 },
@@ -2351,13 +2351,13 @@ apiDescribe('Database', persistence => {
     (persistence.gc === 'lru' ? describe : describe.skip)('offline', () => {
       it('SDK orders query the same way online and offline', async () => {
         const testDocs = {
-          A: { a: 1 },
-          a: { a: 1 },
-          Aa: { a: 1 },
+          'A': { a: 1 },
+          'a': { a: 1 },
+          'Aa': { a: 1 },
           '7': { a: 1 },
-          12: { a: 1 },
+          '12': { a: 1 },
           '__id7__': { a: 1 },
-          __id12__: { a: 1 },
+          '__id12__': { a: 1 },
           '__id-2__': { a: 1 },
           '_id1__': { a: 1 },
           '__id1_': { a: 1 },

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -2260,6 +2260,7 @@ apiDescribe('Database', persistence => {
         '__id-2__': { a: 1 },
         '_id1__': { a: 1 },
         '__id1_': { a: 1 },
+        '__id': { a: 1 },
         // largest long numbers
         '__id9223372036854775807__': { a: 1 },
         '__id9223372036854775806__': { a: 1 },
@@ -2282,6 +2283,7 @@ apiDescribe('Database', persistence => {
           '7',
           'A',
           'Aa',
+          '__id',
           '__id1_',
           '_id1__',
           'a'
@@ -2311,6 +2313,7 @@ apiDescribe('Database', persistence => {
         '__id-2__': { a: 1 },
         '_id1__': { a: 1 },
         '__id1_': { a: 1 },
+        '__id': { a: 1 },
         // largest long numbers
         '__id9223372036854775807__': { a: 1 },
         '__id9223372036854775806__': { a: 1 },
@@ -2361,6 +2364,7 @@ apiDescribe('Database', persistence => {
           '__id-2__': { a: 1 },
           '_id1__': { a: 1 },
           '__id1_': { a: 1 },
+          '__id': { a: 1 },
           // largest long numbers
           '__id9223372036854775807__': { a: 1 },
           '__id9223372036854775806__': { a: 1 },
@@ -2386,6 +2390,7 @@ apiDescribe('Database', persistence => {
               '7',
               'A',
               'Aa',
+              '__id',
               '__id1_',
               '_id1__',
               'a'

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -2259,15 +2259,25 @@ apiDescribe('Database', persistence => {
         __id12__: { a: 1 },
         '__id-2__': { a: 1 },
         '_id1__': { a: 1 },
-        '__id1_': { a: 1 }
+        '__id1_': { a: 1 },
+        // max safe integer +1, +2
+        '__id9007199254740992__': { a: 1 },
+        '__id9007199254740993__': { a: 2 },
+        // smallest long numbers
+        '__id-9223372036854775808__': { a: 3 },
+        '__id-9223372036854775807__': { a: 4 }
       };
 
       return withTestCollection(persistence, testDocs, async collectionRef => {
         const orderedQuery = query(collectionRef, orderBy(documentId()));
         const expectedDocs = [
+          '__id-9223372036854775808__',
+          '__id-9223372036854775807__',
           '__id-2__',
           '__id7__',
           '__id12__',
+          '__id9007199254740992__',
+          '__id9007199254740993__',
           '12',
           '7',
           'A',
@@ -2284,6 +2294,7 @@ apiDescribe('Database', persistence => {
         const unsubscribe = onSnapshot(orderedQuery, storeEvent.storeEvent);
         const watchSnapshot = await storeEvent.awaitEvent();
         expect(toIds(watchSnapshot)).to.deep.equal(expectedDocs);
+
         unsubscribe();
       });
     });
@@ -2299,7 +2310,13 @@ apiDescribe('Database', persistence => {
         __id12__: { a: 1 },
         '__id-2__': { a: 1 },
         '_id1__': { a: 1 },
-        '__id1_': { a: 1 }
+        '__id1_': { a: 1 },
+        // max safe integer +1, +2
+        '__id9007199254740992__': { a: 1 },
+        '__id9007199254740993__': { a: 2 },
+        // smallest long numbers
+        '__id-9223372036854775808__': { a: 3 },
+        '__id-9223372036854775807__': { a: 4 }
       };
 
       return withTestCollection(persistence, testDocs, async collectionRef => {
@@ -2309,7 +2326,15 @@ apiDescribe('Database', persistence => {
           where(documentId(), '>', '__id7__'),
           where(documentId(), '<=', 'Aa')
         );
-        const expectedDocs = ['__id12__', '12', '7', 'A', 'Aa'];
+        const expectedDocs = [
+          '__id12__',
+          '__id9007199254740992__',
+          '__id9007199254740993__',
+          '12',
+          '7',
+          'A',
+          'Aa'
+        ];
 
         const getSnapshot = await getDocsFromServer(filteredQuery);
         expect(toIds(getSnapshot)).to.deep.equal(expectedDocs);
@@ -2335,18 +2360,28 @@ apiDescribe('Database', persistence => {
           __id12__: { a: 1 },
           '__id-2__': { a: 1 },
           '_id1__': { a: 1 },
-          '__id1_': { a: 1 }
+          '__id1_': { a: 1 },
+          // max safe integer +1, +2
+          '__id9007199254740992__': { a: 1 },
+          '__id9007199254740993__': { a: 2 },
+          // smallest long numbers
+          '__id-9223372036854775808__': { a: 3 },
+          '__id-9223372036854775807__': { a: 4 }
         };
 
         return withTestCollection(
-          persistence,
+          persistence.toLruGc(),
           testDocs,
           async collectionRef => {
             const orderedQuery = query(collectionRef, orderBy(documentId()));
             let expectedDocs = [
+              '__id-9223372036854775808__',
+              '__id-9223372036854775807__',
               '__id-2__',
               '__id7__',
               '__id12__',
+              '__id9007199254740992__',
+              '__id9007199254740993__',
               '12',
               '7',
               'A',
@@ -2366,7 +2401,15 @@ apiDescribe('Database', persistence => {
               where(documentId(), '>', '__id7__'),
               where(documentId(), '<=', 'Aa')
             );
-            expectedDocs = ['__id12__', '12', '7', 'A', 'Aa'];
+            expectedDocs = [
+              '__id12__',
+              '__id9007199254740992__',
+              '__id9007199254740993__',
+              '12',
+              '7',
+              'A',
+              'Aa'
+            ];
             await checkOnlineAndOfflineResultsMatch(
               filteredQuery,
               ...expectedDocs


### PR DESCRIPTION
Document ID supports strings and well as long integers in the format of "id" . When sorting documents by document ID, it should be sorted in the following order:
1. Long (numeric order)
2. String (lexicographic order)