### PR TITLE
Adds a "firebase" changeset to release PR as needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ docs/
 # vertexai test data
 vertexai-sdk-test-data
 mocks-lookup.ts
+
+# temp changeset output
+changeset-temp.json

--- a/scripts/ci/add_changeset.ts
+++ b/scripts/ci/add_changeset.ts
@@ -22,11 +22,12 @@
  * For background, see https://github.com/firebase/firebase-js-sdk/issues/4235
  */
 
-import { writeFileSync } from 'fs';
+import { writeFileSync, existsSync } from 'fs';
+import { join } from 'path';
 import { projectRoot } from '../utils';
 import { exec } from 'child-process-promise';
 
-const CONTENT = `
+const APP_CHANGESET_CONTENT = `
 ---
 '@firebase/app': patch
 ---
@@ -34,24 +35,99 @@ const CONTENT = `
 Update SDK_VERSION.
 `;
 
-const FILE_PATH = `${projectRoot}/.changeset/bump-sdk-version.md`;
+function firebaseChangesetContent(type: ReleaseType, maxProducts: string[]) {
+  return `
+---
+'firebase': ${type}
+---
+
+Update root "firebase" package as a "${type}" release due to bumps in:
+${maxProducts.join('\n')}.
+`;
+}
+
+const CHANGESET_DIR_PATH = `${projectRoot}/.changeset/`;
+
+interface ChangesetEntry {
+  releases: Array<{
+    name: string;
+    type: ReleaseType;
+  }>;
+  summary: string;
+  id: string;
+}
+
+type ReleaseType = 'none' | 'patch' | 'minor' | 'major';
+
+const releaseTypeValues: Record<ReleaseType, number> = {
+  'none': 0,
+  'patch': 1,
+  'minor': 2,
+  'major': 3
+};
 
 async function addChangeSet() {
   // check if a few firebase version is being released
   try {
     // The way actions/checkout works, there is no local `main` branch, but it
     // has access to the remote origin/main.
-    const { stdout } = await exec('yarn changeset status');
+    await exec(`yarn changeset status --output changeset-temp.json`);
+    const changesets: ChangesetEntry[] =
+      require(`${projectRoot}/changeset-temp.json`).changesets;
     // only add a changeset for @firebase/app if
     // 1. we are publishing a new firebase version. and
     // 2. @firebase/app is not already being published
-    const firebaseRelease = stdout.includes('- firebase\n');
-    const firebaseAppRelease = stdout.includes('- @firebase/app\n');
-    if (firebaseRelease && !firebaseAppRelease) {
+    let firebaseRelease: ReleaseType = 'none';
+    let firebaseAppRelease: ReleaseType = 'none';
+    let maxProductRelease: ReleaseType = 'none';
+    let maxProducts: string[] = [];
+    for (const changeset of changesets) {
+      for (const release of changeset.releases) {
+        // Track any 'firebase' release
+        if (
+          release.name === 'firebase' &&
+          releaseTypeValues[release.type] > releaseTypeValues[firebaseRelease]
+        ) {
+          firebaseRelease = release.type;
+        }
+        // Track any '@firebase/app' release
+        if (
+          release.name === '@firebase/app' &&
+          releaseTypeValues[release.type] >
+            releaseTypeValues[firebaseAppRelease]
+        ) {
+          firebaseAppRelease = release.type;
+        }
+        // Track any minor or greater release that isn't 'firebase'
+        if (
+          release.name !== 'firebase' &&
+          releaseTypeValues[release.type] >=
+            releaseTypeValues[maxProductRelease]
+        ) {
+          if (
+            releaseTypeValues[release.type] ===
+            releaseTypeValues[maxProductRelease]
+          ) {
+            maxProducts.push(release.name);
+          } else {
+            maxProducts = [release.name];
+          }
+          maxProductRelease = release.type;
+        }
+      }
+    }
+    if (
+      releaseTypeValues[firebaseRelease] > 0 &&
+      releaseTypeValues[firebaseAppRelease] === 0
+    ) {
       console.log('Creating a patch changeset for @firebase/app');
-      writeFileSync(FILE_PATH, CONTENT, {
-        encoding: 'utf-8'
-      });
+      writeFileSync(
+        join(CHANGESET_DIR_PATH, 'bump-sdk-version.md'),
+        APP_CHANGESET_CONTENT,
+        {
+          encoding: 'utf-8'
+        }
+      );
     } else if (firebaseAppRelease) {
       console.log(
         'Skip creating a patch changeset for @firebase/app because it is already part of the release'
@@ -59,6 +135,21 @@ async function addChangeSet() {
     } else {
       console.log(
         'Skip creating a patch changeset for @firebase/app because firebase is not being released'
+      );
+    }
+    if (
+      releaseTypeValues[maxProductRelease] > releaseTypeValues['patch'] &&
+      releaseTypeValues[maxProductRelease] > releaseTypeValues[firebaseRelease]
+    ) {
+      console.log(
+        `Creating a ${maxProductRelease} changeset for firebase due to ${maxProducts.join(', ')}`
+      );
+      writeFileSync(
+        join(CHANGESET_DIR_PATH, 'bump-root-package.md'),
+        firebaseChangesetContent(maxProductRelease, maxProducts),
+        {
+          encoding: 'utf-8'
+        }
       );
     }
   } catch (e) {


### PR DESCRIPTION
Modified the script that runs when generating a staging release PR (the "Version Packages PR"). This will run on staging. It always added a changeset for `@firebase/app` to make sure the `SDK_VERSION` constant got bumped, now we are also checking and adding another changeset for `firebase` if any packages got bumped above a `patch` (basically, `minor`, as we are more deliberate about major version bumps).

This prevents us from having to give confusing instructions to contributors about when they have to add the "firebase" line to their changeset files, which doesn't seem like something an individual product contributor should have to worry about.