### PR TITLE
Fix App Check swallowing errors and returning cached token

### DIFF
--- a/.changeset/honest-days-lick.md
+++ b/.changeset/honest-days-lick.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app-check': minor
+---
+
+Fix App Check swallowing errors and returning cached token

--- a/packages/app-check/src/api.ts
+++ b/packages/app-check/src/api.ts
@@ -206,8 +206,8 @@ export async function getToken(
     appCheckInstance as AppCheckService,
     forceRefresh
   );
-  if (result.error) {
-    throw result.error;
+  if (result.internalError) {
+    throw result.internalError;
   }
   return { token: result.token };
 }


### PR DESCRIPTION

**Summary**
The current implementation checks for result.error, but this property does not exist. Instead, errors are stored in result.internalError. This fix ensures that the correct property is checked, preventing silent failures and ensuring proper error handling.
This change ensures that when an error occurs, it is properly surfaced instead of returning a cached token incorrectly.