### PR TITLE
Make remote config version available through API

### DIFF
--- a/.changeset/selfish-jokes-applaud.md
+++ b/.changeset/selfish-jokes-applaud.md
@@ -1,0 +1,5 @@
+---
+'@firebase/remote-config': patch
+---
+
+Make remote config version available through API

--- a/common/api-review/remote-config.api.md
+++ b/common/api-review/remote-config.api.md
@@ -29,6 +29,7 @@ export interface FetchResponse {
     config?: FirebaseRemoteConfigObject;
     eTag?: string;
     status: number;
+    version?: string;
 }
 
 // @public

--- a/docs-devsite/remote-config.fetchresponse.md
+++ b/docs-devsite/remote-config.fetchresponse.md
@@ -17,7 +17,7 @@ Defines a successful response (200 or 304).
 <b>Signature:</b>
 
 ```typescript
-export interface FetchResponse 
+export interface FetchResponse
 ```
 
 ## Properties
@@ -27,6 +27,7 @@ export interface FetchResponse
 |  [config](./remote-config.fetchresponse.md#fetchresponseconfig) | [FirebaseRemoteConfigObject](./remote-config.firebaseremoteconfigobject.md#firebaseremoteconfigobject_interface) | Defines the map of parameters returned as "entries" in the fetch response body.<p>Only defined for 200 responses. |
 |  [eTag](./remote-config.fetchresponse.md#fetchresponseetag) | string | Defines the ETag response header value.<p>Only defined for 200 and 304 responses. |
 |  [status](./remote-config.fetchresponse.md#fetchresponsestatus) | number | The HTTP status, which is useful for differentiating success responses with data from those without.<p>The Remote Config client is modeled after the native <code>Fetch</code> interface, so HTTP status is first-class.<p>Disambiguation: the fetch response returns a legacy "state" value that is redundant with the HTTP status code. The former is normalized into the latter. |
+|  [version](./remote-config.fetchresponse.md#version) | string | Remote config version. |
 
 ## FetchResponse.config
 
@@ -64,4 +65,14 @@ The HTTP status, which is useful for differentiating success responses with data
 
 ```typescript
 status: number;
+```
+
+## FetchResponse.version
+
+Remote config version.
+
+<b>Signature:</b>
+
+```typescript
+version?: string;
 ```

--- a/packages/remote-config/src/client/rest_client.ts
+++ b/packages/remote-config/src/client/rest_client.ts
@@ -140,6 +140,7 @@ export class RestClient implements RemoteConfigFetchClient {
 
     let config: FirebaseRemoteConfigObject | undefined;
     let state: string | undefined;
+    let version: string | undefined;
 
     // JSON parsing throws SyntaxError if the response body isn't a JSON string.
     // Requesting application/json and checking for a 200 ensures there's JSON data.
@@ -154,6 +155,7 @@ export class RestClient implements RemoteConfigFetchClient {
       }
       config = responseBody['entries'];
       state = responseBody['state'];
+      version = responseBody['templateVersion'];
     }
 
     // Normalizes based on legacy state.
@@ -176,6 +178,6 @@ export class RestClient implements RemoteConfigFetchClient {
       });
     }
 
-    return { status, eTag: responseEtag, config };
+    return { status, eTag: responseEtag, config, version } as FetchResponse;
   }
 }

--- a/packages/remote-config/src/public_types.ts
+++ b/packages/remote-config/src/public_types.ts
@@ -90,6 +90,11 @@ export interface FetchResponse {
    */
   config?: FirebaseRemoteConfigObject;
 
+  /**
+   * Defines remote config version.
+   */
+  version?: string;
+
   // Note: we're not extracting experiment metadata until
   // ABT and Analytics have Web SDKs.
 }

--- a/packages/remote-config/test/client/rest_client.test.ts
+++ b/packages/remote-config/test/client/rest_client.test.ts
@@ -95,7 +95,8 @@ describe('RestClient', () => {
       expect(response).to.deep.eq({
         status: expectedResponse.status,
         eTag: expectedResponse.eTag,
-        config: expectedResponse.entries
+        config: expectedResponse.entries,
+        version: undefined
       });
     });
 
@@ -184,7 +185,8 @@ describe('RestClient', () => {
       expect(response).to.deep.eq({
         status: 304,
         eTag: 'response-etag',
-        config: undefined
+        config: undefined,
+        version: undefined
       });
     });
 
@@ -222,7 +224,8 @@ describe('RestClient', () => {
       expect(response).to.deep.eq({
         status: 304,
         eTag: 'etag',
-        config: undefined
+        config: undefined,
+        version: undefined
       });
     });
 
@@ -239,7 +242,8 @@ describe('RestClient', () => {
         await expect(client.fetch(DEFAULT_REQUEST)).to.eventually.be.deep.eq({
           status: 200,
           eTag: 'etag',
-          config: {}
+          config: {},
+          version: undefined
         });
       }
     });


### PR DESCRIPTION
Hello!

Firebase JS SDK lacks [realtime updates](https://firebase.google.com/docs/remote-config/real-time) support.
I'm not sure why.

But I checked, how Android SDK is working, and implemented my own wrapper around `@firebase/remote-config`, which supports realtime updates. One thing I miss though — is remote config version extraction from the `.../firebase:fetch` endpoint response, in order to use it later in `.../firebase:streamFetchInvalidations` request payload.

I am patching local `@firebase/remote-config` package using `pnpm patch`, but I need to redo the patch every time new version came out.

So I decided it worth trying to make a PR. I figured, that if you are planning to add realtime updates support into JS SDK in future, you will have to add this change anyways.

It doesn't introduce any changes from regular user's perspective, not breaking, nor minor. So it could be new patch version. And it will help me a lot, so I could remove my local package patching.

Thank you for your attention!