### PR TITLE
Filter empty text parts when streaming

### DIFF
--- a/.changeset/seven-oranges-care.md
+++ b/.changeset/seven-oranges-care.md
@@ -1,0 +1,5 @@
+---
+'@firebase/vertexai': patch
+---
+
+Filter out empty text parts from streaming responses.

--- a/packages/vertexai/src/requests/stream-reader.test.ts
+++ b/packages/vertexai/src/requests/stream-reader.test.ts
@@ -18,7 +18,8 @@
 import {
   aggregateResponses,
   getResponseStream,
-  processStream
+  processStream,
+  filterEmptyTextParts
 } from './stream-reader';
 import { expect, use } from 'chai';
 import { restore } from 'sinon';
@@ -402,5 +403,31 @@ describe('aggregateResponses', () => {
         response.candidates?.[0].citationMetadata?.citations[1].startIndex
       ).to.equal(150);
     });
+  });
+});
+
+describe('filterEmptyTextParts', () => {
+  it('Removes only empty text parts', () => {
+    const parts = [
+      {
+        text: 'foo'
+      },
+      {
+        text: ''
+      },
+      {
+        text: 'bar'
+      }
+    ];
+
+    const filteredParts = filterEmptyTextParts(parts);
+    expect(filteredParts).to.deep.equal([
+      {
+        text: 'foo'
+      },
+      {
+        text: 'bar'
+      }
+    ]);
   });
 });

--- a/packages/vertexai/src/requests/stream-reader.test.ts
+++ b/packages/vertexai/src/requests/stream-reader.test.ts
@@ -226,7 +226,6 @@ describe('processStream', () => {
     );
     const result = processStream(fakeResponse as Response);
     const aggregatedResponse = await result.response;
-    console.log(aggregatedResponse.candidates?.[0].content.parts);
     expect(aggregatedResponse.text()).to.equal('1');
     expect(aggregatedResponse.candidates?.length).to.equal(1);
     expect(aggregatedResponse.candidates?.[0].content.parts.length).to.equal(1);

--- a/packages/vertexai/src/requests/stream-reader.test.ts
+++ b/packages/vertexai/src/requests/stream-reader.test.ts
@@ -18,8 +18,7 @@
 import {
   aggregateResponses,
   getResponseStream,
-  processStream,
-  filterEmptyTextParts
+  processStream
 } from './stream-reader';
 import { expect, use } from 'chai';
 import { restore } from 'sinon';
@@ -403,31 +402,5 @@ describe('aggregateResponses', () => {
         response.candidates?.[0].citationMetadata?.citations[1].startIndex
       ).to.equal(150);
     });
-  });
-});
-
-describe('filterEmptyTextParts', () => {
-  it('Removes only empty text parts', () => {
-    const parts = [
-      {
-        text: 'foo'
-      },
-      {
-        text: ''
-      },
-      {
-        text: 'bar'
-      }
-    ];
-
-    const filteredParts = filterEmptyTextParts(parts);
-    expect(filteredParts).to.deep.equal([
-      {
-        text: 'foo'
-      },
-      {
-        text: 'bar'
-      }
-    ]);
   });
 });

--- a/packages/vertexai/src/requests/stream-reader.test.ts
+++ b/packages/vertexai/src/requests/stream-reader.test.ts
@@ -17,7 +17,6 @@
 
 import {
   aggregateResponses,
-  deleteEmptyTextParts,
   getResponseStream,
   processStream
 } from './stream-reader';
@@ -34,7 +33,6 @@ import {
   GenerateContentResponse,
   HarmCategory,
   HarmProbability,
-  Part,
   SafetyRating
 } from '../types';
 
@@ -228,6 +226,7 @@ describe('processStream', () => {
     );
     const result = processStream(fakeResponse as Response);
     const aggregatedResponse = await result.response;
+    console.log(aggregatedResponse.candidates?.[0].content.parts);
     expect(aggregatedResponse.text()).to.equal('1');
     expect(aggregatedResponse.candidates?.length).to.equal(1);
     expect(aggregatedResponse.candidates?.[0].content.parts.length).to.equal(1);
@@ -421,106 +420,5 @@ describe('aggregateResponses', () => {
         response.candidates?.[0].citationMetadata?.citations[1].startIndex
       ).to.equal(150);
     });
-  });
-});
-
-describe('deleteEmptyTextParts', () => {
-  it('removes empty text parts from a single candidate', () => {
-    const parts: Part[] = [
-      {
-        text: ''
-      },
-      {
-        text: 'foo'
-      }
-    ];
-    const generateContentResponse: GenerateContentResponse = {
-      candidates: [
-        {
-          index: 0,
-          content: {
-            role: 'model',
-            parts
-          }
-        }
-      ]
-    };
-
-    deleteEmptyTextParts(generateContentResponse);
-    expect(generateContentResponse.candidates?.[0].content.parts).to.deep.equal(
-      [
-        {
-          text: 'foo'
-        }
-      ]
-    );
-  });
-  it('removes empty text parts from all candidates', () => {
-    const parts: Part[] = [
-      {
-        text: ''
-      },
-      {
-        text: 'foo'
-      }
-    ];
-    const generateContentResponse: GenerateContentResponse = {
-      candidates: [
-        {
-          index: 0,
-          content: {
-            role: 'model',
-            parts
-          }
-        },
-        {
-          index: 1,
-          content: {
-            role: 'model',
-            parts
-          }
-        }
-      ]
-    };
-
-    deleteEmptyTextParts(generateContentResponse);
-    expect(generateContentResponse.candidates?.[0].content.parts).to.deep.equal(
-      [
-        {
-          text: 'foo'
-        }
-      ]
-    );
-    expect(generateContentResponse.candidates?.[1].content.parts).to.deep.equal(
-      [
-        {
-          text: 'foo'
-        }
-      ]
-    );
-  });
-  it('does not remove candidate even if all parts are removed', () => {
-    const parts: Part[] = [
-      {
-        text: ''
-      }
-    ];
-    const generateContentResponse: GenerateContentResponse = {
-      candidates: [
-        {
-          index: 0,
-          content: {
-            role: 'model',
-            parts
-          }
-        }
-      ]
-    };
-
-    deleteEmptyTextParts(generateContentResponse);
-    expect(generateContentResponse.candidates?.length).to.equal(1);
-    expect(generateContentResponse.candidates?.[0].content.parts).to.deep.equal(
-      []
-    );
   });
 });

--- a/packages/vertexai/src/requests/stream-reader.ts
+++ b/packages/vertexai/src/requests/stream-reader.ts
@@ -62,6 +62,16 @@ async function getResponsePromise(
       );
       return enhancedResponse;
     }
+
+    // The backend can send empty text parts, but if they are sent back (e.g. in a chat history) there
+    // will be an error. To prevent this, filter out the empty text part from responses.
+    if (value.candidates && value.candidates.length > 0) {
+      value.candidates.forEach(candidate => {
+        if (candidate.content) {
+          candidate.content.parts = candidate.content.parts.filter(part => part.text !== '');
+        }
+      });
+    }
     allResponses.push(value);
   }
 }
@@ -76,6 +86,15 @@ async function* generateResponseSequence(
       break;
     }
 
+    // The backend can send empty text parts, but if they are sent back (e.g. in a chat history) there
+    // will be an error. To prevent this, filter out the empty text part from responses.
+    if (value.candidates && value.candidates.length > 0) {
+      value.candidates.forEach(candidate => {
+        if (candidate.content) {
+          candidate.content.parts = candidate.content.parts.filter(part => part.text !== '');
+        }
+      });
+    }
     const enhancedResponse = createEnhancedContentResponse(value);
     yield enhancedResponse;
   }
@@ -202,4 +221,14 @@ export function aggregateResponses(
     }
   }
   return aggregatedResponse;
+}
+
+/**
+ * The backend can send empty text parts, but if they are sent back (e.g. in a chat history) there
+ * will be an error. To prevent this, filter out the empty text part from responses.
+ *
+ * @internal
+ */
+export function filterEmptyTextParts(parts: Part[]): Part[] {
+  return parts?.filter(part => part.text !== '');
 }

--- a/packages/vertexai/src/requests/stream-reader.ts
+++ b/packages/vertexai/src/requests/stream-reader.ts
@@ -197,6 +197,13 @@ export function aggregateResponses(
             if (part.functionCall) {
               newPart.functionCall = part.functionCall;
             }
+            if (Object.keys(newPart).length === 0) {
+              throw new VertexAIError(
+                VertexAIErrorCode.INVALID_CONTENT,
+                'Part should have at least one property, but there are none. This is likely caused ' +
+                  'by a malformed response from the backend.'
+              );
+            }
             aggregatedResponse.candidates[i].content.parts.push(
               newPart as Part
             );

--- a/packages/vertexai/src/requests/stream-reader.ts
+++ b/packages/vertexai/src/requests/stream-reader.ts
@@ -68,7 +68,9 @@ async function getResponsePromise(
     if (value.candidates && value.candidates.length > 0) {
       value.candidates.forEach(candidate => {
         if (candidate.content) {
-          candidate.content.parts = candidate.content.parts.filter(part => part.text !== '');
+          candidate.content.parts = candidate.content.parts.filter(
+            part => part.text !== ''
+          );
         }
       });
     }
@@ -91,7 +93,9 @@ async function* generateResponseSequence(
     if (value.candidates && value.candidates.length > 0) {
       value.candidates.forEach(candidate => {
         if (candidate.content) {
-          candidate.content.parts = candidate.content.parts.filter(part => part.text !== '');
+          candidate.content.parts = candidate.content.parts.filter(
+            part => part.text !== ''
+          );
         }
       });
     }
@@ -221,14 +225,4 @@ export function aggregateResponses(
     }
   }
   return aggregatedResponse;
-}
-
-/**
- * The backend can send empty text parts, but if they are sent back (e.g. in a chat history) there
- * will be an error. To prevent this, filter out the empty text part from responses.
- *
- * @internal
- */
-export function filterEmptyTextParts(parts: Part[]): Part[] {
-  return parts?.filter(part => part.text !== '');
 }

--- a/packages/vertexai/src/requests/stream-reader.ts
+++ b/packages/vertexai/src/requests/stream-reader.ts
@@ -197,9 +197,6 @@ export function aggregateResponses(
             if (part.functionCall) {
               newPart.functionCall = part.functionCall;
             }
-            if (Object.keys(newPart).length === 0) {
-              newPart.text = '';
-            }
             aggregatedResponse.candidates[i].content.parts.push(
               newPart as Part
             );

--- a/packages/vertexai/src/requests/stream-reader.ts
+++ b/packages/vertexai/src/requests/stream-reader.ts
@@ -63,17 +63,7 @@ async function getResponsePromise(
       return enhancedResponse;
     }
 
-    // The backend can send empty text parts, but if they are sent back (e.g. in a chat history) there
-    // will be an error. To prevent this, filter out the empty text part from responses.
-    if (value.candidates && value.candidates.length > 0) {
-      value.candidates.forEach(candidate => {
-        if (candidate.content) {
-          candidate.content.parts = candidate.content.parts.filter(
-            part => part.text !== ''
-          );
-        }
-      });
-    }
+    deleteEmptyTextParts(value);
     allResponses.push(value);
   }
 }
@@ -88,17 +78,7 @@ async function* generateResponseSequence(
       break;
     }
 
-    // The backend can send empty text parts, but if they are sent back (e.g. in a chat history) there
-    // will be an error. To prevent this, filter out the empty text part from responses.
-    if (value.candidates && value.candidates.length > 0) {
-      value.candidates.forEach(candidate => {
-        if (candidate.content) {
-          candidate.content.parts = candidate.content.parts.filter(
-            part => part.text !== ''
-          );
-        }
-      });
-    }
+    deleteEmptyTextParts(value);
     const enhancedResponse = createEnhancedContentResponse(value);
     yield enhancedResponse;
   }
@@ -225,4 +205,22 @@ export function aggregateResponses(
     }
   }
   return aggregatedResponse;
+}
+
+/**
+ * The backend can send empty text parts, but if they are sent back (e.g. in a chat history) there
+ * will be an error. To prevent this, filter out the empty text part from responses.
+ *
+ * See: https://github.com/firebase/firebase-js-sdk/issues/8714
+ */
+export function deleteEmptyTextParts(response: GenerateContentResponse): void {
+  if (response.candidates) {
+    response.candidates.forEach(candidate => {
+      if (candidate.content && candidate.content.parts) {
+        candidate.content.parts = candidate.content.parts.filter(
+          part => part.text !== ''
+        );
+      }
+    });
+  }
 }

--- a/packages/vertexai/test-utils/mock-response.ts
+++ b/packages/vertexai/test-utils/mock-response.ts
@@ -49,9 +49,6 @@ export function getMockResponseStreaming(
   filename: string,
   chunkLength: number = 20
 ): Partial<Response> {
-  if (!(filename in mocksLookup)) {
-    throw Error(`Mock response file not found: '${filename}'`);
-  }
   const fullText = mocksLookup[filename];
 
   return {

--- a/packages/vertexai/test-utils/mock-response.ts
+++ b/packages/vertexai/test-utils/mock-response.ts
@@ -49,6 +49,9 @@ export function getMockResponseStreaming(
   filename: string,
   chunkLength: number = 20
 ): Partial<Response> {
+  if (!(filename in mocksLookup)) {
+    throw Error(`Mock response file not found: '${filename}'`);
+  }
   const fullText = mocksLookup[filename];
 
   return {

--- a/scripts/update_vertexai_responses.sh
+++ b/scripts/update_vertexai_responses.sh
@@ -17,7 +17,7 @@
 # This script replaces mock response files for Vertex AI unit tests with a fresh
 # clone of the shared repository of Vertex AI test data.
 
-RESPONSES_VERSION='v5.*' # The major version of mock responses to use
+RESPONSES_VERSION='v6.*' # The major version of mock responses to use
 REPO_NAME="vertexai-sdk-test-data"
 REPO_LINK="https://github.com/FirebaseExtended/$REPO_NAME.git"
 


### PR DESCRIPTION
Fixes #8714 

When streaming responses, remove all empty text parts, since if we send these to the backend we'll get an error.

If a response contained only empty text parts, an error will be thrown in `validateChatHistory` for the candidate having no parts in it's content.