### PR TITLE
test(vertexai): update developerapi mock response dir to googleai

### DIFF
--- a/packages/vertexai/test-utils/convert-mocks.ts
+++ b/packages/vertexai/test-utils/convert-mocks.ts
@@ -30,8 +30,7 @@ type BackendName = 'vertexAI' | 'googleAI';
 
 const mockDirs: Record<BackendName, string> = {
   vertexAI: join(MOCK_RESPONSES_DIR_PATH, 'vertexai'),
-  // Note: the dirname is developerapi is legacy. It should be updated to googleai.
-  googleAI: join(MOCK_RESPONSES_DIR_PATH, 'developerapi')
+  googleAI: join(MOCK_RESPONSES_DIR_PATH, 'googleai')
 };
 
 /**


### PR DESCRIPTION
This directory was renamed to `googleai` in https://github.com/FirebaseExtended/vertexai-sdk-test-data/pull/33.