### PR TITLE
fix regex to include non-numeric

### DIFF
--- a/scripts/release/poll-npm-publish.js
+++ b/scripts/release/poll-npm-publish.js
@@ -35,10 +35,10 @@ async function pollNpmPublish() {
           reject(error);
         }
         const version = stdout.trim();
-        if (!version.match(/^\d+\.\d+\.\d+$/)) {
+        if (!version.match(/^\d+(\.[-\d\w]+)+$/)) {
           reject(
             new Error(
-              `npm view did not return a valid semver version. Received: ${version}`
+              `npm view did not return a valid tag. Received: ${version}`
             )
           );
         }


### PR DESCRIPTION
This should include tags like 11.1.0-canary.ddc3192b5 - it doesn't have to be too precise, the goal is to avoid some case where we get a sentence or error message instead of a version.