### PR TITLE
fix(ci): Update e2e tests to import from ai instead of vertexai

### DIFF
--- a/e2e/smoke-tests/tests/modular.test.ts
+++ b/e2e/smoke-tests/tests/modular.test.ts
@@ -86,12 +86,7 @@ import {
   StorageReference,
   deleteObject
 } from 'firebase/storage';
-import {
-  getGenerativeModel,
-  getAI,
-  AI,
-  VertexAIBackend
-} from 'firebase/ai';
+import { getGenerativeModel, getAI, AI, VertexAIBackend } from 'firebase/ai';
 import { getDataConnect, DataConnect } from 'firebase/data-connect';
 // @ts-ignore
 import { config, testAccount } from '../firebase-config';

--- a/e2e/smoke-tests/tests/modular.test.ts
+++ b/e2e/smoke-tests/tests/modular.test.ts
@@ -91,8 +91,9 @@ import {
   getAI,
   AI,
   VertexAIBackend
-} from 'firebase/vertexai';
+} from 'firebase/ai';
 import { getDataConnect, DataConnect } from 'firebase/data-connect';
+// @ts-ignore
 import { config, testAccount } from '../firebase-config';
 import 'jest';
 

--- a/e2e/smoke-tests/tsconfig.json
+++ b/e2e/smoke-tests/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "typeRoots": ["./node_modules/@types"]
+  }
+}


### PR DESCRIPTION
Need to update the import statement in the E2E test after removing the `firebase/vertexai` alias in https://github.com/firebase/firebase-js-sdk/pull/9081

Also added some tsconfig fixes so that VSCode will not show false positive errors based on using `@types/mocha` (from the outer node_modules directory) for "describe" blocks instead of `@types/jest`.