### PR TITLE
Deprecate getFirestore and initializeFirestore overloads that do not accept databaseId

### DIFF
--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -139,9 +139,34 @@ export class Firestore extends LiteFirestore {
  * @param app - The {@link @firebase/app#FirebaseApp} with which the {@link Firestore} instance will
  * be associated.
  * @param settings - A settings object to configure the {@link Firestore} instance.
+ * @returns A newly initialized {@link Firestore} instance.
+ * @deprecated This function assumes the database name is `(default)`. For new
+ * databases, the database name is specified during creation, and can no longer
+ * be assumed to be '(default)' by the SDK. Please use the function overload
+ * that accepts `databaseId`, {@link initializeFirestore:2}.
+ */
+export function initializeFirestore(
+  app: FirebaseApp,
+  settings: FirestoreSettings
+): Firestore;
+
+/**
+ * Initializes a new instance of {@link Firestore} with the provided settings.
+ * Can only be called before any other function, including
+ * {@link (getFirestore:1)}. If the custom settings are empty, this function is
+ * equivalent to calling {@link (getFirestore:1)}.
+ *
+ * @param app - The {@link @firebase/app#FirebaseApp} with which the {@link Firestore} instance will
+ * be associated.
+ * @param settings - A settings object to configure the {@link Firestore} instance.
  * @param databaseId - The name of the database.
  * @returns A newly initialized {@link Firestore} instance.
  */
+export function initializeFirestore(
+  app: FirebaseApp,
+  settings: FirestoreSettings,
+  databaseId: string
+): Firestore;
 export function initializeFirestore(
   app: FirebaseApp,
   settings: FirestoreSettings,
@@ -206,6 +231,11 @@ export function initializeFirestore(
  * instance with default settings.
  *
  * @returns The default {@link Firestore} instance of the default app.
+ *
+ * @deprecated This function assumes the database name is `(default)`. For new
+ * databases, the database name is specified during creation, and can no longer
+ * be assumed to be '(default)' by the SDK. Please use the function overload
+ * that accepts `databaseId`, {@link getFirestore:3}.
  */
 export function getFirestore(): Firestore;
 /**
@@ -216,6 +246,11 @@ export function getFirestore(): Firestore;
  * @param app - The {@link @firebase/app#FirebaseApp} instance that the returned {@link Firestore}
  * instance is associated with.
  * @returns The default {@link Firestore} instance of the provided app.
+ *
+ * @deprecated This function assumes the database name is `(default)`. For new
+ * databases, the database name is specified during creation, and can no longer
+ * be assumed to be '(default)' by the SDK. Please use the function overload
+ * that accepts `databaseId`, {@link getFirestore:4}.
  */
 export function getFirestore(app: FirebaseApp): Firestore;
 /**
@@ -225,7 +260,6 @@ export function getFirestore(app: FirebaseApp): Firestore;
  *
  * @param databaseId - The name of the database.
  * @returns The named {@link Firestore} instance of the default app.
- * @beta
  */
 export function getFirestore(databaseId: string): Firestore;
 /**
@@ -237,7 +271,6 @@ export function getFirestore(databaseId: string): Firestore;
  * instance is associated with.
  * @param databaseId - The name of the database.
  * @returns The named {@link Firestore} instance of the provided app.
- * @beta
  */
 export function getFirestore(app: FirebaseApp, databaseId: string): Firestore;
 export function getFirestore(

--- a/packages/firestore/src/lite-api/database.ts
+++ b/packages/firestore/src/lite-api/database.ts
@@ -196,6 +196,10 @@ export class Firestore implements FirestoreService {
  * be associated.
  * @param settings - A settings object to configure the `Firestore` instance.
  * @returns A newly initialized `Firestore` instance.
+ * @deprecated This function assumes the database name is `(default)`. For new
+ * databases, the database name is specified during creation, and can no longer
+ * be assumed to be '(default)' by the SDK. Please use the function overload
+ * that accepts `databaseId`, {@link initializeFirestore:2}.
  */
 export function initializeFirestore(
   app: FirebaseApp,
@@ -217,7 +221,7 @@ export function initializeFirestore(
 export function initializeFirestore(
   app: FirebaseApp,
   settings: FirestoreSettings,
-  databaseId?: string
+  databaseId: string
 ): Firestore;
 export function initializeFirestore(
   app: FirebaseApp,
@@ -243,6 +247,11 @@ export function initializeFirestore(
 }
 
 /**
+ * @deprecated This function assumes the database name is `(default)`. For new
+ * databases, the database name is specified during creation, and can no longer
+ * be assumed to be '(default)' by the SDK. Please use the function overload
+ * that accepts `databaseId`, {@link getFirestore:3}.
+ *
  * Returns the existing default {@link Firestore} instance that is associated with the
  * default {@link @firebase/app#FirebaseApp}. If no instance exists, initializes a new
  * instance with default settings.
@@ -251,6 +260,11 @@ export function initializeFirestore(
  */
 export function getFirestore(): Firestore;
 /**
+ * @deprecated This function assumes the database name is `(default)`. For new
+ * databases, the database name is specified during creation, and can no longer
+ * be assumed to be '(default)' by the SDK. Please use the function overload
+ * that accepts `databaseId`, {@link getFirestore:4}.
+ *
  * Returns the existing default {@link Firestore} instance that is associated with the
  * provided {@link @firebase/app#FirebaseApp}. If no instance exists, initializes a new
  * instance with default settings.


### PR DESCRIPTION


Hey there! So you want to contribute to a Firebase SDK? 
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here. 
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help 
    us make Firebase APIs better, please propose your change in an issue so that we 
    can discuss it together.
