### PR TITLE
Create VertexAI Node CJS and ESM bundles

### DIFF
--- a/.changeset/stale-llamas-hide.md
+++ b/.changeset/stale-llamas-hide.md
@@ -1,0 +1,5 @@
+---
+'@firebase/vertexai': patch
+---
+
+Create Node CJS and ESM bundles.

--- a/packages/vertexai/package.json
+++ b/packages/vertexai/package.json
@@ -13,8 +13,8 @@
     ".": {
       "types": "./dist/vertexai-public.d.ts",
       "node": {
-        "require": "./dist/index.cjs.js",
-        "import": "./dist/esm/index.esm2017.js"
+        "require": "./dist/index.node.cjs.js",
+        "import": "./dist/index.node.mjs"
       },
       "browser": {
         "require": "./dist/index.cjs.js",

--- a/packages/vertexai/rollup.config.js
+++ b/packages/vertexai/rollup.config.js
@@ -75,25 +75,37 @@ const browserBuilds = [
   }
 ];
 
-// const nodeBuilds = [
-//   {
-//     input: 'index.node.ts',
-//     output: {
-//      file: pkg.main,
-//      format: 'cjs',
-//      sourcemap: true
-//    },
-//     plugins: buildPlugins,
-//     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
-//   },
-//   {
-//     input: 'index.node.ts',
-//     output: [
-//       { file: pkg.exports['.'].node.import, format: 'es', sourcemap: true }
-//     ],
-//     plugins: [...buildPlugins, emitModulePackageFile()],
-//     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
-//   }
-// ];
+const nodeBuilds = [
+  {
+    input: 'src/index.node.ts',
+    output: {
+      file: pkg.exports['.'].node.import,
+      format: 'es',
+      sourcemap: true
+    },
+    plugins: [
+      ...buildPlugins,
+      replace({
+        ...generateBuildTargetReplaceConfig('esm', 2017),
+      }),
+    ],
+    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+  },
+  {
+    input: 'src/index.node.ts',
+    output: {
+     file: pkg.exports['.'].node.require,
+     format: 'cjs',
+     sourcemap: true
+   },
+    plugins: [
+      ...buildPlugins,
+      replace({
+        ...generateBuildTargetReplaceConfig('cjs', 2017),
+      })
+    ],
+    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+  }
+];
 
-export default [...browserBuilds];
+export default [...browserBuilds, ...nodeBuilds];

--- a/packages/vertexai/rollup.config.js
+++ b/packages/vertexai/rollup.config.js
@@ -86,22 +86,22 @@ const nodeBuilds = [
     plugins: [
       ...buildPlugins,
       replace({
-        ...generateBuildTargetReplaceConfig('esm', 2017),
-      }),
+        ...generateBuildTargetReplaceConfig('esm', 2017)
+      })
     ],
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
   },
   {
     input: 'src/index.node.ts',
     output: {
-     file: pkg.exports['.'].node.require,
-     format: 'cjs',
-     sourcemap: true
-   },
+      file: pkg.exports['.'].node.require,
+      format: 'cjs',
+      sourcemap: true
+    },
     plugins: [
       ...buildPlugins,
       replace({
-        ...generateBuildTargetReplaceConfig('cjs', 2017),
+        ...generateBuildTargetReplaceConfig('cjs', 2017)
       })
     ],
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))

--- a/packages/vertexai/src/index.node.ts
+++ b/packages/vertexai/src/index.node.ts
@@ -1,0 +1,53 @@
+/**
+ * The Vertex AI in Firebase Web SDK.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { registerVersion, _registerComponent } from '@firebase/app';
+import { VertexAIService } from './service';
+import { VERTEX_TYPE } from './constants';
+import { Component, ComponentType } from '@firebase/component';
+import { name, version } from '../package.json';
+
+function registerVertex(): void {
+  _registerComponent(
+    new Component(
+      VERTEX_TYPE,
+      (container, { instanceIdentifier: location }) => {
+        // getImmediate for FirebaseApp will always succeed
+        const app = container.getProvider('app').getImmediate();
+        const auth = container.getProvider('auth-internal');
+        const appCheckProvider = container.getProvider('app-check-internal');
+        return new VertexAIService(app, auth, appCheckProvider, { location });
+      },
+      ComponentType.PUBLIC
+    ).setMultipleInstances(true)
+  );
+
+  registerVersion(name, version);
+  // BUILD_TARGET will be replaced by values like esm2017, cjs2017, etc during the compilation
+  registerVersion(name, version, '__BUILD_TARGET__');
+}
+
+registerVertex();
+
+export * from './api';
+export * from './public-types';

--- a/packages/vertexai/src/index.node.ts
+++ b/packages/vertexai/src/index.node.ts
@@ -42,7 +42,7 @@ function registerVertex(): void {
     ).setMultipleInstances(true)
   );
 
-  registerVersion(name, version);
+  registerVersion(name, version, 'node');
   // BUILD_TARGET will be replaced by values like esm2017, cjs2017, etc during the compilation
   registerVersion(name, version, '__BUILD_TARGET__');
 }


### PR DESCRIPTION
Create a new Node entrypoint `index.node.ts` where we can make Node-specific modifications to the bundles. This will be required for upcoming features where Node and Web bundles use different libraries.

[go/firebase-js-sdk-vertex-node-bundle](http://goto.google.com/firebase-js-sdk-vertex-node-bundle) (internal)