### PR TITLE
Added non-null properties to database.ThenableReference

### DIFF
--- a/.changeset/silver-jeans-sell.md
+++ b/.changeset/silver-jeans-sell.md
@@ -1,0 +1,7 @@
+---
+'@firebase/database-compat': patch
+'@firebase/database-types': patch
+'@firebase/database': patch
+---
+
+Added non-null parent properties to ThenableReference

--- a/common/api-review/database.api.md
+++ b/common/api-review/database.api.md
@@ -228,6 +228,10 @@ export function startAt(value?: number | string | boolean | null, key?: string):
 
 // @public
 export interface ThenableReference extends DatabaseReference, Pick<Promise<DatabaseReference>, 'then' | 'catch'> {
+    // (undocumented)
+    key: string;
+    // (undocumented)
+    parent: DatabaseReference;
 }
 
 // @public

--- a/docs-devsite/database.thenablereference.md
+++ b/docs-devsite/database.thenablereference.md
@@ -19,3 +19,25 @@ export declare interface ThenableReference extends DatabaseReference, Pick<Promi
 ```
 <b>Extends:</b> [DatabaseReference](./database.databasereference.md#databasereference_interface)<!-- -->, Pick&lt;Promise&lt;[DatabaseReference](./database.databasereference.md#databasereference_interface)<!-- -->&gt;, 'then' \| 'catch'&gt;
 
+## Properties
+
+|  Property | Type | Description |
+|  --- | --- | --- |
+|  [key](./database.thenablereference.md#thenablereferencekey) | string |  |
+|  [parent](./database.thenablereference.md#thenablereferenceparent) | [DatabaseReference](./database.databasereference.md#databasereference_interface) |  |
+
+## ThenableReference.key
+
+<b>Signature:</b>
+
+```typescript
+key: string;
+```
+
+## ThenableReference.parent
+
+<b>Signature:</b>
+
+```typescript
+parent: DatabaseReference;
+```

--- a/packages/database-types/index.d.ts
+++ b/packages/database-types/index.d.ts
@@ -164,7 +164,10 @@ export interface TransactionResult {
 
 export interface ThenableReference
   extends Reference,
-    Pick<Promise<Reference>, 'then' | 'catch'> {}
+    Pick<Promise<Reference>, 'then' | 'catch'> {
+  key: string;
+  parent: Reference;
+}
 
 export function enableLogging(
   logger?: boolean | ((a: string) => any),

--- a/packages/database/src/api/Reference.ts
+++ b/packages/database/src/api/Reference.ts
@@ -119,7 +119,10 @@ export interface DatabaseReference extends Query {
  */
 export interface ThenableReference
   extends DatabaseReference,
-    Pick<Promise<DatabaseReference>, 'then' | 'catch'> {}
+    Pick<Promise<DatabaseReference>, 'then' | 'catch'> {
+  key: string;
+  parent: DatabaseReference;
+}
 
 /** A callback that can invoked to remove a listener. */
 export type Unsubscribe = () => void;

--- a/packages/database/src/api/Reference_impl.ts
+++ b/packages/database/src/api/Reference_impl.ts
@@ -568,7 +568,10 @@ export function onDisconnect(ref: DatabaseReference): OnDisconnect {
 
 export interface ThenableReferenceImpl
   extends ReferenceImpl,
-    Pick<Promise<ReferenceImpl>, 'then' | 'catch'> {}
+    Pick<Promise<ReferenceImpl>, 'then' | 'catch'> {
+  key: string;
+  parent: ReferenceImpl;
+}
 
 /**
  * Generates a new child location using a unique key and returns its

--- a/packages/firebase/compat/index.d.ts
+++ b/packages/firebase/compat/index.d.ts
@@ -7370,7 +7370,10 @@ declare namespace firebase.database {
 
   interface ThenableReference
     extends firebase.database.Reference,
-      Pick<Promise<Reference>, 'then' | 'catch'> {}
+      Pick<Promise<Reference>, 'then' | 'catch'> {
+    key: string;
+    parent: Reference;
+  }
 
   /**
    * Logs debugging information to the console.


### PR DESCRIPTION
When using `push` to add data a `ThenableReference` is returned, this reference can never have an undefined `key` (or `parent`) because it's never going to be the root reference.