### PR TITLE
fix(vertexai): add missing quote to chat role error message

### DIFF
--- a/packages/vertexai/src/methods/chat-session-helpers.ts
+++ b/packages/vertexai/src/methods/chat-session-helpers.ts
@@ -111,7 +111,7 @@ export function validateChatHistory(history: Content[]): void {
       if (!validPreviousContentRoles.includes(prevContent.role)) {
         throw new VertexAIError(
           VertexAIErrorCode.INVALID_CONTENT,
-          `Content with role '${role} can't follow '${
+          `Content with role '${role}' can't follow '${
             prevContent.role
           }'. Valid previous roles: ${JSON.stringify(
             VALID_PREVIOUS_CONTENT_ROLES


### PR DESCRIPTION
Add missing closing single quote to error message.

Is a changeset necessary here?