### PR TITLE
build!: specify a minimum TypeScript version using typesVersions

### DIFF
--- a/.changeset/cuddly-apes-check.md
+++ b/.changeset/cuddly-apes-check.md
@@ -1,0 +1,6 @@
+---
+'@firebase/app': minor
+'firebase': minor
+---
+
+Specify a minimum TypeScript version using the `typesVersions` field. Shows an error message if below.

--- a/packages/app-check/test/util.ts
+++ b/packages/app-check/test/util.ts
@@ -35,7 +35,6 @@ import {
 } from '@firebase/component';
 import { AppCheckService } from '../src/factory';
 import { AppCheck, CustomProvider } from '../src';
-import { HeartbeatService } from '@firebase/app/dist/app/src/types';
 
 export const FAKE_SITE_KEY = 'fake-site-key';
 
@@ -112,7 +111,7 @@ export function getFakeHeartbeatServiceProvider(
       () =>
         ({
           getHeartbeatsHeader: () => Promise.resolve(fakeLogString)
-        } as HeartbeatService),
+        } as any),
       ComponentType.PRIVATE
     )
   );

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -8,7 +8,7 @@
   "module": "dist/esm/index.esm2017.js",
   "react-native": "dist/index.cjs.js",
   "typesVersions": {
-    ">=4.5.0": { "*": ["./dist/app-public.d.ts"] },
+    ">=4.5.0": { "*": ["./dist/app/src/index.d.ts"] },
     "<4.5.0": { "*": ["./dist/typescript-not-supported.d.ts"] }
   },
   "exports": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -7,6 +7,10 @@
   "browser": "dist/esm/index.esm2017.js",
   "module": "dist/esm/index.esm2017.js",
   "react-native": "dist/index.cjs.js",
+  "typesVersions": {
+    ">=4.5.0": { "*": ["./dist/app-public.d.ts"] },
+    "<4.5.0": { "*": ["./dist/typescript-not-supported.d.ts"] }
+  },
   "exports": {
     ".": {
       "types": "./dist/app-public.d.ts",
@@ -49,6 +53,7 @@
   "devDependencies": {
     "@rollup/plugin-json": "6.1.0",
     "rollup": "2.79.2",
+    "rollup-plugin-copy": "3.5.0",
     "rollup-plugin-replace": "2.2.0",
     "rollup-plugin-typescript2": "0.36.0",
     "rollup-plugin-dts": "5.3.1",

--- a/packages/app/rollup.config.js
+++ b/packages/app/rollup.config.js
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import copy from 'rollup-plugin-copy';
 import typescriptPlugin from 'rollup-plugin-typescript2';
 import replace from 'rollup-plugin-replace';
 import typescript from 'typescript';
@@ -53,6 +54,14 @@ const esmBuilds = [
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`)),
     plugins: [
       ...buildPlugins,
+      copy({
+        targets: [
+          {
+            src: './typescript-not-supported.d.ts',
+            dest: 'dist/'
+          }
+        ]
+      }),
       replace({
         ...generateBuildTargetReplaceConfig('esm', 2017),
         '__RUNTIME_ENV__': ''

--- a/packages/app/typescript-not-supported.d.ts
+++ b/packages/app/typescript-not-supported.d.ts
@@ -1,0 +1,3 @@
+// Empty typings file to log an error message for unsupported TS versions
+
+"Typescript must be version 4.5 or greater.";

--- a/packages/app/typescript-not-supported.d.ts
+++ b/packages/app/typescript-not-supported.d.ts
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // Empty typings file to log an error message for unsupported TS versions
 
-"Typescript must be version 4.5 or greater.";
+'Typescript must be version 4.5 or greater.';

--- a/scripts/docgen/docgen.ts
+++ b/scripts/docgen/docgen.ts
@@ -65,6 +65,7 @@ const PREFERRED_PARAMS = [
 
 let authApiReportOriginal: string;
 let authApiConfigOriginal: string;
+let appPkgOriginal: string;
 
 yargs
   .command(
@@ -117,6 +118,14 @@ function cleanup() {
       fs.writeFileSync(
         `${projectRoot}/common/api-review/auth.api.md`,
         authApiReportOriginal
+      );
+    }
+    // Restore original app/package.json
+    if (authApiConfigOriginal) {
+      console.log(`Restoring original app/package.json contents.`);
+      fs.writeFileSync(
+        `${projectRoot}/packages/app/package.json`,
+        appPkgOriginal
       );
     }
     for (const excludedPackage of EXCLUDED_PACKAGES) {
@@ -198,10 +207,25 @@ async function generateDocs(
     `"mainEntryPointFilePath": "<projectFolder>/dist/esm2017/index.doc.d.ts"`
   );
 
+  console.log(`Temporarily modifying packages/app/package.json for docgen.`);
+  // Remove typesVersions restriction just for docgen
+  appPkgOriginal = fs.readFileSync(
+    `${projectRoot}/packages/app/package.json`,
+    'utf8'
+  );
+  const appPkgModified = appPkgOriginal.replace(
+    `./dist/typescript-not-supported.d.ts`,
+    `./dist/app/src/index.d.ts`
+  );
+
   try {
     fs.writeFileSync(
       `${projectRoot}/packages/auth/api-extractor.json`,
       authApiConfigModified
+    );
+    fs.writeFileSync(
+      `${projectRoot}/packages/app/package.json`,
+      appPkgModified
     );
 
     if (skipBuild) {


### PR DESCRIPTION
Specified a minimum version of TypeScript required using `typesVersions` field. If the version is below, the TS compiler directs the compiler to use a typings file called `typescript-not-supported.ts` which contains a single string which will be logged as a syntax error in the TS compiler, and provide useful error info to the user.

Following user suggestions here: https://github.com/microsoft/TypeScript/issues/32166

Fixes https://github.com/firebase/firebase-js-sdk/issues/8837

I chose 4.5 because due to the issue above we know that the SDK requires at least 4.5. I'm not sure if there are any other TS features we are using that require an even higher version (in a product or bundle that user wasn't using) but we can increase it if we discover any.

I added a hack to allow our old api-documenter (stuck on TS 4.1.6) to work - docgen.ts removes the `typesVersions` restriction on old versions in packages/app/package.json before running and then puts it back when it's done/exits. We will update api-documenter/extractor soon.