### PR TITLE
bugfix (auth-compat): reliably detect Capacitor/Cordova environment

### DIFF
--- a/packages/auth-compat/src/platform.ts
+++ b/packages/auth-compat/src/platform.ts
@@ -54,7 +54,10 @@ export function _isAndroidOrIosCordovaScheme(ua: string = getUA()): boolean {
     (_getCurrentScheme() === 'file:' ||
       _getCurrentScheme() === 'ionic:' ||
       _getCurrentScheme() === 'capacitor:') &&
-    ua.toLowerCase().match(/iphone|ipad|ipod|android/)
+    (
+      ua.toLowerCase().match(/iphone|ipad|ipod|android/) ||
+      typeof (window as any).Capacitor !== 'undefined' || typeof (window as any).cordova !== 'undefined'
+    )
   );
 }
 


### PR DESCRIPTION
This PR resolves #8755 by adding a check for the `Capacitor`/`cordova` global namespaces on the `window` object as an alternative to checking the user agent string to confirm whether the current runtime environment is a Webview withing a Capacitor/Cordova hybrid mobile app.