### PR TITLE
[Workflows] Grant Create PR workflow content write perms

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -26,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      contents: write
     if: ${{ !startsWith(github.event.head_commit.message, 'Version Packages (#') }}
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
### Discussion

Our staging release workflow failed to merge branch. Grant the PR creation workflow `content` `write` permissions to fix this.

### Testing

N/A.

### API Changes

N/A.
