### PR TITLE
Stephenarosaj/headerz

### DIFF
--- a/.changeset/little-news-sniff.md
+++ b/.changeset/little-news-sniff.md
@@ -1,5 +1,6 @@
 ---
 '@firebase/data-connect': minor
+'firebase': minor
 ---
 
 Add custom request headers based on type of SDK calling Core SDK

--- a/.changeset/little-news-sniff.md
+++ b/.changeset/little-news-sniff.md
@@ -1,0 +1,5 @@
+---
+'@firebase/data-connect': minor
+---
+
+Add custom request headers based on type of SDK calling Core SDK

--- a/.changeset/little-news-sniff.md
+++ b/.changeset/little-news-sniff.md
@@ -3,4 +3,4 @@
 'firebase': minor
 ---
 
-Add custom request headers based on type of SDK calling Core SDK
+Add custom request headers based on the type of SDK (JS/TS, React, Angular, etc) that's invoking Data Connect requests. This will help us understand how users interact with Data Connect when using the Web SDK.

--- a/common/api-review/data-connect.api.md
+++ b/common/api-review/data-connect.api.md
@@ -12,6 +12,19 @@ import { LogLevelString } from '@firebase/logger';
 import { Provider } from '@firebase/component';
 
 // @public
+export type CallerSdkType = 'Base' | 'Generated' | 'TanstackReactCore' | 'GeneratedReact' | 'TanstackAngularCore' | 'GeneratedAngular';
+
+// @public (undocumented)
+export const CallerSdkTypeEnum: Readonly<{
+    readonly Base: "Base";
+    readonly Generated: "Generated";
+    readonly TanstackReactCore: "TanstackReactCore";
+    readonly GeneratedReact: "GeneratedReact";
+    readonly TanstackAngularCore: "TanstackAngularCore";
+    readonly GeneratedAngular: "GeneratedAngular";
+}>;
+
+// @public
 export function connectDataConnectEmulator(dc: DataConnect, host: string, port?: number, sslEnabled?: boolean): void;
 
 // @public

--- a/common/api-review/data-connect.api.md
+++ b/common/api-review/data-connect.api.md
@@ -15,14 +15,14 @@ import { Provider } from '@firebase/component';
 export type CallerSdkType = 'Base' | 'Generated' | 'TanstackReactCore' | 'GeneratedReact' | 'TanstackAngularCore' | 'GeneratedAngular';
 
 // @public (undocumented)
-export const CallerSdkTypeEnum: Readonly<{
+export const CallerSdkTypeEnum: {
     readonly Base: "Base";
     readonly Generated: "Generated";
     readonly TanstackReactCore: "TanstackReactCore";
     readonly GeneratedReact: "GeneratedReact";
     readonly TanstackAngularCore: "TanstackAngularCore";
     readonly GeneratedAngular: "GeneratedAngular";
-}>;
+};
 
 // @public
 export function connectDataConnectEmulator(dc: DataConnect, host: string, port?: number, sslEnabled?: boolean): void;

--- a/packages/data-connect/src/api/DataConnect.ts
+++ b/packages/data-connect/src/api/DataConnect.ts
@@ -122,7 +122,6 @@ export class DataConnect {
       this._isUsingGeneratedSdk = true;
     }
   }
-  // @internal
   _setCallerSdkType(callerSdkType: CallerSdkType): void {
     this._callerSdkType = callerSdkType;
     if (this._initialized) {

--- a/packages/data-connect/src/api/DataConnect.ts
+++ b/packages/data-connect/src/api/DataConnect.ts
@@ -94,7 +94,7 @@ export class DataConnect {
   _isUsingGeneratedSdk: boolean = false;
   _isUsingTanStackSdk: boolean = false;
   _isUsingReactSdk: boolean = false;
-  _isUsingAngularFireSdk: boolean = false;
+  _isUsingAngularSdk: boolean = false;
   private _appCheckTokenProvider?: AppCheckTokenProvider;
   // @internal
   constructor(
@@ -124,17 +124,26 @@ export class DataConnect {
     if (!this._isUsingTanStackSdk) {
       this._isUsingTanStackSdk = true;
     }
+    if (this._transport) {
+      this._transport._useTanStack();
+    }
   }
   // @internal
   _useReactSdk(): void {
     if (!this._isUsingReactSdk) {
       this._isUsingReactSdk = true;
     }
+    if (this._transport) {
+      this._transport._useReact();
+    }
   }
   // @internal
-  _useAngularFireSdk(): void {
-    if (!this._isUsingAngularFireSdk) {
-      this._isUsingAngularFireSdk = true;
+  _useAngularSdk(): void {
+    if (!this._isUsingAngularSdk) {
+      this._isUsingAngularSdk = true;
+    }
+    if (this._transport) {
+      this._transport._useAngular();
     }
   }
   _delete(): Promise<void> {
@@ -188,7 +197,7 @@ export class DataConnect {
       this._isUsingGeneratedSdk,
       this._isUsingTanStackSdk,
       this._isUsingReactSdk,
-      this._isUsingAngularFireSdk
+      this._isUsingAngularSdk
     );
     if (this._transportOptions) {
       this._transport.useEmulator(

--- a/packages/data-connect/src/api/DataConnect.ts
+++ b/packages/data-connect/src/api/DataConnect.ts
@@ -125,6 +125,7 @@ export class DataConnect {
   // @internal
   _setCallerSdkType(callerSdkType: CallerSdkType): void {
     this._callerSdkType = callerSdkType;
+    this._transport._setCallerSdkType(callerSdkType);
   }
   _delete(): Promise<void> {
     _removeServiceInstance(

--- a/packages/data-connect/src/api/DataConnect.ts
+++ b/packages/data-connect/src/api/DataConnect.ts
@@ -33,7 +33,7 @@ import {
 } from '../core/FirebaseAuthProvider';
 import { QueryManager } from '../core/QueryManager';
 import { logDebug, logError } from '../logger';
-import { DataConnectTransport, TransportClass } from '../network';
+import { CallerSdkType, CallerSdkTypeEnum, DataConnectTransport, TransportClass } from '../network';
 import { RESTTransport } from '../network/transport/rest';
 
 import { MutationManager } from './Mutation';
@@ -91,10 +91,7 @@ export class DataConnect {
   private _transportClass: TransportClass | undefined;
   private _transportOptions?: TransportOptions;
   private _authTokenProvider?: AuthTokenProvider;
-  _isUsingGeneratedSdk: boolean = false;
-  _isUsingTanStackSdk: boolean = false;
-  _isUsingReactSdk: boolean = false;
-  _isUsingAngularSdk: boolean = false;
+  _callerSdkType: CallerSdkType = CallerSdkTypeEnum.Base;
   private _appCheckTokenProvider?: AppCheckTokenProvider;
   // @internal
   constructor(
@@ -114,37 +111,8 @@ export class DataConnect {
     }
   }
   // @internal
-  _useGeneratedSdk(): void {
-    if (!this._isUsingGeneratedSdk) {
-      this._isUsingGeneratedSdk = true;
-    }
-  }
-  // @internal
-  _useTanStackSdk(): void {
-    if (!this._isUsingTanStackSdk) {
-      this._isUsingTanStackSdk = true;
-    }
-    if (this._transport) {
-      this._transport._useTanStack();
-    }
-  }
-  // @internal
-  _useReactSdk(): void {
-    if (!this._isUsingReactSdk) {
-      this._isUsingReactSdk = true;
-    }
-    if (this._transport) {
-      this._transport._useReact();
-    }
-  }
-  // @internal
-  _useAngularSdk(): void {
-    if (!this._isUsingAngularSdk) {
-      this._isUsingAngularSdk = true;
-    }
-    if (this._transport) {
-      this._transport._useAngular();
-    }
+  _setCallerSdkType(callerSdkType: CallerSdkType): void {
+    this._callerSdkType = callerSdkType;
   }
   _delete(): Promise<void> {
     _removeServiceInstance(
@@ -194,10 +162,7 @@ export class DataConnect {
       this._authTokenProvider,
       this._appCheckTokenProvider,
       undefined,
-      this._isUsingGeneratedSdk,
-      this._isUsingTanStackSdk,
-      this._isUsingReactSdk,
-      this._isUsingAngularSdk
+      this._callerSdkType
     );
     if (this._transportOptions) {
       this._transport.useEmulator(

--- a/packages/data-connect/src/api/DataConnect.ts
+++ b/packages/data-connect/src/api/DataConnect.ts
@@ -33,7 +33,12 @@ import {
 } from '../core/FirebaseAuthProvider';
 import { QueryManager } from '../core/QueryManager';
 import { logDebug, logError } from '../logger';
-import { CallerSdkType, CallerSdkTypeEnum, DataConnectTransport, TransportClass } from '../network';
+import {
+  CallerSdkType,
+  CallerSdkTypeEnum,
+  DataConnectTransport,
+  TransportClass
+} from '../network';
 import { RESTTransport } from '../network/transport/rest';
 
 import { MutationManager } from './Mutation';
@@ -91,6 +96,7 @@ export class DataConnect {
   private _transportClass: TransportClass | undefined;
   private _transportOptions?: TransportOptions;
   private _authTokenProvider?: AuthTokenProvider;
+  _isUsingGeneratedSdk: boolean = false;
   _callerSdkType: CallerSdkType = CallerSdkTypeEnum.Base;
   private _appCheckTokenProvider?: AppCheckTokenProvider;
   // @internal
@@ -108,6 +114,12 @@ export class DataConnect {
         this.isEmulator = true;
         this._transportOptions = parseOptions(host);
       }
+    }
+  }
+  // @internal
+  _useGeneratedSdk(): void {
+    if (!this._isUsingGeneratedSdk) {
+      this._isUsingGeneratedSdk = true;
     }
   }
   // @internal
@@ -162,6 +174,7 @@ export class DataConnect {
       this._authTokenProvider,
       this._appCheckTokenProvider,
       undefined,
+      this._isUsingGeneratedSdk,
       this._callerSdkType
     );
     if (this._transportOptions) {

--- a/packages/data-connect/src/api/DataConnect.ts
+++ b/packages/data-connect/src/api/DataConnect.ts
@@ -92,6 +92,9 @@ export class DataConnect {
   private _transportOptions?: TransportOptions;
   private _authTokenProvider?: AuthTokenProvider;
   _isUsingGeneratedSdk: boolean = false;
+  _isUsingTanStackSdk: boolean = false;
+  _isUsingReactSdk: boolean = false;
+  _isUsingAngularFireSdk: boolean = false;
   private _appCheckTokenProvider?: AppCheckTokenProvider;
   // @internal
   constructor(
@@ -114,6 +117,24 @@ export class DataConnect {
   _useGeneratedSdk(): void {
     if (!this._isUsingGeneratedSdk) {
       this._isUsingGeneratedSdk = true;
+    }
+  }
+  // @internal
+  _useTanStackSdk(): void {
+    if (!this._isUsingTanStackSdk) {
+      this._isUsingTanStackSdk = true;
+    }
+  }
+  // @internal
+  _useReactSdk(): void {
+    if (!this._isUsingReactSdk) {
+      this._isUsingReactSdk = true;
+    }
+  }
+  // @internal
+  _useAngularFireSdk(): void {
+    if (!this._isUsingAngularFireSdk) {
+      this._isUsingAngularFireSdk = true;
     }
   }
   _delete(): Promise<void> {
@@ -164,7 +185,10 @@ export class DataConnect {
       this._authTokenProvider,
       this._appCheckTokenProvider,
       undefined,
-      this._isUsingGeneratedSdk
+      this._isUsingGeneratedSdk,
+      this._isUsingTanStackSdk,
+      this._isUsingReactSdk,
+      this._isUsingAngularFireSdk
     );
     if (this._transportOptions) {
       this._transport.useEmulator(

--- a/packages/data-connect/src/api/DataConnect.ts
+++ b/packages/data-connect/src/api/DataConnect.ts
@@ -125,7 +125,9 @@ export class DataConnect {
   // @internal
   _setCallerSdkType(callerSdkType: CallerSdkType): void {
     this._callerSdkType = callerSdkType;
-    this._transport._setCallerSdkType(callerSdkType);
+    if (this._initialized) {
+      this._transport._setCallerSdkType(callerSdkType);
+    }
   }
   _delete(): Promise<void> {
     _removeServiceInstance(

--- a/packages/data-connect/src/network/fetch.ts
+++ b/packages/data-connect/src/network/fetch.ts
@@ -43,7 +43,7 @@ function getWebFrameworkValue(
     str += ' react/';
   }
   if (_isUsingAngular) {
-    str += ' angularfire/';
+    str += ' angular/';
   }
   // no framework SDK used
   if (str === '') {

--- a/packages/data-connect/src/network/fetch.ts
+++ b/packages/data-connect/src/network/fetch.ts
@@ -27,15 +27,12 @@ export function initializeFetch(fetchImpl: typeof fetch): void {
 }
 function getGoogApiClientValue(_callerSdkType: CallerSdkType): string {
   let str = 'gl-js/ fire/' + SDK_VERSION;
-  if (_callerSdkType !== CallerSdkTypeEnum.Base) {
+  if (_callerSdkType === CallerSdkTypeEnum.Generated) {
     str += ' js/gen';
+  } else if (_callerSdkType !== CallerSdkTypeEnum.Base) {
+    str += ' js/' + _callerSdkType.toLowerCase();
   }
   return str;
-}
-function getWebFrameworkValue(
-  _callerSdkType: CallerSdkType
-): string {
-  return _callerSdkType + "/";
 }
 export interface DataConnectFetchBody<T> {
   name: string;
@@ -49,6 +46,7 @@ export function dcFetch<T, U>(
   appId: string | null,
   accessToken: string | null,
   appCheckToken: string | null,
+  _isUsingGen: boolean,
   _callerSdkType: CallerSdkType
 ): Promise<{ data: T; errors: Error[] }> {
   if (!connectFetch) {
@@ -56,9 +54,7 @@ export function dcFetch<T, U>(
   }
   const headers: HeadersInit = {
     'Content-Type': 'application/json',
-    'X-Goog-Api-Client': getGoogApiClientValue(_callerSdkType),
-    'X-Firebase-DataConnect-Web-Frameworks':
-      getWebFrameworkValue(_callerSdkType)
+    'X-Goog-Api-Client': getGoogApiClientValue(_callerSdkType)
   };
   if (accessToken) {
     headers['X-Firebase-Auth-Token'] = accessToken;

--- a/packages/data-connect/src/network/fetch.ts
+++ b/packages/data-connect/src/network/fetch.ts
@@ -33,7 +33,7 @@ function getGoogApiClientValue(_isUsingGen: boolean): string {
 function getWebFrameworkValue(
   _isUsingTanStack: boolean,
   _isUsingReact: boolean,
-  _isUsingAngularFire: boolean
+  _isUsingAngular: boolean
 ): string {
   let str = '';
   if (_isUsingTanStack) {
@@ -42,7 +42,7 @@ function getWebFrameworkValue(
   if (_isUsingReact) {
     str += ' react/';
   }
-  if (_isUsingAngularFire) {
+  if (_isUsingAngular) {
     str += ' angularfire/';
   }
   // no framework SDK used
@@ -66,7 +66,7 @@ export function dcFetch<T, U>(
   _isUsingGen: boolean,
   _isUsingTanStack: boolean,
   _isUsingReact: boolean,
-  _isUsingAngularFire: boolean
+  _isUsingAngular: boolean
 ): Promise<{ data: T; errors: Error[] }> {
   if (!connectFetch) {
     throw new DataConnectError(Code.OTHER, 'No Fetch Implementation detected!');
@@ -77,7 +77,7 @@ export function dcFetch<T, U>(
     'X-Firebase-DataConnect-Web-Frameworks': getWebFrameworkValue(
       _isUsingTanStack,
       _isUsingReact,
-      _isUsingAngularFire
+      _isUsingAngular
     )
   };
   if (accessToken) {

--- a/packages/data-connect/src/network/fetch.ts
+++ b/packages/data-connect/src/network/fetch.ts
@@ -27,10 +27,10 @@ export function initializeFetch(fetchImpl: typeof fetch): void {
 }
 function getGoogApiClientValue(_isUsingGen: boolean, _callerSdkType: CallerSdkType): string {
   let str = 'gl-js/ fire/' + SDK_VERSION;
-  if (_isUsingGen || _callerSdkType === CallerSdkTypeEnum.Generated) {
-    str += ' js/gen';
-  } else if (_callerSdkType !== CallerSdkTypeEnum.Base) {
+  if (_callerSdkType !== CallerSdkTypeEnum.Base && _callerSdkType !== CallerSdkTypeEnum.Generated) {
     str += ' js/' + _callerSdkType.toLowerCase();
+  } else if (_isUsingGen || _callerSdkType === CallerSdkTypeEnum.Generated)  {
+    str += ' js/gen';
   }
   return str;
 }

--- a/packages/data-connect/src/network/fetch.ts
+++ b/packages/data-connect/src/network/fetch.ts
@@ -25,9 +25,9 @@ let connectFetch: typeof fetch | null = globalThis.fetch;
 export function initializeFetch(fetchImpl: typeof fetch): void {
   connectFetch = fetchImpl;
 }
-function getGoogApiClientValue(_callerSdkType: CallerSdkType): string {
+function getGoogApiClientValue(_isUsingGen: boolean, _callerSdkType: CallerSdkType): string {
   let str = 'gl-js/ fire/' + SDK_VERSION;
-  if (_callerSdkType === CallerSdkTypeEnum.Generated) {
+  if (_isUsingGen || _callerSdkType === CallerSdkTypeEnum.Generated) {
     str += ' js/gen';
   } else if (_callerSdkType !== CallerSdkTypeEnum.Base) {
     str += ' js/' + _callerSdkType.toLowerCase();
@@ -54,7 +54,7 @@ export function dcFetch<T, U>(
   }
   const headers: HeadersInit = {
     'Content-Type': 'application/json',
-    'X-Goog-Api-Client': getGoogApiClientValue(_callerSdkType)
+    'X-Goog-Api-Client': getGoogApiClientValue(_isUsingGen, _callerSdkType)
   };
   if (accessToken) {
     headers['X-Firebase-Auth-Token'] = accessToken;

--- a/packages/data-connect/src/network/fetch.ts
+++ b/packages/data-connect/src/network/fetch.ts
@@ -30,6 +30,27 @@ function getGoogApiClientValue(_isUsingGen: boolean): string {
   }
   return str;
 }
+function getWebFrameworkValue(
+  _isUsingTanStack: boolean,
+  _isUsingReact: boolean,
+  _isUsingAngularFire: boolean
+): string {
+  let str = '';
+  if (_isUsingTanStack) {
+    str += ' tanstack/';
+  }
+  if (_isUsingReact) {
+    str += ' react/';
+  }
+  if (_isUsingAngularFire) {
+    str += ' angularfire/';
+  }
+  // no framework SDK used
+  if (str === '') {
+    str = 'vanilla/';
+  }
+  return str.trim();
+}
 export interface DataConnectFetchBody<T> {
   name: string;
   operationName: string;
@@ -42,14 +63,22 @@ export function dcFetch<T, U>(
   appId: string | null,
   accessToken: string | null,
   appCheckToken: string | null,
-  _isUsingGen: boolean
+  _isUsingGen: boolean,
+  _isUsingTanStack: boolean,
+  _isUsingReact: boolean,
+  _isUsingAngularFire: boolean
 ): Promise<{ data: T; errors: Error[] }> {
   if (!connectFetch) {
     throw new DataConnectError(Code.OTHER, 'No Fetch Implementation detected!');
   }
   const headers: HeadersInit = {
     'Content-Type': 'application/json',
-    'X-Goog-Api-Client': getGoogApiClientValue(_isUsingGen)
+    'X-Goog-Api-Client': getGoogApiClientValue(_isUsingGen),
+    'X-Firebase-DataConnect-Web-Frameworks': getWebFrameworkValue(
+      _isUsingTanStack,
+      _isUsingReact,
+      _isUsingAngularFire
+    )
   };
   if (accessToken) {
     headers['X-Firebase-Auth-Token'] = accessToken;

--- a/packages/data-connect/src/network/fetch.ts
+++ b/packages/data-connect/src/network/fetch.ts
@@ -25,11 +25,17 @@ let connectFetch: typeof fetch | null = globalThis.fetch;
 export function initializeFetch(fetchImpl: typeof fetch): void {
   connectFetch = fetchImpl;
 }
-function getGoogApiClientValue(_isUsingGen: boolean, _callerSdkType: CallerSdkType): string {
+function getGoogApiClientValue(
+  _isUsingGen: boolean,
+  _callerSdkType: CallerSdkType
+): string {
   let str = 'gl-js/ fire/' + SDK_VERSION;
-  if (_callerSdkType !== CallerSdkTypeEnum.Base && _callerSdkType !== CallerSdkTypeEnum.Generated) {
+  if (
+    _callerSdkType !== CallerSdkTypeEnum.Base &&
+    _callerSdkType !== CallerSdkTypeEnum.Generated
+  ) {
     str += ' js/' + _callerSdkType.toLowerCase();
-  } else if (_isUsingGen || _callerSdkType === CallerSdkTypeEnum.Generated)  {
+  } else if (_isUsingGen || _callerSdkType === CallerSdkTypeEnum.Generated) {
     str += ' js/gen';
   }
   return str;

--- a/packages/data-connect/src/network/transport/index.ts
+++ b/packages/data-connect/src/network/transport/index.ts
@@ -33,6 +33,9 @@ export interface DataConnectTransport {
   ): Promise<{ data: T; errors: Error[] }>;
   useEmulator(host: string, port?: number, sslEnabled?: boolean): void;
   onTokenChanged: (token: string | null) => void;
+  _useTanStack(): void;
+  _useReact(): void;
+  _useAngular(): void;
 }
 
 /**
@@ -48,5 +51,5 @@ export type TransportClass = new (
   _isUsingGen?: boolean,
   _isUsingTanStack?: boolean,
   _isUsingReact?: boolean,
-  _isUsingAngularFire?: boolean
+  _isUsingAngular?: boolean
 ) => DataConnectTransport;

--- a/packages/data-connect/src/network/transport/index.ts
+++ b/packages/data-connect/src/network/transport/index.ts
@@ -67,5 +67,6 @@ export type TransportClass = new (
   authProvider?: AuthTokenProvider,
   appCheckProvider?: AppCheckTokenProvider,
   transportOptions?: TransportOptions,
-  _callerSdkType?: CallerSdkType
+  _isUsingGen?: boolean,
+    _callerSdkType?: CallerSdkType
 ) => DataConnectTransport;

--- a/packages/data-connect/src/network/transport/index.ts
+++ b/packages/data-connect/src/network/transport/index.ts
@@ -20,6 +20,26 @@ import { AppCheckTokenProvider } from '../../core/AppCheckTokenProvider';
 import { AuthTokenProvider } from '../../core/FirebaseAuthProvider';
 
 /**
+ * enum representing different flavors of the SDK used by developers
+ * use the CallerSdkType for type-checking, and the CallerSdkTypeEnum for value-checking/assigning
+ */
+export type CallerSdkType =
+  | 'Base' // Core JS SDK
+  | 'Generated' // Generated JS SDK
+  | 'TanstackReactCore' // Tanstack non-generated React SDK
+  | 'GeneratedReact' // Generated React SDK
+  | 'TanstackAngularCore' // Tanstack non-generated Angular SDK
+  | 'GeneratedAngular'; // Generated Angular SDK
+export const CallerSdkTypeEnum = Object.freeze({
+  Base: 'Base', // Core JS SDK
+  Generated: 'Generated', // Generated JS SDK
+  TanstackReactCore: 'TanstackReactCore', // Tanstack non-generated React SDK
+  GeneratedReact: 'GeneratedReact', // Tanstack non-generated Angular SDK
+  TanstackAngularCore: 'TanstackAngularCore', // Tanstack non-generated Angular SDK
+  GeneratedAngular: 'GeneratedAngular' // Generated Angular SDK
+} as const);
+
+/**
  * @internal
  */
 export interface DataConnectTransport {
@@ -33,9 +53,8 @@ export interface DataConnectTransport {
   ): Promise<{ data: T; errors: Error[] }>;
   useEmulator(host: string, port?: number, sslEnabled?: boolean): void;
   onTokenChanged: (token: string | null) => void;
-  _useTanStack(): void;
-  _useReact(): void;
-  _useAngular(): void;
+  // @internal
+  _setCallerSdkType(callerSdkType: CallerSdkType): void;
 }
 
 /**
@@ -48,8 +67,5 @@ export type TransportClass = new (
   authProvider?: AuthTokenProvider,
   appCheckProvider?: AppCheckTokenProvider,
   transportOptions?: TransportOptions,
-  _isUsingGen?: boolean,
-  _isUsingTanStack?: boolean,
-  _isUsingReact?: boolean,
-  _isUsingAngular?: boolean
+  _callerSdkType?: CallerSdkType
 ) => DataConnectTransport;

--- a/packages/data-connect/src/network/transport/index.ts
+++ b/packages/data-connect/src/network/transport/index.ts
@@ -68,5 +68,5 @@ export type TransportClass = new (
   appCheckProvider?: AppCheckTokenProvider,
   transportOptions?: TransportOptions,
   _isUsingGen?: boolean,
-    _callerSdkType?: CallerSdkType
+  _callerSdkType?: CallerSdkType
 ) => DataConnectTransport;

--- a/packages/data-connect/src/network/transport/index.ts
+++ b/packages/data-connect/src/network/transport/index.ts
@@ -45,5 +45,8 @@ export type TransportClass = new (
   authProvider?: AuthTokenProvider,
   appCheckProvider?: AppCheckTokenProvider,
   transportOptions?: TransportOptions,
-  _isUsingGen?: boolean
+  _isUsingGen?: boolean,
+  _isUsingTanStack?: boolean,
+  _isUsingReact?: boolean,
+  _isUsingAngularFire?: boolean
 ) => DataConnectTransport;

--- a/packages/data-connect/src/network/transport/index.ts
+++ b/packages/data-connect/src/network/transport/index.ts
@@ -30,14 +30,14 @@ export type CallerSdkType =
   | 'GeneratedReact' // Generated React SDK
   | 'TanstackAngularCore' // Tanstack non-generated Angular SDK
   | 'GeneratedAngular'; // Generated Angular SDK
-export const CallerSdkTypeEnum = Object.freeze({
+export const CallerSdkTypeEnum = {
   Base: 'Base', // Core JS SDK
   Generated: 'Generated', // Generated JS SDK
   TanstackReactCore: 'TanstackReactCore', // Tanstack non-generated React SDK
   GeneratedReact: 'GeneratedReact', // Tanstack non-generated Angular SDK
   TanstackAngularCore: 'TanstackAngularCore', // Tanstack non-generated Angular SDK
   GeneratedAngular: 'GeneratedAngular' // Generated Angular SDK
-} as const);
+} as const;
 
 /**
  * @internal

--- a/packages/data-connect/src/network/transport/index.ts
+++ b/packages/data-connect/src/network/transport/index.ts
@@ -53,7 +53,6 @@ export interface DataConnectTransport {
   ): Promise<{ data: T; errors: Error[] }>;
   useEmulator(host: string, port?: number, sslEnabled?: boolean): void;
   onTokenChanged: (token: string | null) => void;
-  // @internal
   _setCallerSdkType(callerSdkType: CallerSdkType): void;
 }
 

--- a/packages/data-connect/src/network/transport/rest.ts
+++ b/packages/data-connect/src/network/transport/rest.ts
@@ -44,7 +44,7 @@ export class RESTTransport implements DataConnectTransport {
     private appCheckProvider?: AppCheckTokenProvider | undefined,
     transportOptions?: TransportOptions | undefined,
     private _isUsingGen = false,
-    private _callerSdkType: CallerSdkType = CallerSdkTypeEnum.Base,
+    private _callerSdkType: CallerSdkType = CallerSdkTypeEnum.Base
   ) {
     if (transportOptions) {
       if (typeof transportOptions.port === 'number') {

--- a/packages/data-connect/src/network/transport/rest.ts
+++ b/packages/data-connect/src/network/transport/rest.ts
@@ -43,6 +43,7 @@ export class RESTTransport implements DataConnectTransport {
     private authProvider?: AuthTokenProvider | undefined,
     private appCheckProvider?: AppCheckTokenProvider | undefined,
     transportOptions?: TransportOptions | undefined,
+    private _isUsingGen = false,
     private _callerSdkType: CallerSdkType = CallerSdkTypeEnum.Base,
   ) {
     if (transportOptions) {
@@ -180,6 +181,7 @@ export class RESTTransport implements DataConnectTransport {
         this.appId,
         this._accessToken,
         this._appCheckToken,
+        this._isUsingGen,
         this._callerSdkType
       )
     );
@@ -205,6 +207,7 @@ export class RESTTransport implements DataConnectTransport {
         this.appId,
         this._accessToken,
         this._appCheckToken,
+        this._isUsingGen,
         this._callerSdkType
       );
     });

--- a/packages/data-connect/src/network/transport/rest.ts
+++ b/packages/data-connect/src/network/transport/rest.ts
@@ -45,7 +45,7 @@ export class RESTTransport implements DataConnectTransport {
     transportOptions?: TransportOptions | undefined,
     private _isUsingGen = false,
     private _isUsingReact = false,
-    private _isUsingAngularFire = false,
+    private _isUsingAngular = false,
     private _isUsingTanStack = false
   ) {
     if (transportOptions) {
@@ -186,7 +186,7 @@ export class RESTTransport implements DataConnectTransport {
         this._isUsingGen,
         this._isUsingTanStack,
         this._isUsingReact,
-        this._isUsingAngularFire
+        this._isUsingAngular
       )
     );
     return withAuth;
@@ -214,9 +214,25 @@ export class RESTTransport implements DataConnectTransport {
         this._isUsingGen,
         this._isUsingTanStack,
         this._isUsingReact,
-        this._isUsingAngularFire
+        this._isUsingAngular
       );
     });
     return taskResult;
   };
+
+  _useTanStack(): void {
+    if (!this._isUsingTanStack) {
+      this._isUsingTanStack = true;
+    }
+  }
+  _useReact(): void {
+    if (!this._isUsingReact) {
+      this._isUsingReact = true;
+    }
+  }
+  _useAngular(): void {
+    if (!this._isUsingAngular) {
+      this._isUsingAngular = true;
+    }
+  }
 }

--- a/packages/data-connect/src/network/transport/rest.ts
+++ b/packages/data-connect/src/network/transport/rest.ts
@@ -23,7 +23,7 @@ import { logDebug } from '../../logger';
 import { addToken, urlBuilder } from '../../util/url';
 import { dcFetch } from '../fetch';
 
-import { DataConnectTransport } from '.';
+import { CallerSdkType, CallerSdkTypeEnum, DataConnectTransport } from '.';
 
 export class RESTTransport implements DataConnectTransport {
   private _host = '';
@@ -43,10 +43,7 @@ export class RESTTransport implements DataConnectTransport {
     private authProvider?: AuthTokenProvider | undefined,
     private appCheckProvider?: AppCheckTokenProvider | undefined,
     transportOptions?: TransportOptions | undefined,
-    private _isUsingGen = false,
-    private _isUsingReact = false,
-    private _isUsingAngular = false,
-    private _isUsingTanStack = false
+    private _callerSdkType: CallerSdkType = CallerSdkTypeEnum.Base,
   ) {
     if (transportOptions) {
       if (typeof transportOptions.port === 'number') {
@@ -183,10 +180,7 @@ export class RESTTransport implements DataConnectTransport {
         this.appId,
         this._accessToken,
         this._appCheckToken,
-        this._isUsingGen,
-        this._isUsingTanStack,
-        this._isUsingReact,
-        this._isUsingAngular
+        this._callerSdkType
       )
     );
     return withAuth;
@@ -211,28 +205,14 @@ export class RESTTransport implements DataConnectTransport {
         this.appId,
         this._accessToken,
         this._appCheckToken,
-        this._isUsingGen,
-        this._isUsingTanStack,
-        this._isUsingReact,
-        this._isUsingAngular
+        this._callerSdkType
       );
     });
     return taskResult;
   };
 
-  _useTanStack(): void {
-    if (!this._isUsingTanStack) {
-      this._isUsingTanStack = true;
-    }
-  }
-  _useReact(): void {
-    if (!this._isUsingReact) {
-      this._isUsingReact = true;
-    }
-  }
-  _useAngular(): void {
-    if (!this._isUsingAngular) {
-      this._isUsingAngular = true;
-    }
+  // @internal
+  _setCallerSdkType(callerSdkType: CallerSdkType): void {
+    this._callerSdkType = callerSdkType;
   }
 }

--- a/packages/data-connect/src/network/transport/rest.ts
+++ b/packages/data-connect/src/network/transport/rest.ts
@@ -43,7 +43,10 @@ export class RESTTransport implements DataConnectTransport {
     private authProvider?: AuthTokenProvider | undefined,
     private appCheckProvider?: AppCheckTokenProvider | undefined,
     transportOptions?: TransportOptions | undefined,
-    private _isUsingGen = false
+    private _isUsingGen = false,
+    private _isUsingReact = false,
+    private _isUsingAngularFire = false,
+    private _isUsingTanStack = false
   ) {
     if (transportOptions) {
       if (typeof transportOptions.port === 'number') {
@@ -180,7 +183,10 @@ export class RESTTransport implements DataConnectTransport {
         this.appId,
         this._accessToken,
         this._appCheckToken,
-        this._isUsingGen
+        this._isUsingGen,
+        this._isUsingTanStack,
+        this._isUsingReact,
+        this._isUsingAngularFire
       )
     );
     return withAuth;
@@ -205,7 +211,10 @@ export class RESTTransport implements DataConnectTransport {
         this.appId,
         this._accessToken,
         this._appCheckToken,
-        this._isUsingGen
+        this._isUsingGen,
+        this._isUsingTanStack,
+        this._isUsingReact,
+        this._isUsingAngularFire
       );
     });
     return taskResult;

--- a/packages/data-connect/src/network/transport/rest.ts
+++ b/packages/data-connect/src/network/transport/rest.ts
@@ -214,7 +214,6 @@ export class RESTTransport implements DataConnectTransport {
     return taskResult;
   };
 
-  // @internal
   _setCallerSdkType(callerSdkType: CallerSdkType): void {
     this._callerSdkType = callerSdkType;
   }

--- a/packages/data-connect/test/unit/fetch.test.ts
+++ b/packages/data-connect/test/unit/fetch.test.ts
@@ -52,6 +52,7 @@ describe('fetch', () => {
         null,
         null,
         null,
+        false,
         CallerSdkTypeEnum.Base
       )
     ).to.eventually.be.rejectedWith(message);
@@ -75,6 +76,7 @@ describe('fetch', () => {
         null,
         null,
         null,
+        false,
         CallerSdkTypeEnum.Base
       )
     ).to.eventually.be.rejectedWith(JSON.stringify(json));

--- a/packages/data-connect/test/unit/fetch.test.ts
+++ b/packages/data-connect/test/unit/fetch.test.ts
@@ -115,9 +115,9 @@ describe('fetch', () => {
         let expectedHeaderRegex: RegExp;
         if (callerSdkType === CallerSdkTypeEnum.Base) {
           // should not contain any "js/xxx" substring
-          expectedHeaderRegex = RegExp(`^((?!js\/\w).)*$`);
+          expectedHeaderRegex = RegExp(/^((?!js\/\w).)*$/);
         } else if (callerSdkType === CallerSdkTypeEnum.Generated) {
-          expectedHeaderRegex = RegExp(`js\/gen`);
+          expectedHeaderRegex = RegExp(/js\/gen/);
         } else {
           expectedHeaderRegex = RegExp(`js\/${callerSdkType.toLowerCase()}`);
         }

--- a/packages/data-connect/test/unit/fetch.test.ts
+++ b/packages/data-connect/test/unit/fetch.test.ts
@@ -92,13 +92,11 @@ describe('fetch', () => {
     };
     const fakeFetchImpl = mockFetch(json, false);
 
-    const callerSdkTypesUsed: string[] = [];
-
     for (const callerSdkType in CallerSdkTypeEnum) {
+      // this check is done to follow the best practices outlined by the "guard-for-in" eslint rule
       if (
         Object.prototype.hasOwnProperty.call(CallerSdkTypeEnum, callerSdkType)
       ) {
-        callerSdkTypesUsed.push(callerSdkType);
         await dcFetch(
           'http://localhost',
           {
@@ -143,6 +141,7 @@ describe('fetch', () => {
     const fakeFetchImpl = mockFetch(json, false);
 
     for (const callerSdkType in CallerSdkTypeEnum) {
+      // this check is done to follow the best practices outlined by the "guard-for-in" eslint rule
       if (
         Object.prototype.hasOwnProperty.call(CallerSdkTypeEnum, callerSdkType)
       ) {

--- a/packages/data-connect/test/unit/fetch.test.ts
+++ b/packages/data-connect/test/unit/fetch.test.ts
@@ -20,6 +20,7 @@ import chaiAsPromised from 'chai-as-promised';
 import * as sinon from 'sinon';
 
 import { dcFetch, initializeFetch } from '../../src/network/fetch';
+import { CallerSdkTypeEnum } from '../../src/network/transport';
 use(chaiAsPromised);
 function mockFetch(json: object): void {
   const fakeFetchImpl = sinon.stub().returns(
@@ -51,10 +52,7 @@ describe('fetch', () => {
         null,
         null,
         null,
-        false,
-        false,
-        false,
-        false
+        CallerSdkTypeEnum.Base
       )
     ).to.eventually.be.rejectedWith(message);
   });
@@ -77,10 +75,7 @@ describe('fetch', () => {
         null,
         null,
         null,
-        false,
-        false,
-        false,
-        false
+        CallerSdkTypeEnum.Base
       )
     ).to.eventually.be.rejectedWith(JSON.stringify(json));
   });

--- a/packages/data-connect/test/unit/fetch.test.ts
+++ b/packages/data-connect/test/unit/fetch.test.ts
@@ -51,6 +51,9 @@ describe('fetch', () => {
         null,
         null,
         null,
+        false,
+        false,
+        false,
         false
       )
     ).to.eventually.be.rejectedWith(message);
@@ -74,6 +77,9 @@ describe('fetch', () => {
         null,
         null,
         null,
+        false,
+        false,
+        false,
         false
       )
     ).to.eventually.be.rejectedWith(JSON.stringify(json));


### PR DESCRIPTION
Add support for web framework tracking via custom headers
- add `CallerSdkTypeEnum` enum to differentiate between frameworks
- add `_callerSdkType` field and `_setCallerSdkType()` methods to `DataConnect` type, as well as `DataConnectTransport` types
- remove `_isUsingGen` fields and functions (`_isUsingGen = false` is now represented by `CallerSdkTypeEnum.Base`, while `_isUsingGen = true` is represented by any value other than `CallerSdkTypeEnum.Base`)