### PR TITLE
Vertex AI Integration Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ mocks-lookup.ts
 
 # temp changeset output
 changeset-temp.json
+
+# Vertex AI integration test Firebase project config
+packages/vertexai/integration/firebase-config.ts

--- a/config/karma.base.js
+++ b/config/karma.base.js
@@ -60,7 +60,7 @@ const config = {
   preprocessors: {
     'test/**/*.ts': ['webpack', 'sourcemap'],
     'src/**/*.test.ts': ['webpack', 'sourcemap'],
-    'integration/**/*.test.ts': ['webpack', 'sourcemap']
+    'integration/**/*.ts': ['webpack', 'sourcemap']
   },
 
   mime: { 'text/x-typescript': ['ts', 'tsx'] },

--- a/config/karma.base.js
+++ b/config/karma.base.js
@@ -59,7 +59,8 @@ const config = {
   // https://npmjs.org/browse/keyword/karma-preprocessor
   preprocessors: {
     'test/**/*.ts': ['webpack', 'sourcemap'],
-    'src/**/*.test.ts': ['webpack', 'sourcemap']
+    'src/**/*.test.ts': ['webpack', 'sourcemap'],
+    'integration/**/*.test.ts': ['webpack', 'sourcemap']
   },
 
   mime: { 'text/x-typescript': ['ts', 'tsx'] },

--- a/packages/vertexai/integration/constants.ts
+++ b/packages/vertexai/integration/constants.ts
@@ -1,6 +1,4 @@
-import { initializeApp } from "@firebase/app";
-import { Content, GenerationConfig, HarmBlockMethod, HarmBlockThreshold, HarmCategory, Modality, SafetySetting, getGenerativeModel, getVertexAI } from "../src";
-import { expect } from "chai";
+import { Content, GenerationConfig, HarmBlockMethod, HarmBlockThreshold, HarmCategory, SafetySetting } from "../src";
 
 // TODO (dlarocque): Use seperate Firebase config specifically for Vertex AI
 // TODO (dlarocque): Load this from environment variables, so we can set the config as a 
@@ -16,17 +14,17 @@ export const config = {
   measurementId: "G-1VL38N8YFE"
 };
 
-initializeApp(config);
-const MODEL_NAME = 'gemini-1.5-pro'; 
+export const MODEL_NAME = 'gemini-1.5-pro'; 
 
-let generationConfig: GenerationConfig = {
+/// TODO (dlarocque): Fix the naming on these.
+export const generationConfig: GenerationConfig = {
   temperature: 0,
   topP: 0,
   topK: 1,
   responseMimeType: 'text/plain'
 }
 
-let safetySettings: SafetySetting[] = [
+export const safetySettings: SafetySetting[] = [
   {
     category: HarmCategory.HARM_CATEGORY_HARASSMENT,
     threshold: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
@@ -47,7 +45,7 @@ let safetySettings: SafetySetting[] = [
   },
 ];
 
-let systemInstruction: Content = {
+export const systemInstruction: Content = {
   role: 'system',
   parts: [
     {
@@ -55,27 +53,3 @@ let systemInstruction: Content = {
     }
   ]
 };
-
-describe('VertexAIService', () => {
-  it('CountTokens text', async () => {
-    const vertexAI = getVertexAI(); 
-    const model = getGenerativeModel(
-      vertexAI, 
-      {
-        model: MODEL_NAME, 
-        generationConfig,
-        systemInstruction,
-        safetySettings
-      }
-    );
-
-    let response = await model.countTokens('Why is the sky blue?');
-
-    expect(response.totalTokens).to.equal(6);
-    expect(response.totalBillableCharacters).to.equal(16);
-    expect(response.promptTokensDetails).to.not.be.null;
-    expect(response.promptTokensDetails!.length).to.equal(1);
-    expect(response.promptTokensDetails![0].modality).to.equal(Modality.TEXT);
-    expect(response.promptTokensDetails![0].tokenCount).to.equal(6);
-  });
-});

--- a/packages/vertexai/integration/constants.ts
+++ b/packages/vertexai/integration/constants.ts
@@ -1,26 +1,10 @@
 import { Content, GenerationConfig, HarmBlockMethod, HarmBlockThreshold, HarmCategory, SafetySetting } from "../src";
 
-// TODO (dlarocque): Use seperate Firebase config specifically for Vertex AI
-// TODO (dlarocque): Load this from environment variables, so we can set the config as a 
-// secret in CI.
-export const config = {
-  apiKey: "AIzaSyBNHCyZ-bpv-WA-HpXTmigJm2aq3z1kaH8",
-  authDomain: "jscore-sandbox-141b5.firebaseapp.com",
-  databaseURL: "https://jscore-sandbox-141b5.firebaseio.com",
-  projectId: "jscore-sandbox-141b5",
-  storageBucket: "jscore-sandbox-141b5.appspot.com",
-  messagingSenderId: "280127633210",
-  appId: "1:280127633210:web:1eb2f7e8799c4d5a46c203",
-  measurementId: "G-1VL38N8YFE"
-};
-
 export const MODEL_NAME = 'gemini-1.5-pro'; 
 
-/// TODO (dlarocque): Fix the naming on these.
 export const generationConfig: GenerationConfig = {
   temperature: 0,
   topP: 0,
-  topK: 1,
   responseMimeType: 'text/plain'
 }
 

--- a/packages/vertexai/integration/count-tokens.test.ts
+++ b/packages/vertexai/integration/count-tokens.test.ts
@@ -1,0 +1,31 @@
+import { expect } from "chai";
+import { Modality, getGenerativeModel, getVertexAI } from "../src";
+import { MODEL_NAME, generationConfig, systemInstruction, safetySettings, config } from "./constants";
+import { initializeApp } from "@firebase/app";
+
+describe('Count Tokens', () => {
+
+  before(() => initializeApp(config))
+
+  it('CountTokens text', async () => {
+    const vertexAI = getVertexAI(); 
+    const model = getGenerativeModel(
+      vertexAI, 
+      {
+        model: MODEL_NAME, 
+        generationConfig,
+        systemInstruction,
+        safetySettings
+      }
+    );
+
+    let response = await model.countTokens('Why is the sky blue?');
+
+    expect(response.totalTokens).to.equal(6);
+    expect(response.totalBillableCharacters).to.equal(16);
+    expect(response.promptTokensDetails).to.not.be.null;
+    expect(response.promptTokensDetails!.length).to.equal(1);
+    expect(response.promptTokensDetails![0].modality).to.equal(Modality.TEXT);
+    expect(response.promptTokensDetails![0].tokenCount).to.equal(6);
+  });
+});

--- a/packages/vertexai/integration/count-tokens.test.ts
+++ b/packages/vertexai/integration/count-tokens.test.ts
@@ -1,11 +1,12 @@
 import { expect } from "chai";
 import { Modality, getGenerativeModel, getVertexAI } from "../src";
-import { MODEL_NAME, generationConfig, systemInstruction, safetySettings, config } from "./constants";
+import { MODEL_NAME, generationConfig, systemInstruction, safetySettings, } from "./constants";
 import { initializeApp } from "@firebase/app";
+import { FIREBASE_CONFIG } from "./firebase-config";
 
 describe('Count Tokens', () => {
 
-  before(() => initializeApp(config))
+  before(() => initializeApp(FIREBASE_CONFIG))
 
   it('CountTokens text', async () => {
     const vertexAI = getVertexAI(); 
@@ -28,4 +29,10 @@ describe('Count Tokens', () => {
     expect(response.promptTokensDetails![0].modality).to.equal(Modality.TEXT);
     expect(response.promptTokensDetails![0].tokenCount).to.equal(6);
   });
+  // TODO (dlarocque): Test countTokens() with the following:
+  // - inline data
+  // - public storage reference
+  // - private storage reference (testing auth integration)
+  // - count tokens
+  // - JSON schema
 });

--- a/packages/vertexai/integration/generate-content.test.ts
+++ b/packages/vertexai/integration/generate-content.test.ts
@@ -1,0 +1,37 @@
+import { expect } from "chai";
+import { getGenerativeModel, getVertexAI } from "../src";
+import { MODEL_NAME, generationConfig, systemInstruction, safetySettings, config } from "./constants";
+import { initializeApp } from "@firebase/app";
+
+// Token counts are only expected to differ by at most this number of tokens.
+// Set to 1 for whitespace that is not always present.
+const TOKEN_COUNT_DELTA = 1;
+
+describe('Generate Content', () => {
+
+  before(() => initializeApp(config))
+
+  it('generateContent', async () => {
+    const vertexAI = getVertexAI(); 
+    const model = getGenerativeModel(
+      vertexAI, 
+      {
+        model: MODEL_NAME, 
+        generationConfig,
+        systemInstruction,
+        safetySettings
+      }
+    );
+
+    const result = await model.generateContent("Where is Google headquarters located? Answer with the city name only.");
+    const response = result.response;
+    
+    const trimmedText = response.text().trim();
+    expect(trimmedText).to.equal('Mountain View');
+
+    console.log(JSON.stringify(response));
+
+    expect(response.usageMetadata).to.not.be.null;
+    expect(response.usageMetadata!.promptTokenCount).to.be.closeTo(21, TOKEN_COUNT_DELTA);
+  });
+});

--- a/packages/vertexai/integration/generate-content.test.ts
+++ b/packages/vertexai/integration/generate-content.test.ts
@@ -1,7 +1,8 @@
 import { expect } from "chai";
-import { getGenerativeModel, getVertexAI } from "../src";
-import { MODEL_NAME, generationConfig, systemInstruction, safetySettings, config } from "./constants";
+import { Modality, getGenerativeModel, getVertexAI } from "../src";
+import { MODEL_NAME, generationConfig, systemInstruction, safetySettings } from "./constants";
 import { initializeApp } from "@firebase/app";
+import { FIREBASE_CONFIG } from "./firebase-config";
 
 // Token counts are only expected to differ by at most this number of tokens.
 // Set to 1 for whitespace that is not always present.
@@ -9,7 +10,7 @@ const TOKEN_COUNT_DELTA = 1;
 
 describe('Generate Content', () => {
 
-  before(() => initializeApp(config))
+  before(() => initializeApp(FIREBASE_CONFIG))
 
   it('generateContent', async () => {
     const vertexAI = getVertexAI(); 
@@ -29,9 +30,18 @@ describe('Generate Content', () => {
     const trimmedText = response.text().trim();
     expect(trimmedText).to.equal('Mountain View');
 
-    console.log(JSON.stringify(response));
-
     expect(response.usageMetadata).to.not.be.null;
     expect(response.usageMetadata!.promptTokenCount).to.be.closeTo(21, TOKEN_COUNT_DELTA);
+    expect(response.usageMetadata!.candidatesTokenCount).to.be.closeTo(4, TOKEN_COUNT_DELTA);
+    expect(response.usageMetadata!.totalTokenCount).to.be.closeTo(25, TOKEN_COUNT_DELTA*2);
+    expect(response.usageMetadata!.promptTokensDetails).to.not.be.null;
+    expect(response.usageMetadata!.promptTokensDetails!.length).to.equal(1);
+    expect(response.usageMetadata!.promptTokensDetails![0].modality).to.equal(Modality.TEXT);
+    expect(response.usageMetadata!.promptTokensDetails![0].tokenCount).to.equal(21);
+    expect(response.usageMetadata!.candidatesTokensDetails).to.not.be.null;
+    expect(response.usageMetadata!.candidatesTokensDetails!.length).to.equal(1);
+    expect(response.usageMetadata!.candidatesTokensDetails![0].modality).to.equal(Modality.TEXT);
+    expect(response.usageMetadata!.candidatesTokensDetails![0].tokenCount).to.equal(4);
   });
+  // TODO (dlarocque): Test generateContentStream
 });

--- a/packages/vertexai/integration/index.test.ts
+++ b/packages/vertexai/integration/index.test.ts
@@ -1,0 +1,81 @@
+import { initializeApp } from "@firebase/app";
+import { Content, GenerationConfig, HarmBlockMethod, HarmBlockThreshold, HarmCategory, Modality, SafetySetting, getGenerativeModel, getVertexAI } from "../src";
+import { expect } from "chai";
+
+// TODO (dlarocque): Use seperate Firebase config specifically for Vertex AI
+// TODO (dlarocque): Load this from environment variables, so we can set the config as a 
+// secret in CI.
+export const config = {
+  apiKey: "AIzaSyBNHCyZ-bpv-WA-HpXTmigJm2aq3z1kaH8",
+  authDomain: "jscore-sandbox-141b5.firebaseapp.com",
+  databaseURL: "https://jscore-sandbox-141b5.firebaseio.com",
+  projectId: "jscore-sandbox-141b5",
+  storageBucket: "jscore-sandbox-141b5.appspot.com",
+  messagingSenderId: "280127633210",
+  appId: "1:280127633210:web:1eb2f7e8799c4d5a46c203",
+  measurementId: "G-1VL38N8YFE"
+};
+
+initializeApp(config);
+const MODEL_NAME = 'gemini-1.5-pro'; 
+
+let generationConfig: GenerationConfig = {
+  temperature: 0,
+  topP: 0,
+  topK: 1,
+  responseMimeType: 'text/plain'
+}
+
+let safetySettings: SafetySetting[] = [
+  {
+    category: HarmCategory.HARM_CATEGORY_HARASSMENT,
+    threshold: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+    method: HarmBlockMethod.PROBABILITY
+  },
+  {
+    category: HarmCategory.HARM_CATEGORY_HATE_SPEECH,
+    threshold: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+    method: HarmBlockMethod.SEVERITY
+  },
+  {
+    category: HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
+    threshold: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+  },
+  {
+    category: HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+    threshold: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+  },
+];
+
+let systemInstruction: Content = {
+  role: 'system',
+  parts: [
+    {
+      text: 'You are a friendly and helpful assistant.'
+    }
+  ]
+};
+
+describe('VertexAIService', () => {
+  it('CountTokens text', async () => {
+    const vertexAI = getVertexAI(); 
+    const model = getGenerativeModel(
+      vertexAI, 
+      {
+        model: MODEL_NAME, 
+        generationConfig,
+        systemInstruction,
+        safetySettings
+      }
+    );
+
+    let response = await model.countTokens('Why is the sky blue?');
+
+    expect(response.totalTokens).to.equal(6);
+    expect(response.totalBillableCharacters).to.equal(16);
+    expect(response.promptTokensDetails).to.not.be.null;
+    expect(response.promptTokensDetails!.length).to.equal(1);
+    expect(response.promptTokensDetails![0].modality).to.equal(Modality.TEXT);
+    expect(response.promptTokensDetails![0].tokenCount).to.equal(6);
+  });
+});

--- a/packages/vertexai/karma.conf.js
+++ b/packages/vertexai/karma.conf.js
@@ -18,6 +18,11 @@
 const karmaBase = require('../../config/karma.base');
 const { argv } = require('yargs');
 
+// Validate that required environment variables are defined
+if (!process.env.VERTEXAI_INTEGRATION_FIREBASE_CONFIG_JSON) {
+  throw new Error('VERTEXAI_INTEGRATION_FIREBASE_CONFIG_JSON is not defined in env. Set this env variable to be the JSON of a Firebase project config to run the integration tests with.')
+}
+
 module.exports = function (config) {
   const karmaConfig = {
     ...karmaBase,
@@ -25,7 +30,7 @@ module.exports = function (config) {
     // files to load into karma
     files: (() => {
       if (argv.integration) {
-        return ['integration/**/*.test.ts'];
+        return ['integration/**'];
       } else {
         return ['src/**/*.test.ts'];
       }
@@ -34,7 +39,10 @@ module.exports = function (config) {
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
     frameworks: ['mocha']
+
   };
+
+  config.client.args.push(process.env.VERTEXAI_INTEGRATION_FIREBASE_CONFIG_JSON);
 
   config.set(karmaConfig);
 };

--- a/packages/vertexai/karma.conf.js
+++ b/packages/vertexai/karma.conf.js
@@ -19,6 +19,8 @@ const karmaBase = require('../../config/karma.base');
 const { argv } = require('yargs');
 const { existsSync } = require('fs');
 
+const files = [`src/**/*.test.ts`];
+
 // Validate that the file that defines the Firebase config to be used in the integration tests exists.
 if (argv.integration) {
   if (!existsSync('integration/firebase-config.ts')) {
@@ -42,10 +44,9 @@ module.exports = function (config) {
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
     frameworks: ['mocha']
-
   };
-
-  config.client.args.push(process.env.VERTEXAI_INTEGRATION_FIREBASE_CONFIG_JSON);
 
   config.set(karmaConfig);
 };
+
+module.exports.files = files;

--- a/packages/vertexai/karma.conf.js
+++ b/packages/vertexai/karma.conf.js
@@ -17,10 +17,13 @@
 
 const karmaBase = require('../../config/karma.base');
 const { argv } = require('yargs');
+const { existsSync } = require('fs');
 
-// Validate that required environment variables are defined
-if (!process.env.VERTEXAI_INTEGRATION_FIREBASE_CONFIG_JSON) {
-  throw new Error('VERTEXAI_INTEGRATION_FIREBASE_CONFIG_JSON is not defined in env. Set this env variable to be the JSON of a Firebase project config to run the integration tests with.')
+// Validate that the file that defines the Firebase config to be used in the integration tests exists.
+if (argv.integration) {
+  if (!existsSync('integration/firebase-config.ts')) {
+    throw new Error(`integration/firebase-config.ts does not exist. This file must contain a Firebase config for a project with Vertex AI enabled.`)
+  }
 }
 
 module.exports = function (config) {

--- a/packages/vertexai/karma.conf.js
+++ b/packages/vertexai/karma.conf.js
@@ -16,14 +16,21 @@
  */
 
 const karmaBase = require('../../config/karma.base');
-
-const files = [`src/**/*.test.ts`];
+const { argv } = require('yargs');
 
 module.exports = function (config) {
   const karmaConfig = {
     ...karmaBase,
+
     // files to load into karma
-    files,
+    files: (() => {
+      if (argv.integration) {
+        return ['integration/**/*.test.ts'];
+      } else {
+        return ['src/**/*.test.ts'];
+      }
+    })(),
+
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
     frameworks: ['mocha']
@@ -31,5 +38,3 @@ module.exports = function (config) {
 
   config.set(karmaConfig);
 };
-
-module.exports.files = files;

--- a/packages/vertexai/package.json
+++ b/packages/vertexai/package.json
@@ -39,6 +39,7 @@
     "test:ci": "yarn testsetup && node ../../scripts/run_tests_in_ci.js -s test",
     "test:skip-clone": "karma start",
     "test:browser": "yarn testsetup && karma start",
+    "test:integration": "karma start --integration",
     "api-report": "api-extractor run --local --verbose",
     "typings:public": "node ../../scripts/build/use_typings.js ./dist/vertexai-public.d.ts",
     "trusted-type-check": "tsec -p tsconfig.json --noEmit"


### PR DESCRIPTION
Add integration tests using a secret config defined in `integration/firebase-config.ts`. I'm not using JSCore sandbox here because in the future we'll want to run these integration tests using a Firebase project that has access to APIs that aren't pubilc yet (which is also why the config is 'secret'). 

When running tests locally, we can manually create a file that exports the firebase config. When running tests in CI, we'll have to add a step to write the config from a GH secret to a file using something like `echo "export const FIREBASE_CONFIG = '$(echo "$FIREBASE_CONFIG" | jq -r .)'" > packages/vertexai/integration/firebase-config.ts`.

The next step is to get this running in CI on a daily CRON schedule, and in PRs that make changes to vertexAI.