### PR TITLE
Fix: display WebChannel error message

### DIFF
--- a/packages/firestore/src/platform/browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform/browser/webchannel_connection.ts
@@ -326,8 +326,10 @@ export class WebChannelConnection extends RestConnection {
         closed = true;
         logWarn(
           LOG_TAG,
-          `RPC '${rpcName}' stream ${streamId} transport errored:`,
-          err
+          `RPC '${rpcName}' stream ${streamId} transport errored. Name:`,
+          err.name,
+          'Message:',
+          err.message
         );
         streamBridge.callOnClose(
           new FirestoreError(


### PR DESCRIPTION
Display the error name and message instead of [object object], ie: `@firebase/firestore: Firestore (11.6.0): WebChannelConnection RPC 'Listen' stream 0x24eae879 transport errored: [object Object]`