### PR TITLE
Updated to only show banner when calling connect*Emulator

### DIFF
--- a/.changeset/large-windows-mate.md
+++ b/.changeset/large-windows-mate.md
@@ -1,0 +1,10 @@
+---
+"@firebase/auth": patch
+"@firebase/data-connect": patch
+"@firebase/database": patch
+"@firebase/firestore": patch
+"@firebase/functions": patch
+"@firebase/storage": patch
+---
+
+Updated to only show banner when calling connect*Emulator

--- a/packages/auth/src/core/auth/emulator.ts
+++ b/packages/auth/src/core/auth/emulator.ts
@@ -18,7 +18,12 @@ import { Auth } from '../../model/public_types';
 import { AuthErrorCode } from '../errors';
 import { _assert } from '../util/assert';
 import { _castAuth } from './auth_impl';
-import { deepEqual, isCloudWorkstation, pingServer } from '@firebase/util';
+import {
+  deepEqual,
+  isCloudWorkstation,
+  pingServer,
+  updateEmulatorBanner
+} from '@firebase/util';
 
 /**
  * Changes the {@link Auth} instance to communicate with the Firebase Auth Emulator, instead of production
@@ -97,13 +102,12 @@ export function connectAuthEmulator(
   authInternal.emulatorConfig = emulatorConfig;
   authInternal.settings.appVerificationDisabledForTesting = true;
 
-  if (!disableWarnings) {
-    emitEmulatorWarning();
-  }
-
   // Workaround to get cookies in Firebase Studio
   if (isCloudWorkstation(host)) {
     void pingServer(`${protocol}//${host}${portStr}`);
+    updateEmulatorBanner('Auth', true);
+  } else if (!disableWarnings) {
+    emitEmulatorWarning();
   }
 }
 

--- a/packages/data-connect/src/api/DataConnect.ts
+++ b/packages/data-connect/src/api/DataConnect.ts
@@ -24,7 +24,11 @@ import {
 import { AppCheckInternalComponentName } from '@firebase/app-check-interop-types';
 import { FirebaseAuthInternalName } from '@firebase/auth-interop-types';
 import { Provider } from '@firebase/component';
-import { isCloudWorkstation, pingServer } from '@firebase/util';
+import {
+  isCloudWorkstation,
+  pingServer,
+  updateEmulatorBanner
+} from '@firebase/util';
 
 import { AppCheckTokenProvider } from '../core/AppCheckTokenProvider';
 import { Code, DataConnectError } from '../core/error';
@@ -241,6 +245,7 @@ export function connectDataConnectEmulator(
   // Workaround to get cookies in Firebase Studio
   if (isCloudWorkstation(host)) {
     void pingServer(`https://${host}${port ? `:${port}` : ''}`);
+    updateEmulatorBanner('Data Connect', true);
   }
   dc.enableEmulator({ host, port, sslEnabled });
 }

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -31,7 +31,8 @@ import {
   EmulatorMockTokenOptions,
   getDefaultEmulatorHostnameAndPort,
   isCloudWorkstation,
-  pingServer
+  pingServer,
+  updateEmulatorBanner
 } from '@firebase/util';
 
 import { AppCheckTokenProvider } from '../core/AppCheckTokenProvider';
@@ -393,6 +394,7 @@ export function connectDatabaseEmulator(
   // Workaround to get cookies in Firebase Studio
   if (isCloudWorkstation(host)) {
     void pingServer(host);
+    updateEmulatorBanner('Database', true);
   }
 
   // Modify the repo to apply emulator settings

--- a/packages/firestore/src/lite-api/database.ts
+++ b/packages/firestore/src/lite-api/database.ts
@@ -28,7 +28,8 @@ import {
   EmulatorMockTokenOptions,
   getDefaultEmulatorHostnameAndPort,
   isCloudWorkstation,
-  pingServer
+  pingServer,
+  updateEmulatorBanner
 } from '@firebase/util';
 
 import {
@@ -336,6 +337,7 @@ export function connectFirestoreEmulator(
   const newHostSetting = `${host}:${port}`;
   if (useSsl) {
     void pingServer(`https://${newHostSetting}`);
+    updateEmulatorBanner('Firestore', true);
   }
   if (settings.host !== DEFAULT_HOST && settings.host !== newHostSetting) {
     logWarn(

--- a/packages/functions/src/service.ts
+++ b/packages/functions/src/service.ts
@@ -30,7 +30,11 @@ import { Provider } from '@firebase/component';
 import { FirebaseAuthInternalName } from '@firebase/auth-interop-types';
 import { MessagingInternalComponentName } from '@firebase/messaging-interop-types';
 import { AppCheckInternalComponentName } from '@firebase/app-check-interop-types';
-import { isCloudWorkstation, pingServer } from '@firebase/util';
+import {
+  isCloudWorkstation,
+  pingServer,
+  updateEmulatorBanner
+} from '@firebase/util';
 
 export const DEFAULT_REGION = 'us-central1';
 
@@ -182,6 +186,7 @@ export function connectFunctionsEmulator(
   // Workaround to get cookies in Firebase Studio
   if (useSsl) {
     void pingServer(functionsInstance.emulatorOrigin);
+    updateEmulatorBanner('Functions', true);
   }
 }
 

--- a/packages/storage/src/service.ts
+++ b/packages/storage/src/service.ts
@@ -46,7 +46,8 @@ import {
   createMockUserToken,
   EmulatorMockTokenOptions,
   isCloudWorkstation,
-  pingServer
+  pingServer,
+  updateEmulatorBanner
 } from '@firebase/util';
 import { Connection, ConnectionType } from './implementation/connection';
 
@@ -150,6 +151,7 @@ export function connectStorageEmulator(
   // Workaround to get cookies in Firebase Studio
   if (useSsl) {
     void pingServer(`https://${storage.host}`);
+    updateEmulatorBanner('Storage', true);
   }
   storage._isUsingEmulator = true;
   storage._protocol = useSsl ? 'https' : 'http';


### PR DESCRIPTION
Only show emulator banner when:
* Calling `connect*Emulator`
* On Firebase Studio