### PR TITLE
Have renovate ignore karma-webpack

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,8 @@
     "rollup-plugin-copy-assets",
     "typedoc",
     "@microsoft/tsdoc",
-    "idb"
+    "idb",
+    "karma-webpack"
   ],
   "ignorePaths": ["auth/demo", "auth/cordova/demo", "auth-compat/demo"],
   "assignees": ["@hsubox76"],


### PR DESCRIPTION
We need to stay on karma-webpack 5.0.0 - 5.0.1 has a ton of changes, one of which breaks us.

TLDR, karma-webpack 5.0.0 has one breaking bug for us that we get around by using patch-package. This bug was fixed in 5.0.1, but 5.0.1 also contained many other changes, one of which introduces a new bug for us. We must stay on 5.0.0 for now and continue using patch-package.