### PR TITLE
Surface all App Check errors in public getToken() method

### DIFF
--- a/.changeset/fluffy-otters-whisper.md
+++ b/.changeset/fluffy-otters-whisper.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app-check': patch
+---
+
+Improve error handling in AppCheck. The publicly-exported `getToken()` will now throw `internalError` strings it was previously ignoring.

--- a/packages/app-check/src/api.ts
+++ b/packages/app-check/src/api.ts
@@ -209,6 +209,9 @@ export async function getToken(
   if (result.error) {
     throw result.error;
   }
+  if (result.internalError) {
+    throw result.internalError;
+  }
   return { token: result.token };
 }
 

--- a/packages/app-check/src/errors.ts
+++ b/packages/app-check/src/errors.ts
@@ -27,7 +27,8 @@ export const enum AppCheckError {
   STORAGE_GET = 'storage-get',
   STORAGE_WRITE = 'storage-set',
   RECAPTCHA_ERROR = 'recaptcha-error',
-  THROTTLED = 'throttled'
+  THROTTLED = 'throttled',
+  INITIAL_THROTTLE = 'initial-throttle'
 }
 
 const ERRORS: ErrorMap<AppCheckError> = {
@@ -54,7 +55,8 @@ const ERRORS: ErrorMap<AppCheckError> = {
   [AppCheckError.STORAGE_WRITE]:
     'Error thrown when writing to storage. Original error: {$originalErrorMessage}.',
   [AppCheckError.RECAPTCHA_ERROR]: 'ReCAPTCHA error.',
-  [AppCheckError.THROTTLED]: `Requests throttled due to {$httpStatus} error. Attempts allowed again after {$time}`
+  [AppCheckError.INITIAL_THROTTLE]: `{$httpStatus} error. Attempts allowed again after {$time}`,
+  [AppCheckError.THROTTLED]: `Requests throttled due to previous {$httpStatus} error. Attempts allowed again after {$time}`
 };
 
 interface ErrorParams {
@@ -67,6 +69,7 @@ interface ErrorParams {
   [AppCheckError.STORAGE_GET]: { originalErrorMessage?: string };
   [AppCheckError.STORAGE_WRITE]: { originalErrorMessage?: string };
   [AppCheckError.THROTTLED]: { time: string; httpStatus: number };
+  [AppCheckError.INITIAL_THROTTLE]: { time: string; httpStatus: number };
 }
 
 export const ERROR_FACTORY = new ErrorFactory<AppCheckError, ErrorParams>(

--- a/packages/app-check/src/errors.ts
+++ b/packages/app-check/src/errors.ts
@@ -27,8 +27,8 @@ export const enum AppCheckError {
   STORAGE_GET = 'storage-get',
   STORAGE_WRITE = 'storage-set',
   RECAPTCHA_ERROR = 'recaptcha-error',
-  THROTTLED = 'throttled',
-  INITIAL_THROTTLE = 'initial-throttle'
+  INITIAL_THROTTLE = 'initial-throttle',
+  THROTTLED = 'throttled'
 }
 
 const ERRORS: ErrorMap<AppCheckError> = {
@@ -68,8 +68,8 @@ interface ErrorParams {
   [AppCheckError.STORAGE_OPEN]: { originalErrorMessage?: string };
   [AppCheckError.STORAGE_GET]: { originalErrorMessage?: string };
   [AppCheckError.STORAGE_WRITE]: { originalErrorMessage?: string };
-  [AppCheckError.THROTTLED]: { time: string; httpStatus: number };
   [AppCheckError.INITIAL_THROTTLE]: { time: string; httpStatus: number };
+  [AppCheckError.THROTTLED]: { time: string; httpStatus: number };
 }
 
 export const ERROR_FACTORY = new ErrorFactory<AppCheckError, ErrorParams>(

--- a/packages/app-check/src/internal-api.test.ts
+++ b/packages/app-check/src/internal-api.test.ts
@@ -153,7 +153,6 @@ describe('internal api', () => {
     });
 
     it('resolves with a dummy token and an error if failed to get a token', async () => {
-      const errorStub = stub(console, 'error');
       const appCheck = initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
       });
@@ -170,14 +169,9 @@ describe('internal api', () => {
         token: formatDummyToken(defaultTokenErrorData),
         error
       });
-      expect(errorStub.args[0][1].message).to.include(
-        'oops, something went wrong'
-      );
-      errorStub.restore();
     });
 
     it('resolves with a dummy token and an error if failed to get a token in debug mode', async () => {
-      const errorStub = stub(console, 'error');
       window.FIREBASE_APPCHECK_DEBUG_TOKEN = true;
       const appCheck = initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
@@ -192,15 +186,10 @@ describe('internal api', () => {
         token: formatDummyToken(defaultTokenErrorData),
         error
       });
-      expect(errorStub.args[0][1].message).to.include(
-        'oops, something went wrong'
-      );
       delete window.FIREBASE_APPCHECK_DEBUG_TOKEN;
-      errorStub.restore();
     });
 
     it('resolves with a dummy token and an error if recaptcha failed', async () => {
-      const errorStub = stub(console, 'error');
       const appCheck = initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
       });
@@ -213,10 +202,6 @@ describe('internal api', () => {
       expect(reCAPTCHASpy).to.be.called;
       expect(exchangeTokenStub).to.not.be.called;
       expect(token.token).to.equal(formatDummyToken(defaultTokenErrorData));
-      expect(errorStub.args[0][1].message).to.include(
-        AppCheckError.RECAPTCHA_ERROR
-      );
-      errorStub.restore();
     });
 
     it('notifies listeners using cached token', async () => {
@@ -290,7 +275,6 @@ describe('internal api', () => {
     });
 
     it('calls 3P error handler if there is an error getting a token', async () => {
-      stub(console, 'error');
       const appCheck = initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY),
         isTokenAutoRefreshEnabled: true
@@ -314,7 +298,6 @@ describe('internal api', () => {
     });
 
     it('ignores listeners that throw', async () => {
-      stub(console, 'error');
       const appCheck = initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY),
         isTokenAutoRefreshEnabled: true

--- a/packages/app-check/src/internal-api.ts
+++ b/packages/app-check/src/internal-api.ts
@@ -139,9 +139,6 @@ export async function getToken(
       if ((e as FirebaseError).code === `appCheck/${AppCheckError.THROTTLED}`) {
         // Warn if throttled, but do not treat it as an error.
         logger.warn((e as FirebaseError).message);
-      } else {
-        // `getToken()` should never throw, but logging error text to console will aid debugging.
-        logger.error(e);
       }
       // Return dummy token and error
       return makeDummyTokenResult(e as FirebaseError);
@@ -170,9 +167,6 @@ export async function getToken(
     if ((e as FirebaseError).code === `appCheck/${AppCheckError.THROTTLED}`) {
       // Warn if throttled, but do not treat it as an error.
       logger.warn((e as FirebaseError).message);
-    } else {
-      // `getToken()` should never throw, but logging error text to console will aid debugging.
-      logger.error(e);
     }
     // Always save error to be added to dummy token.
     error = e as FirebaseError;

--- a/packages/app-check/src/internal-api.ts
+++ b/packages/app-check/src/internal-api.ts
@@ -60,7 +60,8 @@ export function formatDummyToken(
  */
 export async function getToken(
   appCheck: AppCheckService,
-  forceRefresh = false
+  forceRefresh = false,
+  shouldLogErrors = false
 ): Promise<AppCheckTokenResult> {
   const app = appCheck.app;
   ensureActivated(app);
@@ -136,9 +137,15 @@ export async function getToken(
       state.token = tokenFromDebugExchange;
       return { token: tokenFromDebugExchange.token };
     } catch (e) {
-      if ((e as FirebaseError).code === `appCheck/${AppCheckError.THROTTLED}`) {
+      if (
+        (e as FirebaseError).code === `appCheck/${AppCheckError.THROTTLED}` ||
+        (e as FirebaseError).code ===
+          `appCheck/${AppCheckError.INITIAL_THROTTLE}`
+      ) {
         // Warn if throttled, but do not treat it as an error.
         logger.warn((e as FirebaseError).message);
+      } else if (shouldLogErrors) {
+        logger.error(e);
       }
       // Return dummy token and error
       return makeDummyTokenResult(e as FirebaseError);
@@ -164,9 +171,14 @@ export async function getToken(
     }
     token = await getStateReference(app).exchangeTokenPromise;
   } catch (e) {
-    if ((e as FirebaseError).code === `appCheck/${AppCheckError.THROTTLED}`) {
+    if (
+      (e as FirebaseError).code === `appCheck/${AppCheckError.THROTTLED}` ||
+      (e as FirebaseError).code === `appCheck/${AppCheckError.INITIAL_THROTTLE}`
+    ) {
       // Warn if throttled, but do not treat it as an error.
       logger.warn((e as FirebaseError).message);
+    } else if (shouldLogErrors) {
+      logger.error(e);
     }
     // Always save error to be added to dummy token.
     error = e as FirebaseError;

--- a/packages/app-check/src/providers.ts
+++ b/packages/app-check/src/providers.ts
@@ -92,7 +92,7 @@ export class ReCaptchaV3Provider implements AppCheckProvider {
           Number((e as FirebaseError).customData?.httpStatus),
           this._throttleData
         );
-        throw ERROR_FACTORY.create(AppCheckError.THROTTLED, {
+        throw ERROR_FACTORY.create(AppCheckError.INITIAL_THROTTLE, {
           time: getDurationString(
             this._throttleData.allowRequestsAfter - Date.now()
           ),
@@ -185,7 +185,7 @@ export class ReCaptchaEnterpriseProvider implements AppCheckProvider {
           Number((e as FirebaseError).customData?.httpStatus),
           this._throttleData
         );
-        throw ERROR_FACTORY.create(AppCheckError.THROTTLED, {
+        throw ERROR_FACTORY.create(AppCheckError.INITIAL_THROTTLE, {
           time: getDurationString(
             this._throttleData.allowRequestsAfter - Date.now()
           ),


### PR DESCRIPTION
The two main changes here are

- throw "internalError" (background: https://github.com/firebase/firebase-js-sdk/pull/6617) in the public-facing `getToken()` method. Errors here should not block 2P calls to App Check (internal calls from Auth, Firestore, etc)
- Distinguish between an initial network error that causes throttling, and an error thrown by attempting to make a call while a throttle is in effect

I've also decided to stop logging getToken errors with `console.error` - these should all be thrown by the public `getToken()` now, and the internal products calling getToken internally (Auth, Firestore, etc.) have access to the error message in a property of AppCheckTokenResult which they can log in the format they choose.

Fixes #8822 