### PR TITLE
fix(ai): Only include unexpected `prediction` element in error message

### DIFF
--- a/.changeset/calm-guests-pump.md
+++ b/.changeset/calm-guests-pump.md
@@ -1,0 +1,5 @@
+---
+'@firebase/ai': patch
+---
+
+Fixed an issue where `AIError` messages were too long after including an entire response body.

--- a/packages/ai/src/requests/response-helpers.ts
+++ b/packages/ai/src/requests/response-helpers.ts
@@ -299,7 +299,9 @@ export async function handlePredictResponse<
     } else {
       throw new AIError(
         AIErrorCode.RESPONSE_ERROR,
-        `Unexpected element in 'predictions' array in response: '${prediction}'`
+        `Unexpected element in 'predictions' array in response: '${JSON.stringify(
+          prediction
+        )}'`
       );
     }
   }

--- a/packages/ai/src/requests/response-helpers.ts
+++ b/packages/ai/src/requests/response-helpers.ts
@@ -299,9 +299,7 @@ export async function handlePredictResponse<
     } else {
       throw new AIError(
         AIErrorCode.RESPONSE_ERROR,
-        `Predictions array in response has missing properties. Response: ${JSON.stringify(
-          responseJson
-        )}`
+        `Unexpected element in 'predictions' array in response: '${prediction}'`
       );
     }
   }


### PR DESCRIPTION
If the `responseJson` from the Predict request has an image, the entire image base64 will be included in the error message. This can make the error message >400kB (!!), which could cause a variety of issues in client apps.

I ran into this when testing https://github.com/firebase/firebase-js-sdk/pull/9216. The new `safetyAttributes` field being included in the `predictions` array in responses caused this error to be raised. But, since the `predictions` array *also* had images, the error message would be massive and caused serious performance issues when rendered in the sample app.