### PR TITLE
Publish VertexAI API's tagged with `@beta`

### DIFF
--- a/packages/vertexai/api-extractor.json
+++ b/packages/vertexai/api-extractor.json
@@ -5,6 +5,6 @@
     "dtsRollup": {
         "enabled": true,
         "untrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>.d.ts",
-        "publicTrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>-public.d.ts"
+        "betaTrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>-public.d.ts"
     }
 }


### PR DESCRIPTION
`publicTrimmedFilePath` trims all APIs with the `@beta` release tag. To allow beta/preview APIs to be published, we need to publish the `betaTrimmedFilePath`. This will be used for labelling Imagen APIs as public preview in #8683. Since we don't label any APIs as `@beta` or `@alpha` yet, there is no change to the typings (I confirmed that the diff is empty).

See: https://api-extractor.com/pages/setup/configure_rollup/