### PR TITLE
Accept test command as argument to `test_changed` script

### DIFF
--- a/scripts/ci-test/test_changed.ts
+++ b/scripts/ci-test/test_changed.ts
@@ -25,7 +25,7 @@ const root = resolve(__dirname, '../..');
 
 const argv = yargs.parseSync();
 const inputTestConfigName = argv._[0].toString();
-const testCommand = 'test:ci';
+const testCommand = argv._[1]?.toString() ?? 'test:ci';
 
 const allTestConfigNames = Object.keys(testConfig);
 if (!inputTestConfigName) {


### PR DESCRIPTION
This allows us to run other tests with this script. The default is still `test:ci`.