### PR TITLE
Add `systemInstruction`, `tools`, and `generationConfig` to `CountTokensRequest`

### DIFF
--- a/common/api-review/vertexai.api.md
+++ b/common/api-review/vertexai.api.md
@@ -88,6 +88,9 @@ export interface Content {
 export interface CountTokensRequest {
     // (undocumented)
     contents: Content[];
+    generationConfig?: GenerationConfig;
+    systemInstruction?: string | Part | Content;
+    tools?: Tool[];
 }
 
 // @public

--- a/docs-devsite/vertexai.counttokensrequest.md
+++ b/docs-devsite/vertexai.counttokensrequest.md
@@ -23,6 +23,9 @@ export interface CountTokensRequest
 |  Property | Type | Description |
 |  --- | --- | --- |
 |  [contents](./vertexai.counttokensrequest.md#counttokensrequestcontents) | [Content](./vertexai.content.md#content_interface)<!-- -->\[\] |  |
+|  [generationConfig](./vertexai.counttokensrequest.md#counttokensrequestgenerationconfig) | [GenerationConfig](./vertexai.generationconfig.md#generationconfig_interface) | Configuration options used for content-related requests. |
+|  [systemInstruction](./vertexai.counttokensrequest.md#counttokensrequestsysteminstruction) | string \| [Part](./vertexai.md#part) \| [Content](./vertexai.content.md#content_interface) | Instructions that direct the model to behave a certain way. |
+|  [tools](./vertexai.counttokensrequest.md#counttokensrequesttools) | [Tool](./vertexai.md#tool)<!-- -->\[\] | <code>[Tool](./vertexai.md#tool)</code> configuration. |
 
 ## CountTokensRequest.contents
 
@@ -30,4 +33,34 @@ export interface CountTokensRequest
 
 ```typescript
 contents: Content[];
+```
+
+## CountTokensRequest.generationConfig
+
+Configuration options used for content-related requests.
+
+<b>Signature:</b>
+
+```typescript
+generationConfig?: GenerationConfig;
+```
+
+## CountTokensRequest.systemInstruction
+
+Instructions that direct the model to behave a certain way.
+
+<b>Signature:</b>
+
+```typescript
+systemInstruction?: string | Part | Content;
+```
+
+## CountTokensRequest.tools
+
+<code>[Tool](./vertexai.md#tool)</code> configuration.
+
+<b>Signature:</b>
+
+```typescript
+tools?: Tool[];
 ```

--- a/packages/vertexai/src/types/requests.ts
+++ b/packages/vertexai/src/types/requests.ts
@@ -114,6 +114,18 @@ export interface StartChatParams extends BaseParams {
  */
 export interface CountTokensRequest {
   contents: Content[];
+  /**
+   * Instructions that direct the model to behave a certain way.
+   */
+  systemInstruction?: string | Part | Content;
+  /**
+   * <code>{@link Tool}</code> configuration.
+   */
+  tools?: Tool[];
+  /**
+   * Configuration options used for content-related requests.
+   */
+  generationConfig?: GenerationConfig;
 }
 
 /**


### PR DESCRIPTION
Fixes [b/397973753](http://b/397973753) (internal)

Add `systemInstruction`, `tools`, and `generationConfig` to `CountTokensRequest`.
This allows users to count `totalBillableChracters` for requests that include anything beyond the content.