### PR TITLE
AI Hybrid Inference: guard against undefined mode

### DIFF
--- a/packages/ai/src/methods/chrome-adapter.test.ts
+++ b/packages/ai/src/methods/chrome-adapter.test.ts
@@ -109,6 +109,14 @@ describe('ChromeAdapter', () => {
     });
   });
   describe('isAvailable', () => {
+    it('returns false if mode is undefined', async () => {
+      const adapter = new ChromeAdapter();
+      expect(
+        await adapter.isAvailable({
+          contents: []
+        })
+      ).to.be.false;
+    });
     it('returns false if mode is only cloud', async () => {
       const adapter = new ChromeAdapter(undefined, 'only_in_cloud');
       expect(
@@ -239,7 +247,10 @@ describe('ChromeAdapter', () => {
       const createStub = stub(languageModelProvider, 'create').returns(
         downloadPromise
       );
-      const adapter = new ChromeAdapter(languageModelProvider);
+      const adapter = new ChromeAdapter(
+        languageModelProvider,
+        'prefer_on_device'
+      );
       await adapter.isAvailable({
         contents: [{ role: 'user', parts: [{ text: 'hi' }] }]
       });
@@ -260,7 +271,10 @@ describe('ChromeAdapter', () => {
       const createStub = stub(languageModelProvider, 'create').returns(
         downloadPromise
       );
-      const adapter = new ChromeAdapter(languageModelProvider);
+      const adapter = new ChromeAdapter(
+        languageModelProvider,
+        'prefer_on_device'
+      );
       await adapter.isAvailable({
         contents: [{ role: 'user', parts: [{ text: 'hi' }] }]
       });

--- a/packages/ai/src/methods/chrome-adapter.ts
+++ b/packages/ai/src/methods/chrome-adapter.ts
@@ -68,7 +68,7 @@ export class ChromeAdapter {
    * separation of concerns.</p>
    */
   async isAvailable(request: GenerateContentRequest): Promise<boolean> {
-    if (this.mode === 'only_in_cloud') {
+    if (!this.mode || this.mode === 'only_in_cloud') {
       logger.debug(
         `On-device inference unavailable because mode is "only_in_cloud".`
       );
@@ -83,20 +83,25 @@ export class ChromeAdapter {
     }
 
     // Applies prefer_on_device logic.
-    if (availability !== Availability.available) {
+    const isAvailable = availability === Availability.available;
+    const isOnDeviceRequest = ChromeAdapter.isOnDeviceRequest(request);
+    if (isAvailable && isOnDeviceRequest) {
+      return true;
+    }
+
+    if (!isAvailable) {
       logger.debug(
         `On-device inference unavailable because availability is "${availability}".`
       );
-      return false;
     }
-    if (!ChromeAdapter.isOnDeviceRequest(request)) {
+
+    if (!isOnDeviceRequest) {
       logger.debug(
         `On-device inference unavailable because request is incompatible.`
       );
-      return false;
     }
 
-    return true;
+    return false;
   }
 
   /**

--- a/packages/ai/src/methods/chrome-adapter.ts
+++ b/packages/ai/src/methods/chrome-adapter.ts
@@ -83,25 +83,20 @@ export class ChromeAdapter {
     }
 
     // Applies prefer_on_device logic.
-    const isAvailable = availability === Availability.available;
-    const isOnDeviceRequest = ChromeAdapter.isOnDeviceRequest(request);
-    if (isAvailable && isOnDeviceRequest) {
-      return true;
-    }
-
-    if (!isAvailable) {
+    if (availability !== Availability.available) {
       logger.debug(
         `On-device inference unavailable because availability is "${availability}".`
       );
+      return false;
     }
-
-    if (!isOnDeviceRequest) {
+    if (!ChromeAdapter.isOnDeviceRequest(request)) {
       logger.debug(
         `On-device inference unavailable because request is incompatible.`
       );
+      return false;
     }
 
-    return false;
+    return true;
   }
 
   /**

--- a/packages/ai/src/methods/chrome-adapter.ts
+++ b/packages/ai/src/methods/chrome-adapter.ts
@@ -68,7 +68,13 @@ export class ChromeAdapter {
    * separation of concerns.</p>
    */
   async isAvailable(request: GenerateContentRequest): Promise<boolean> {
-    if (!this.mode || this.mode === 'only_in_cloud') {
+    if (!this.mode) {
+      logger.debug(
+        `On-device inference unavailable because mode is undefined.`
+      );
+      return false;
+    }
+    if (this.mode === 'only_in_cloud') {
       logger.debug(
         `On-device inference unavailable because mode is "only_in_cloud".`
       );


### PR DESCRIPTION
# Problem Statement

I was using the e2e test and noticed it was throwing an exception from `countToken`.

We intentionally throw from `countToken` in the hybrid case, but it was surprising to see that error in the non-hybrid case. 

Turns out, `mode` is undefined in the non-hybrid case, but we weren't guarding for that.

# Solution

Explicitly guard against an undefined `mode`
