### PR TITLE
Fix: fix the "TextEncoder undefined" issue

### DIFF
--- a/packages/firestore/src/util/misc.ts
+++ b/packages/firestore/src/util/misc.ts
@@ -16,6 +16,7 @@
  */
 
 import { randomBytes } from '../platform/random_bytes';
+import { newTextEncoder } from '../platform/text_serializer';
 
 import { debugAssert } from './assert';
 
@@ -77,8 +78,8 @@ export interface Equatable<T> {
 /** Compare strings in UTF-8 encoded byte order */
 export function compareUtf8Strings(left: string, right: string): number {
   // Convert the string to UTF-8 encoded bytes
-  const encodedLeft = new TextEncoder().encode(left);
-  const encodedRight = new TextEncoder().encode(right);
+  const encodedLeft = newTextEncoder().encode(left);
+  const encodedRight = newTextEncoder().encode(right);
 
   for (let i = 0; i < Math.min(encodedLeft.length, encodedRight.length); i++) {
     const comparison = primitiveComparator(encodedLeft[i], encodedRight[i]);


### PR DESCRIPTION
use platform based `newTextEncoder` creation instead of calling `TextEncoder` directly.