### PR TITLE
fix: allow graceful failure if serviceWorker is unavailable

### DIFF
--- a/packages/messaging/src/helpers/register.ts
+++ b/packages/messaging/src/helpers/register.ts
@@ -40,6 +40,11 @@ import { name, version } from '../../package.json';
 const WindowMessagingFactory: InstanceFactory<'messaging'> = (
   container: ComponentContainer
 ) => {
+  if (!navigator.serviceWorker) {
+    console.warn("Service workers are not supported in this environment.");
+    return;
+  }
+
   const messaging = new MessagingService(
     container.getProvider('app').getImmediate(),
     container.getProvider('installations-internal').getImmediate(),


### PR DESCRIPTION
Addresses (but doesn't fully fix) #7309

This allows `@firebase/messaging` to fail gracefully if the service worker is not found for whatever reason (i.e. Capacitor app (my use case), iOS PWA, etc) instead of crashing the entire application.