### PR TITLE
AI Hybrid Inference: migrate to LanguageModelMessage

### DIFF
--- a/common/api-review/ai.api.md
+++ b/common/api-review/ai.api.md
@@ -706,9 +706,9 @@ export interface LanguageModelMessage {
 // @public (undocumented)
 export interface LanguageModelMessageContent {
     // (undocumented)
-    content: LanguageModelMessageContentValue;
-    // (undocumented)
     type: LanguageModelMessageType;
+    // (undocumented)
+    value: LanguageModelMessageContentValue;
 }
 
 // @public (undocumented)

--- a/packages/ai/src/methods/chrome-adapter.test.ts
+++ b/packages/ai/src/methods/chrome-adapter.test.ts
@@ -349,7 +349,7 @@ describe('ChromeAdapter', () => {
           content: [
             {
               type: 'text',
-              content: request.contents[0].parts[0].text
+              value: request.contents[0].parts[0].text
             }
           ]
         }
@@ -413,11 +413,11 @@ describe('ChromeAdapter', () => {
           content: [
             {
               type: 'text',
-              content: request.contents[0].parts[0].text
+              value: request.contents[0].parts[0].text
             },
             {
               type: 'image',
-              content: match.instanceOf(ImageBitmap)
+              value: match.instanceOf(ImageBitmap)
             }
           ]
         }
@@ -464,7 +464,7 @@ describe('ChromeAdapter', () => {
             content: [
               {
                 type: 'text',
-                content: request.contents[0].parts[0].text
+                value: request.contents[0].parts[0].text
               }
             ]
           }
@@ -496,7 +496,7 @@ describe('ChromeAdapter', () => {
           content: [
             {
               type: 'text',
-              content: request.contents[0].parts[0].text
+              value: request.contents[0].parts[0].text
             }
           ]
         }
@@ -577,7 +577,7 @@ describe('ChromeAdapter', () => {
           content: [
             {
               type: 'text',
-              content: request.contents[0].parts[0].text
+              value: request.contents[0].parts[0].text
             }
           ]
         }
@@ -638,11 +638,11 @@ describe('ChromeAdapter', () => {
           content: [
             {
               type: 'text',
-              content: request.contents[0].parts[0].text
+              value: request.contents[0].parts[0].text
             },
             {
               type: 'image',
-              content: match.instanceOf(ImageBitmap)
+              value: match.instanceOf(ImageBitmap)
             }
           ]
         }
@@ -684,7 +684,7 @@ describe('ChromeAdapter', () => {
             content: [
               {
                 type: 'text',
-                content: request.contents[0].parts[0].text
+                value: request.contents[0].parts[0].text
               }
             ]
           }
@@ -718,7 +718,7 @@ describe('ChromeAdapter', () => {
           content: [
             {
               type: 'text',
-              content: request.contents[0].parts[0].text
+              value: request.contents[0].parts[0].text
             }
           ]
         }

--- a/packages/ai/src/methods/chrome-adapter.ts
+++ b/packages/ai/src/methods/chrome-adapter.ts
@@ -253,7 +253,7 @@ export class ChromeAdapter {
     if (part.text) {
       return {
         type: 'text',
-        content: part.text
+        value: part.text
       };
     } else if (part.inlineData) {
       const formattedImageContent = await fetch(
@@ -263,7 +263,7 @@ export class ChromeAdapter {
       const imageBitmap = await createImageBitmap(imageBlob);
       return {
         type: 'image',
-        content: imageBitmap
+        value: imageBitmap
       };
     }
     // Assumes contents have been verified to contain only a single TextPart.

--- a/packages/ai/src/methods/chrome-adapter.ts
+++ b/packages/ai/src/methods/chrome-adapter.ts
@@ -23,12 +23,16 @@ import {
   InferenceMode,
   Part,
   AIErrorCode,
-  OnDeviceParams
+  OnDeviceParams,
+  Content,
+  Role
 } from '../types';
 import {
   Availability,
   LanguageModel,
-  LanguageModelMessageContent
+  LanguageModelMessage,
+  LanguageModelMessageContent,
+  LanguageModelMessageRole
 } from '../types/language-model';
 
 /**
@@ -115,10 +119,8 @@ export class ChromeAdapter {
    */
   async generateContent(request: GenerateContentRequest): Promise<Response> {
     const session = await this.createSession();
-    // TODO: support multiple content objects when Chrome supports
-    // sequence<LanguageModelMessage>
     const contents = await Promise.all(
-      request.contents[0].parts.map(ChromeAdapter.toLanguageModelMessageContent)
+      request.contents.map(ChromeAdapter.toLanguageModelMessage)
     );
     const text = await session.prompt(
       contents,
@@ -139,10 +141,8 @@ export class ChromeAdapter {
     request: GenerateContentRequest
   ): Promise<Response> {
     const session = await this.createSession();
-    // TODO: support multiple content objects when Chrome supports
-    // sequence<LanguageModelMessage>
     const contents = await Promise.all(
-      request.contents[0].parts.map(ChromeAdapter.toLanguageModelMessageContent)
+      request.contents.map(ChromeAdapter.toLanguageModelMessage)
     );
     const stream = await session.promptStreaming(
       contents,
@@ -169,12 +169,8 @@ export class ChromeAdapter {
     }
 
     for (const content of request.contents) {
-      // Returns false if the request contains multiple roles, eg a chat history.
-      // TODO: remove this guard once LanguageModelMessage is supported.
-      if (content.role !== 'user') {
-        logger.debug(
-          `Non-user role "${content.role}" rejected for on-device inference.`
-        );
+      if (content.role === 'function') {
+        logger.debug(`"Function" role rejected for on-device inference.`);
         return false;
       }
 
@@ -234,6 +230,21 @@ export class ChromeAdapter {
   }
 
   /**
+   * Converts Vertex {@link Content} object to a Chrome {@link LanguageModelMessage} object.
+   */
+  private static async toLanguageModelMessage(
+    content: Content
+  ): Promise<LanguageModelMessage> {
+    const languageModelMessageContents = await Promise.all(
+      content.parts.map(ChromeAdapter.toLanguageModelMessageContent)
+    );
+    return {
+      role: ChromeAdapter.toLanguageModelMessageRole(content.role),
+      content: languageModelMessageContents
+    };
+  }
+
+  /**
    * Converts a Vertex Part object to a Chrome LanguageModelMessageContent object.
    */
   private static async toLanguageModelMessageContent(
@@ -258,6 +269,16 @@ export class ChromeAdapter {
     // Assumes contents have been verified to contain only a single TextPart.
     // TODO: support other input types
     throw new Error('Not yet implemented');
+  }
+
+  /**
+   * Converts a Vertex {@link Role} string to a {@link LanguageModelMessageRole} string.
+   */
+  private static toLanguageModelMessageRole(
+    role: Role
+  ): LanguageModelMessageRole {
+    // Assumes 'function' rule has been filtered by isOnDeviceRequest
+    return role === 'model' ? 'assistant' : 'user';
   }
 
   /**

--- a/packages/ai/src/types/language-model.ts
+++ b/packages/ai/src/types/language-model.ts
@@ -76,7 +76,7 @@ export interface LanguageModelMessageShorthand {
 }
 export interface LanguageModelMessageContent {
   type: LanguageModelMessageType;
-  content: LanguageModelMessageContentValue;
+  value: LanguageModelMessageContentValue;
 }
 export type LanguageModelMessageRole = 'system' | 'user' | 'assistant';
 export type LanguageModelMessageType = 'text' | 'image' | 'audio';

--- a/packages/ai/src/types/language-model.ts
+++ b/packages/ai/src/types/language-model.ts
@@ -14,7 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+/**
+ * {@see https://github.com/webmachinelearning/prompt-api#full-api-surface-in-web-idl}
+ */
 export interface LanguageModel extends EventTarget {
   create(options?: LanguageModelCreateOptions): Promise<LanguageModel>;
   availability(options?: LanguageModelCreateCoreOptions): Promise<Availability>;
@@ -57,8 +59,10 @@ export interface LanguageModelExpectedInput {
   type: LanguageModelMessageType;
   languages?: string[];
 }
-// TODO: revert to type from Prompt API explainer once it's supported.
-export type LanguageModelPrompt = LanguageModelMessageContent[];
+export type LanguageModelPrompt =
+  | LanguageModelMessage[]
+  | LanguageModelMessageShorthand[]
+  | string;
 export type LanguageModelInitialPrompts =
   | LanguageModelMessage[]
   | LanguageModelMessageShorthand[];


### PR DESCRIPTION
NOTE: this is a placeholder until support is added

Chrome will add support for the official `LanguageModelMessage[]` input type, so this change updates the hybrid SDK to normalize to that type rather than `LanguageModelMessageContent[]`.

