### PR TITLE
CI Worflows: point the Chrome mismatch strings to secrets

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -23,8 +23,8 @@ env:
   # the behavior to use the new URLs.
   CHROMEDRIVER_CDNURL: https://googlechromelabs.github.io/
   CHROMEDRIVER_CDNBINARIESURL: https://storage.googleapis.com/chrome-for-testing-public
-  CHROME_VALIDATED_VERSION: linux-120.0.6099.71
-  CHROME_VERSION_MISMATCH_MESSAGE: "The Chrome version doesn't match the previously validated version. Consider updating CHROME_VALIDATED_VERSION in the GitHub workflow if tests pass."
+  CHROME_VALIDATED_VERSION: ${{secrets.CHROME_VALIDATED_VERSION}}
+  CHROME_VERSION_MISMATCH_MESSAGE: "The Chrome version doesn't match the previously validated version. Consider updating CHROME_VALIDATED_VERSION in GitHub secrets if tests pass, or rollback the installed Chrome version if tests fail."
   artifactRetentionDays: 14
   # Bump Node memory limit
   NODE_OPTIONS: "--max_old_space_size=4096"
@@ -117,13 +117,9 @@ jobs:
         npx @puppeteer/browsers install chrome@stable
         chromeVersionString=$(ls chrome)
         if [ "$CHROME_VALIDATED_VERSION" != "$chromeVersionString" ]; then
-        echo "::warning ::The Chrome version doesn't match the previously validated version. Consider updating CHROME_VALIDATED_VERSION in the GitHub workflow if tests pass."
+        echo "::warning ::${CHROME_VERSION_MISMATCH_MESSAGE}"
         echo "::warning ::Previously validated version: ${CHROME_VALIDATED_VERSION} vs. Installed version: $chromeVersionString"
-        echo "CHROME_VERSION_NOTES=$CHROME_VERSION_MISMATCH_MESSAGE" >> "$GITHUB_ENV"
         fi
-    - name: Test Evn TEMP
-      run: |
-        echo $CHROME_VERSION_NOTES=$CHROME_VERSION_MISMATCH_MESSAGE
     - name: Download build archive
       uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
### Discussion

We have some debug warnings if the latest installed Chrome verison doesn't match the latest vetted Chrome version for Auth Tests. This change was originally made due the Chrome version causing certain Auth tests to fail, but determining the issue was due to a Chrome version change was cumbeersome and a second thought.

This change pushes the configuration of `CHROME_VALIDATED_VERSION` out of the CI workflow and into our GitHub secrets. This should let us update the value easier as it wouldn't require a PR. 

### Testing

CI

### API Changes

None.