### PR TITLE
firestore: fix `undefined` document snapshot data after "clear site data"

### DIFF
--- a/.changeset/slow-students-fry.md
+++ b/.changeset/slow-students-fry.md
@@ -1,0 +1,6 @@
+---
+'@firebase/firestore': patch
+'firebase': patch
+---
+
+Fix issue where Firestore would produce `undefined` for document snapshot data if using IndexedDB persistence and "clear site data" (or equivalent) button was pressed in the web browser.

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -158,7 +158,7 @@ export class SimpleDbTransaction {
  */
 export class SimpleDb {
   private db?: IDBDatabase;
-  private lastDbVersion: number | null = null;
+  private lastClosedDbVersion: number | null = null;
   private versionchangelistener?: (event: IDBVersionChangeEvent) => void;
 
   /** Deletes the specified database. */
@@ -346,8 +346,8 @@ export class SimpleDb {
           );
           const db = (event.target as IDBOpenDBRequest).result;
           if (
-            this.lastDbVersion !== null &&
-            this.lastDbVersion !== event.oldVersion
+            this.lastClosedDbVersion !== null &&
+            this.lastClosedDbVersion !== event.oldVersion
           ) {
             // This thrown error will get passed to the `onerror` callback
             // registered above, and will then be propagated correctly.
@@ -357,7 +357,7 @@ export class SimpleDb {
                 `could be caused by clicking the "clear site data" button in ` +
                 `a web browser; try reloading the web page to re-initialize ` +
                 `the IndexedDB database: ` +
-                `lastDbVersion=${this.lastDbVersion}, ` +
+                `lastClosedDbVersion=${this.lastClosedDbVersion}, ` +
                 `event.oldVersion=${event.oldVersion}, ` +
                 `event.newVersion=${event.newVersion}, ` +
                 `db.version=${db.version}`
@@ -383,7 +383,7 @@ export class SimpleDb {
         'close',
         event => {
           const db = event.target as IDBDatabase;
-          this.lastDbVersion = db.version;
+          this.lastClosedDbVersion = db.version;
         },
         { passive: true }
       );

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -158,6 +158,7 @@ export class SimpleDbTransaction {
  */
 export class SimpleDb {
   private db?: IDBDatabase;
+  private lastDbVersion: number | null = null;
   private versionchangelistener?: (event: IDBVersionChangeEvent) => void;
 
   /** Deletes the specified database. */
@@ -344,6 +345,24 @@ export class SimpleDb {
             event.oldVersion
           );
           const db = (event.target as IDBOpenDBRequest).result;
+          if (
+            this.lastDbVersion !== null &&
+            this.lastDbVersion !== event.oldVersion
+          ) {
+            // This thrown error will get passed to the `onerror` callback
+            // registered above, and will then be propagated correctly.
+            throw new Error(
+              `refusing to open IndexedDB database due to potential ` +
+                `corruption of the IndexedDB database data; this corruption ` +
+                `could be caused by clicking the "clear site data" button in ` +
+                `a web browser; try reloading the web page to re-initialize ` +
+                `the IndexedDB database: ` +
+                `lastDbVersion=${this.lastDbVersion}, ` +
+                `event.oldVersion=${event.oldVersion}, ` +
+                `event.newVersion=${event.newVersion}, ` +
+                `db.version=${db.version}`
+            );
+          }
           this.schemaConverter
             .createOrUpgrade(
               db,
@@ -359,11 +378,21 @@ export class SimpleDb {
             });
         };
       });
+
+      this.db.addEventListener(
+        'close',
+        event => {
+          const db = event.target as IDBDatabase;
+          this.lastDbVersion = db.version;
+        },
+        { passive: true }
+      );
     }
 
     if (this.versionchangelistener) {
       this.db.onversionchange = event => this.versionchangelistener!(event);
     }
+
     return this.db;
   }
 


### PR DESCRIPTION
If using IndexedDB persistence with Firestore and a user clicks the "Clear Site Data" button in a web browser, the IndexedDB database is closed (as expected); however, it is re-opened as soon as it is needed again, under the assumption that the database contents haven't changed. This incorrect assumption can lead to writing inconsistent data into the database, causing all sorts of problems.

One notable problem is that if a snapshot listener receives an "update" after "Clear Site Data" was clicked, then it will write the updated document contents into the database as if the rest of the information (e.g. the target) is also in the database. This is an inconsistent database state. If, then, the web page is reloaded, it will misinterpret the data in the database and produce document snapshots with erroneous `undefined` snapshot data.

To avoid this corruption, this PR improves the `SimpleDB` class to detect the "Clear Site Data" button click and to refuse to re-open the database thereafter. This avoids database corruption and leads to a working Firestore after reloading the web page. This does, however, completely break the Firestore client until the web page is reloaded; however, since a page refresh seems like a probable next step after a "Clear Site Data" button click, this probably is reasonable, and better than a perpetually-unusable Firestore SDK.

Fixes #8593