### PR TITLE
Updated warning message logged in getAuth()

### DIFF
--- a/packages/auth/index.rn.ts
+++ b/packages/auth/index.rn.ts
@@ -76,7 +76,7 @@ export function getAuth(app: FirebaseApp = getApp()): Auth {
   }
 
   // Only warn if getAuth() is called before initializeAuth()
-  _logWarn(NO_PERSISTENCE_WARNING);
+  _logWarn('getAuth() has been called before initializeAuth(). Make sure to call initializeAuth() first.');
 
   return initializeAuthOriginal(app);
 }


### PR DESCRIPTION
Updated warning message logged when getAuth() is called before initializeAuth().

Issue raised [here](https://github.com/firebase/firebase-js-sdk/issues/8798#issuecomment-2661435779)