### PR TITLE
[vertexai] Use json of unary-success-citations

### DIFF
--- a/packages/vertexai/src/googleai-mappers.test.ts
+++ b/packages/vertexai/src/googleai-mappers.test.ts
@@ -131,7 +131,7 @@ describe('Google AI Mappers', () => {
   describe('mapGenerateContentResponse', () => {
     it('should map a full Google AI response', async () => {
       const googleAIMockResponse: GoogleAIGenerateContentResponse = await (
-        getMockResponse('googleAI', 'unary-success-citations.txt') as Response
+        getMockResponse('googleAI', 'unary-success-citations.json') as Response
       ).json();
       const mappedResponse = mapGenerateContentResponse(googleAIMockResponse);
 

--- a/scripts/update_vertexai_responses.sh
+++ b/scripts/update_vertexai_responses.sh
@@ -17,7 +17,7 @@
 # This script replaces mock response files for Vertex AI unit tests with a fresh
 # clone of the shared repository of Vertex AI test data.
 
-RESPONSES_VERSION='v10.*' # The major version of mock responses to use
+RESPONSES_VERSION='v11.*' # The major version of mock responses to use
 REPO_NAME="vertexai-sdk-test-data"
 REPO_LINK="https://github.com/FirebaseExtended/$REPO_NAME.git"
 


### PR DESCRIPTION
The test files have been updated to include `json` extension versions of the tests files. The old, `txt` extension files are deprecated and will be deleted eventually.