### PR TITLE
fix(ai): Add deprecation tag to `totalBillableCharacters`

### DIFF
--- a/.changeset/old-candles-confess.md
+++ b/.changeset/old-candles-confess.md
@@ -1,0 +1,5 @@
+---
+'@firebase/ai': patch
+---
+
+Add deprecation label to `totalBillableCharacters`. `totalTokens` should be used instead.

--- a/common/api-review/ai.api.md
+++ b/common/api-review/ai.api.md
@@ -164,6 +164,7 @@ export interface CountTokensRequest {
 // @public
 export interface CountTokensResponse {
     promptTokensDetails?: ModalityTokenCount[];
+    // @deprecated (undocumented)
     totalBillableCharacters?: number;
     totalTokens: number;
 }

--- a/docs-devsite/ai.counttokensresponse.md
+++ b/docs-devsite/ai.counttokensresponse.md
@@ -23,7 +23,7 @@ export interface CountTokensResponse
 |  Property | Type | Description |
 |  --- | --- | --- |
 |  [promptTokensDetails](./ai.counttokensresponse.md#counttokensresponseprompttokensdetails) | [ModalityTokenCount](./ai.modalitytokencount.md#modalitytokencount_interface)<!-- -->\[\] | The breakdown, by modality, of how many tokens are consumed by the prompt. |
-|  [totalBillableCharacters](./ai.counttokensresponse.md#counttokensresponsetotalbillablecharacters) | number | The total number of billable characters counted across all instances from the request.<!-- -->This property is only supported when using the Vertex AI Gemini API ([VertexAIBackend](./ai.vertexaibackend.md#vertexaibackend_class)<!-- -->). When using the Gemini Developer API ([GoogleAIBackend](./ai.googleaibackend.md#googleaibackend_class)<!-- -->), this property is not supported and will default to 0. |
+|  [totalBillableCharacters](./ai.counttokensresponse.md#counttokensresponsetotalbillablecharacters) | number |  |
 |  [totalTokens](./ai.counttokensresponse.md#counttokensresponsetotaltokens) | number | The total number of tokens counted across all instances from the request. |
 
 ## CountTokensResponse.promptTokensDetails
@@ -38,9 +38,12 @@ promptTokensDetails?: ModalityTokenCount[];
 
 ## CountTokensResponse.totalBillableCharacters
 
-The total number of billable characters counted across all instances from the request.
-
-This property is only supported when using the Vertex AI Gemini API ([VertexAIBackend](./ai.vertexaibackend.md#vertexaibackend_class)<!-- -->). When using the Gemini Developer API ([GoogleAIBackend](./ai.googleaibackend.md#googleaibackend_class)<!-- -->), this property is not supported and will default to 0.
+> Warning: This API is now obsolete.
+> 
+> Use `totalTokens` instead. This property is undefined when using models greater than `gemini-1.5-*`<!-- -->.
+> 
+> The total number of billable characters counted across all instances from the request.
+> 
 
 <b>Signature:</b>
 

--- a/packages/ai/src/types/responses.ts
+++ b/packages/ai/src/types/responses.ts
@@ -270,11 +270,10 @@ export interface CountTokensResponse {
    */
   totalTokens: number;
   /**
+   * @deprecated Use `totalTokens` instead. This property is undefined when using models greater than `gemini-1.5-*`.
+   *
    * The total number of billable characters counted across all instances
    * from the request.
-   *
-   * This property is only supported when using the Vertex AI Gemini API ({@link VertexAIBackend}).
-   * When using the Gemini Developer API ({@link GoogleAIBackend}), this property is not supported and will default to 0.
    */
   totalBillableCharacters?: number;
   /**


### PR DESCRIPTION
Add deprecation tag to `totalBillableCharacters`. This field is no longer populated when using models greater than `gemini-1.5-*`, since the newer models count tokens, not characters. Developers should use `totalTokens` instead.