### PR TITLE
Close webchannel instances on terminate

### DIFF
--- a/.changeset/spotty-ghosts-kneel.md
+++ b/.changeset/spotty-ghosts-kneel.md
@@ -1,0 +1,5 @@
+---
+"@firebase/firestore": patch
+---
+
+Clean up leaked WebChannel instances when the Firestore instance is terminated.

--- a/packages/firestore/src/platform/browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform/browser/webchannel_connection.ts
@@ -452,7 +452,7 @@ export class WebChannelConnection extends RestConnection {
   }
 
   /**
-   * Remove a WebChannel instance to the collection of open instances.
+   * Remove a WebChannel instance from the collection of open instances.
    * @param webChannel
    */
   removeOpenWebChannel(webChannel: WebChannel): void {


### PR DESCRIPTION
CI logs showed that some WebChannel connections were being left open after tests. This change implements the `terminate()` method on the `WebChannelConnection` class to ensure that any open WebChannelConnections are closed when the SDK terminates.