### PR TITLE
Give `check-changeset` job write permissions on pull requests

### DIFF
--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -28,6 +28,9 @@ jobs:
     name: Check changeset vs changed files
     runs-on: ubuntu-latest
 
+    permissions:
+      pull-requests: write
+
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4


### PR DESCRIPTION
This fixes an issue where a step fails with a 403 for no write permissions: https://github.com/firebase/firebase-js-sdk/actions/runs/13706506246/job/38332961549