### PR TITLE
Backfill fixes for hybrid docs

### DIFF
--- a/docs-devsite/ai.chromeadapter.md
+++ b/docs-devsite/ai.chromeadapter.md
@@ -24,15 +24,15 @@ export interface ChromeAdapter
 
 |  Method | Description |
 |  --- | --- |
-|  [generateContent(request)](./ai.chromeadapter.md#chromeadaptergeneratecontent) | Generates content using on-device inference.<p>This is comparable to [GenerativeModel.generateContent()](./ai.generativemodel.md#generativemodelgeneratecontent) for generating content using in-cloud inference.</p> |
-|  [generateContentStream(request)](./ai.chromeadapter.md#chromeadaptergeneratecontentstream) | Generates a content stream using on-device inference.<p>This is comparable to [GenerativeModel.generateContentStream()](./ai.generativemodel.md#generativemodelgeneratecontentstream) for generating a content stream using in-cloud inference.</p> |
+|  [generateContent(request)](./ai.chromeadapter.md#chromeadaptergeneratecontent) | Generates content using on-device inference.<!-- -->This is comparable to [GenerativeModel.generateContent()](./ai.generativemodel.md#generativemodelgeneratecontent) for generating content using in-cloud inference. |
+|  [generateContentStream(request)](./ai.chromeadapter.md#chromeadaptergeneratecontentstream) | Generates a content stream using on-device inference.<!-- -->This is comparable to [GenerativeModel.generateContentStream()](./ai.generativemodel.md#generativemodelgeneratecontentstream) for generating a content stream using in-cloud inference. |
 |  [isAvailable(request)](./ai.chromeadapter.md#chromeadapterisavailable) | Checks if the on-device model is capable of handling a given request. |
 
 ## ChromeAdapter.generateContent()
 
 Generates content using on-device inference.
 
-<p>This is comparable to [GenerativeModel.generateContent()](./ai.generativemodel.md#generativemodelgeneratecontent) for generating content using in-cloud inference.</p>
+This is comparable to [GenerativeModel.generateContent()](./ai.generativemodel.md#generativemodelgeneratecontent) for generating content using in-cloud inference.
 
 <b>Signature:</b>
 
@@ -54,7 +54,7 @@ Promise&lt;Response&gt;
 
 Generates a content stream using on-device inference.
 
-<p>This is comparable to [GenerativeModel.generateContentStream()](./ai.generativemodel.md#generativemodelgeneratecontentstream) for generating a content stream using in-cloud inference.</p>
+This is comparable to [GenerativeModel.generateContentStream()](./ai.generativemodel.md#generativemodelgeneratecontentstream) for generating a content stream using in-cloud inference.
 
 <b>Signature:</b>
 

--- a/docs-devsite/ai.chromeadapter.md
+++ b/docs-devsite/ai.chromeadapter.md
@@ -24,8 +24,8 @@ export interface ChromeAdapter
 
 |  Method | Description |
 |  --- | --- |
-|  [generateContent(request)](./ai.chromeadapter.md#chromeadaptergeneratecontent) | Generates content using on-device inference.<!-- -->This is comparable to [GenerativeModel.generateContent()](./ai.generativemodel.md#generativemodelgeneratecontent) for generating content using in-cloud inference. |
-|  [generateContentStream(request)](./ai.chromeadapter.md#chromeadaptergeneratecontentstream) | Generates a content stream using on-device inference.<!-- -->This is comparable to [GenerativeModel.generateContentStream()](./ai.generativemodel.md#generativemodelgeneratecontentstream) for generating a content stream using in-cloud inference. |
+|  [generateContent(request)](./ai.chromeadapter.md#chromeadaptergeneratecontent) | Generates content using on-device inference. |
+|  [generateContentStream(request)](./ai.chromeadapter.md#chromeadaptergeneratecontentstream) | Generates a content stream using on-device inference. |
 |  [isAvailable(request)](./ai.chromeadapter.md#chromeadapterisavailable) | Checks if the on-device model is capable of handling a given request. |
 
 ## ChromeAdapter.generateContent()

--- a/docs-devsite/ai.requestoptions.md
+++ b/docs-devsite/ai.requestoptions.md
@@ -22,12 +22,12 @@ export interface RequestOptions
 
 |  Property | Type | Description |
 |  --- | --- | --- |
-|  [baseUrl](./ai.requestoptions.md#requestoptionsbaseurl) | string | Base url for endpoint. Defaults to https://firebasevertexai.googleapis.com |
+|  [baseUrl](./ai.requestoptions.md#requestoptionsbaseurl) | string | Base url for endpoint. Defaults to https://firebasevertexai.googleapis.com, which is the [Firebase AI Logic API](https://console.cloud.google.com/apis/library/firebasevertexai.googleapis.com?project=_) (used regardless of your chosen Gemini API provider). |
 |  [timeout](./ai.requestoptions.md#requestoptionstimeout) | number | Request timeout in milliseconds. Defaults to 180 seconds (180000ms). |
 
 ## RequestOptions.baseUrl
 
-Base url for endpoint. Defaults to https://firebasevertexai.googleapis.com
+Base url for endpoint. Defaults to https://firebasevertexai.googleapis.com, which is the [Firebase AI Logic API](https://console.cloud.google.com/apis/library/firebasevertexai.googleapis.com?project=_) (used regardless of your chosen Gemini API provider).
 
 <b>Signature:</b>
 

--- a/packages/ai/src/methods/chrome-adapter.ts
+++ b/packages/ai/src/methods/chrome-adapter.ts
@@ -129,6 +129,7 @@ export class ChromeAdapterImpl implements ChromeAdapter {
   /**
    * Generates content on device.
    *
+   * @remarks
    * This is comparable to {@link GenerativeModel.generateContent} for generating content in
    * Cloud.
    * @param request - a standard Firebase AI {@link GenerateContentRequest}
@@ -149,6 +150,7 @@ export class ChromeAdapterImpl implements ChromeAdapter {
   /**
    * Generates content stream on device.
    *
+   * @remarks
    * This is comparable to {@link GenerativeModel.generateContentStream} for generating content in
    * Cloud.
    * @param request - a standard Firebase AI {@link GenerateContentRequest}

--- a/packages/ai/src/methods/chrome-adapter.ts
+++ b/packages/ai/src/methods/chrome-adapter.ts
@@ -61,17 +61,17 @@ export class ChromeAdapterImpl implements ChromeAdapter {
   /**
    * Checks if a given request can be made on-device.
    *
-   * <ol>Encapsulates a few concerns:
-   *   <li>the mode</li>
-   *   <li>API existence</li>
-   *   <li>prompt formatting</li>
-   *   <li>model availability, including triggering download if necessary</li>
-   * </ol>
+   * Encapsulates a few concerns:
+   *   the mode
+   *   API existence
+   *   prompt formatting
+   *   model availability, including triggering download if necessary
+   * 
    *
-   * <p>Pros: callers needn't be concerned with details of on-device availability.</p>
-   * <p>Cons: this method spans a few concerns and splits request validation from usage.
+   * Pros: callers needn't be concerned with details of on-device availability.</p>
+   * Cons: this method spans a few concerns and splits request validation from usage.
    * If instance variables weren't already part of the API, we could consider a better
-   * separation of concerns.</p>
+   * separation of concerns.
    */
   async isAvailable(request: GenerateContentRequest): Promise<boolean> {
     if (!this.mode) {
@@ -129,8 +129,8 @@ export class ChromeAdapterImpl implements ChromeAdapter {
   /**
    * Generates content on device.
    *
-   * <p>This is comparable to {@link GenerativeModel.generateContent} for generating content in
-   * Cloud.</p>
+   * This is comparable to {@link GenerativeModel.generateContent} for generating content in
+   * Cloud.
    * @param request - a standard Firebase AI {@link GenerateContentRequest}
    * @returns {@link Response}, so we can reuse common response formatting.
    */
@@ -149,8 +149,8 @@ export class ChromeAdapterImpl implements ChromeAdapter {
   /**
    * Generates content stream on device.
    *
-   * <p>This is comparable to {@link GenerativeModel.generateContentStream} for generating content in
-   * Cloud.</p>
+   * This is comparable to {@link GenerativeModel.generateContentStream} for generating content in
+   * Cloud.
    * @param request - a standard Firebase AI {@link GenerateContentRequest}
    * @returns {@link Response}, so we can reuse common response formatting.
    */
@@ -228,11 +228,11 @@ export class ChromeAdapterImpl implements ChromeAdapter {
   /**
    * Triggers out-of-band download of an on-device model.
    *
-   * <p>Chrome only downloads models as needed. Chrome knows a model is needed when code calls
-   * LanguageModel.create.</p>
+   * Chrome only downloads models as needed. Chrome knows a model is needed when code calls
+   * LanguageModel.create.
    *
-   * <p>Since Chrome manages the download, the SDK can only avoid redundant download requests by
-   * tracking if a download has previously been requested.</p>
+   * Since Chrome manages the download, the SDK can only avoid redundant download requests by
+   * tracking if a download has previously been requested.
    */
   private download(): void {
     if (this.isDownloading) {
@@ -302,12 +302,12 @@ export class ChromeAdapterImpl implements ChromeAdapter {
   /**
    * Abstracts Chrome session creation.
    *
-   * <p>Chrome uses a multi-turn session for all inference. Firebase AI uses single-turn for all
+   * Chrome uses a multi-turn session for all inference. Firebase AI uses single-turn for all
    * inference. To map the Firebase AI API to Chrome's API, the SDK creates a new session for all
-   * inference.</p>
+   * inference.
    *
-   * <p>Chrome will remove a model from memory if it's no longer in use, so this method ensures a
-   * new session is created before an old session is destroyed.</p>
+   * Chrome will remove a model from memory if it's no longer in use, so this method ensures a
+   * new session is created before an old session is destroyed.
    */
   private async createSession(): Promise<LanguageModel> {
     if (!this.languageModelProvider) {

--- a/packages/ai/src/methods/chrome-adapter.ts
+++ b/packages/ai/src/methods/chrome-adapter.ts
@@ -66,7 +66,7 @@ export class ChromeAdapterImpl implements ChromeAdapter {
    *   API existence
    *   prompt formatting
    *   model availability, including triggering download if necessary
-   * 
+   *
    *
    * Pros: callers needn't be concerned with details of on-device availability.</p>
    * Cons: this method spans a few concerns and splits request validation from usage.

--- a/packages/ai/src/types/chrome-adapter.ts
+++ b/packages/ai/src/types/chrome-adapter.ts
@@ -37,6 +37,7 @@ export interface ChromeAdapter {
   /**
    * Generates content using on-device inference.
    *
+   * @remarks
    * This is comparable to {@link GenerativeModel.generateContent} for generating
    * content using in-cloud inference.
    * @param request - a standard Firebase AI {@link GenerateContentRequest}
@@ -46,6 +47,7 @@ export interface ChromeAdapter {
   /**
    * Generates a content stream using on-device inference.
    *
+   * @remarks
    * This is comparable to {@link GenerativeModel.generateContentStream} for generating
    * a content stream using in-cloud inference.
    * @param request - a standard Firebase AI {@link GenerateContentRequest}

--- a/packages/ai/src/types/chrome-adapter.ts
+++ b/packages/ai/src/types/chrome-adapter.ts
@@ -37,8 +37,8 @@ export interface ChromeAdapter {
   /**
    * Generates content using on-device inference.
    *
-   * <p>This is comparable to {@link GenerativeModel.generateContent} for generating
-   * content using in-cloud inference.</p>
+   * This is comparable to {@link GenerativeModel.generateContent} for generating
+   * content using in-cloud inference.
    * @param request - a standard Firebase AI {@link GenerateContentRequest}
    */
   generateContent(request: GenerateContentRequest): Promise<Response>;
@@ -46,8 +46,8 @@ export interface ChromeAdapter {
   /**
    * Generates a content stream using on-device inference.
    *
-   * <p>This is comparable to {@link GenerativeModel.generateContentStream} for generating
-   * a content stream using in-cloud inference.</p>
+   * This is comparable to {@link GenerativeModel.generateContentStream} for generating
+   * a content stream using in-cloud inference.
    * @param request - a standard Firebase AI {@link GenerateContentRequest}
    */
   generateContentStream(request: GenerateContentRequest): Promise<Response>;

--- a/packages/ai/src/types/requests.ts
+++ b/packages/ai/src/types/requests.ts
@@ -165,7 +165,10 @@ export interface RequestOptions {
    */
   timeout?: number;
   /**
-   * Base url for endpoint. Defaults to https://firebasevertexai.googleapis.com
+   * Base url for endpoint. Defaults to
+   * https://firebasevertexai.googleapis.com, which is the
+   * {@link https://console.cloud.google.com/apis/library/firebasevertexai.googleapis.com?project=_ | Firebase AI Logic API}
+   * (used regardless of your chosen Gemini API provider).
    */
   baseUrl?: string;
 }


### PR DESCRIPTION
Backfill documentation fixes per cl/791925900 (internal).

- remove `<p>` tags - these are not generally necessary and cause markdown inside them to not work
- add a link to console to the RequestOptions description
- use `@remarks` to separate extra details of a method from the summary that should go in the table of contents at the top