### PR TITLE
Deprecate `GroundingAttribution`

### DIFF
--- a/.changeset/tricky-geese-shout.md
+++ b/.changeset/tricky-geese-shout.md
@@ -2,4 +2,4 @@
 '@firebase/vertexai': patch
 ---
 
-Mark `GroundingAttribution` as deprecated.
+Label `GroundingAttribution` as deprecated.

--- a/.changeset/tricky-geese-shout.md
+++ b/.changeset/tricky-geese-shout.md
@@ -1,5 +1,5 @@
 ---
-'@firebase/vertexai': minor
+'@firebase/vertexai': patch
 ---
 
-Deprecate `GroundingAttribution`.
+Mark `GroundingAttribution` as deprecated.

--- a/.changeset/tricky-geese-shout.md
+++ b/.changeset/tricky-geese-shout.md
@@ -1,0 +1,5 @@
+---
+'@firebase/vertexai': minor
+---
+
+Deprecate `GroundingAttribution`.

--- a/common/api-review/vertexai.api.md
+++ b/common/api-review/vertexai.api.md
@@ -366,7 +366,7 @@ export interface GroundingAttribution {
 
 // @public
 export interface GroundingMetadata {
-    // (undocumented)
+    // @deprecated (undocumented)
     groundingAttributions: GroundingAttribution[];
     // (undocumented)
     retrievalQueries?: string[];

--- a/common/api-review/vertexai.api.md
+++ b/common/api-review/vertexai.api.md
@@ -352,7 +352,7 @@ export function getImagenModel(vertexAI: VertexAI, modelParams: ImagenModelParam
 // @public
 export function getVertexAI(app?: FirebaseApp, options?: VertexAIOptions): VertexAI;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface GroundingAttribution {
     // (undocumented)
     confidenceScore?: number;

--- a/docs-devsite/vertexai.groundingattribution.md
+++ b/docs-devsite/vertexai.groundingattribution.md
@@ -10,6 +10,9 @@ https://github.com/firebase/firebase-js-sdk
 {% endcomment %}
 
 # GroundingAttribution interface
+> Warning: This API is now obsolete.
+> 
+> 
 
 <b>Signature:</b>
 

--- a/docs-devsite/vertexai.groundingmetadata.md
+++ b/docs-devsite/vertexai.groundingmetadata.md
@@ -28,6 +28,10 @@ export interface GroundingMetadata
 
 ## GroundingMetadata.groundingAttributions
 
+> Warning: This API is now obsolete.
+> 
+> 
+
 <b>Signature:</b>
 
 ```typescript

--- a/packages/vertexai/src/types/responses.ts
+++ b/packages/vertexai/src/types/responses.ts
@@ -160,6 +160,7 @@ export interface GroundingMetadata {
 }
 
 /**
+ * @deprecated
  * @public
  */
 export interface GroundingAttribution {

--- a/packages/vertexai/src/types/responses.ts
+++ b/packages/vertexai/src/types/responses.ts
@@ -153,6 +153,9 @@ export interface Citation {
 export interface GroundingMetadata {
   webSearchQueries?: string[];
   retrievalQueries?: string[];
+  /**
+   * @deprecated
+   */
   groundingAttributions: GroundingAttribution[];
 }
 


### PR DESCRIPTION
`GroundingAttribution` is deprecated and will never be defined. We should label this as deprecated so users don't use it. In the next major release, we should remove this.