### PR TITLE
Catch errors in debug token exchange logic

### DIFF
--- a/.changeset/tough-kiwis-smile.md
+++ b/.changeset/tough-kiwis-smile.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app-check': patch
+---
+
+Fixed a bug that caused an error to be thrown when the debug exchange failed.

--- a/packages/app-check/src/internal-api.test.ts
+++ b/packages/app-check/src/internal-api.test.ts
@@ -195,7 +195,7 @@ describe('internal api', () => {
       expect(errorStub.args[0][1].message).to.include(
         'oops, something went wrong'
       );
-      window.FIREBASE_APPCHECK_DEBUG_TOKEN = false;
+      delete window.FIREBASE_APPCHECK_DEBUG_TOKEN;
       errorStub.restore();
     });
 

--- a/packages/app-check/src/internal-api.test.ts
+++ b/packages/app-check/src/internal-api.test.ts
@@ -176,6 +176,29 @@ describe('internal api', () => {
       errorStub.restore();
     });
 
+    it('resolves with a dummy token and an error if failed to get a token in debug mode', async () => {
+      const errorStub = stub(console, 'error');
+      window.FIREBASE_APPCHECK_DEBUG_TOKEN = true;
+      const appCheck = initializeAppCheck(app, {
+        provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
+      });
+
+      const error = new Error('oops, something went wrong');
+      stub(client, 'exchangeToken').returns(Promise.reject(error));
+
+      const token = await getToken(appCheck as AppCheckService);
+
+      expect(token).to.deep.equal({
+        token: formatDummyToken(defaultTokenErrorData),
+        error
+      });
+      expect(errorStub.args[0][1].message).to.include(
+        'oops, something went wrong'
+      );
+      window.FIREBASE_APPCHECK_DEBUG_TOKEN = false;
+      errorStub.restore();
+    });
+
     it('resolves with a dummy token and an error if recaptcha failed', async () => {
       const errorStub = stub(console, 'error');
       const appCheck = initializeAppCheck(app, {

--- a/packages/app-check/src/internal-api.ts
+++ b/packages/app-check/src/internal-api.ts
@@ -141,7 +141,7 @@ export async function getToken(
         logger.warn((e as FirebaseError).message);
       } else {
         // `getToken()` should never throw, but logging error text to console will aid debugging.
-        logger.warn(e);
+        logger.error(e);
       }
       // Return dummy token and error
       return makeDummyTokenResult(e as FirebaseError);
@@ -172,7 +172,7 @@ export async function getToken(
       logger.warn((e as FirebaseError).message);
     } else {
       // `getToken()` should never throw, but logging error text to console will aid debugging.
-      logger.warn(e);
+      logger.error(e);
     }
     // Always save error to be added to dummy token.
     error = e as FirebaseError;


### PR DESCRIPTION
The internal `getToken()` method should never throw - it's used by other product SDKs (auth, etc.) and it's up to those product SDKs to handle errors, which are attached to the token as a string property. We have a try/catch around the exchange logic for the normal token, which returns a dummy token and the error string when an error is caught, but we didn't have this same try/catch around the logic where we try to exchange the debug token. Added it.