### PR TITLE
Throw error if mock response file not found

### DIFF
--- a/packages/vertexai/test-utils/mock-response.ts
+++ b/packages/vertexai/test-utils/mock-response.ts
@@ -49,6 +49,9 @@ export function getMockResponseStreaming(
   filename: string,
   chunkLength: number = 20
 ): Partial<Response> {
+  if (!(filename in mocksLookup)) {
+    throw Error(`Mock response file '${filename}' not found.`);
+  }
   const fullText = mocksLookup[filename];
 
   return {
@@ -57,6 +60,9 @@ export function getMockResponseStreaming(
 }
 
 export function getMockResponse(filename: string): Partial<Response> {
+  if (!(filename in mocksLookup)) {
+    throw Error(`Mock response file '${filename}' not found.`);
+  }
   const fullText = mocksLookup[filename];
   return {
     ok: true,


### PR DESCRIPTION
If we call `getMockResponse` with a filename that doesn't exist, we'll get some confusing error like not being able to read a property from undefined. It'd be better if we just threw an error if the mock response file doesn't exist.