### PR TITLE
Fix Data Connect Types

### DIFF
--- a/.changeset/hungry-snails-drive.md
+++ b/.changeset/hungry-snails-drive.md
@@ -1,0 +1,5 @@
+---
+"@firebase/data-connect": patch
+---
+
+Fix DataConnectOperationError.

--- a/common/api-review/data-connect.api.md
+++ b/common/api-review/data-connect.api.md
@@ -7,6 +7,7 @@
 import { AppCheckInternalComponentName } from '@firebase/app-check-interop-types';
 import { FirebaseApp } from '@firebase/app';
 import { FirebaseAuthInternalName } from '@firebase/auth-interop-types';
+import { FirebaseError } from '@firebase/util';
 import { LogLevelString } from '@firebase/logger';
 import { Provider } from '@firebase/component';
 
@@ -21,6 +22,20 @@ export const CallerSdkTypeEnum: {
     readonly GeneratedReact: "GeneratedReact";
     readonly TanstackAngularCore: "TanstackAngularCore";
     readonly GeneratedAngular: "GeneratedAngular";
+};
+
+// @public (undocumented)
+export type Code = DataConnectErrorCode;
+
+// @public (undocumented)
+export const Code: {
+    OTHER: DataConnectErrorCode;
+    ALREADY_INITIALIZED: DataConnectErrorCode;
+    NOT_INITIALIZED: DataConnectErrorCode;
+    NOT_SUPPORTED: DataConnectErrorCode;
+    INVALID_ARGUMENT: DataConnectErrorCode;
+    PARTIAL_ERROR: DataConnectErrorCode;
+    UNAUTHORIZED: DataConnectErrorCode;
 };
 
 // @public
@@ -51,20 +66,19 @@ export class DataConnect {
     setInitialized(): void;
 }
 
+// @public
+export class DataConnectError extends FirebaseError {
+    /* Excluded from this release type: name */
+    constructor(code: Code, message: string);
+}
+
 // @public (undocumented)
 export type DataConnectErrorCode = 'other' | 'already-initialized' | 'not-initialized' | 'not-supported' | 'invalid-argument' | 'partial-error' | 'unauthorized';
 
 // @public
-export class DataConnectOperationError {
+export class DataConnectOperationError extends DataConnectError {
     /* Excluded from this release type: name */
-    code: string;
-    customData?: Record<string, unknown>;
-    // (undocumented)
-    message: string;
-    name: string;
     readonly response: DataConnectOperationFailureResponse;
-    // (undocumented)
-    stack?: string;
 }
 
 // @public (undocumented)
@@ -98,7 +112,7 @@ export interface DataConnectResult<Data, Variables> extends OpResult<Data> {
 // @public
 export interface DataConnectSubscription<Data, Variables> {
     // (undocumented)
-    errCallback?: (e?: DataConnectOperationError) => void;
+    errCallback?: (e?: DataConnectError) => void;
     // (undocumented)
     unsubscribe: () => void;
     // (undocumented)
@@ -149,7 +163,7 @@ export interface MutationResult<Data, Variables> extends DataConnectResult<Data,
 export type OnCompleteSubscription = () => void;
 
 // @public
-export type OnErrorSubscription = (err?: DataConnectOperationError) => void;
+export type OnErrorSubscription = (err?: DataConnectError) => void;
 
 // @public
 export type OnResultSubscription<Data, Variables> = (res: QueryResult<Data, Variables>) => void;

--- a/common/api-review/data-connect.api.md
+++ b/common/api-review/data-connect.api.md
@@ -7,7 +7,6 @@
 import { AppCheckInternalComponentName } from '@firebase/app-check-interop-types';
 import { FirebaseApp } from '@firebase/app';
 import { FirebaseAuthInternalName } from '@firebase/auth-interop-types';
-import { FirebaseError } from '@firebase/util';
 import { LogLevelString } from '@firebase/logger';
 import { Provider } from '@firebase/component';
 
@@ -52,17 +51,20 @@ export class DataConnect {
     setInitialized(): void;
 }
 
-// @public
-export class DataConnectError extends FirebaseError {
-    }
-
 // @public (undocumented)
 export type DataConnectErrorCode = 'other' | 'already-initialized' | 'not-initialized' | 'not-supported' | 'invalid-argument' | 'partial-error' | 'unauthorized';
 
 // @public
-export class DataConnectOperationError extends DataConnectError {
+export class DataConnectOperationError {
     /* Excluded from this release type: name */
+    code: string;
+    customData?: Record<string, unknown>;
+    // (undocumented)
+    message: string;
+    name: string;
     readonly response: DataConnectOperationFailureResponse;
+    // (undocumented)
+    stack?: string;
 }
 
 // @public (undocumented)
@@ -96,7 +98,7 @@ export interface DataConnectResult<Data, Variables> extends OpResult<Data> {
 // @public
 export interface DataConnectSubscription<Data, Variables> {
     // (undocumented)
-    errCallback?: (e?: DataConnectError) => void;
+    errCallback?: (e?: DataConnectOperationError) => void;
     // (undocumented)
     unsubscribe: () => void;
     // (undocumented)
@@ -147,7 +149,7 @@ export interface MutationResult<Data, Variables> extends DataConnectResult<Data,
 export type OnCompleteSubscription = () => void;
 
 // @public
-export type OnErrorSubscription = (err?: DataConnectError) => void;
+export type OnErrorSubscription = (err?: DataConnectOperationError) => void;
 
 // @public
 export type OnResultSubscription<Data, Variables> = (res: QueryResult<Data, Variables>) => void;

--- a/packages/data-connect/src/api/index.ts
+++ b/packages/data-connect/src/api/index.ts
@@ -24,7 +24,6 @@ export { setLogLevel } from '../logger';
 export { validateArgs } from '../util/validateArgs';
 export {
   DataConnectErrorCode,
-  DataConnectError,
   DataConnectOperationError,
   DataConnectOperationFailureResponse,
   DataConnectOperationFailureResponseErrorInfo

--- a/packages/data-connect/src/api/index.ts
+++ b/packages/data-connect/src/api/index.ts
@@ -24,6 +24,8 @@ export { setLogLevel } from '../logger';
 export { validateArgs } from '../util/validateArgs';
 export {
   DataConnectErrorCode,
+  Code,
+  DataConnectError,
   DataConnectOperationError,
   DataConnectOperationFailureResponse,
   DataConnectOperationFailureResponseErrorInfo

--- a/packages/data-connect/src/core/error.ts
+++ b/packages/data-connect/src/core/error.ts
@@ -43,7 +43,6 @@ export class DataConnectError extends FirebaseError {
   /** @internal */
   readonly name: string = 'DataConnectError';
 
-  /** @hideconstructor */
   constructor(code: Code, message: string) {
     super(code, message);
 


### PR DESCRIPTION
`DataConnectOperationError` extends `DataConnectError`, both of which have tags `@hideconstructor`. This means that in public builds, our output marks the constructors as `private`. However, this causes an error to be thrown: `cannot extend private constructor`, because `DataConnectOperationError` extends `DataConnectError`, which has a private constructor. The reason why this wasn't caught during integration tests is because to integration tests, the constructors aren't private, but for public builds (that are used by external devs), the constructors *are* private. So the only way we could've caught this would've been to use the published version (or packaged version) of the SDK.

TL;DR: Fix error where if we exported `DataConnectError`, then when using the types, the user would get a `cannot extend private constructor` due to the fact that `DataConnectOperationError` would extend `DataConnectError`. 

The fix for this is to remove the `@hideconstructor` annotation. The *right* fix would have been to not export `DataConnectError` at all, but if we do that, it would result in a breaking change for those who use `DataConnectError`. (Though, the argument can be made that no one is even able to use that type because the types are broken).