### PR TITLE
fix(scripts): Prevent empty strings in changed files list

### DIFF
--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -29,7 +29,7 @@ export async function getChangedFiles(): Promise<string[]> {
   console.log(projectRoot);
   const git = simpleGit(projectRoot);
   const diff = await git.diff(['--name-only', 'origin/main...HEAD']);
-  const changedFiles = diff.split('\n');
+  const changedFiles = diff.split('\n').filter(Boolean);
 
   return changedFiles;
 }


### PR DESCRIPTION
Filter Boolean removes empty strings from the array, which can happen if the git output has a trailing newline.