### PR TITLE
fix: Add "react-native" entry point to @firebase/app

### DIFF
--- a/.changeset/giant-lamps-live.md
+++ b/.changeset/giant-lamps-live.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app': patch
+---
+
+Add "react-native" entry point to @firebase/app

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -6,10 +6,12 @@
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm2017.js",
   "module": "dist/esm/index.esm2017.js",
+  "react-native": "dist/index.cjs.js",
   "exports": {
     ".": {
       "types": "./dist/app-public.d.ts",
       "require": "./dist/index.cjs.js",
+      "react-native": "./dist/index.cjs.js",
       "default": "./dist/esm/index.esm2017.js"
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
Fixes #8988

See https://github.com/expo/expo/issues/36598#issuecomment-2848750540 for a user's helpful explanation of the root cause. `@firebase/app` has no specific "react-native" entry point so metro resolves it  using the `exports["."].default` path in package.json I guess, which is ESM, while the auth and firestore "react-native" bundles are CJS and use "require" statements which cause them to import firebase/app CJS code. This causes two unconnected versions of firestore/app to exist in the developer's app.

This PR follows the suggested fix in the second bullet point, to add a "react-native" entry point to firebase/app which points to the CJS bundle. This fixes the issue in my repro case.

I tested this to see if there is a similar problem with the other product packages that are supported on React Native (ai, functions, database) but don't have a "react-native" entry point, but even if Metro brings in the ESM versions of those packages, they still seem to play nice with (register with) the CJS app bundle, in this configuration. It just seems that CJS product packages can't register with an ESM `firebase/app`, but the other way around is fine.