### PR TITLE
VinF Hybrid Inference #0: add dom-chromium-ai dep

### DIFF
--- a/packages/vertexai/package.json
+++ b/packages/vertexai/package.json
@@ -58,6 +58,7 @@
   "devDependencies": {
     "@firebase/app": "0.11.3",
     "@rollup/plugin-json": "6.1.0",
+    "@types/dom-chromium-ai": "0.0.6",
     "rollup": "2.79.2",
     "rollup-plugin-replace": "2.2.0",
     "rollup-plugin-typescript2": "0.36.0",

--- a/repo-scripts/changelog-generator/tsconfig.json
+++ b/repo-scripts/changelog-generator/tsconfig.json
@@ -3,6 +3,7 @@
     "strict": true,
     "outDir": "dist",
     "lib": [
+      "dom",
       "ESNext"
     ],
     "module": "CommonJS",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2949,6 +2949,11 @@
   resolved "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
   integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
 
+"@types/dom-chromium-ai@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.npmjs.org/@types/dom-chromium-ai/-/dom-chromium-ai-0.0.6.tgz#0c9e5712d8db3d26586cd9f175001b509cd2e514"
+  integrity sha512-/jUGe9a3BLzsjjg18Olk/Ul64PZ0P4aw8uNxrXeXVTni5PSxyCfyhHb4UohsXNVByOnwYGzlqUcb3vYKVsG4mg==
+
 "@types/eslint-scope@^3.7.7":
   version "3.7.7"
   resolved "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz#3108bd5f18b0cdb277c867b3dd449c9ed7079ac5"


### PR DESCRIPTION
# Problem Statement

https://github.com/firebase/firebase-js-sdk/pull/8874#discussion_r2035942547 asks why we need to add "dom" to the posttinstall script's tsconfig. The reason is because adding the @types/dom-chromium-ai to vertex causes the postinstall script to fail with errors like:
```
~/firebase-js-sdk $ yarn                                                                                   
...
[5/5] 🔨  Building fresh packages...
$ patch-package && yarn --cwd repo-scripts/changelog-generator build
patch-package 7.0.2
Applying patches...
karma-webpack@5.0.0 ✔
yarn run v1.22.22
$ tsc
../../node_modules/@types/dom-chromium-ai/index.d.ts:20:29 - error TS2304: Cannot find name 'AddEventListenerOptions'.

20         options?: boolean | AddEventListenerOptions,
                               ~~~~~~~~~~~~~~~~~~~~~~~
```

If this passes in CI, that'll be a clue for how to proceed.

# Repro Steps

1. Create branch based on integration branch
2. Run `git clean -fdx` from repo root
3. Run `yarn` and observe success
4. cd into packages/vertexai
5. Install AI types: `yarn add -D @types/dom-chromium-ai`
6. cd back into repo root
7. Run `yarn` and observe error
8. Add "dom" lib to changelog script's tsconfig
9. Run `yarn` from root and `yarn test` from vertex dir and observe success
