### PR TITLE
perf: Use charCodeAt instead of TextEncoder for improved UTF string comparison performance.

### DIFF
--- a/packages/firestore/src/model/path.ts
+++ b/packages/firestore/src/model/path.ts
@@ -19,7 +19,7 @@ import { Integer } from '@firebase/webchannel-wrapper/bloom-blob';
 
 import { debugAssert, fail } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
-import { primitiveComparator, compareUtf8Strings } from '../util/misc';
+import { primitiveComparator, compareUtf16Strings } from '../util/misc';
 
 export const DOCUMENT_KEY_NAME = '__name__';
 
@@ -202,7 +202,7 @@ abstract class BasePath<B extends BasePath<B>> {
       );
     } else {
       // both non-numeric
-      return compareUtf8Strings(lhs, rhs);
+      return compareUtf16Strings(lhs, rhs);
     }
   }
 

--- a/packages/firestore/src/model/values.ts
+++ b/packages/firestore/src/model/values.ts
@@ -28,7 +28,7 @@ import { fail } from '../util/assert';
 import {
   arrayEquals,
   primitiveComparator,
-  compareUtf8Strings
+  compareUtf16Strings
 } from '../util/misc';
 import { forEach, objectSize } from '../util/obj';
 import { isNegativeZero } from '../util/types';
@@ -255,7 +255,7 @@ export function valueCompare(left: Value, right: Value): number {
         getLocalWriteTime(right)
       );
     case TypeOrder.StringValue:
-      return compareUtf8Strings(left.stringValue!, right.stringValue!);
+      return compareUtf16Strings(left.stringValue!, right.stringValue!);
     case TypeOrder.BlobValue:
       return compareBlobs(left.bytesValue!, right.bytesValue!);
     case TypeOrder.RefValue:
@@ -404,7 +404,7 @@ function compareMaps(left: MapValue, right: MapValue): number {
   rightKeys.sort();
 
   for (let i = 0; i < leftKeys.length && i < rightKeys.length; ++i) {
-    const keyCompare = compareUtf8Strings(leftKeys[i], rightKeys[i]);
+    const keyCompare = compareUtf16Strings(leftKeys[i], rightKeys[i]);
     if (keyCompare !== 0) {
       return keyCompare;
     }

--- a/packages/firestore/src/util/misc.ts
+++ b/packages/firestore/src/util/misc.ts
@@ -75,20 +75,15 @@ export interface Equatable<T> {
   isEqual(other: T): boolean;
 }
 
-/** Compare strings in UTF-8 encoded byte order */
-export function compareUtf8Strings(left: string, right: string): number {
-  // Convert the string to UTF-8 encoded bytes
-  const encodedLeft = newTextEncoder().encode(left);
-  const encodedRight = newTextEncoder().encode(right);
-
-  for (let i = 0; i < Math.min(encodedLeft.length, encodedRight.length); i++) {
-    const comparison = primitiveComparator(encodedLeft[i], encodedRight[i]);
+/** Compare strings in UTF-16 encoded byte order */
+export function compareUtf16Strings(left: string, right: string): number {
+  for (let i = 0; i < Math.min(left.length, right.length); i++) {
+    const comparison = primitiveComparator(left.charCodeAt(i), right.charCodeAt(i));
     if (comparison !== 0) {
       return comparison;
     }
   }
-
-  return primitiveComparator(encodedLeft.length, encodedRight.length);
+  return primitiveComparator(left.length, right.length);
 }
 
 export interface Iterable<V> {


### PR DESCRIPTION
See https://github.com/firebase/firebase-js-sdk/issues/8778