### PR TITLE
VinF Hybrid Inference: throw if only_on_device and model is unavailable

### DIFF
--- a/e2e/sample-apps/modular.js
+++ b/e2e/sample-apps/modular.js
@@ -314,7 +314,7 @@ async function callVertexAI(app) {
   console.log('[VERTEXAI] start');
   const vertexAI = getVertexAI(app);
   const model = getGenerativeModel(vertexAI, {
-    mode: 'prefer_on_device'
+    mode: 'only_on_device'
   });
   const singleResult = await model.generateContent([
     { text: 'describe the following:' },

--- a/packages/vertexai/src/methods/chrome-adapter.test.ts
+++ b/packages/vertexai/src/methods/chrome-adapter.test.ts
@@ -194,7 +194,20 @@ describe('ChromeAdapter', () => {
       ).to.be.false;
     });
   });
-  describe('generateContentOnDevice', () => {
+  describe('generateContent', () => {
+    it('throws if Chrome API is undefined', async () => {
+      const adapter = new ChromeAdapter(undefined, 'only_on_device');
+      await expect(
+        adapter.generateContent({
+          contents: []
+        })
+      )
+        .to.eventually.be.rejectedWith(
+          VertexAIError,
+          'Chrome AI requested for unsupported browser version.'
+        )
+        .and.have.property('code', VertexAIErrorCode.REQUEST_ERROR);
+    });
     it('generates content', async () => {
       const languageModelProvider = {
         create: () => Promise.resolve({})

--- a/packages/vertexai/src/methods/chrome-adapter.test.ts
+++ b/packages/vertexai/src/methods/chrome-adapter.test.ts
@@ -61,19 +61,8 @@ describe('ChromeAdapter', () => {
         })
       ).to.be.false;
     });
-    it('returns false if AI API is undefined', async () => {
-      const adapter = new ChromeAdapter(undefined, 'prefer_on_device');
-      expect(
-        await adapter.isAvailable({
-          contents: []
-        })
-      ).to.be.false;
-    });
     it('returns false if LanguageModel API is undefined', async () => {
-      const adapter = new ChromeAdapter(
-        {} as LanguageModel,
-        'prefer_on_device'
-      );
+      const adapter = new ChromeAdapter(undefined, 'prefer_on_device');
       expect(
         await adapter.isAvailable({
           contents: []
@@ -82,7 +71,9 @@ describe('ChromeAdapter', () => {
     });
     it('returns false if request contents empty', async () => {
       const adapter = new ChromeAdapter(
-        {} as LanguageModel,
+        {
+          availability: async () => Availability.available
+        } as LanguageModel,
         'prefer_on_device'
       );
       expect(
@@ -93,7 +84,9 @@ describe('ChromeAdapter', () => {
     });
     it('returns false if request content has function role', async () => {
       const adapter = new ChromeAdapter(
-        {} as LanguageModel,
+        {
+          availability: async () => Availability.available
+        } as LanguageModel,
         'prefer_on_device'
       );
       expect(
@@ -104,51 +97,6 @@ describe('ChromeAdapter', () => {
               parts: []
             }
           ]
-        })
-      ).to.be.false;
-    });
-    it('returns false if request system instruction has function role', async () => {
-      const adapter = new ChromeAdapter(
-        {} as LanguageModel,
-        'prefer_on_device'
-      );
-      expect(
-        await adapter.isAvailable({
-          contents: [],
-          systemInstruction: {
-            role: 'function',
-            parts: []
-          }
-        })
-      ).to.be.false;
-    });
-    it('returns false if request system instruction has multiple parts', async () => {
-      const adapter = new ChromeAdapter(
-        {} as LanguageModel,
-        'prefer_on_device'
-      );
-      expect(
-        await adapter.isAvailable({
-          contents: [],
-          systemInstruction: {
-            role: 'function',
-            parts: [{ text: 'a' }, { text: 'b' }]
-          }
-        })
-      ).to.be.false;
-    });
-    it('returns false if request system instruction has non-text part', async () => {
-      const adapter = new ChromeAdapter(
-        {} as LanguageModel,
-        'prefer_on_device'
-      );
-      expect(
-        await adapter.isAvailable({
-          contents: [],
-          systemInstruction: {
-            role: 'function',
-            parts: [{ inlineData: { mimeType: 'a', data: 'b' } }]
-          }
         })
       ).to.be.false;
     });

--- a/packages/vertexai/src/methods/chrome-adapter.ts
+++ b/packages/vertexai/src/methods/chrome-adapter.ts
@@ -63,10 +63,9 @@ export class ChromeAdapter {
     if (this.mode === 'only_in_cloud') {
       return false;
     }
-    console.log(this.languageModelProvider);
     const availability = await this.languageModelProvider?.availability();
     if (availability === Availability.downloadable) {
-      // Triggers async model download.
+      // Triggers async model download so it'll be available next time.
       this.download();
     }
     if (this.mode === 'only_on_device') {

--- a/packages/vertexai/src/methods/chrome-adapter.ts
+++ b/packages/vertexai/src/methods/chrome-adapter.ts
@@ -63,14 +63,18 @@ export class ChromeAdapter {
     if (this.mode === 'only_in_cloud') {
       return false;
     }
+
     const availability = await this.languageModelProvider?.availability();
+
+    // Triggers async model download so it'll be available next time.
     if (availability === Availability.downloadable) {
-      // Triggers async model download so it'll be available next time.
       this.download();
     }
+
     if (this.mode === 'only_on_device') {
       return true;
     }
+
     // Applies prefer_on_device logic.
     return (
       availability === Availability.available &&
@@ -214,6 +218,12 @@ export class ChromeAdapter {
     // TODO: define a default value, since these are optional.
     options: LanguageModelCreateOptions
   ): Promise<LanguageModel> {
+    if (!this.languageModelProvider) {
+      throw new VertexAIError(
+        VertexAIErrorCode.REQUEST_ERROR,
+        'Chrome AI requested for unsupported browser version.'
+      );
+    }
     // TODO: could we use this.onDeviceParams instead of passing in options?
     ChromeAdapter.addImageTypeAsExpectedInput(options);
     const newSession = await this.languageModelProvider!.create(options);


### PR DESCRIPTION
Problem: we're currently falling back to Cloud even if the mode is only_on_device.

Proposal:
1. isAvailable should return true unconditionally if mode is only_on_device
2. createSession should throw if the model is unavailable

Also: remove stale tests for systemInstruction; I added a backlog item for figuring out if we want to honor systemInstruction passed in the request vs onDeviceParams.
