### PR TITLE
firestore: null out IndexedDB connection when it is unexpectedly closed

### DIFF
--- a/.changeset/slow-students-fry.md
+++ b/.changeset/slow-students-fry.md
@@ -1,0 +1,6 @@
+---
+'@firebase/firestore': patch
+'firebase': patch
+---
+
+Ensure that IndexedDB connections are discarded if they are closed unexpectedly.


### PR DESCRIPTION
This change simply avoids using a known-closed IndexedDB connection, which would be guaranteed to fail.