### PR TITLE
Fix 'window is not defined' error when calling `clearIndexedDbPersistence`

### DIFF
--- a/.changeset/gentle-rocks-repeat.md
+++ b/.changeset/gentle-rocks-repeat.md
@@ -1,0 +1,6 @@
+---
+'@firebase/firestore': patch
+'firebase': patch
+---
+
+Fix 'window is not defined' error when calling `clearIndexedDbPersistence` from a service worker

--- a/packages/firestore/externs.json
+++ b/packages/firestore/externs.json
@@ -31,6 +31,7 @@
     "packages/util/dist/src/emulator.d.ts",
     "packages/util/dist/src/environment.d.ts",
     "packages/util/dist/src/compat.d.ts",
+    "packages/util/dist/src/global.d.ts",
     "packages/util/dist/src/obj.d.ts",
     "packages/firestore/src/protos/firestore_bundle_proto.ts",
     "packages/firestore/src/protos/firestore_proto_api.ts",

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { getUA, isIndexedDBAvailable } from '@firebase/util';
+import { getGlobal, getUA, isIndexedDBAvailable } from '@firebase/util';
 
 import { debugAssert } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
@@ -24,7 +24,7 @@ import { Deferred } from '../util/promise';
 
 import { PersistencePromise } from './persistence_promise';
 
-// References to `window` are guarded by SimpleDb.isAvailable()
+// References to `indexedDB` are guarded by SimpleDb.isAvailable() and getGlobal()
 /* eslint-disable no-restricted-globals */
 
 const LOG_TAG = 'SimpleDb';
@@ -164,7 +164,10 @@ export class SimpleDb {
   /** Deletes the specified database. */
   static delete(name: string): Promise<void> {
     logDebug(LOG_TAG, 'Removing database:', name);
-    return wrapRequest<void>(window.indexedDB.deleteDatabase(name)).toPromise();
+    const globals = getGlobal();
+    return wrapRequest<void>(
+      globals.indexedDB.deleteDatabase(name)
+    ).toPromise();
   }
 
   /** Returns true if IndexedDB is available in the current environment. */


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/6465

Call the "indexedDb" on `self/window/global` based on availability.