### PR TITLE
Fix languageCode parameter in action_code_url

### DIFF
--- a/.changeset/great-cheetahs-invite.md
+++ b/.changeset/great-cheetahs-invite.md
@@ -1,0 +1,5 @@
+---
+'@firebase/auth': patch
+---
+
+Fixed: `ActionCodeURL` not populating `languageCode` from the url.

--- a/packages/auth/src/core/action_code_url.test.ts
+++ b/packages/auth/src/core/action_code_url.test.ts
@@ -30,7 +30,7 @@ describe('core/action_code_url', () => {
         'oobCode=CODE&mode=signIn&apiKey=API_KEY&' +
         'continueUrl=' +
         encodeURIComponent(continueUrl) +
-        '&languageCode=en&tenantId=TENANT_ID&state=bla';
+        '&lang=en&tenantId=TENANT_ID&state=bla';
       const actionCodeUrl = ActionCodeURL.parseLink(actionLink);
       expect(actionCodeUrl!.operation).to.eq(ActionCodeOperation.EMAIL_SIGNIN);
       expect(actionCodeUrl!.code).to.eq('CODE');
@@ -46,7 +46,7 @@ describe('core/action_code_url', () => {
         const actionLink =
           'https://www.example.com/finishSignIn?' +
           'oobCode=CODE&mode=signIn&apiKey=API_KEY&' +
-          'languageCode=en';
+          'lang=en';
         const actionCodeUrl = ActionCodeURL.parseLink(actionLink);
         expect(actionCodeUrl!.operation).to.eq(
           ActionCodeOperation.EMAIL_SIGNIN
@@ -57,7 +57,7 @@ describe('core/action_code_url', () => {
         const actionLink =
           'https://www.example.com/finishSignIn?' +
           'oobCode=CODE&mode=verifyAndChangeEmail&apiKey=API_KEY&' +
-          'languageCode=en';
+          'lang=en';
         const actionCodeUrl = ActionCodeURL.parseLink(actionLink);
         expect(actionCodeUrl!.operation).to.eq(
           ActionCodeOperation.VERIFY_AND_CHANGE_EMAIL
@@ -68,7 +68,7 @@ describe('core/action_code_url', () => {
         const actionLink =
           'https://www.example.com/finishSignIn?' +
           'oobCode=CODE&mode=verifyEmail&apiKey=API_KEY&' +
-          'languageCode=en';
+          'lang=en';
         const actionCodeUrl = ActionCodeURL.parseLink(actionLink);
         expect(actionCodeUrl!.operation).to.eq(
           ActionCodeOperation.VERIFY_EMAIL
@@ -79,7 +79,7 @@ describe('core/action_code_url', () => {
         const actionLink =
           'https://www.example.com/finishSignIn?' +
           'oobCode=CODE&mode=recoverEmail&apiKey=API_KEY&' +
-          'languageCode=en';
+          'lang=en';
         const actionCodeUrl = ActionCodeURL.parseLink(actionLink);
         expect(actionCodeUrl!.operation).to.eq(
           ActionCodeOperation.RECOVER_EMAIL
@@ -90,7 +90,7 @@ describe('core/action_code_url', () => {
         const actionLink =
           'https://www.example.com/finishSignIn?' +
           'oobCode=CODE&mode=resetPassword&apiKey=API_KEY&' +
-          'languageCode=en';
+          'lang=en';
         const actionCodeUrl = ActionCodeURL.parseLink(actionLink);
         expect(actionCodeUrl!.operation).to.eq(
           ActionCodeOperation.PASSWORD_RESET
@@ -101,7 +101,7 @@ describe('core/action_code_url', () => {
         const actionLink =
           'https://www.example.com/finishSignIn?' +
           'oobCode=CODE&mode=revertSecondFactorAddition&apiKey=API_KEY&' +
-          'languageCode=en';
+          'lang=en';
         const actionCodeUrl = ActionCodeURL.parseLink(actionLink);
         expect(actionCodeUrl!.operation).to.eq(
           ActionCodeOperation.REVERT_SECOND_FACTOR_ADDITION

--- a/packages/auth/src/core/action_code_url.ts
+++ b/packages/auth/src/core/action_code_url.ts
@@ -29,7 +29,7 @@ const enum QueryField {
   API_KEY = 'apiKey',
   CODE = 'oobCode',
   CONTINUE_URL = 'continueUrl',
-  LANGUAGE_CODE = 'languageCode',
+  LANGUAGE_CODE = 'lang',
   MODE = 'mode',
   TENANT_ID = 'tenantId'
 }


### PR DESCRIPTION
It was observed that the parameter used for language code in the backend is `lang` and not `languageCode`, due to which `ActionCode.languageCode` will always be null. This is to fix the query parameter, so that the languageCode is populated correctly after parsing.

Issue was originally reported for ios-sdk at https://github.com/firebase/firebase-ios-sdk/issues/14664

### Testing
Updated unit tests.