### PR TITLE
Stream full logs of test-all firestore job

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -178,8 +178,7 @@ jobs:
       run: echo "FIREBASE_CI_TEST_START_TIME=$(date +%s)" >> $GITHUB_ENV
     - name: Run unit tests
       run: |
-        xvfb-run yarn lerna run test:ci --scope '@firebase/firestore*'
-        node scripts/print_test_logs.js
+        yarn lerna run test:all:ci --scope '@firebase/firestore*' --stream --concurrency 1
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}
         EXPERIMENTAL_MODE: true


### PR DESCRIPTION
Use lerna --stream and skip run_tests_in_ci script to ensure we are not missing any logs from failed tests.

This causes really long logs but we don't lose the error. So far on this PR, I tried 2 runs and it errored in 2 different places, which is more info than we were getting before.