### PR TITLE
Skip flaky auth recaptcha test

### DIFF
--- a/packages/auth/test/integration/flows/recaptcha_enterprise.test.ts
+++ b/packages/auth/test/integration/flows/recaptcha_enterprise.test.ts
@@ -104,6 +104,10 @@ describe('Integration test: phone auth with reCAPTCHA Enterprise ENFORCE mode', 
   });
 
   it('throws error if recaptcha token is invalid', async function () {
+    // Test is ignored for now as it fails with auth/too-many-requests.
+    // TODO: Increase quota or remove this test
+    this.skip();
+
     if (emulatorUrl) {
       this.skip();
     }


### PR DESCRIPTION
['throws error if recaptcha token is invalid'](https://github.com/firebase/firebase-js-sdk/blob/main/packages/auth/test/integration/flows/recaptcha_enterprise.test.ts#L106) sometimes fails with `auth/too-many-requests`. Skip the test for now to unblock the other PRs and the release.

We will consider increasing the quota for this API.