### PR TITLE
Workflow CI: Update CHROME_VALIDATED_VERSION for Auth tests

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -23,7 +23,7 @@ env:
   # the behavior to use the new URLs.
   CHROMEDRIVER_CDNURL: https://googlechromelabs.github.io/
   CHROMEDRIVER_CDNBINARIESURL: https://storage.googleapis.com/chrome-for-testing-public
-  CHROME_VALIDATED_VERSION: linux-132.0.6834.190
+  CHROME_VALIDATED_VERSION: linux-132.0.6834.110
   CHROME_VERSION_MISMATCH_MESSAGE: "The Chrome version doesn't match the previously validated version. Consider updating CHROME_VALIDATED_VERSION in the GitHub workflow if tests pass, or rollback the installed Chrome version if tests fail."
   artifactRetentionDays: 14
   # Bump Node memory limit

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -23,8 +23,8 @@ env:
   # the behavior to use the new URLs.
   CHROMEDRIVER_CDNURL: https://googlechromelabs.github.io/
   CHROMEDRIVER_CDNBINARIESURL: https://storage.googleapis.com/chrome-for-testing-public
-  CHROME_VALIDATED_VERSION: linux-132.0.6834.110
-  CHROME_VERSION_MISMATCH_MESSAGE: "The Chrome version doesn't match the previously validated version. Consider updating CHROME_VALIDATED_VERSION in the GitHub workflow if tests pass."
+  CHROME_VALIDATED_VERSION: linux-132.0.6834.190
+  CHROME_VERSION_MISMATCH_MESSAGE: "The Chrome version doesn't match the previously validated version. Consider updating CHROME_VALIDATED_VERSION in the GitHub workflow if tests pass, or rollback the installed Chrome version if tests fail."
   artifactRetentionDays: 14
   # Bump Node memory limit
   NODE_OPTIONS: "--max_old_space_size=4096"
@@ -119,13 +119,9 @@ jobs:
         npx @puppeteer/browsers install chrome@stable
         chromeVersionString=$(ls chrome)
         if [ "$CHROME_VALIDATED_VERSION" != "$chromeVersionString" ]; then
-        echo "::warning ::The Chrome version doesn't match the previously validated version. Consider updating CHROME_VALIDATED_VERSION in the GitHub workflow if tests pass."
+        echo "::warning ::${CHROME_VERSION_MISMATCH_MESSAGE}"
         echo "::warning ::Previously validated version: ${CHROME_VALIDATED_VERSION} vs. Installed version: $chromeVersionString"
-        echo "CHROME_VERSION_NOTES=$CHROME_VERSION_MISMATCH_MESSAGE" >> "$GITHUB_ENV"
         fi
-    - name: Test Evn TEMP
-      run: |
-        echo $CHROME_VERSION_NOTES=$CHROME_VERSION_MISMATCH_MESSAGE
     - name: Download build archive
       uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -23,7 +23,7 @@ env:
   # the behavior to use the new URLs.
   CHROMEDRIVER_CDNURL: https://googlechromelabs.github.io/
   CHROMEDRIVER_CDNBINARIESURL: https://storage.googleapis.com/chrome-for-testing-public
-  CHROME_VALIDATED_VERSION: linux-120.0.6099.71
+  CHROME_VALIDATED_VERSION: linux-132.0.6834.110
   CHROME_VERSION_MISMATCH_MESSAGE: "The Chrome version doesn't match the previously validated version. Consider updating CHROME_VALIDATED_VERSION in the GitHub workflow if tests pass."
   artifactRetentionDays: 14
   # Bump Node memory limit


### PR DESCRIPTION
### Discussion

Update our CI's logged `CHROME_VALIDATED_VERSION` to the currently tested version. We haven't updated it in a while.

Keeping this up to date should reduce support burden later.

### Testing

CI

### API Changes

N/A