### PR TITLE
VinF Hybrid Inference: disable multi-turn support

### DIFF
--- a/packages/vertexai/src/methods/chrome-adapter.test.ts
+++ b/packages/vertexai/src/methods/chrome-adapter.test.ts
@@ -82,7 +82,7 @@ describe('ChromeAdapter', () => {
         })
       ).to.be.false;
     });
-    it('returns false if request content has function role', async () => {
+    it('returns false if request content has non-user role', async () => {
       const adapter = new ChromeAdapter(
         {
           availability: async () => Availability.available
@@ -93,7 +93,7 @@ describe('ChromeAdapter', () => {
         await adapter.isAvailable({
           contents: [
             {
-              role: 'function',
+              role: 'model',
               parts: []
             }
           ]

--- a/packages/vertexai/src/methods/chrome-adapter.ts
+++ b/packages/vertexai/src/methods/chrome-adapter.ts
@@ -144,9 +144,10 @@ export class ChromeAdapter {
       return false;
     }
 
-    // Applies the same checks as above, but for each content item.
     for (const content of request.contents) {
-      if (content.role === 'function') {
+      // Returns false if the request contains multiple roles, eg a chat history.
+      // TODO: remove this guard once LanguageModelMessage is supported.
+      if (content.role !== 'user') {
         return false;
       }
     }


### PR DESCRIPTION
# Problem statement

We can't differentiate roles until Chrome supports the [LanguageModelMessage type](https://github.com/webmachinelearning/prompt-api?tab=readme-ov-file#full-api-surface-in-web-idl).

Multi-turn requests [differentiate turns by role](https://github.com/firebase/firebase-js-sdk/blob/dd0c4b10d21bd783b856b24e8594b5b030fc4a56/packages/vertexai/src/methods/chat-session.ts#L110-L115), so without roles, we can't support multi-turn.

We can't throw to indicate a lack of support, like we can with countToken, because ChromeAdapter integrates below 
ChatSession.

Bug: b/413402604

# Proposal

This change indicates a lack of support for multi-turn requests by updating the request validator to fail if a request contains non-"user" roles. We can relax this once LanguageModelMessage is released.

