### PR TITLE
Temp rollback of PR#8718 so we can add tests before release

### DIFF
--- a/.changeset/chilled-clocks-remember.md
+++ b/.changeset/chilled-clocks-remember.md
@@ -1,6 +1,0 @@
----
-"@firebase/database": patch
-'firebase': patch
----
-
-Fix a potential for a negative offset when calculating last reconnect times. This could cause lengthy reconnect delays in some scenarios. Fixes #8718.

--- a/packages/database/src/core/PersistentConnection.ts
+++ b/packages/database/src/core/PersistentConnection.ts
@@ -797,10 +797,8 @@ export class PersistentConnection extends ServerActions {
         this.lastConnectionEstablishedTime_ = null;
       }
 
-      const timeSinceLastConnectAttempt = Math.max(
-        0,
-        new Date().getTime() - this.lastConnectionAttemptTime_
-      );
+      const timeSinceLastConnectAttempt =
+        new Date().getTime() - this.lastConnectionAttemptTime_;
       let reconnectDelay = Math.max(
         0,
         this.reconnectDelay_ - timeSinceLastConnectAttempt


### PR DESCRIPTION
### Discussion

I had merged #8718 after approved reviews, but @maneesht would like to add tests to ensure the fix doesn't affect anything, and so that we can prevent future regressions. I'm going to roll that merged PR back now since we plan to stage a release tomorrow and time is running out to add those tests.

### Testing

CI.

### API Changes

N/A.