### PR TITLE
[Workflows] Give Create PR workflow pull-request write perms

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -24,6 +24,8 @@ jobs:
   release:
     name: Create Release PR
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     if: ${{ !startsWith(github.event.head_commit.message, 'Version Packages (#') }}
     steps:
       - name: Checkout Repo


### PR DESCRIPTION

### Discussion

Our staging release workflow failed to create a Version Packages PR. Grant the PR creation workflow `pull-request` `write` permissions.

### Testing

N/A.

### API Changes

N/A.
