### PR TITLE
Emulator Idempotency: Database

### DIFF
--- a/.changeset/forty-bags-arrive.md
+++ b/.changeset/forty-bags-arrive.md
@@ -1,0 +1,8 @@
+---
+'@firebase/database-compat': patch
+'@firebase/database': patch
+'firebase': patch
+---
+
+Fixed: invoking `connectDatabaseEmulator` multiple times with the same parameters will no longer
+cause an error. Fixes [GitHub Issue #6824](https://github.com/firebase/firebase-js-sdk/issues/6824).

--- a/packages/database-compat/test/database.test.ts
+++ b/packages/database-compat/test/database.test.ts
@@ -301,7 +301,9 @@ describe('Database Tests', () => {
 
     expect(() => {
       db.useEmulator('localhost', 1234);
-    }).to.throw(/FIREBASE FATAL ERROR: connectDatabaseEmulator() cannot initialize/);
+    }).to.throw(
+      'FIREBASE FATAL ERROR: connectDatabaseEmulator() cannot initialize or alter the emulator configuration after the database instance has started.'
+    );
   });
 
   it('refFromURL returns an emulated ref with useEmulator', () => {

--- a/packages/database-compat/test/database.test.ts
+++ b/packages/database-compat/test/database.test.ts
@@ -301,7 +301,7 @@ describe('Database Tests', () => {
 
     expect(() => {
       db.useEmulator('localhost', 1234);
-    }).to.throw(/Cannot call useEmulator/);
+    }).to.throw(/connectDatabaseEmulator() cannot initialize/);
   });
 
   it('refFromURL returns an emulated ref with useEmulator', () => {

--- a/packages/database-compat/test/database.test.ts
+++ b/packages/database-compat/test/database.test.ts
@@ -301,7 +301,7 @@ describe('Database Tests', () => {
 
     expect(() => {
       db.useEmulator('localhost', 1234);
-    }).to.throw(/connectDatabaseEmulator() cannot initialize/);
+    }).to.throw(/FIREBASE FATAL ERROR: connectDatabaseEmulator() cannot initialize/);
   });
 
   it('refFromURL returns an emulated ref with useEmulator', () => {

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -27,7 +27,7 @@ import { Provider } from '@firebase/component';
 import {
   getModularInstance,
   createMockUserToken,
-  // deepEqual,
+  deepEqual,
   EmulatorMockTokenOptions,
   getDefaultEmulatorHostnameAndPort
 } from '@firebase/util';
@@ -358,9 +358,8 @@ export function connectDatabaseEmulator(
     // If the instance has already been started, then silenty fail if this function is called again
     // with the same parameters. If the parameters differ then assert.
     if (
-      true
-      // hostAndPort === db._repoInternal.repoInfo_.host //&&
-      //deepEqual(options, repo.repoInfo_.emulatorOptions)
+      hostAndPort === db._repoInternal.repoInfo_.host &&
+      deepEqual(options, repo.repoInfo_.emulatorOptions)
     ) {
       return;
     }

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -27,7 +27,7 @@ import { Provider } from '@firebase/component';
 import {
   getModularInstance,
   createMockUserToken,
-  deepEqual,
+  // deepEqual,
   EmulatorMockTokenOptions,
   getDefaultEmulatorHostnameAndPort
 } from '@firebase/util';
@@ -356,8 +356,8 @@ export function connectDatabaseEmulator(
     // If the instance has already been started, then silenty fail if this function is called again
     // with the same parameters. If the parameters differ then assert.
     if (
-      hostAndPort === db._repoInternal.repoInfo_.host &&
-      deepEqual(options, repo.repoInfo_.emulatorOptions)
+      hostAndPort === db._repoInternal.repoInfo_.host //&&
+      //deepEqual(options, repo.repoInfo_.emulatorOptions)
     ) {
       return;
     }

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -27,7 +27,6 @@ import { Provider } from '@firebase/component';
 import {
   getModularInstance,
   createMockUserToken,
-  // deepEqual,
   EmulatorMockTokenOptions,
   getDefaultEmulatorHostnameAndPort
 } from '@firebase/util';
@@ -85,11 +84,12 @@ let useRestClient = false;
  */
 function repoManagerApplyEmulatorSettings(
   repo: Repo,
-  hostAndPort: string,
+  host: string,
+  port: number,
   tokenProvider?: AuthTokenProvider
 ): void {
   repo.repoInfo_ = new RepoInfo(
-    hostAndPort,
+    `${host}:${port}`,
     /* secure= */ false,
     repo.repoInfo_.namespace,
     repo.repoInfo_.webSocketOnly,
@@ -350,22 +350,13 @@ export function connectDatabaseEmulator(
 ): void {
   db = getModularInstance(db);
   db._checkNotDeleted('useEmulator');
-  const hostAndPort = `${host}:${port}`;
-  const repo = db._repoInternal;
   if (db._instanceStarted) {
-    // If the instance has already been started, then silenty fail if this function is called again
-    // with the same parameters. If the parameters differ then assert.
-    if (
-      hostAndPort === db._repoInternal.repoInfo_.host //&&
-      //deepEqual(options, repo.repoInfo_.emulatorOptions)
-    ) {
-      return;
-    }
     fatal(
-      'connectDatabaseEmulator() cannot alter the emulator configuration after the database instance has started.'
+      'Cannot call useEmulator() after instance has already been initialized.'
     );
   }
 
+  const repo = db._repoInternal;
   let tokenProvider: EmulatorTokenProvider | undefined = undefined;
   if (repo.repoInfo_.nodeAdmin) {
     if (options.mockUserToken) {
@@ -383,7 +374,7 @@ export function connectDatabaseEmulator(
   }
 
   // Modify the repo to apply emulator settings
-  repoManagerApplyEmulatorSettings(repo, hostAndPort, tokenProvider);
+  repoManagerApplyEmulatorSettings(repo, host, port, tokenProvider);
 }
 
 /**

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -39,7 +39,7 @@ import {
   FirebaseAuthTokenProvider
 } from '../core/AuthTokenProvider';
 import { Repo, repoInterrupt, repoResume, repoStart } from '../core/Repo';
-import { RepoInfo, RepoInfoEmulatorOptions} from '../core/RepoInfo';
+import { RepoInfo, RepoInfoEmulatorOptions } from '../core/RepoInfo';
 import { parseRepoInfo } from '../core/util/libs/parser';
 import { newEmptyPath, pathIsEmpty } from '../core/util/Path';
 import {
@@ -87,7 +87,7 @@ function repoManagerApplyEmulatorSettings(
   repo: Repo,
   hostAndPort: string,
   emulatorOptions: RepoInfoEmulatorOptions,
-  tokenProvider?: AuthTokenProvider,
+  tokenProvider?: AuthTokenProvider
 ): void {
   repo.repoInfo_ = new RepoInfo(
     hostAndPort,

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -364,7 +364,7 @@ export function connectDatabaseEmulator(
       return;
     }
     fatal(
-      'connectDatabaseEmulator() cannot alter the emulator configuration after the database instance has started.'
+      'connectDatabaseEmulator() cannot initialize or alter the emulator configuration after the database instance has started.'
     );
   }
 

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -84,12 +84,11 @@ let useRestClient = false;
  */
 function repoManagerApplyEmulatorSettings(
   repo: Repo,
-  host: string,
-  port: number,
+  hostAndPort: string,
   tokenProvider?: AuthTokenProvider
 ): void {
   repo.repoInfo_ = new RepoInfo(
-    `${host}:${port}`,
+    hostAndPort,
     /* secure= */ false,
     repo.repoInfo_.namespace,
     repo.repoInfo_.webSocketOnly,
@@ -350,6 +349,7 @@ export function connectDatabaseEmulator(
 ): void {
   db = getModularInstance(db);
   db._checkNotDeleted('useEmulator');
+  const hostAndPort = `${host}:${port}`;
   if (db._instanceStarted) {
     fatal(
       'Cannot call useEmulator() after instance has already been initialized.'
@@ -374,7 +374,7 @@ export function connectDatabaseEmulator(
   }
 
   // Modify the repo to apply emulator settings
-  repoManagerApplyEmulatorSettings(repo, host, port, tokenProvider);
+  repoManagerApplyEmulatorSettings(repo, hostAndPort, tokenProvider);
 }
 
 /**

--- a/packages/database/src/core/RepoInfo.ts
+++ b/packages/database/src/core/RepoInfo.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { assert } from '@firebase/util';
+import { assert, EmulatorMockTokenOptions } from '@firebase/util';
 
 import { LONG_POLLING, WEBSOCKET } from '../realtime/Constants';
 
@@ -28,6 +28,9 @@ import { each } from './util/util';
 export class RepoInfo {
   private _host: string;
   private _domain: string;
+  private _emulatorOptions: {
+    mockUserToken?: EmulatorMockTokenOptions | string;
+  };
   internalHost: string;
 
   /**
@@ -50,6 +53,7 @@ export class RepoInfo {
   ) {
     this._host = host.toLowerCase();
     this._domain = this._host.substr(this._host.indexOf('.') + 1);
+    this._emulatorOptions = {};
     this.internalHost =
       (PersistentStorage.get('host:' + host) as string) || this._host;
   }
@@ -76,6 +80,12 @@ export class RepoInfo {
         PersistentStorage.set('host:' + this._host, this.internalHost);
       }
     }
+  }
+
+  get emulatorOptions(): {
+    mockUserToken?: EmulatorMockTokenOptions | string;
+  } {
+    return this._emulatorOptions;
   }
 
   toString(): string {

--- a/packages/database/src/core/RepoInfo.ts
+++ b/packages/database/src/core/RepoInfo.ts
@@ -24,7 +24,7 @@ import { each } from './util/util';
 
 export interface RepoInfoEmulatorOptions {
   mockUserToken?: string | EmulatorMockTokenOptions;
-};
+}
 
 /**
  * A class that holds metadata about a Repo object

--- a/packages/database/src/core/RepoInfo.ts
+++ b/packages/database/src/core/RepoInfo.ts
@@ -22,15 +22,16 @@ import { LONG_POLLING, WEBSOCKET } from '../realtime/Constants';
 import { PersistentStorage } from './storage/storage';
 import { each } from './util/util';
 
+export interface RepoInfoEmulatorOptions {
+  mockUserToken?: string | EmulatorMockTokenOptions;
+};
+
 /**
  * A class that holds metadata about a Repo object
  */
 export class RepoInfo {
   private _host: string;
   private _domain: string;
-  private _emulatorOptions: {
-    mockUserToken?: EmulatorMockTokenOptions | string;
-  };
   internalHost: string;
 
   /**
@@ -49,11 +50,11 @@ export class RepoInfo {
     public readonly nodeAdmin: boolean = false,
     public readonly persistenceKey: string = '',
     public readonly includeNamespaceInQueryParams: boolean = false,
-    public readonly isUsingEmulator: boolean = false
+    public readonly isUsingEmulator: boolean = false,
+    public readonly emulatorOptions: RepoInfoEmulatorOptions | null = null
   ) {
     this._host = host.toLowerCase();
     this._domain = this._host.substr(this._host.indexOf('.') + 1);
-    this._emulatorOptions = {};
     this.internalHost =
       (PersistentStorage.get('host:' + host) as string) || this._host;
   }
@@ -80,12 +81,6 @@ export class RepoInfo {
         PersistentStorage.set('host:' + this._host, this.internalHost);
       }
     }
-  }
-
-  get emulatorOptions(): {
-    mockUserToken?: EmulatorMockTokenOptions | string;
-  } {
-    return this._emulatorOptions;
   }
 
   toString(): string {

--- a/packages/database/test/exp/integration.test.ts
+++ b/packages/database/test/exp/integration.test.ts
@@ -138,6 +138,44 @@ describe('Database@exp Tests', () => {
     unsubscribe();
   });
 
+  /*it('can connected to emulator', async () => {
+    if (isEmulatorActive()) {
+      const db = getDatabase(defaultApp);
+      connectDatabaseEmulator(db, 'localhost', parseInt(EMULATOR_PORT, 10));
+      await get(refFromURL(db, `${DATABASE_ADDRESS}/foo/bar`));
+    }
+  });
+  it('can chnage emulator config before network operations', async () => {
+    if (isEmulatorActive()) {
+      const db = getDatabase(defaultApp);
+      const port = parseInt(EMULATOR_PORT, 10);
+      connectDatabaseEmulator(db, 'localhost', port + 1);
+      connectDatabaseEmulator(db, 'localhost', port);
+      await get(refFromURL(db, `${DATABASE_ADDRESS}/foo/bar`));
+    }
+  });
+  it('can connected to emulator after network operations with same parameters', async () => {
+    if (isEmulatorActive()) {
+      const db = getDatabase(defaultApp);
+      const port = parseInt(EMULATOR_PORT, 10);
+      connectDatabaseEmulator(db, 'localhost', port);
+      await get(refFromURL(db, `${DATABASE_ADDRESS}/foo/bar`));
+      connectDatabaseEmulator(db, 'localhost', port);
+    }
+  });
+  it('cannot connect to emulator after network operations with different parameters', async () => {
+    if (isEmulatorActive()) {
+      const db = getDatabase(defaultApp);
+      const port = parseInt(EMULATOR_PORT, 10);
+      connectDatabaseEmulator(db, 'localhost', port);
+      await get(refFromURL(db, `${DATABASE_ADDRESS}/foo/bar`));
+      expect(() => {
+        connectDatabaseEmulator(db, 'localhost', 9001);
+      }).to.throw();
+    }
+  });
+  */
+
   it('can properly handle unknown deep merges', async () => {
     // Note: This test requires `testIndex` to be added as an index.
     // Please run `yarn test:setup` to ensure that this gets added.

--- a/packages/database/test/exp/integration.test.ts
+++ b/packages/database/test/exp/integration.test.ts
@@ -141,14 +141,14 @@ describe('Database@exp Tests', () => {
     unsubscribe();
   });
 
-  it('can connected to emulator', async () => {
+  it('can connect to emulator', async () => {
     if (USE_EMULATOR) {
       const db = getDatabase(defaultApp);
       connectDatabaseEmulator(db, 'localhost', parseInt(EMULATOR_PORT, 10));
       await get(refFromURL(db, `${DATABASE_ADDRESS}/foo/bar`));
     }
   });
-  it('can chnage emulator config before network operations', async () => {
+  it('can change emulator config before network operations', async () => {
     if (USE_EMULATOR) {
       const db = getDatabase(defaultApp);
       const port = parseInt(EMULATOR_PORT, 10);
@@ -157,7 +157,7 @@ describe('Database@exp Tests', () => {
       await get(refFromURL(db, `${DATABASE_ADDRESS}/foo/bar`));
     }
   });
-  it('can connected to emulator after network operations with same parameters', async () => {
+  it('can connect to emulator after network operations with same parameters', async () => {
     if (USE_EMULATOR) {
       const db = getDatabase(defaultApp);
       const port = parseInt(EMULATOR_PORT, 10);

--- a/packages/database/test/exp/integration.test.ts
+++ b/packages/database/test/exp/integration.test.ts
@@ -35,6 +35,7 @@ import {
   orderByKey
 } from '../../src/api/Reference_impl';
 import {
+  connectDatabaseEmulator,
   getDatabase,
   goOffline,
   goOnline,
@@ -46,8 +47,10 @@ import { EventAccumulatorFactory } from '../helpers/EventAccumulator';
 import {
   DATABASE_ADDRESS,
   DATABASE_URL,
+  EMULATOR_PORT,
   getFreshRepo,
   getRWRefs,
+  USE_EMULATOR,
   waitFor,
   waitUntil,
   writeAndValidate
@@ -138,15 +141,15 @@ describe('Database@exp Tests', () => {
     unsubscribe();
   });
 
-  /*it('can connected to emulator', async () => {
-    if (isEmulatorActive()) {
+  it('can connected to emulator', async () => {
+    if (USE_EMULATOR) {
       const db = getDatabase(defaultApp);
       connectDatabaseEmulator(db, 'localhost', parseInt(EMULATOR_PORT, 10));
       await get(refFromURL(db, `${DATABASE_ADDRESS}/foo/bar`));
     }
   });
   it('can chnage emulator config before network operations', async () => {
-    if (isEmulatorActive()) {
+    if (USE_EMULATOR) {
       const db = getDatabase(defaultApp);
       const port = parseInt(EMULATOR_PORT, 10);
       connectDatabaseEmulator(db, 'localhost', port + 1);
@@ -155,7 +158,7 @@ describe('Database@exp Tests', () => {
     }
   });
   it('can connected to emulator after network operations with same parameters', async () => {
-    if (isEmulatorActive()) {
+    if (USE_EMULATOR) {
       const db = getDatabase(defaultApp);
       const port = parseInt(EMULATOR_PORT, 10);
       connectDatabaseEmulator(db, 'localhost', port);
@@ -164,7 +167,7 @@ describe('Database@exp Tests', () => {
     }
   });
   it('cannot connect to emulator after network operations with different parameters', async () => {
-    if (isEmulatorActive()) {
+    if (USE_EMULATOR) {
       const db = getDatabase(defaultApp);
       const port = parseInt(EMULATOR_PORT, 10);
       connectDatabaseEmulator(db, 'localhost', port);
@@ -174,7 +177,6 @@ describe('Database@exp Tests', () => {
       }).to.throw();
     }
   });
-  */
 
   it('can properly handle unknown deep merges', async () => {
     // Note: This test requires `testIndex` to be added as an index.

--- a/packages/database/test/exp/integration.test.ts
+++ b/packages/database/test/exp/integration.test.ts
@@ -141,33 +141,27 @@ describe('Database@exp Tests', () => {
     unsubscribe();
   });
 
-  it('can connect to emulator', async () => {
-    if (USE_EMULATOR) {
+  if (USE_EMULATOR) {
+    it('can connect to emulator', async () => {
       const db = getDatabase(defaultApp);
       connectDatabaseEmulator(db, 'localhost', parseInt(EMULATOR_PORT, 10));
       await get(refFromURL(db, `${DATABASE_ADDRESS}/foo/bar`));
-    }
-  });
-  it('can change emulator config before network operations', async () => {
-    if (USE_EMULATOR) {
+    });
+    it('can change emulator config before network operations', async () => {
       const db = getDatabase(defaultApp);
       const port = parseInt(EMULATOR_PORT, 10);
       connectDatabaseEmulator(db, 'localhost', port + 1);
       connectDatabaseEmulator(db, 'localhost', port);
       await get(refFromURL(db, `${DATABASE_ADDRESS}/foo/bar`));
-    }
-  });
-  it('can connect to emulator after network operations with same parameters', async () => {
-    if (USE_EMULATOR) {
+    });
+    it('can connect to emulator after network operations with same parameters', async () => {
       const db = getDatabase(defaultApp);
       const port = parseInt(EMULATOR_PORT, 10);
       connectDatabaseEmulator(db, 'localhost', port);
       await get(refFromURL(db, `${DATABASE_ADDRESS}/foo/bar`));
       connectDatabaseEmulator(db, 'localhost', port);
-    }
-  });
-  it('cannot connect to emulator after network operations with different parameters', async () => {
-    if (USE_EMULATOR) {
+    });
+    it('cannot connect to emulator after network operations with different parameters', async () => {
       const db = getDatabase(defaultApp);
       const port = parseInt(EMULATOR_PORT, 10);
       connectDatabaseEmulator(db, 'localhost', port);
@@ -175,8 +169,8 @@ describe('Database@exp Tests', () => {
       expect(() => {
         connectDatabaseEmulator(db, 'localhost', 9001);
       }).to.throw();
-    }
-  });
+    });
+  }
 
   it('can properly handle unknown deep merges', async () => {
     // Note: This test requires `testIndex` to be added as an index.

--- a/packages/database/test/helpers/util.ts
+++ b/packages/database/test/helpers/util.ts
@@ -33,9 +33,9 @@ import { EventAccumulator } from './EventAccumulator';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 export const TEST_PROJECT = require('../../../../config/project.json');
-const EMULATOR_PORT = process.env.RTDB_EMULATOR_PORT;
+export const EMULATOR_PORT = process.env.RTDB_EMULATOR_PORT;
 const EMULATOR_NAMESPACE = process.env.RTDB_EMULATOR_NAMESPACE;
-const USE_EMULATOR = !!EMULATOR_PORT;
+export const USE_EMULATOR = !!EMULATOR_PORT;
 
 let freshRepoId = 0;
 const activeFreshApps: FirebaseApp[] = [];


### PR DESCRIPTION
### Discussion

Update the `connectDatabaseEmulator` function to support its invocation more than once. If the Database instance is already in use, and `connectDatabaseEmulator` is invoked with the same configuration, then the invocation will now succeed instead of assert.

This unlocks support for web frameworks which may render the page numerous times with the same instances of RTDB. Before this PR customers needed to add extra code to guard against calling `connectDatabaseEmulator` in their SSR logic. Now we do that guarding logic on their behalf which should simplify our customer's apps.

Fixes #6824.

### Testing

CI, new tests added to integration tests.

### API Changes

N/A