### PR TITLE
ci: Reorder reporters to prevent log message duplication

### DIFF
--- a/config/karma.base.js
+++ b/config/karma.base.js
@@ -68,7 +68,7 @@ const config = {
   // test results reporter to use
   // possible values: 'dots', 'progress'
   // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-  reporters: ['mocha', 'coverage-istanbul'],
+  reporters: ['coverage-istanbul', 'mocha'],
 
   // web server port
   port: 8089,


### PR DESCRIPTION
Reorder reporters in karma config to prevent log message duplication. Currently in CI actions that run Karma, all SDK logging is rendered twice ([example](https://github.com/firebase/firebase-js-sdk/actions/runs/15026164402/job/42227656801?pr=9039#step:7:509)). This fixes the issue.

See also: https://github.com/karma-runner/karma/issues/2342#issuecomment-1304180955