### PR TITLE
Fix error handling when fetching fresh token in App Check

### DIFF
--- a/.changeset/afraid-moose-think.md
+++ b/.changeset/afraid-moose-think.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app-check': minor
+---
+
+Fix issue where forceRefresh errors in App Check token retrieval were silently handled, ensuring proper error propagation.

--- a/packages/app-check/src/internal-api.ts
+++ b/packages/app-check/src/internal-api.ts
@@ -192,10 +192,19 @@ export async function getToken(
       // count this as a failed attempt and use the backoff instead of
       // retrying repeatedly with no delay, but any 3P listeners will not
       // be hindered in getting the still-valid token.
-      interopTokenResult = {
-        token: token.token,
-        internalError: error
-      };
+      if (forceRefresh) {
+        // If forceRefresh is true, return the error alongside the token
+        // to propagate the failure properly.
+        interopTokenResult = {
+          token: token.token,
+          error
+        };
+      } else {
+        interopTokenResult = {
+          token: token.token,
+          internalError: error
+        };
+      }
     } else {
       // No invalid tokens should make it to this step. Memory and cached tokens
       // are checked. Other tokens are from fresh exchanges. But just in case.


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/8822

#### Issue: 
When calling Firebase App Check’s getToken with `forceRefresh: true` while a cached token exists, if fetching a new token failed, the error is stored in `internalError` but not returned or thrown to third-party callers. This leads to silent failures, causing the function to return a cached token instead of propagating the error.
#### Impact: 
This misleads the caller, who has no clue that the cached token was returned instead of a new one, preventing proper error handling. While the cached token may still be valid, forceRefresh is intended to fetch a new token, making this behavior inconsistent with its purpose.
#### Fix:
Now, when `forceRefresh` is `true`, the function returns both the error and token, ensuring failure is recognized.
#### Why This is Correct:
This aligns with the expected behavior—if forceRefresh is requested, failures should be surfaced, not masked.
#### Benefit:
Allows third-party apps to handle errors properly and take proper corrective actions.
