### PR TITLE
Upgrade two more `download-artifact` v3 actions to v4  in Firestore workflow

### DIFF
--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -232,7 +232,7 @@ jobs:
         with:
           node-version: 22.10.0
       - name: Download build archive
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build.tar.gz
       - name: Unzip build artifact
@@ -259,7 +259,7 @@ jobs:
     if: ${{ needs.build.outputs.changed == 'true'}}
     steps:
       - name: Download build archive
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build.tar.gz
       - name: Unzip build artifact

--- a/config/karma.base.js
+++ b/config/karma.base.js
@@ -54,8 +54,8 @@ const config = {
   // Doing 65 seconds to allow for the 20 second firestore tests
   browserNoActivityTimeout: 65000,
 
-  // preprocess matching files before serving them to the browser
-  // available preprocessors:
+  // Preprocess matching files before serving them to the browser.
+  // Available preprocessors:
   // https://npmjs.org/browse/keyword/karma-preprocessor
   preprocessors: {
     'test/**/*.ts': ['webpack', 'sourcemap'],


### PR DESCRIPTION
### Discussion

There were a pair of `download-artifact` GitHub actions that were still set to `v3` instead of `v4`. The `v3` actions were unable to find the build archive in the test-changed-firestore workflow. This PR upgrades those to `v4` actions.

For an example of this failure, [check this CI run](https://github.com/firebase/firebase-js-sdk/actions/runs/12774755988/workflow?pr=8651).

### Testing

CI.

### API Changes

N/A.
