### PR TITLE
fix(vertexai): pass `GenerativeModel`'s `BaseParams` to `ChatSession`

### DIFF
--- a/.changeset/fast-mangos-chew.md
+++ b/.changeset/fast-mangos-chew.md
@@ -1,0 +1,5 @@
+---
+'@firebase/vertexai': patch
+---
+
+Pass `GenerativeModel`'s `BaseParams` to created chat sessions. This fixes an issue where `GenerationConfig` would not be inherited from `ChatSession`.

--- a/packages/vertexai/src/models/generative-model.test.ts
+++ b/packages/vertexai/src/models/generative-model.test.ts
@@ -256,7 +256,10 @@ describe('GenerativeModel', () => {
         { functionDeclarations: [{ name: 'myfunc', description: 'mydesc' }] }
       ],
       toolConfig: { functionCallingConfig: { mode: FunctionCallingMode.NONE } },
-      systemInstruction: { role: 'system', parts: [{ text: 'be friendly' }] }
+      systemInstruction: { role: 'system', parts: [{ text: 'be friendly' }] },
+      generationConfig: {
+        responseMimeType: 'image/jpeg'
+      }
     });
     expect(genModel.tools?.length).to.equal(1);
     expect(genModel.toolConfig?.functionCallingConfig?.mode).to.equal(
@@ -282,7 +285,10 @@ describe('GenerativeModel', () => {
         toolConfig: {
           functionCallingConfig: { mode: FunctionCallingMode.AUTO }
         },
-        systemInstruction: { role: 'system', parts: [{ text: 'be formal' }] }
+        systemInstruction: { role: 'system', parts: [{ text: 'be formal' }] },
+        generationConfig: {
+          responseMimeType: 'image/png'
+        }
       })
       .sendMessage('hello');
     expect(makeRequestStub).to.be.calledWith(
@@ -294,7 +300,9 @@ describe('GenerativeModel', () => {
         return (
           value.includes('otherfunc') &&
           value.includes(FunctionCallingMode.AUTO) &&
-          value.includes('be formal')
+          value.includes('be formal') &&
+          value.includes('image/png') &&
+          !value.includes('image/jpeg')
         );
       }),
       {}

--- a/packages/vertexai/src/models/generative-model.test.ts
+++ b/packages/vertexai/src/models/generative-model.test.ts
@@ -165,22 +165,6 @@ describe('GenerativeModel', () => {
     );
     restore();
   });
-  it('overrides base model params with startChatParams', () => {
-    const genModel = new GenerativeModel(fakeVertexAI, {
-      model: 'my-model',
-      generationConfig: {
-        topK: 1
-      }
-    });
-    const chatSession = genModel.startChat({
-      generationConfig: {
-        topK: 2
-      }
-    });
-    expect(chatSession.params?.generationConfig).to.deep.equal({
-      topK: 2
-    });
-  });
   it('passes params through to chat.sendMessage', async () => {
     const genModel = new GenerativeModel(fakeVertexAI, {
       model: 'my-model',

--- a/packages/vertexai/src/models/generative-model.test.ts
+++ b/packages/vertexai/src/models/generative-model.test.ts
@@ -165,6 +165,35 @@ describe('GenerativeModel', () => {
     );
     restore();
   });
+  it('passes base model params through to ChatSession when there are no startChatParams', async () => {
+    const genModel = new GenerativeModel(fakeVertexAI, {
+      model: 'my-model',
+      generationConfig: {
+        topK: 1
+      }
+    });
+    const chatSession = genModel.startChat();
+    expect(chatSession.params?.generationConfig).to.deep.equal({
+      topK: 1
+    });
+    restore();
+  });
+  it('overrides base model params with startChatParams', () => {
+    const genModel = new GenerativeModel(fakeVertexAI, {
+      model: 'my-model',
+      generationConfig: {
+        topK: 1
+      }
+    });
+    const chatSession = genModel.startChat({
+      generationConfig: {
+        topK: 2
+      }
+    });
+    expect(chatSession.params?.generationConfig).to.deep.equal({
+      topK: 2
+    });
+  });
   it('passes params through to chat.sendMessage', async () => {
     const genModel = new GenerativeModel(fakeVertexAI, {
       model: 'my-model',

--- a/packages/vertexai/src/models/generative-model.test.ts
+++ b/packages/vertexai/src/models/generative-model.test.ts
@@ -165,19 +165,6 @@ describe('GenerativeModel', () => {
     );
     restore();
   });
-  it('passes base model params through to ChatSession when there are no startChatParams', async () => {
-    const genModel = new GenerativeModel(fakeVertexAI, {
-      model: 'my-model',
-      generationConfig: {
-        topK: 1
-      }
-    });
-    const chatSession = genModel.startChat();
-    expect(chatSession.params?.generationConfig).to.deep.equal({
-      topK: 1
-    });
-    restore();
-  });
   it('overrides base model params with startChatParams', () => {
     const genModel = new GenerativeModel(fakeVertexAI, {
       model: 'my-model',
@@ -201,7 +188,10 @@ describe('GenerativeModel', () => {
         { functionDeclarations: [{ name: 'myfunc', description: 'mydesc' }] }
       ],
       toolConfig: { functionCallingConfig: { mode: FunctionCallingMode.NONE } },
-      systemInstruction: { role: 'system', parts: [{ text: 'be friendly' }] }
+      systemInstruction: { role: 'system', parts: [{ text: 'be friendly' }] },
+      generationConfig: {
+        topK: 1
+      }
     });
     expect(genModel.tools?.length).to.equal(1);
     expect(genModel.toolConfig?.functionCallingConfig?.mode).to.equal(
@@ -225,7 +215,8 @@ describe('GenerativeModel', () => {
         return (
           value.includes('myfunc') &&
           value.includes(FunctionCallingMode.NONE) &&
-          value.includes('be friendly')
+          value.includes('be friendly') &&
+          value.includes('topK')
         );
       }),
       {}

--- a/packages/vertexai/src/models/generative-model.ts
+++ b/packages/vertexai/src/models/generative-model.ts
@@ -132,6 +132,13 @@ export class GenerativeModel extends VertexAIModel {
         tools: this.tools,
         toolConfig: this.toolConfig,
         systemInstruction: this.systemInstruction,
+        generationConfig: this.generationConfig,
+        safetySettings: this.safetySettings,
+        /**
+         * Overrides params inherited from GenerativeModel with those explicitly set in the
+         * StartChatParams. For example, if startChatParams.generationConfig is set, it'll override
+         * this.generationConfig.
+         */
         ...startChatParams
       },
       this.requestOptions


### PR DESCRIPTION
DO NOT MERGE.

`startChat` wasn't passing `GenerativeModel`'s `BaseParams` to `ChatSession`. 
So, if a model had a `generationConfig`, it would never be passed to `ChatSession`.

This is how the other SDKs behave.