### PR TITLE
fix(reference): update function name in error message

### DIFF
--- a/packages/firestore/src/lite-api/reference.ts
+++ b/packages/firestore/src/lite-api/reference.ts
@@ -651,7 +651,7 @@ export function doc<AppModelType, DbModelType extends DocumentData>(
     ) {
       throw new FirestoreError(
         Code.INVALID_ARGUMENT,
-        'Expected first argument to collection() to be a CollectionReference, ' +
+        'Expected first argument to doc() to be a CollectionReference, ' +
           'a DocumentReference or FirebaseFirestore'
       );
     }


### PR DESCRIPTION
Currently, the error message for the invalid first argument in the `doc()` function says "expected first argument to collection()"... instead of "to doc()".  This seems to be a copy-paste of the validation logic from `collection()`.  This commit corrects the name.

Today it caught me during debugging when it pointed me in incorrect direction, until I was so desperate to read the source code and find this little gem :)
