### PR TITLE
test: Correct source maps for test failure reporting

### DIFF
--- a/config/webpack.test.js
+++ b/config/webpack.test.js
@@ -28,7 +28,7 @@ const PLATFORM_RE = /^(.*)\/platform\/([^.\/]*)(\.ts)?$/;
 
 module.exports = {
   mode: 'development',
-  devtool: 'source-map',
+  devtool: 'inline-source-map',
   optimization: {
     runtimeChunk: false,
     splitChunks: false,


### PR DESCRIPTION
When running browser tests with Karma, failed assertions would produce stack traces pointing to line numbers within the final webpack bundle (e.g., `chat.test.3891121195.js:26044:55`), rather than the source. This made it difficult and time-consuming to trace the failure back to the original source TypeScript file.

Cause:
1. Compilation: `.ts` compiled to `.js`, and source maps are generated in `.js.map` files.
2. Instrumentation: `istanbul-instrument-loader` injects code into the `.js` files to generate code coverage reports. Since lines were added to the `.js` files, the `.js.map` files are made inaccurate.

Fix:
The previous `devtool: 'source-map'` config is what instructs webpack to write source maps to a seperate `.js.map` file. By changing to `devtool: 'inline-source-map'`, the source maps are embedded directly in the JS bundles we load into karma, so the source maps always reflect the state of the `.js` bundles.

New output:
```
FAILED TESTS:
  Chat Session
    Google AI gemini-2.0-flash
      ✖ startChat and sendMessage: text input, text output
        Chrome Headless 137.0.0.0 (Mac OS 10.15.7)
      AssertionError: expected 4 to equal 2

      + expected - actual

      -4
      +2

    at Context.<anonymous> (webpack://firebase/ai/integration/chat.test.ts:87:35 <- chat.test.3891121195.js:26044:55)
```

Old output:
```
FAILED TESTS:
  Chat Session
    Google AI gemini-2.0-flash
      ✖ startChat and sendMessage: text input, text output
        Chrome Headless 137.0.0.0 (Mac OS 10.15.7)
      AssertionError: expected 4 to equal 2

      + expected - actual

      -4
      +2

    at Context.<anonymous> (chat.test.3891121195.js:26044:55)
```