### PR TITLE
Vaihi add langmodel types.

### DIFF
--- a/packages/vertexai/src/types/index.ts
+++ b/packages/vertexai/src/types/index.ts
@@ -17,7 +17,6 @@
 
 export * from './content';
 export * from './enums';
-export * from './language-model';
 export * from './requests';
 export * from './responses';
 export * from './error';

--- a/packages/vertexai/src/types/index.ts
+++ b/packages/vertexai/src/types/index.ts
@@ -17,6 +17,7 @@
 
 export * from './content';
 export * from './enums';
+export * from './language-model';
 export * from './requests';
 export * from './responses';
 export * from './error';

--- a/packages/vertexai/src/types/language-model.ts
+++ b/packages/vertexai/src/types/language-model.ts
@@ -1,54 +1,94 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export interface LanguageModel extends EventTarget {
-    create(options?: LanguageModelCreateOptions): Promise<LanguageModel>;
-    availability(options?: LanguageModelCreateCoreOptions): Promise<Availability>;
-    prompt(input: LanguageModelPrompt, options?: LanguageModelPromptOptions): Promise<string>;
-    promptStreaming(input: LanguageModelPrompt, options?: LanguageModelPromptOptions): ReadableStream;
-    measureInputUsage(input: LanguageModelPrompt, options?: LanguageModelPromptOptions): Promise<number>;
-    destroy(): undefined;
+  create(options?: LanguageModelCreateOptions): Promise<LanguageModel>;
+  availability(options?: LanguageModelCreateCoreOptions): Promise<Availability>;
+  prompt(
+    input: LanguageModelPrompt,
+    options?: LanguageModelPromptOptions
+  ): Promise<string>;
+  promptStreaming(
+    input: LanguageModelPrompt,
+    options?: LanguageModelPromptOptions
+  ): ReadableStream;
+  measureInputUsage(
+    input: LanguageModelPrompt,
+    options?: LanguageModelPromptOptions
+  ): Promise<number>;
+  destroy(): undefined;
 }
-enum Availability { "unavailable", "downloadable", "downloading", "available" };
+enum Availability {
+  'unavailable',
+  'downloadable',
+  'downloading',
+  'available'
+}
 interface LanguageModelParams {
-    readonly defaultTopK: number;
-    readonly maxTopK: number;
-    readonly defaultTemperature: number;
-    readonly maxTemperature: number;
+  readonly defaultTopK: number;
+  readonly maxTopK: number;
+  readonly defaultTemperature: number;
+  readonly maxTemperature: number;
 }
 interface LanguageModelCreateCoreOptions {
-    topK?: number;
-    temperature?: number;
-    expectedInputs?: LanguageModelExpectedInput[];
+  topK?: number;
+  temperature?: number;
+  expectedInputs?: LanguageModelExpectedInput[];
 }
 interface LanguageModelCreateOptions extends LanguageModelCreateCoreOptions {
-    signal?: AbortSignal;
-    systemPrompt?: string;
-    initialPrompts?: LanguageModelInitialPrompts;
+  signal?: AbortSignal;
+  systemPrompt?: string;
+  initialPrompts?: LanguageModelInitialPrompts;
 }
 interface LanguageModelPromptOptions {
-    signal?: AbortSignal;
+  signal?: AbortSignal;
 }
 interface LanguageModelExpectedInput {
-    type: LanguageModelMessageType;
-    languages?: string[];
+  type: LanguageModelMessageType;
+  languages?: string[];
 }
-type LanguageModelPrompt = LanguageModelMessage[] | LanguageModelMessageShorthand[] | string;
-type LanguageModelInitialPrompts = LanguageModelMessage[] | LanguageModelMessageShorthand[];
+type LanguageModelPrompt =
+  | LanguageModelMessage[]
+  | LanguageModelMessageShorthand[]
+  | string;
+type LanguageModelInitialPrompts =
+  | LanguageModelMessage[]
+  | LanguageModelMessageShorthand[];
 interface LanguageModelMessage {
-    role: LanguageModelMessageRole;
-    content: LanguageModelMessageContent[];
+  role: LanguageModelMessageRole;
+  content: LanguageModelMessageContent[];
 }
 interface LanguageModelMessageShorthand {
-    role: LanguageModelMessageRole;
-    content: string;
+  role: LanguageModelMessageRole;
+  content: string;
 }
 interface LanguageModelMessageContent {
-    type: LanguageModelMessageType;
-    content: LanguageModelMessageContentValue;
+  type: LanguageModelMessageType;
+  content: LanguageModelMessageContentValue;
 }
 interface LanguageModelPromptDict {
-    role?: LanguageModelMessageRole;
-    type?: LanguageModelMessageType;
-    content: LanguageModelMessageContent;
+  role?: LanguageModelMessageRole;
+  type?: LanguageModelMessageType;
+  content: LanguageModelMessageContent;
 }
-type LanguageModelMessageRole = "system" | "user" | "assistant";
-type LanguageModelMessageType = "text" | "image" | "audio";
-type LanguageModelMessageContentValue = ImageBitmapSource | AudioBuffer | BufferSource | string;
+type LanguageModelMessageRole = 'system' | 'user' | 'assistant';
+type LanguageModelMessageType = 'text' | 'image' | 'audio';
+type LanguageModelMessageContentValue =
+  | ImageBitmapSource
+  | AudioBuffer
+  | BufferSource
+  | string;

--- a/packages/vertexai/src/types/language-model.ts
+++ b/packages/vertexai/src/types/language-model.ts
@@ -6,50 +6,49 @@ export interface LanguageModel extends EventTarget {
     measureInputUsage(input: LanguageModelPrompt, options?: LanguageModelPromptOptions): Promise<number>;
     destroy(): undefined;
 }
-export enum Availability { "unavailable", "downloadable", "downloading", "available" };
-export interface LanguageModelParams {
+enum Availability { "unavailable", "downloadable", "downloading", "available" };
+interface LanguageModelParams {
     readonly defaultTopK: number;
     readonly maxTopK: number;
     readonly defaultTemperature: number;
     readonly maxTemperature: number;
 }
-export interface LanguageModelCreateCoreOptions {
+interface LanguageModelCreateCoreOptions {
     topK?: number;
     temperature?: number;
     expectedInputs?: LanguageModelExpectedInput[];
 }
-export interface LanguageModelCreateOptions extends LanguageModelCreateCoreOptions {
+interface LanguageModelCreateOptions extends LanguageModelCreateCoreOptions {
     signal?: AbortSignal;
-    monitor?: AICreateMonitorCallback;
     systemPrompt?: string;
     initialPrompts?: LanguageModelInitialPrompts;
 }
-export interface LanguageModelPromptOptions {
+interface LanguageModelPromptOptions {
     signal?: AbortSignal;
 }
-export interface LanguageModelExpectedInput {
+interface LanguageModelExpectedInput {
     type: LanguageModelMessageType;
     languages?: string[];
 }
-export type LanguageModelPrompt = LanguageModelMessage[] | LanguageModelMessageShorthand[] | string;
-export type LanguageModelInitialPrompts = LanguageModelMessage[] | LanguageModelMessageShorthand[];
-export interface LanguageModelMessage {
+type LanguageModelPrompt = LanguageModelMessage[] | LanguageModelMessageShorthand[] | string;
+type LanguageModelInitialPrompts = LanguageModelMessage[] | LanguageModelMessageShorthand[];
+interface LanguageModelMessage {
     role: LanguageModelMessageRole;
     content: LanguageModelMessageContent[];
 }
-export interface LanguageModelMessageShorthand {
+interface LanguageModelMessageShorthand {
     role: LanguageModelMessageRole;
     content: string;
 }
-export interface LanguageModelMessageContent {
+interface LanguageModelMessageContent {
     type: LanguageModelMessageType;
     content: LanguageModelMessageContentValue;
 }
-export interface LanguageModelPromptDict {
+interface LanguageModelPromptDict {
     role?: LanguageModelMessageRole;
     type?: LanguageModelMessageType;
     content: LanguageModelMessageContent;
 }
-export type LanguageModelMessageRole = "system" | "user" | "assistant";
-export type LanguageModelMessageType = "text" | "image" | "audio";
-export type LanguageModelMessageContentValue = ImageBitmapSource | AudioBuffer | BufferSource | string;
+type LanguageModelMessageRole = "system" | "user" | "assistant";
+type LanguageModelMessageType = "text" | "image" | "audio";
+type LanguageModelMessageContentValue = ImageBitmapSource | AudioBuffer | BufferSource | string;

--- a/packages/vertexai/src/types/language-model.ts
+++ b/packages/vertexai/src/types/language-model.ts
@@ -16,7 +16,7 @@ export interface LanguageModelParams {
 export interface LanguageModelCreateCoreOptions {
     topK?: number;
     temperature?: number;
-    expectedInputs?: Array<LanguageModelExpectedInput>;
+    expectedInputs?: LanguageModelExpectedInput[];
 }
 export interface LanguageModelCreateOptions extends LanguageModelCreateCoreOptions {
     signal?: AbortSignal;
@@ -25,18 +25,17 @@ export interface LanguageModelCreateOptions extends LanguageModelCreateCoreOptio
     initialPrompts?: LanguageModelInitialPrompts;
 }
 export interface LanguageModelPromptOptions {
-    responseJSONSchema?: any;
     signal?: AbortSignal;
 }
 export interface LanguageModelExpectedInput {
     type: LanguageModelMessageType;
-    languages?: Array<string>;
+    languages?: string[];
 }
-export type LanguageModelPrompt = Array<LanguageModelMessage> | Array<LanguageModelMessageShorthand> | string;
-export type LanguageModelInitialPrompts = Array<LanguageModelMessage> | Array<LanguageModelMessageShorthand>;
+export type LanguageModelPrompt = LanguageModelMessage[] | LanguageModelMessageShorthand[] | string;
+export type LanguageModelInitialPrompts = LanguageModelMessage[] | LanguageModelMessageShorthand[];
 export interface LanguageModelMessage {
     role: LanguageModelMessageRole;
-    content: Array<LanguageModelMessageContent>;
+    content: LanguageModelMessageContent[];
 }
 export interface LanguageModelMessageShorthand {
     role: LanguageModelMessageRole;

--- a/packages/vertexai/src/types/language-model.ts
+++ b/packages/vertexai/src/types/language-model.ts
@@ -1,0 +1,56 @@
+export interface LanguageModel extends EventTarget {
+    create(options?: LanguageModelCreateOptions): Promise<LanguageModel>;
+    availability(options?: LanguageModelCreateCoreOptions): Promise<Availability>;
+    prompt(input: LanguageModelPrompt, options?: LanguageModelPromptOptions): Promise<string>;
+    promptStreaming(input: LanguageModelPrompt, options?: LanguageModelPromptOptions): ReadableStream;
+    measureInputUsage(input: LanguageModelPrompt, options?: LanguageModelPromptOptions): Promise<number>;
+    destroy(): undefined;
+}
+export enum Availability { "unavailable", "downloadable", "downloading", "available" };
+export interface LanguageModelParams {
+    readonly defaultTopK: number;
+    readonly maxTopK: number;
+    readonly defaultTemperature: number;
+    readonly maxTemperature: number;
+}
+export interface LanguageModelCreateCoreOptions {
+    topK?: number;
+    temperature?: number;
+    expectedInputs?: Array<LanguageModelExpectedInput>;
+}
+export interface LanguageModelCreateOptions extends LanguageModelCreateCoreOptions {
+    signal?: AbortSignal;
+    monitor?: AICreateMonitorCallback;
+    systemPrompt?: string;
+    initialPrompts?: LanguageModelInitialPrompts;
+}
+export interface LanguageModelPromptOptions {
+    responseJSONSchema?: any;
+    signal?: AbortSignal;
+}
+export interface LanguageModelExpectedInput {
+    type: LanguageModelMessageType;
+    languages?: Array<string>;
+}
+export type LanguageModelPrompt = Array<LanguageModelMessage> | Array<LanguageModelMessageShorthand> | string;
+export type LanguageModelInitialPrompts = Array<LanguageModelMessage> | Array<LanguageModelMessageShorthand>;
+export interface LanguageModelMessage {
+    role: LanguageModelMessageRole;
+    content: Array<LanguageModelMessageContent>;
+}
+export interface LanguageModelMessageShorthand {
+    role: LanguageModelMessageRole;
+    content: string;
+}
+export interface LanguageModelMessageContent {
+    type: LanguageModelMessageType;
+    content: LanguageModelMessageContentValue;
+}
+export interface LanguageModelPromptDict {
+    role?: LanguageModelMessageRole;
+    type?: LanguageModelMessageType;
+    content: LanguageModelMessageContent;
+}
+export type LanguageModelMessageRole = "system" | "user" | "assistant";
+export type LanguageModelMessageType = "text" | "image" | "audio";
+export type LanguageModelMessageContentValue = ImageBitmapSource | AudioBuffer | BufferSource | string;

--- a/packages/vertexai/src/types/language-model.ts
+++ b/packages/vertexai/src/types/language-model.ts
@@ -38,12 +38,6 @@ enum Availability {
   'downloading',
   'available'
 }
-interface LanguageModelParams {
-  readonly defaultTopK: number;
-  readonly maxTopK: number;
-  readonly defaultTemperature: number;
-  readonly maxTemperature: number;
-}
 interface LanguageModelCreateCoreOptions {
   topK?: number;
   temperature?: number;
@@ -79,11 +73,6 @@ interface LanguageModelMessageShorthand {
 interface LanguageModelMessageContent {
   type: LanguageModelMessageType;
   content: LanguageModelMessageContentValue;
-}
-interface LanguageModelPromptDict {
-  role?: LanguageModelMessageRole;
-  type?: LanguageModelMessageType;
-  content: LanguageModelMessageContent;
 }
 type LanguageModelMessageRole = 'system' | 'user' | 'assistant';
 type LanguageModelMessageType = 'text' | 'image' | 'audio';


### PR DESCRIPTION
Add LanguageModel types.

Based off: https://github.com/webmachinelearning/prompt-api?tab=readme-ov-file#full-api-surface-in-web-idl.