### PR TITLE
Pass API Key as request param for Regional Auth requests

### DIFF
--- a/packages/auth/src/api/authentication/exchange_token.test.ts
+++ b/packages/auth/src/api/authentication/exchange_token.test.ts
@@ -37,7 +37,8 @@ describe('api/authentication/exchange_token', () => {
   let regionalAuth: TestAuth;
   const request = {
     parent: 'test-parent',
-    token: 'custom-token'
+    // eslint-disable-next-line camelcase
+    id_token: 'custom-token'
   };
 
   beforeEach(async () => {
@@ -52,6 +53,7 @@ describe('api/authentication/exchange_token', () => {
     const mock = mockRegionalEndpointWithParent(
       RegionalEndpoint.EXCHANGE_TOKEN,
       'test-parent',
+      'test-api-key',
       { accessToken: 'outbound-token', expiresIn: '1000' }
     );
 
@@ -60,7 +62,8 @@ describe('api/authentication/exchange_token', () => {
     expect(response.expiresIn).equal('1000');
     expect(mock.calls[0].request).to.eql({
       parent: 'test-parent',
-      token: 'custom-token'
+      // eslint-disable-next-line camelcase
+      id_token: 'custom-token'
     });
     expect(mock.calls[0].method).to.eq('POST');
     expect(mock.calls[0].headers!.get(HttpHeader.CONTENT_TYPE)).to.eq(
@@ -79,6 +82,7 @@ describe('api/authentication/exchange_token', () => {
     const mock = mockRegionalEndpointWithParent(
       RegionalEndpoint.EXCHANGE_TOKEN,
       'test-parent',
+      'test-api-key',
       {
         error: {
           code: 400,

--- a/packages/auth/src/api/authentication/exchange_token.ts
+++ b/packages/auth/src/api/authentication/exchange_token.ts
@@ -23,7 +23,7 @@ import { Auth } from '../../model/public_types';
 
 export interface ExchangeTokenRequest {
   parent: string;
-  token: string;
+  id_token: string;
 }
 
 export interface ExchangeTokenResponse {

--- a/packages/auth/src/api/index.test.ts
+++ b/packages/auth/src/api/index.test.ts
@@ -652,6 +652,7 @@ describe('api/_performRegionalApiRequest', () => {
       const mock = mockRegionalEndpointWithParent(
         RegionalEndpoint.EXCHANGE_TOKEN,
         'test-parent',
+        'test-api-key',
         serverResponse
       );
       const response = await _performRegionalApiRequest<
@@ -689,6 +690,7 @@ describe('api/_performRegionalApiRequest', () => {
       const mock = mockRegionalEndpointWithParent(
         RegionalEndpoint.EXCHANGE_TOKEN,
         'test-parent',
+        'test-api-key',
         serverResponse
       );
       await _performRegionalApiRequest<typeof request, typeof serverResponse>(

--- a/packages/auth/src/api/index.ts
+++ b/packages/auth/src/api/index.ts
@@ -168,17 +168,10 @@ async function performApiRequest<T, V>(
       }
     }
 
-    let queryParamString: string;
-    if (isRegionalAuthInitialized(auth)) {
-      queryParamString = querystring({
-        ...params
-      }).slice(1);
-    } else {
-      queryParamString = querystring({
+    const queryParamString = querystring({
         key: auth.config.apiKey,
         ...params
       }).slice(1);
-    }
 
     const headers = await (auth as AuthInternal)._getAdditionalHeaders();
     headers[HttpHeader.CONTENT_TYPE] = 'application/json';

--- a/packages/auth/src/core/strategies/exchange_token.test.ts
+++ b/packages/auth/src/core/strategies/exchange_token.test.ts
@@ -52,6 +52,7 @@ describe('core/strategies/exchangeToken', () => {
     const mock = mockRegionalEndpointWithParent(
       RegionalEndpoint.EXCHANGE_TOKEN,
       'projects/test-project-id/locations/us/tenants/tenant-1/idpConfigs/idp-config',
+      'test-api-key',
       { accessToken: 'outbound-token', expiresIn: 10 }
     );
 
@@ -64,7 +65,8 @@ describe('core/strategies/exchangeToken', () => {
     expect(mock.calls[0].request).to.eql({
       parent:
         'projects/test-project-id/locations/us/tenants/tenant-1/idpConfigs/idp-config',
-      token: 'custom-token'
+      // eslint-disable-next-line camelcase
+      id_token: 'custom-token'
     });
     expect(mock.calls[0].method).to.eq('POST');
     expect(mock.calls[0].headers!.get(HttpHeader.CONTENT_TYPE)).to.eq(
@@ -87,6 +89,7 @@ describe('core/strategies/exchangeToken', () => {
     const mock = mockRegionalEndpointWithParent(
       RegionalEndpoint.EXCHANGE_TOKEN,
       'projects/test-project-id/locations/us/tenants/tenant-1/idpConfigs/idp-config',
+      'test-api-key',
       {
         error: {
           code: 400,
@@ -107,7 +110,8 @@ describe('core/strategies/exchangeToken', () => {
     expect(mock.calls[0].request).to.eql({
       parent:
         'projects/test-project-id/locations/us/tenants/tenant-1/idpConfigs/idp-config',
-      token: 'custom-token'
+      // eslint-disable-next-line camelcase
+      id_token: 'custom-token'
     });
     expect(mock.calls[0].method).to.eq('POST');
     expect(mock.calls[0].headers!.get(HttpHeader.CONTENT_TYPE)).to.eq(

--- a/packages/auth/src/core/strategies/exhange_token.ts
+++ b/packages/auth/src/core/strategies/exhange_token.ts
@@ -52,7 +52,8 @@ export async function exchangeToken(
   const authInternal = _castAuth(auth);
   const token = await getToken(authInternal, {
     parent: buildParent(auth, idpConfigId),
-    token: customToken
+    // eslint-disable-next-line camelcase
+    id_token: customToken
   });
   if (token) {
     await authInternal._updateFirebaseToken({

--- a/packages/auth/test/helpers/api/helper.ts
+++ b/packages/auth/test/helpers/api/helper.ts
@@ -59,10 +59,12 @@ export function mockEndpointWithParams(
 export function mockRegionalEndpointWithParent(
   endpoint: RegionalEndpoint,
   parent: string,
+  key: string,
   response: object,
   status = 200
 ): Route {
-  const url = `${TEST_SCHEME}://${TEST_HOST}${parent}${endpoint}`;
-  console.log('here ', url);
+  let url = `${TEST_SCHEME}://${TEST_HOST}${parent}${endpoint}`;
+  url += "?key=";
+  url += key; 
   return mock(url, response, status);
 }


### PR DESCRIPTION
### Discussion

  * Pass API Key as request param for Regional Auth requests

### Testing

  * Unit Test
  * Tested using Demo App. Follow-up PR for demo app changes.
