### PR TITLE
Use base browsers variable in Firestore karma config

### DIFF
--- a/packages/firestore/karma.conf.js
+++ b/packages/firestore/karma.conf.js
@@ -21,7 +21,6 @@ const { argv } = require('yargs');
 module.exports = function (config) {
   const karmaConfig = {
     ...karmaBase,
-    browsers: getTestBrowsers(argv),
     // files to load into karma
     files: getTestFiles(argv),
 
@@ -74,14 +73,6 @@ function getTestFiles(argv) {
   } else {
     return [unitTests, legacyIntegrationTests];
   }
-}
-
-function getTestBrowsers(argv) {
-  let browsers = ['ChromeHeadless'];
-  if (process.env?.BROWSERS && argv.unit) {
-    browsers = process.env?.BROWSERS?.split(',');
-  }
-  return browsers;
 }
 
 module.exports.files = getTestFiles(argv);

--- a/packages/firestore/test/unit/util/bundle.test.ts
+++ b/packages/firestore/test/unit/util/bundle.test.ts
@@ -239,9 +239,21 @@ function genericBundleReadingTests(bytesPerRead: number): void {
         'Reached the end of bundle when a length string is expected.'
       );
 
-      await expect(
-        generateBundleAndParse('{metadata: "no length prefix"}', bytesPerRead)
-      ).to.be.rejectedWith(/(Unexpected end of )(?=.*JSON\b).*/gi);
+      // The multiple "rejectedWith" checks below are an attempt to make the
+      // test robust in the presence of various permutations of the error
+      // message, which is produced by the JavaScript runtime.
+      // Chrome produces: Unexpected end of JSON input
+      // Webkit produces: JSON Parse error: Unexpected EOF
+      const noLengthPrefixPromise = generateBundleAndParse(
+        '{metadata: "no length prefix"}',
+        bytesPerRead
+      );
+      await expect(noLengthPrefixPromise).to.be.rejectedWith(
+        /(\b|^)unexpected ((end of)|(eof))(\b|$)/gi
+      );
+      await expect(noLengthPrefixPromise).to.be.rejectedWith(
+        /(\b|^)JSON(\b|$)/g
+      );
 
       await expect(
         generateBundleAndParse(


### PR DESCRIPTION
Firestore's Karma config overwrites the `browsers` that are set in the base karma config:https://github.com/firebase/firebase-js-sdk/blob/main/packages/firestore/karma.conf.js#L24
`getTestBrowsers(argv)` only uses the `BROWSERS` environment variable if it's running the unit tests: https://github.com/firebase/firebase-js-sdk/blob/main/packages/firestore/karma.conf.js#L81
We want the `BROWSERS` environment to always define the browser to use- regardless of whether we're running unit tests.