### PR TITLE
fix(firestore): revert fix for `undefined` document snapshot data after "clear site data"

### DIFF
--- a/.changeset/heavy-ties-learn.md
+++ b/.changeset/heavy-ties-learn.md
@@ -1,0 +1,5 @@
+---
+'@firebase/firestore': patch
+---
+
+Revert fix for issue where Firestore would produce `undefined` for document snapshot if "clear site data" button was pressed in the web browser. This fix was introduced in v11.6.1 but inadvertantly caused issues for some customers (https://github.com/firebase/firebase-js-sdk/issues/9056).

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -160,7 +160,6 @@ export class SimpleDbTransaction {
 export class SimpleDb {
   private db?: IDBDatabase;
   private databaseDeletedListener?: DatabaseDeletedListener;
-  private lastClosedDbVersion: number | null = null;
 
   /** Deletes the specified database. */
   static delete(name: string): Promise<void> {
@@ -349,24 +348,6 @@ export class SimpleDb {
             event.oldVersion
           );
           const db = (event.target as IDBOpenDBRequest).result;
-          if (
-            this.lastClosedDbVersion !== null &&
-            this.lastClosedDbVersion !== event.oldVersion
-          ) {
-            // This thrown error will get passed to the `onerror` callback
-            // registered above, and will then be propagated correctly.
-            throw new Error(
-              `refusing to open IndexedDB database due to potential ` +
-                `corruption of the IndexedDB database data; this corruption ` +
-                `could be caused by clicking the "clear site data" button in ` +
-                `a web browser; try reloading the web page to re-initialize ` +
-                `the IndexedDB database: ` +
-                `lastClosedDbVersion=${this.lastClosedDbVersion}, ` +
-                `event.oldVersion=${event.oldVersion}, ` +
-                `event.newVersion=${event.newVersion}, ` +
-                `db.version=${db.version}`
-            );
-          }
           this.schemaConverter
             .createOrUpgrade(
               db,
@@ -382,15 +363,6 @@ export class SimpleDb {
             });
         };
       });
-
-      this.db.addEventListener(
-        'close',
-        event => {
-          const db = event.target as IDBDatabase;
-          this.lastClosedDbVersion = db.version;
-        },
-        { passive: true }
-      );
     }
 
     this.db.addEventListener(


### PR DESCRIPTION
This PR reverts https://github.com/firebase/firebase-js-sdk/pull/8871 which fixed https://github.com/firebase/firebase-js-sdk/issues/8593, a bug where an irrecoverable `undefined` document snapshot would be produced after the user clicked "Clear Site Data" in the web browser.

The fix is being reverted because it has unintended consequences, such as https://github.com/firebase/firebase-js-sdk/issues/9056, where the Firestore instance was erroneously rendered useless. This same problem began to surface in Firestore's continuous integration tests, suggesting more widespread negative user impacts than intended.

Fixes #9056