### PR TITLE
VinF Hybrid Inference: flatten request contents rather than plucking the first

### DIFF
--- a/packages/vertexai/src/methods/chrome-adapter.ts
+++ b/packages/vertexai/src/methods/chrome-adapter.ts
@@ -92,10 +92,13 @@ export class ChromeAdapter {
    */
   async generateContent(request: GenerateContentRequest): Promise<Response> {
     const session = await this.createSession();
-    // TODO: support multiple content objects when Chrome supports
+    // NOTE: assumes all parts are from the same role, enforced by isOnDeviceRequest validation.
+    // TODO: stop stripping roles when Chrome supports
     // sequence<LanguageModelMessage>
     const contents = await Promise.all(
-      request.contents[0].parts.map(ChromeAdapter.toLanguageModelMessageContent)
+      request.contents.flatMap(content =>
+        content.parts.map(ChromeAdapter.toLanguageModelMessageContent)
+      )
     );
     const text = await session.prompt(contents);
     return ChromeAdapter.toResponse(text);
@@ -113,10 +116,13 @@ export class ChromeAdapter {
     request: GenerateContentRequest
   ): Promise<Response> {
     const session = await this.createSession();
-    // TODO: support multiple content objects when Chrome supports
+    // NOTE: assumes all parts are from the same role, enforced by isOnDeviceRequest validation.
+    // TODO: stop stripping roles when Chrome supports
     // sequence<LanguageModelMessage>
     const contents = await Promise.all(
-      request.contents[0].parts.map(ChromeAdapter.toLanguageModelMessageContent)
+      request.contents.flatMap(content =>
+        content.parts.map(ChromeAdapter.toLanguageModelMessageContent)
+      )
     );
     const stream = await session.promptStreaming(contents);
     return ChromeAdapter.toStreamResponse(stream);


### PR DESCRIPTION
# Context 

While waiting for the Prompt API to support sequence<LanguageModelMessage> input, we were ignoring all but the first item in the list of Content objects in the prompt request. We fall back to Cloud for Chat support for the same reason.

Note the fallback logic we use for chat support checks if a given request has multiple roles, and this logic runs for _all_ requests as part of `isAvailable`.

# Problem Statement

We had some feedback that we should log a warning when we ignore input.

# Solution

Given we're already ensuring a request only has a single role before running it on device, it's safe to flatten all content objects, rather than just plucking the first.
