### PR TITLE
VinF Hybrid Inference: Define Availability values

### DIFF
--- a/packages/vertexai/src/types/language-model.ts
+++ b/packages/vertexai/src/types/language-model.ts
@@ -33,10 +33,10 @@ export interface LanguageModel extends EventTarget {
   destroy(): undefined;
 }
 export enum Availability {
-  'unavailable',
-  'downloadable',
-  'downloading',
-  'available'
+  'unavailable' = 'unavailable',
+  'downloadable' = 'downloadable',
+  'downloading' = 'downloading',
+  'available' = 'available'
 }
 export interface LanguageModelCreateCoreOptions {
   topK?: number;


### PR DESCRIPTION
`LanguageModel.availability()` returns `Availability` in TS, but a string in JS, causing the comparison to fail. Since we define the TS types for `LanguageModel` (for now, at least), we can define string values for the `Availability` enum, which enables the comparison to work as expected.
