### PR TITLE
Clean up vscode launch file and add vertexai debug config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,26 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "AI Unit Tests (node)",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceFolder}/node_modules/.bin/_mocha",
+      "cwd": "${workspaceRoot}/packages/vertexai",
+      "args": [
+        "--require",
+        "ts-node/register",
+        "--require",
+        "src/index.node.ts",
+        "--timeout",
+        "5000",
+        "src/**/*.test.ts"
+      ],
+      "env": {
+        "TS_NODE_COMPILER_OPTIONS": "{\"module\":\"commonjs\"}"
+      },
+      "sourceMaps": true
+    },
+    {
       "type": "node",
       "request": "launch",
       "name": "Prune .d.ts",
@@ -18,9 +38,9 @@
         "${workspaceFolder}/repo-scripts/prune-dts/*.test.ts"
       ],
       "env": {
-        "TS_NODE_COMPILER_OPTIONS" : "{\"module\":\"commonjs\"}"
+        "TS_NODE_COMPILER_OPTIONS": "{\"module\":\"commonjs\"}"
       },
-      "sourceMaps": true,
+      "sourceMaps": true
     },
     {
       "type": "node",
@@ -30,16 +50,17 @@
       "cwd": "${workspaceRoot}/packages/database",
       "args": [
         "test/{,!(browser)/**/}*.test.ts",
-        "--file", "src/index.node.ts",
-        "--config", "../../config/mocharc.node.js",
+        "--file",
+        "src/index.node.ts",
+        "--config",
+        "../../config/mocharc.node.js"
       ],
       "env": {
-        "TS_NODE_FILES":true,
+        "TS_NODE_FILES": true,
         "TS_NODE_CACHE": "NO",
-        "TS_NODE_COMPILER_OPTIONS" : "{\"module\":\"commonjs\"}"
+        "TS_NODE_COMPILER_OPTIONS": "{\"module\":\"commonjs\"}"
       },
-      "sourceMaps": true,
-      "protocol": "inspector"
+      "sourceMaps": true
     },
     {
       "type": "node",
@@ -48,14 +69,16 @@
       "program": "${workspaceRoot}/node_modules/.bin/_mocha",
       "cwd": "${workspaceRoot}/packages/firestore",
       "args": [
-        "--require", "babel-register.js",
-        "--require", "src/index.node.ts",
-        "--timeout", "5000",
+        "--require",
+        "babel-register.js",
+        "--require",
+        "src/index.node.ts",
+        "--timeout",
+        "5000",
         "test/{,!(browser|integration)/**/}*.test.ts",
         "--exit"
       ],
-      "sourceMaps": true,
-      "protocol": "inspector"
+      "sourceMaps": true
     },
     {
       "type": "node",
@@ -64,18 +87,21 @@
       "program": "${workspaceRoot}/node_modules/.bin/_mocha",
       "cwd": "${workspaceRoot}/packages/firestore",
       "args": [
-        "--require", "babel-register.js",
-        "--require", "index.node.ts",
-        "--require", "test/util/node_persistence.ts",
-        "--timeout", "5000",
+        "--require",
+        "babel-register.js",
+        "--require",
+        "index.node.ts",
+        "--require",
+        "test/util/node_persistence.ts",
+        "--timeout",
+        "5000",
         "test/{,!(browser|integration)/**/}*.test.ts",
         "--exit"
       ],
       "env": {
         "USE_MOCK_PERSISTENCE": "YES"
       },
-      "sourceMaps": true,
-      "protocol": "inspector"
+      "sourceMaps": true
     },
     {
       "type": "node",
@@ -84,17 +110,19 @@
       "program": "${workspaceRoot}/node_modules/.bin/_mocha",
       "cwd": "${workspaceRoot}/packages/firestore",
       "args": [
-        "--require", "babel-register.js",
-        "--require", "index.node.ts",
-        "--timeout", "5000",
+        "--require",
+        "babel-register.js",
+        "--require",
+        "index.node.ts",
+        "--timeout",
+        "5000",
         "test/{,!(browser|unit)/**/}*.test.ts",
         "--exit"
       ],
       "env": {
-        "FIRESTORE_TARGET_BACKEND" : "emulator",
+        "FIRESTORE_TARGET_BACKEND": "emulator"
       },
-      "sourceMaps": true,
-      "protocol": "inspector"
+      "sourceMaps": true
     },
     {
       "type": "node",
@@ -103,19 +131,22 @@
       "program": "${workspaceRoot}/node_modules/.bin/_mocha",
       "cwd": "${workspaceRoot}/packages/firestore",
       "args": [
-        "--require", "babel-register.js",
-        "--require", "index.node.ts",
-        "--require", "test/util/node_persistence.ts",
-        "--timeout", "5000",
+        "--require",
+        "babel-register.js",
+        "--require",
+        "index.node.ts",
+        "--require",
+        "test/util/node_persistence.ts",
+        "--timeout",
+        "5000",
         "test/{,!(browser|unit)/**/}*.test.ts",
         "--exit"
       ],
       "env": {
         "USE_MOCK_PERSISTENCE": "YES",
-        "FIRESTORE_TARGET_BACKEND" : "emulator",
+        "FIRESTORE_TARGET_BACKEND": "emulator"
       },
-      "sourceMaps": true,
-      "protocol": "inspector"
+      "sourceMaps": true
     },
     {
       "type": "node",
@@ -123,12 +154,7 @@
       "name": "Firestore Unit Tests (Browser)",
       "program": "${workspaceRoot}/node_modules/.bin/karma",
       "cwd": "${workspaceRoot}/packages/firestore",
-      "args": [
-        "start",
-        "--auto-watch",
-        "--unit",
-        "--browsers", "Chrome"
-      ]
+      "args": ["start", "--auto-watch", "--unit", "--browsers", "Chrome"]
     },
     {
       "type": "node",
@@ -136,12 +162,7 @@
       "name": "Firestore Integration Tests (Browser)",
       "program": "${workspaceRoot}/node_modules/.bin/karma",
       "cwd": "${workspaceRoot}/packages/firestore",
-      "args": [
-        "start",
-        "--auto-watch",
-        "--integration",
-        "--browsers", "Chrome"
-      ]
+      "args": ["start", "--auto-watch", "--integration", "--browsers", "Chrome"]
     }
   ]
 }


### PR DESCRIPTION
- Added debug launch config for `AI Unit Tests (node)`
- Formatted the file (VSCode's JSON auto-formatter)
- Removed `"protocol": "inspector"`. I believe this is no longer supported since VSCode gives a warning `Property protocol is not allowed`.