### PR TITLE
Fix Auth Port for Firebase Studio

### DIFF
--- a/.changeset/lemon-tomatoes-breathe.md
+++ b/.changeset/lemon-tomatoes-breathe.md
@@ -1,0 +1,5 @@
+---
+"@firebase/auth": patch
+---
+
+Fix issue where auth port wasn't properly set when setting up cookies in Firebase Studio.

--- a/packages/auth/src/core/auth/emulator.test.ts
+++ b/packages/auth/src/core/auth/emulator.test.ts
@@ -29,6 +29,7 @@ import { Endpoint } from '../../api';
 import { UserInternal } from '../../model/user';
 import { _castAuth } from './auth_impl';
 import { connectAuthEmulator } from './emulator';
+import * as Util from '@firebase/util';
 
 use(sinonChai);
 use(chaiAsPromised);
@@ -38,8 +39,10 @@ describe('core/auth/emulator', () => {
   let user: UserInternal;
   let normalEndpoint: fetch.Route;
   let emulatorEndpoint: fetch.Route;
+  let testStub: sinon.SinonStub;
 
   beforeEach(async () => {
+    testStub = sinon.stub(Util, 'pingServer');
     auth = await testAuth();
     user = testUser(_castAuth(auth), 'uid', 'email', true);
     fetch.setUp();
@@ -153,6 +156,19 @@ describe('core/auth/emulator', () => {
             'Do not use with production credentials.'
         );
       }
+    });
+    it('calls pingServer with port if specified', () => {
+      connectAuthEmulator(auth, 'https://abc.cloudworkstations.dev:2020');
+      expect(testStub).to.have.been.calledWith(
+        'https://abc.cloudworkstations.dev:2020'
+      );
+    });
+
+    it('calls pingServer with no port if none specified', () => {
+      connectAuthEmulator(auth, 'https://abc.cloudworkstations.dev');
+      expect(testStub).to.have.been.calledWith(
+        'https://abc.cloudworkstations.dev'
+      );
     });
 
     it('logs out a warning to the console', () => {

--- a/packages/auth/src/core/auth/emulator.test.ts
+++ b/packages/auth/src/core/auth/emulator.test.ts
@@ -39,10 +39,10 @@ describe('core/auth/emulator', () => {
   let user: UserInternal;
   let normalEndpoint: fetch.Route;
   let emulatorEndpoint: fetch.Route;
-  let testStub: sinon.SinonStub;
+  let utilStub: sinon.SinonStub;
 
   beforeEach(async () => {
-    testStub = sinon.stub(Util, 'pingServer');
+    utilStub = sinon.stub(Util, 'pingServer');
     auth = await testAuth();
     user = testUser(_castAuth(auth), 'uid', 'email', true);
     fetch.setUp();
@@ -159,14 +159,14 @@ describe('core/auth/emulator', () => {
     });
     it('calls pingServer with port if specified', () => {
       connectAuthEmulator(auth, 'https://abc.cloudworkstations.dev:2020');
-      expect(testStub).to.have.been.calledWith(
+      expect(utilStub).to.have.been.calledWith(
         'https://abc.cloudworkstations.dev:2020'
       );
     });
 
     it('calls pingServer with no port if none specified', () => {
       connectAuthEmulator(auth, 'https://abc.cloudworkstations.dev');
-      expect(testStub).to.have.been.calledWith(
+      expect(utilStub).to.have.been.calledWith(
         'https://abc.cloudworkstations.dev'
       );
     });

--- a/packages/auth/src/core/auth/emulator.ts
+++ b/packages/auth/src/core/auth/emulator.ts
@@ -103,7 +103,7 @@ export function connectAuthEmulator(
 
   // Workaround to get cookies in Firebase Studio
   if (isCloudWorkstation(host)) {
-    void pingServer(`${protocol}//${host}:${port}`);
+    void pingServer(`${protocol}//${host}${portStr}`);
   }
 }
 


### PR DESCRIPTION
Fix an emulator issue where if no auth port is specified, then `null` is passed into the `pingServer` URL.