### PR TITLE
Discard earliest heartbeat once there are 30 heartbeats

### DIFF
--- a/.changeset/yellow-rice-kneel.md
+++ b/.changeset/yellow-rice-kneel.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app': patch
+---
+
+Discard the earliest heartbeat once a limit of 30 heartbeats in storage has been hit.

--- a/packages/app/src/heartbeatService.test.ts
+++ b/packages/app/src/heartbeatService.test.ts
@@ -283,14 +283,18 @@ describe('HeartbeatServiceImpl', () => {
         clock.tick(24 * 60 * 60 * 1000);
       }
 
-      expect(heartbeatService._heartbeatsCache?.heartbeats.length).to.equal(MAX_NUM_STORED_HEARTBEATS);
+      expect(heartbeatService._heartbeatsCache?.heartbeats.length).to.equal(
+        MAX_NUM_STORED_HEARTBEATS
+      );
       const earliestHeartbeatDate = getEarliestHeartbeatIdx(
         heartbeatService._heartbeatsCache?.heartbeats!
       );
       const earliestHeartbeat =
         heartbeatService._heartbeatsCache?.heartbeats[earliestHeartbeatDate]!;
       await heartbeatService.triggerHeartbeat();
-      expect(heartbeatService._heartbeatsCache?.heartbeats.length).to.equal(MAX_NUM_STORED_HEARTBEATS);
+      expect(heartbeatService._heartbeatsCache?.heartbeats.length).to.equal(
+        MAX_NUM_STORED_HEARTBEATS
+      );
       expect(
         heartbeatService._heartbeatsCache?.heartbeats.indexOf(earliestHeartbeat)
       ).to.equal(-1);

--- a/packages/app/src/heartbeatService.test.ts
+++ b/packages/app/src/heartbeatService.test.ts
@@ -295,7 +295,7 @@ describe('HeartbeatServiceImpl', () => {
         heartbeatService._heartbeatsCache?.heartbeats.indexOf(earliestHeartbeat)
       ).to.equal(-1);
     });
-    it('triggerHeartbeat() never exceeds MAX_NUM_STORED_HEARTBEATS heartbeats', async () => {
+    it('triggerHeartbeat() never exceeds max heartbeats', async () => {
       for (let i = 0; i <= 50; i++) {
         await heartbeatService.triggerHeartbeat();
         clock.tick(24 * 60 * 60 * 1000);

--- a/packages/app/src/heartbeatService.test.ts
+++ b/packages/app/src/heartbeatService.test.ts
@@ -274,7 +274,7 @@ describe('HeartbeatServiceImpl', () => {
       const emptyHeaders = await heartbeatService.getHeartbeatsHeader();
       expect(emptyHeaders).to.equal('');
     });
-    it('triggerHeartbeat() removes the earliest heartbeat once it exceeds the max number of heartbeats', async () => {
+    it('triggerHeartbeat() removes the earliest heartbeat once the max number of heartbeats is exceeded', async () => {
       // Trigger heartbeats until we reach the limit
       const numHeartbeats =
         heartbeatService._heartbeatsCache?.heartbeats.length!;
@@ -295,7 +295,7 @@ describe('HeartbeatServiceImpl', () => {
         heartbeatService._heartbeatsCache?.heartbeats.indexOf(earliestHeartbeat)
       ).to.equal(-1);
     });
-    it('triggerHeartbeat() never exceeds max heartbeats', async () => {
+    it('triggerHeartbeat() never causes the heartbeat count to exceed the max', async () => {
       for (let i = 0; i <= 50; i++) {
         await heartbeatService.triggerHeartbeat();
         clock.tick(24 * 60 * 60 * 1000);

--- a/packages/app/src/heartbeatService.ts
+++ b/packages/app/src/heartbeatService.ts
@@ -36,7 +36,7 @@ import {
 import { logger } from './logger';
 
 const MAX_HEADER_BYTES = 1024;
-const MAX_NUM_STORED_HEARTBEATS = 30;
+export const MAX_NUM_STORED_HEARTBEATS = 30;
 
 export class HeartbeatServiceImpl implements HeartbeatService {
   /**


### PR DESCRIPTION
Currently, we discard heartbeats once they are 30 days old. This PR changes this behaviour to only discard the earliest heartbeat once a limit of 30 heartbeats in IndexedDB has been reached.