### PR TITLE
ci: Fix Firefox error and streamline cross-browser tests

### DIFF
--- a/config/karma.base.js
+++ b/config/karma.base.js
@@ -20,8 +20,6 @@ const path = require('path');
 const webpackTestConfig = require('./webpack.test');
 const { argv } = require('yargs');
 
-// FIXME: trigger all tests
-
 function determineBrowsers() {
   const supportedBrowsers = ['ChromeHeadless', 'WebkitHeadless', 'Firefox'];
 

--- a/config/karma.base.js
+++ b/config/karma.base.js
@@ -20,6 +20,8 @@ const path = require('path');
 const webpackTestConfig = require('./webpack.test');
 const { argv } = require('yargs');
 
+// FIXME: trigger all tests
+
 function determineBrowsers() {
   const supportedBrowsers = ['ChromeHeadless', 'WebkitHeadless', 'Firefox'];
 

--- a/packages/util/test/errors.test.ts
+++ b/packages/util/test/errors.test.ts
@@ -90,6 +90,8 @@ describe('FirebaseError', () => {
     } catch (error) {
       assert.isDefined((error as Error).stack);
       // Multi-line match trick - .* does not match \n
+      console.log('** Error stack **');
+      console.log((error as Error).stack);
       assert.match((error as Error).stack!, /FirebaseError[\s\S]/);
     }
   });

--- a/packages/util/test/errors.test.ts
+++ b/packages/util/test/errors.test.ts
@@ -89,10 +89,8 @@ describe('FirebaseError', () => {
       throw e;
     } catch (error) {
       assert.isDefined((error as Error).stack);
-      // Multi-line match trick - .* does not match \n
-      console.log('** Error stack **');
-      console.log((error as Error).stack);
-      assert.match((error as Error).stack!, /FirebaseError[\s\S]/);
+      // Firefox no longer puts the error class name in the stack
+      // as of 139.0 so we don't have a string to match on.
     }
   });
 

--- a/scripts/run_tests_in_ci.js
+++ b/scripts/run_tests_in_ci.js
@@ -61,19 +61,28 @@ const argv = yargs.options({
   const myPath = argv.d;
   let scriptName = argv.s;
   const dir = path.resolve(myPath);
-  const { name } = require(`${dir}/package.json`);
+  const { name, scripts } = require(`${dir}/package.json`);
 
   let testProcessOutput = '';
   try {
     if (process.env?.BROWSERS) {
+      if (scripts['test:browser']) {
+          scriptName = 'test:browser';
+      }
       for (const package in crossBrowserPackages) {
         if (dir.endsWith(package)) {
           scriptName = crossBrowserPackages[package];
-        } else {
-          scriptName = "test:browser"
         }
       }
+      // console.log(
+      //   `[${name}][${process.env.BROWSERS}]: Running script ${scriptName}`
+      // );
     }
+
+    console.log(
+      `[${name}][${process.env.BROWSERS ?? 'chrome/node'}]: Running script ${scriptName}`
+    );
+
     const testProcess = spawn('yarn', ['--cwd', dir, scriptName]);
 
     testProcess.childProcess.stdout.on('data', data => {

--- a/scripts/run_tests_in_ci.js
+++ b/scripts/run_tests_in_ci.js
@@ -27,7 +27,9 @@ const crossBrowserPackages = {
   'packages/auth': 'test:browser:unit',
   'packages/auth-compat': 'test:browser:unit',
   'packages/firestore': 'test:browser:unit',
-  'packages/firestore-compat': 'test:browser'
+  'packages/firestore-compat': 'test:browser',
+  'packages/storage': 'test:browser:unit',
+  'packages/storage-compat': 'test:browser:unit'
 };
 
 function writeLogs(status, name, logText) {
@@ -67,6 +69,8 @@ const argv = yargs.options({
       for (const package in crossBrowserPackages) {
         if (dir.endsWith(package)) {
           scriptName = crossBrowserPackages[package];
+        } else {
+          scriptName = "test:browser"
         }
       }
     }

--- a/scripts/run_tests_in_ci.js
+++ b/scripts/run_tests_in_ci.js
@@ -67,7 +67,7 @@ const argv = yargs.options({
   try {
     if (process.env?.BROWSERS) {
       if (scripts['test:browser']) {
-          scriptName = 'test:browser';
+        scriptName = 'test:browser';
       }
       for (const package in crossBrowserPackages) {
         if (dir.endsWith(package)) {
@@ -80,7 +80,9 @@ const argv = yargs.options({
     }
 
     console.log(
-      `[${name}][${process.env.BROWSERS ?? 'chrome/node'}]: Running script ${scriptName}`
+      `[${name}][${
+        process.env.BROWSERS ?? 'chrome/node'
+      }]: Running script ${scriptName}`
     );
 
     const testProcess = spawn('yarn', ['--cwd', dir, scriptName]);

--- a/scripts/run_tests_in_ci.js
+++ b/scripts/run_tests_in_ci.js
@@ -74,9 +74,6 @@ const argv = yargs.options({
           scriptName = crossBrowserPackages[package];
         }
       }
-      // console.log(
-      //   `[${name}][${process.env.BROWSERS}]: Running script ${scriptName}`
-      // );
     }
 
     console.log(


### PR DESCRIPTION
The main purpose was to fix a Firefox CI test error on one of the util tests - a recent version of Firefox causes the error class to no longer be stored in `error.stack` and our test that checks for the "FirebaseError" string on a purposefully thrown error now fails. There's no recognizable string in the stack anymore (just code locations), so I just changed it to just check for its existence.

In the course of trying to diagnose this I followed a false trail thinking it might be because Node tests were running during Firefox and Webkit tests. That wasn't the cause but they shouldn't be running during those jobs, it's pointless. Node tests already run during the main Chrome test job. I changed it so that all packages running a cross-browser test use:

1. "test:browser" if available
2. special npm script like "test:browser:unit" if specified in the map of special packages (this functionality already existed), to avoid "test:browser:integration" and the like
3. fall back to "test" if none of those is available

This should make those jobs a little faster and more streamlined.