### PR TITLE
Add Vertex and DataConnect E2E smoke tests

### DIFF
--- a/e2e/sample-apps/modular.js
+++ b/e2e/sample-apps/modular.js
@@ -58,6 +58,9 @@ import {
   onValue,
   off
 } from 'firebase/database';
+import { getGenerativeModel, getVertexAI, VertexAI } from 'firebase/vertexai';
+import { getDataConnect, DataConnect } from 'firebase/data-connect';
+
 /**
  * The config file should look like:
  *
@@ -287,7 +290,7 @@ function callAppCheck(app) {
 }
 
 /**
- * Analytics smoke test.
+ * Performance smoke test.
  * Just make sure some functions can be called without obvious errors.
  */
 function callPerformance(app) {
@@ -301,6 +304,32 @@ function callPerformance(app) {
     "[PERFORMANCE] trace (should be 'perftestvalue')",
     trace.getAttribute('testattr')
   );
+}
+
+/**
+ * VertexAI smoke test.
+ * Just make sure some functions can be called without obvious errors.
+ */
+async function callVertexAI(app) {
+  console.log('[VERTEXAI] start');
+  const vertexAI = getVertexAI(app);
+  const model = getGenerativeModel(vertexAI, { model: 'gemini-1.5-flash' });
+  const result = await model.countTokens('abcdefg');
+  console.log(`[VERTEXAI] counted tokens: ${result.totalTokens}`);
+}
+
+/**
+ * DataConnect smoke test.
+ * Just make sure some functions can be called without obvious errors.
+ */
+function callDataConnect(app) {
+  console.log('[DATACONNECT] start');
+  getDataConnect(app, {
+    location: 'a-location',
+    connector: 'a-connector',
+    service: 'service'
+  });
+  console.log('[DATACONNECT] initialized');
 }
 
 /**
@@ -321,6 +350,8 @@ async function main() {
   callAnalytics(app);
   callPerformance(app);
   await callFunctions(app);
+  await callVertexAI(app);
+  callDataConnect(app);
   await authLogout(app);
   console.log('DONE');
 }

--- a/e2e/tests/modular.test.ts
+++ b/e2e/tests/modular.test.ts
@@ -86,6 +86,8 @@ import {
   StorageReference,
   deleteObject
 } from 'firebase/storage';
+import { getGenerativeModel, getVertexAI, VertexAI } from 'firebase/vertexai';
+import { getDataConnect, DataConnect } from 'firebase/data-connect';
 import { config, testAccount } from '../firebase-config';
 import 'jest';
 
@@ -302,6 +304,33 @@ describe('MODULAR', () => {
       trace.stop();
       trace.putAttribute('testattr', 'perftestvalue');
       expect(trace.getAttribute('testattr')).toBe('perftestvalue');
+    });
+  });
+
+  describe('VERTEXAI', () => {
+    let vertexAI: VertexAI;
+    it('getVertexAI()', () => {
+      vertexAI = getVertexAI(app);
+    });
+    it('getGenerativeModel() and countTokens()', async () => {
+      const model = getGenerativeModel(vertexAI, { model: 'gemini-1.5-flash' });
+      expect(model.model).toMatch(/gemini-1.5-flash$/);
+      const result = await model.countTokens('abcdefg');
+      expect(result.totalTokens).toBeTruthy;
+    });
+  });
+
+  describe('DATA CONNECT', () => {
+    let dataConnect: DataConnect;
+    it('getDataConnect()', () => {
+      dataConnect = getDataConnect(app, {
+        location: 'a-location',
+        connector: 'a-connector',
+        service: 'service'
+      });
+    });
+    it('dataConnect.getSettings()', () => {
+      expect(dataConnect.getSettings().location).toBe('a-location');
     });
   });
 });


### PR DESCRIPTION
Add post-npm publish smoke tests for VertexAI and DataConnect. Also added the same cases to the sample apps.