### PR TITLE
Fix issue where we ping an endpoint that hasn't been implemented

### DIFF
--- a/packages/storage/src/service.ts
+++ b/packages/storage/src/service.ts
@@ -150,7 +150,7 @@ export function connectStorageEmulator(
   const useSsl = isCloudWorkstation(host);
   // Workaround to get cookies in Firebase Studio
   if (useSsl) {
-    void pingServer(`https://${storage.host}`);
+    void pingServer(`https://${storage.host}/b`);
     updateEmulatorBanner('Storage', true);
   }
   storage._isUsingEmulator = true;


### PR DESCRIPTION
When attempting to get cookies for the storage emulator, the endpoint returns with 501 because `/` hasn't been implemented. Instead, we should be calling `/`.