### PR TITLE
Add script to run AI integration tests in Node

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -40,6 +40,7 @@
     "test:skip-clone": "karma start",
     "test:browser": "yarn testsetup && karma start",
     "test:integration": "karma start --integration",
+    "test:integration:node": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha integration/**/*.test.ts --config ../../config/mocharc.node.js",
     "api-report": "api-extractor run --local --verbose",
     "typings:public": "node ../../scripts/build/use_typings.js ./dist/ai-public.d.ts",
     "trusted-type-check": "tsec -p tsconfig.json --noEmit"


### PR DESCRIPTION
Add script to run AI integration tests in a Node environment. This helps us ensure we fully support Node. This will be useful for Bidi where our implementation will be using different websocket implementations for Node and Browser environments.