### PR TITLE
karma.base.js: replace "BROWSER" with "BROWSERS" in log messages, to reflect the actual name of the environment variable

### DIFF
--- a/config/karma.base.js
+++ b/config/karma.base.js
@@ -31,7 +31,7 @@ function determineBrowsers() {
     );
     if (validBrowsers.length === 0) {
       console.error(
-        `The \'BROWSER\' environment variable was set, but no supported browsers were listed. The supported browsers are ${JSON.stringify(
+        `The \'BROWSERS\' environment variable was set, but no supported browsers were listed. The supported browsers are ${JSON.stringify(
           supportedBrowsers
         )}.`
       );
@@ -41,7 +41,7 @@ function determineBrowsers() {
     }
   } else {
     console.log(
-      "The 'BROWSER' environment variable is undefined. Defaulting to 'ChromeHeadless'."
+      "The 'BROWSERS' environment variable is undefined. Defaulting to 'ChromeHeadless'."
     );
     return ['ChromeHeadless'];
   }


### PR DESCRIPTION
See #8491