### PR TITLE
Remove `files` from all karma module exports.

### DIFF
--- a/integration/compat-interop/karma.conf.js
+++ b/integration/compat-interop/karma.conf.js
@@ -32,5 +32,3 @@ module.exports = function (config) {
 
   config.set(karmaConfig);
 };
-
-module.exports.files = files;

--- a/integration/firestore/karma.conf.js
+++ b/integration/firestore/karma.conf.js
@@ -32,5 +32,3 @@ module.exports = function (config) {
 
   config.set(karmaConfig);
 };
-
-module.exports.files = files;

--- a/packages/analytics-compat/karma.conf.js
+++ b/packages/analytics-compat/karma.conf.js
@@ -28,5 +28,3 @@ module.exports = function (config) {
     frameworks: ['mocha']
   });
 };
-
-module.exports.files = files;

--- a/packages/analytics/karma.conf.js
+++ b/packages/analytics/karma.conf.js
@@ -28,5 +28,3 @@ module.exports = function (config) {
     frameworks: ['mocha']
   });
 };
-
-module.exports.files = files;

--- a/packages/analytics/karma.integration.conf.js
+++ b/packages/analytics/karma.integration.conf.js
@@ -28,5 +28,3 @@ module.exports = function (config) {
     frameworks: ['mocha']
   });
 };
-
-module.exports.files = files;

--- a/packages/app-check-compat/karma.conf.js
+++ b/packages/app-check-compat/karma.conf.js
@@ -28,5 +28,3 @@ module.exports = function (config) {
     frameworks: ['mocha']
   });
 };
-
-module.exports.files = files;

--- a/packages/app-check/karma.conf.js
+++ b/packages/app-check/karma.conf.js
@@ -28,5 +28,3 @@ module.exports = function (config) {
     frameworks: ['mocha']
   });
 };
-
-module.exports.files = files;

--- a/packages/app-compat/karma.conf.js
+++ b/packages/app-compat/karma.conf.js
@@ -31,5 +31,3 @@ module.exports = function (config) {
 
   config.set(karmaConfig);
 };
-
-module.exports.files = files;

--- a/packages/app/karma.conf.js
+++ b/packages/app/karma.conf.js
@@ -31,5 +31,3 @@ module.exports = function (config) {
 
   config.set(karmaConfig);
 };
-
-module.exports.files = files;

--- a/packages/auth/karma.conf.js
+++ b/packages/auth/karma.conf.js
@@ -93,5 +93,3 @@ function getClientConfig(argv) {
     authEmulatorHost: process.env.FIREBASE_AUTH_EMULATOR_HOST
   };
 }
-
-module.exports.files = getTestFiles(argv);

--- a/packages/component/karma.conf.js
+++ b/packages/component/karma.conf.js
@@ -32,5 +32,3 @@ module.exports = function (config) {
     frameworks: ['mocha']
   });
 };
-
-module.exports.files = files;

--- a/packages/data-connect/karma.conf.js
+++ b/packages/data-connect/karma.conf.js
@@ -30,5 +30,3 @@ module.exports = function (config) {
 
   config.set(karmaConfig);
 };
-
-module.exports.files = files;

--- a/packages/database-compat/karma.conf.js
+++ b/packages/database-compat/karma.conf.js
@@ -30,5 +30,3 @@ module.exports = function (config) {
 
   config.set(karmaConfig);
 };
-
-module.exports.files = files;

--- a/packages/database/karma.conf.js
+++ b/packages/database/karma.conf.js
@@ -30,5 +30,3 @@ module.exports = function (config) {
 
   config.set(karmaConfig);
 };
-
-module.exports.files = files;

--- a/packages/firestore-compat/karma.conf.js
+++ b/packages/firestore-compat/karma.conf.js
@@ -57,5 +57,3 @@ function getTestFiles(argv) {
   const integrationTests = 'test/bootstrap.ts';
   return [integrationTests];
 }
-
-module.exports.files = getTestFiles(argv);

--- a/packages/firestore/karma.conf.js
+++ b/packages/firestore/karma.conf.js
@@ -83,5 +83,3 @@ function getTestBrowsers(argv) {
   }
   return browsers;
 }
-
-module.exports.files = getTestFiles(argv);

--- a/packages/functions-compat/karma.conf.js
+++ b/packages/functions-compat/karma.conf.js
@@ -31,5 +31,3 @@ module.exports = function (config) {
 
   config.set(karmaConfig);
 };
-
-module.exports.files = files;

--- a/packages/functions/karma.conf.js
+++ b/packages/functions/karma.conf.js
@@ -31,5 +31,3 @@ module.exports = function (config) {
 
   config.set(karmaConfig);
 };
-
-module.exports.files = files;

--- a/packages/installations-compat/karma.conf.js
+++ b/packages/installations-compat/karma.conf.js
@@ -31,5 +31,3 @@ module.exports = function (config) {
 
   config.set(karmaConfig);
 };
-
-module.exports.files = files;

--- a/packages/installations/karma.conf.js
+++ b/packages/installations/karma.conf.js
@@ -31,5 +31,3 @@ module.exports = function (config) {
 
   config.set(karmaConfig);
 };
-
-module.exports.files = files;

--- a/packages/logger/karma.conf.js
+++ b/packages/logger/karma.conf.js
@@ -30,5 +30,3 @@ module.exports = function (config) {
 
   config.set(karmaConfig);
 };
-
-module.exports.files = files;

--- a/packages/messaging-compat/karma.conf.js
+++ b/packages/messaging-compat/karma.conf.js
@@ -28,5 +28,3 @@ module.exports = function (config) {
 
   config.set(karmaConfig);
 };
-
-module.exports.files = files;

--- a/packages/messaging/karma.conf.js
+++ b/packages/messaging/karma.conf.js
@@ -28,5 +28,3 @@ module.exports = function (config) {
 
   config.set(karmaConfig);
 };
-
-module.exports.files = files;

--- a/packages/performance-compat/karma.conf.js
+++ b/packages/performance-compat/karma.conf.js
@@ -31,5 +31,3 @@ module.exports = function (config) {
 
   config.set(karmaConfig);
 };
-
-module.exports.files = files;

--- a/packages/performance/karma.conf.js
+++ b/packages/performance/karma.conf.js
@@ -30,5 +30,3 @@ module.exports = function (config) {
     frameworks: ['mocha']
   });
 };
-
-module.exports.files = files;

--- a/packages/remote-config-compat/karma.conf.js
+++ b/packages/remote-config-compat/karma.conf.js
@@ -31,5 +31,3 @@ module.exports = function (config) {
 
   config.set(karmaConfig);
 };
-
-module.exports.files = files;

--- a/packages/remote-config/karma.conf.js
+++ b/packages/remote-config/karma.conf.js
@@ -32,5 +32,3 @@ module.exports = function (config) {
 
   config.set(karmaConfig);
 };
-
-module.exports.files = files;

--- a/packages/storage-compat/karma.conf.js
+++ b/packages/storage-compat/karma.conf.js
@@ -42,5 +42,3 @@ function getTestFiles(argv) {
     return [...unitTestFiles, ...integrationTestFiles];
   }
 }
-
-module.exports.files = getTestFiles(argv);

--- a/packages/storage/karma.conf.js
+++ b/packages/storage/karma.conf.js
@@ -42,5 +42,3 @@ function getTestFiles(argv) {
     return [...unitTestFiles, ...integrationTestFiles];
   }
 }
-
-module.exports.files = getTestFiles(argv);

--- a/packages/template/karma.conf.js
+++ b/packages/template/karma.conf.js
@@ -31,5 +31,3 @@ module.exports = function (config) {
 
   config.set(karmaConfig);
 };
-
-module.exports.files = files;

--- a/packages/util/karma.conf.js
+++ b/packages/util/karma.conf.js
@@ -30,5 +30,3 @@ module.exports = function (config) {
 
   config.set(karmaConfig);
 };
-
-module.exports.files = files;

--- a/packages/vertexai/karma.conf.js
+++ b/packages/vertexai/karma.conf.js
@@ -31,5 +31,3 @@ module.exports = function (config) {
 
   config.set(karmaConfig);
 };
-
-module.exports.files = files;


### PR DESCRIPTION
`module.exports.files` are not used by Karma, so I believe there is no need to export it. Karma instead uses the `files` property that is assigned on the config object. https://karma-runner.github.io/6.4/config/files.html

Running tests locally, it seems that the same set of tests are ran after this change.

One side-effect of this change could be that files importing the another `karma.conf.js` file may use these exported files, but I can not find cases of this.