### PR TITLE
Add initializeServerApp() without args

### DIFF
--- a/.changeset/poor-penguins-play.md
+++ b/.changeset/poor-penguins-play.md
@@ -1,0 +1,7 @@
+---
+'@firebase/app': patch
+---
+
+Support zero-args `initializeServerApp()`
+
+* Added overloads to allow initializeServerApp() without parameters.


### PR DESCRIPTION
## Summary

This PR lets server-rendered apps call `initializeServerApp()` with no args. The existing `(options, config)` signature remains unchanged.

## Motivation

`initializeApp()` already supports no-args init on the client.  

Closes #8863 

## Changes

Added overload to allow initializeServerApp() without parameters.
