### PR TITLE
Emulator Idempotency: Firestore

### DIFF
--- a/common/api-review/firestore-lite.api.md
+++ b/common/api-review/firestore-lite.api.md
@@ -494,4 +494,5 @@ export class WriteBatch {
 // @public
 export function writeBatch(firestore: Firestore): WriteBatch;
 
+
 ```

--- a/packages/firestore/src/lite-api/database.ts
+++ b/packages/firestore/src/lite-api/database.ts
@@ -72,7 +72,9 @@ export class Firestore implements FirestoreService {
 
   private _settings = new FirestoreSettingsImpl({});
   private _settingsFrozen = false;
-  private _emulatorOptions? : { mockUserToken?: EmulatorMockTokenOptions | string; };  
+  private _emulatorOptions?: {
+    mockUserToken?: EmulatorMockTokenOptions | string;
+  };
 
   // A task that is assigned when the terminate() is invoked and resolved when
   // all components have shut down. Otherwise, Firestore is not terminated,
@@ -122,22 +124,18 @@ export class Firestore implements FirestoreService {
     }
     this._settings = new FirestoreSettingsImpl(settings);
     this._emulatorOptions = settings.emulatorOptions;
-    
+
     if (settings.credentials !== undefined) {
       this._authCredentials = makeAuthCredentialsProvider(settings.credentials);
     }
   }
 
-  _getSettings(): FirestoreSettingsImpl {
-    return this._settings;
-  }
-
-  _getPrivateSettings() : PrivateSettings {
-    const privateSettings : PrivateSettings   = {
+  _getSettings(): PrivateSettings {
+    const privateSettings: PrivateSettings = {
       ...this._settings,
       emulatorOptions: this._emulatorOptions
     };
-    if(this._settings.localCache !== undefined) {
+    if (this._settings.localCache !== undefined) {
       privateSettings.localCache = this._settings.localCache;
     }
     return privateSettings;
@@ -330,7 +328,7 @@ export function connectFirestoreEmulator(
   } = {}
 ): void {
   firestore = cast(firestore, Firestore);
-  const settings = firestore._getPrivateSettings();
+  const settings = firestore._getSettings();
   const newHostSetting = `${host}:${port}`;
 
   if (settings.host !== DEFAULT_HOST && settings.host !== newHostSetting) {
@@ -348,11 +346,11 @@ export function connectFirestoreEmulator(
 
   // No-op if the new configuration matches the current configuration. This supports SSR
   // enviornments which might call `connectFirestoreEmulator` multiple times as a standard practice.
-  if(deepEqual(newSettings, settings)) {
-    console.error("DEDB settings are the same!");
+  if (deepEqual(newSettings, settings)) {
+    console.error('DEDB settings are the same!');
     return;
   }
-  console.error("DEDB settings differ!")
+  console.error('DEDB settings differ!');
 
   firestore._setSettings(newSettings);
 

--- a/packages/firestore/src/lite-api/database.ts
+++ b/packages/firestore/src/lite-api/database.ts
@@ -130,7 +130,11 @@ export class Firestore implements FirestoreService {
     }
   }
 
-  _getSettings(): PrivateSettings {
+  _getSettings(): FirestoreSettingsImpl {
+    return this._settings;
+  }
+
+  _getPrivateSettings(): PrivateSettings {
     const privateSettings: PrivateSettings = {
       ...this._settings,
       emulatorOptions: this._emulatorOptions
@@ -328,7 +332,7 @@ export function connectFirestoreEmulator(
   } = {}
 ): void {
   firestore = cast(firestore, Firestore);
-  const settings = firestore._getSettings();
+  const settings = firestore._getPrivateSettings();
   const newHostSetting = `${host}:${port}`;
 
   if (settings.host !== DEFAULT_HOST && settings.host !== newHostSetting) {

--- a/packages/firestore/src/lite-api/database.ts
+++ b/packages/firestore/src/lite-api/database.ts
@@ -72,9 +72,9 @@ export class Firestore implements FirestoreService {
 
   private _settings = new FirestoreSettingsImpl({});
   private _settingsFrozen = false;
-  private _emulatorOptions?: {
+  private _emulatorOptions: {
     mockUserToken?: EmulatorMockTokenOptions | string;
-  };
+  } = {};
 
   // A task that is assigned when the terminate() is invoked and resolved when
   // all components have shut down. Otherwise, Firestore is not terminated,
@@ -123,7 +123,7 @@ export class Firestore implements FirestoreService {
       );
     }
     this._settings = new FirestoreSettingsImpl(settings);
-    this._emulatorOptions = settings.emulatorOptions;
+    this._emulatorOptions = settings.emulatorOptions || {};
 
     if (settings.credentials !== undefined) {
       this._authCredentials = makeAuthCredentialsProvider(settings.credentials);
@@ -134,15 +134,8 @@ export class Firestore implements FirestoreService {
     return this._settings;
   }
 
-  _getPrivateSettings(): PrivateSettings {
-    const privateSettings: PrivateSettings = {
-      ...this._settings,
-      emulatorOptions: this._emulatorOptions
-    };
-    if (this._settings.localCache !== undefined) {
-      privateSettings.localCache = this._settings.localCache;
-    }
-    return privateSettings;
+  _getEmulatorOptions(): { mockUserToken?: EmulatorMockTokenOptions | string } {
+    return this._emulatorOptions;
   }
 
   _freezeSettings(): FirestoreSettingsImpl {
@@ -332,16 +325,20 @@ export function connectFirestoreEmulator(
   } = {}
 ): void {
   firestore = cast(firestore, Firestore);
-  const settings = firestore._getPrivateSettings();
-  const newHostSetting = `${host}:${port}`;
+  const settings = firestore._getSettings();
+  const existingConfig = {
+    ...settings,
+    emultorOptions: firestore._getEmulatorOptions()
+  };
 
+  const newHostSetting = `${host}:${port}`;
   if (settings.host !== DEFAULT_HOST && settings.host !== newHostSetting) {
     logWarn(
       'Host has been set in both settings() and connectFirestoreEmulator(), emulator host ' +
         'will be used.'
     );
   }
-  const newSettings = {
+  const newConfig = {
     ...settings,
     host: newHostSetting,
     ssl: false,
@@ -350,13 +347,13 @@ export function connectFirestoreEmulator(
 
   // No-op if the new configuration matches the current configuration. This supports SSR
   // enviornments which might call `connectFirestoreEmulator` multiple times as a standard practice.
-  if (deepEqual(newSettings, settings)) {
+  if (deepEqual(newConfig, existingConfig)) {
     console.error('DEDB settings are the same!');
     return;
   }
   console.error('DEDB settings differ!');
 
-  firestore._setSettings(newSettings);
+  firestore._setSettings(newConfig);
 
   if (options.mockUserToken) {
     let token: string;

--- a/packages/firestore/src/lite-api/database.ts
+++ b/packages/firestore/src/lite-api/database.ts
@@ -24,6 +24,7 @@ import {
 } from '@firebase/app';
 import {
   createMockUserToken,
+  deepEqual,
   EmulatorMockTokenOptions,
   getDefaultEmulatorHostnameAndPort
 } from '@firebase/util';
@@ -324,12 +325,20 @@ export function connectFirestoreEmulator(
         'will be used.'
     );
   }
-
-  firestore._setSettings({
+  const privateSettings = {
     ...settings,
     host: newHostSetting,
     ssl: false
-  });
+  };
+
+  // Turn this invocation into a no-op if the new configuration matches the current configuration.
+  // This helps support SSR enviornments where `connectFirestoreEmulator` could be called multiple
+  // times.
+  if(deepEqual(privateSettings, settings)) {
+    return;
+  }
+
+  firestore._setSettings(privateSettings);
 
   if (options.mockUserToken) {
     let token: string;

--- a/packages/firestore/src/lite-api/database.ts
+++ b/packages/firestore/src/lite-api/database.ts
@@ -328,9 +328,8 @@ export function connectFirestoreEmulator(
   const settings = firestore._getSettings();
   const existingConfig = {
     ...settings,
-    emultorOptions: firestore._getEmulatorOptions()
+    emulatorOptions: firestore._getEmulatorOptions()
   };
-
   const newHostSetting = `${host}:${port}`;
   if (settings.host !== DEFAULT_HOST && settings.host !== newHostSetting) {
     logWarn(
@@ -344,14 +343,11 @@ export function connectFirestoreEmulator(
     ssl: false,
     emulatorOptions: options
   };
-
   // No-op if the new configuration matches the current configuration. This supports SSR
   // enviornments which might call `connectFirestoreEmulator` multiple times as a standard practice.
   if (deepEqual(newConfig, existingConfig)) {
-    console.error('DEDB settings are the same!');
     return;
   }
-  console.error('DEDB settings differ!');
 
   firestore._setSettings(newConfig);
 

--- a/packages/firestore/src/lite-api/settings.ts
+++ b/packages/firestore/src/lite-api/settings.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { EmulatorMockTokenOptions } from '@firebase/util';
+
 import { FirestoreLocalCache } from '../api/cache_config';
 import { CredentialsSettings } from '../api/credentials';
 import {
@@ -29,7 +31,6 @@ import {
 import { LRU_MINIMUM_CACHE_SIZE_BYTES } from '../local/lru_garbage_collector_impl';
 import { Code, FirestoreError } from '../util/error';
 import { validateIsNotUsedTogether } from '../util/input_validation';
-import { EmulatorMockTokenOptions } from '@firebase/util';
 
 // settings() defaults:
 export const DEFAULT_HOST = 'firestore.googleapis.com';
@@ -81,7 +82,7 @@ export interface PrivateSettings extends FirestoreSettings {
   experimentalAutoDetectLongPolling?: boolean;
   experimentalLongPollingOptions?: ExperimentalLongPollingOptions;
   useFetchStreams?: boolean;
-  emulatorOptions?: { mockUserToken?: EmulatorMockTokenOptions | string; };
+  emulatorOptions?: { mockUserToken?: EmulatorMockTokenOptions | string };
 
   localCache?: FirestoreLocalCache;
 }

--- a/packages/firestore/src/lite-api/settings.ts
+++ b/packages/firestore/src/lite-api/settings.ts
@@ -29,6 +29,7 @@ import {
 import { LRU_MINIMUM_CACHE_SIZE_BYTES } from '../local/lru_garbage_collector_impl';
 import { Code, FirestoreError } from '../util/error';
 import { validateIsNotUsedTogether } from '../util/input_validation';
+import { EmulatorMockTokenOptions } from '@firebase/util';
 
 // settings() defaults:
 export const DEFAULT_HOST = 'firestore.googleapis.com';
@@ -80,6 +81,7 @@ export interface PrivateSettings extends FirestoreSettings {
   experimentalAutoDetectLongPolling?: boolean;
   experimentalLongPollingOptions?: ExperimentalLongPollingOptions;
   useFetchStreams?: boolean;
+  emulatorOptions?: { mockUserToken?: EmulatorMockTokenOptions | string; };
 
   localCache?: FirestoreLocalCache;
 }

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -65,7 +65,8 @@ import {
   ALT_PROJECT_ID,
   DEFAULT_PROJECT_ID,
   TARGET_DB_ID,
-  USE_EMULATOR
+  USE_EMULATOR,
+  getEmulatorPort
 } from '../util/settings';
 
 // We're using 'as any' to pass invalid values to APIs for testing purposes.
@@ -209,10 +210,11 @@ apiDescribe('Validation:', persistence => {
       'allows calling connectFirestoreEmulator() after use with same config',
       async db => {
         if (USE_EMULATOR) {
-          connectFirestoreEmulator(db, '127.0.0.1', 9000);
+          const port = getEmulatorPort();
+          connectFirestoreEmulator(db, '127.0.0.1', port);
           await setDoc(doc(db, 'foo/bar'), {});
           expect(() =>
-            connectFirestoreEmulator(db, '127.0.0.1', 9000)
+            connectFirestoreEmulator(db, '127.0.0.1', port)
           ).to.not.throw();
         }
       }
@@ -225,10 +227,11 @@ apiDescribe('Validation:', persistence => {
         if (USE_EMULATOR) {
           const errorMsg =
             'Firestore has already been started and its settings can no longer be changed.';
-          connectFirestoreEmulator(db, '127.0.0.1', 9000);
+          const port = getEmulatorPort();
+          connectFirestoreEmulator(db, '127.0.0.1', port);
           await setDoc(doc(db, 'foo/bar'), {});
           expect(() =>
-            connectFirestoreEmulator(db, '127.0.0.1', 9001)
+            connectFirestoreEmulator(db, '127.0.0.1', port + 1)
           ).to.throw(errorMsg);
         }
       }

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -179,13 +179,39 @@ apiDescribe('Validation:', persistence => {
 
     validationIt(
       persistence,
-      'disallows calling connectFirestoreEmulator() after use',
+      'disallows calling connectFirestoreEmulator() for first time after use',
       async db => {
         const errorMsg =
           'Firestore has already been started and its settings can no longer be changed.';
 
         await setDoc(doc(db, 'foo/bar'), {});
         expect(() => connectFirestoreEmulator(db, '127.0.0.1', 9000)).to.throw(
+          errorMsg
+        );
+      }
+    );
+
+    validationIt(
+      persistence,
+      'allows calling connectFirestoreEmulator() after use with same config',
+      async db => {
+        connectFirestoreEmulator(db, '127.0.0.1', 9000);
+        await setDoc(doc(db, 'foo/bar'), {});
+        expect(() =>
+          connectFirestoreEmulator(db, '127.0.0.1', 9000)
+        ).to.not.throw();
+      }
+    );
+
+    validationIt(
+      persistence,
+      'disallows calling connectFirestoreEmulator() after use with different config',
+      async db => {
+        const errorMsg =
+          'Firestore has already been started and its settings can no longer be changed.';
+        connectFirestoreEmulator(db, '127.0.0.1', 9000);
+        await setDoc(doc(db, 'foo/bar'), {});
+        expect(() => connectFirestoreEmulator(db, '127.0.0.1', 9001)).to.throw(
           errorMsg
         );
       }

--- a/packages/firestore/test/integration/util/settings.ts
+++ b/packages/firestore/test/integration/util/settings.ts
@@ -110,6 +110,10 @@ function getFirestoreHost(targetBackend: TargetBackend): string {
   }
 }
 
+export function getEmulatorPort(): number {
+  return parseInt(process.env.FIRESTORE_EMULATOR_PORT || '8080', 10);
+}
+
 function getSslEnabled(targetBackend: TargetBackend): boolean {
   return targetBackend !== TargetBackend.EMULATOR;
 }

--- a/packages/firestore/test/unit/api/database.test.ts
+++ b/packages/firestore/test/unit/api/database.test.ts
@@ -553,6 +553,19 @@ describe('Settings', () => {
     expect(db._getSettings().ssl).to.be.false;
   });
 
+  it('gets privateSettings from useEmulator', () => {
+    // Use a new instance of Firestore in order to configure settings.
+    const db = newTestFirestore();
+    const emulatorOptions = { mockUserToken: 'test' };
+    connectFirestoreEmulator(db, '127.0.0.1', 9000, emulatorOptions);
+
+    expect(db._getPrivateSettings().host).to.exist.and.to.equal(
+      '127.0.0.1:9000'
+    );
+    expect(db._getPrivateSettings().ssl).to.exist.and.to.be.false;
+    expect(db._getPrivateSettings().emulatorOptions).to.equal(emulatorOptions);
+  });
+
   it('prefers host from useEmulator to host from settings', () => {
     // Use a new instance of Firestore in order to configure settings.
     const db = newTestFirestore();

--- a/packages/firestore/test/unit/api/database.test.ts
+++ b/packages/firestore/test/unit/api/database.test.ts
@@ -559,11 +559,9 @@ describe('Settings', () => {
     const emulatorOptions = { mockUserToken: 'test' };
     connectFirestoreEmulator(db, '127.0.0.1', 9000, emulatorOptions);
 
-    expect(db._getPrivateSettings().host).to.exist.and.to.equal(
-      '127.0.0.1:9000'
-    );
-    expect(db._getPrivateSettings().ssl).to.exist.and.to.be.false;
-    expect(db._getPrivateSettings().emulatorOptions).to.equal(emulatorOptions);
+    expect(db._getSettings().host).to.exist.and.to.equal('127.0.0.1:9000');
+    expect(db._getSettings().ssl).to.exist.and.to.be.false;
+    expect(db._getEmulatorOptions()).to.equal(emulatorOptions);
   });
 
   it('prefers host from useEmulator to host from settings', () => {


### PR DESCRIPTION
### Discussion

Update `connectFirestoreEmulator` to support its invocation more than once. If the Firestore instance is already in use, and `connectFirestoreEmulator` is invoked with the same configuration, then the invocation will now succeed instead of assert.

The implementation takes the Data Connect implementation as inspiration. Data Connect stores the parameters passed to `connectDataConnectEmulator` on the instance of Data Connect itself, so that they can be quickly checked to see if subsequent invocations match. This PR implements a similar storage and compare process with the optional `emulatorOptions` parameter (host and port are already stored).

This PR unlocks support for SSR frameworks which render the page numerous times with the same instances of Firestore. Before this PR customers were required to guard against calling `connectFirestoreEmulator` in their SSR logic, which added to code complexity. Now the Firebase SDK does that guarding logic so that our users' apps don't have to.

### Testing

CI, new tests added to `packages/firestore/test/integration/api/validation.test.ts` and `packages/firestore/test/unit/api/database.test.ts`.

### API Changes

N/A