### PR TITLE
Emulator Idempotency: Auth

### DIFF
--- a/.changeset/lemon-candles-vanish.md
+++ b/.changeset/lemon-candles-vanish.md
@@ -1,0 +1,8 @@
+---
+'@firebase/auth': patch
+'firebase': patch
+---
+
+Fixed: invoking `connectAuthEmulator` mulitiple times with the same parameters will no longer cause
+an error. Fixes [GitHub Issue #6824](https://github.com/firebase/firebase-js-sdk/issues/6824).
+

--- a/.changeset/lemon-candles-vanish.md
+++ b/.changeset/lemon-candles-vanish.md
@@ -3,6 +3,6 @@
 'firebase': patch
 ---
 
-Fixed: invoking `connectAuthEmulator` mulitiple times with the same parameters will no longer cause
+Fixed: invoking `connectAuthEmulator` multiple times with the same parameters will no longer cause
 an error. Fixes [GitHub Issue #6824](https://github.com/firebase/firebase-js-sdk/issues/6824).
 

--- a/packages/auth/src/core/auth/emulator.test.ts
+++ b/packages/auth/src/core/auth/emulator.test.ts
@@ -76,6 +76,41 @@ describe('core/auth/emulator', () => {
       );
     });
 
+    it('passes with same config if a network request has already been made', async () => {
+      expect(() => connectAuthEmulator(auth, 'http://127.0.0.1:2020')).to.not
+        .throw;
+      await user.delete();
+      expect(() => connectAuthEmulator(auth, 'http://127.0.0.1:2020')).to.not
+        .throw;
+    });
+
+    it('fails with differeing config if a network request has already been made', async () => {
+      expect(() => connectAuthEmulator(auth, 'http://127.0.0.1:2020')).to.not
+        .throw;
+      await user.delete();
+      expect(() => connectAuthEmulator(auth, 'http://127.0.0.1:2021')).to.throw(
+        FirebaseError,
+        'auth/emulator-config-failed'
+      );
+    });
+
+    it('subsequent calls update the endpoint appropriately', async () => {
+      connectAuthEmulator(auth, 'http://127.0.0.2:2020');
+      expect(auth.emulatorConfig).to.eql({
+        protocol: 'http',
+        host: '127.0.0.2',
+        port: 2020,
+        options: { disableWarnings: false }
+      });
+      connectAuthEmulator(auth, 'http://127.0.0.1:2020');
+      expect(auth.emulatorConfig).to.eql({
+        protocol: 'http',
+        host: '127.0.0.1',
+        port: 2020,
+        options: { disableWarnings: false }
+      });
+    });
+
     it('updates the endpoint appropriately', async () => {
       connectAuthEmulator(auth, 'http://127.0.0.1:2020');
       await user.delete();

--- a/packages/auth/src/core/auth/emulator.test.ts
+++ b/packages/auth/src/core/auth/emulator.test.ts
@@ -84,7 +84,7 @@ describe('core/auth/emulator', () => {
         .throw;
     });
 
-    it('fails with differeing config if a network request has already been made', async () => {
+    it('fails with alternate config if a network request has already been made', async () => {
       expect(() => connectAuthEmulator(auth, 'http://127.0.0.1:2020')).to.not
         .throw;
       await user.delete();
@@ -95,11 +95,11 @@ describe('core/auth/emulator', () => {
     });
 
     it('subsequent calls update the endpoint appropriately', async () => {
-      connectAuthEmulator(auth, 'http://127.0.0.2:2020');
+      connectAuthEmulator(auth, 'http://127.0.0.1:2021');
       expect(auth.emulatorConfig).to.eql({
         protocol: 'http',
-        host: '127.0.0.2',
-        port: 2020,
+        host: '127.0.0.1',
+        port: 2021,
         options: { disableWarnings: false }
       });
       connectAuthEmulator(auth, 'http://127.0.0.1:2020');

--- a/packages/auth/src/core/auth/emulator.ts
+++ b/packages/auth/src/core/auth/emulator.ts
@@ -44,7 +44,7 @@ import { _castAuth } from './auth_impl';
 export function connectAuthEmulator(
   auth: Auth,
   url: string,
-  options: { disableWarnings: boolean } = { disableWarnings: false }
+  options?: { disableWarnings: boolean }
 ): void {
   const authInternal = _castAuth(auth);
   _assert(

--- a/packages/auth/src/core/auth/emulator.ts
+++ b/packages/auth/src/core/auth/emulator.ts
@@ -77,6 +77,7 @@ export function connectAuthEmulator(
       authInternal,
       AuthErrorCode.EMULATOR_CONFIG_FAILED
     );
+    return;
   }
 
   authInternal.config.emulator = emulator;

--- a/packages/auth/src/core/auth/emulator.ts
+++ b/packages/auth/src/core/auth/emulator.ts
@@ -18,6 +18,7 @@ import { Auth } from '../../model/public_types';
 import { AuthErrorCode } from '../errors';
 import { _assert } from '../util/assert';
 import { _castAuth } from './auth_impl';
+import { deepEqual } from '@firebase/util';
 
 /**
  * Changes the {@link Auth} instance to communicate with the Firebase Auth Emulator, instead of production
@@ -70,10 +71,8 @@ export function connectAuthEmulator(
 
   if (!authInternal._canInitEmulator) {
     _assert(
-      JSON.stringify(emulator) ===
-        JSON.stringify(authInternal.config.emulator) &&
-        JSON.stringify(emulatorConfig) ===
-          JSON.stringify(authInternal.emulatorConfig),
+      deepEqual(emulator, authInternal.config.emulator || {}) &&
+        deepEqual(emulatorConfig, authInternal.emulatorConfig || {}),
       authInternal,
       AuthErrorCode.EMULATOR_CONFIG_FAILED
     );


### PR DESCRIPTION
### Discussion

Update the `connectAuthEmulator` function to support its invocation more than once. If the Auth instance is already in use, and `connectAuthEmulator` is invoked with the same configuration, then the invocation will now succeed instead of assert.

This unlocks support for web frameworks which may render the page numerous times with the same instances of auth. Before this PR customers needed to add extra code to guard against calling `connectAuthEmulator` in their SSR logic. Now we do that guarding logic on their behalf which should simplify our customer's apps.

Fixes #6824.

### Testing

CI, new tests added to `packages/auth/src/core/auth/emulator.test.ts`.

### API Changes

N/A