### PR TITLE
fix(ai): remove accidental factory export

### DIFF
--- a/.changeset/stupid-files-reflect.md
+++ b/.changeset/stupid-files-reflect.md
@@ -1,0 +1,5 @@
+---
+'@firebase/ai': patch
+---
+
+Remove accidental `factory` export.

--- a/common/api-review/ai.api.md
+++ b/common/api-review/ai.api.md
@@ -4,18 +4,10 @@
 
 ```ts
 
-import { AppCheckInternalComponentName } from '@firebase/app-check-interop-types';
 import { AppCheckTokenResult } from '@firebase/app-check-interop-types';
-import { ComponentContainer } from '@firebase/component';
 import { FirebaseApp } from '@firebase/app';
-import { FirebaseAppCheckInternal } from '@firebase/app-check-interop-types';
-import { FirebaseAuthInternal } from '@firebase/auth-interop-types';
-import { FirebaseAuthInternalName } from '@firebase/auth-interop-types';
 import { FirebaseAuthTokenData } from '@firebase/auth-interop-types';
 import { FirebaseError } from '@firebase/util';
-import { _FirebaseService } from '@firebase/app';
-import { InstanceFactoryOptions } from '@firebase/component';
-import { Provider } from '@firebase/component';
 
 // @public
 export interface AI {
@@ -244,11 +236,6 @@ export interface ErrorDetails {
     metadata?: Record<string, unknown>;
     reason?: string;
 }
-
-// Warning: (ae-forgotten-export) The symbol "AIService" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
-export function factory(container: ComponentContainer, { instanceIdentifier }: InstanceFactoryOptions): AIService;
 
 // @public
 export interface FileData {

--- a/docs-devsite/ai.md
+++ b/docs-devsite/ai.md
@@ -22,8 +22,6 @@ The Firebase AI Web SDK.
 |  [getGenerativeModel(ai, modelParams, requestOptions)](./ai.md#getgenerativemodel_c63f46a) | Returns a [GenerativeModel](./ai.generativemodel.md#generativemodel_class) class with methods for inference and other functionality. |
 |  [getImagenModel(ai, modelParams, requestOptions)](./ai.md#getimagenmodel_e1f6645) | <b><i>(Public Preview)</i></b> Returns an [ImagenModel](./ai.imagenmodel.md#imagenmodel_class) class with methods for using Imagen.<!-- -->Only Imagen 3 models (named <code>imagen-3.0-*</code>) are supported. |
 |  [getLiveGenerativeModel(ai, modelParams)](./ai.md#getlivegenerativemodel_f2099ac) | <b><i>(Public Preview)</i></b> Returns a [LiveGenerativeModel](./ai.livegenerativemodel.md#livegenerativemodel_class) class for real-time, bidirectional communication.<!-- -->The Live API is only supported in modern browser windows and Node &gt;<!-- -->= 22. |
-|  <b>function(container, ...)</b> |
-|  [factory(container, { instanceIdentifier })](./ai.md#factory_6581aeb) |  |
 |  <b>function(liveSession, ...)</b> |
 |  [startAudioConversation(liveSession, options)](./ai.md#startaudioconversation_01c8e7f) | <b><i>(Public Preview)</i></b> Starts a real-time, bidirectional audio conversation with the model. This helper function manages the complexities of microphone access, audio recording, playback, and interruptions. |
 
@@ -326,27 +324,6 @@ export declare function getLiveGenerativeModel(ai: AI, modelParams: LiveModelPar
 #### Exceptions
 
 If the `apiKey` or `projectId` fields are missing in your Firebase config.
-
-## function(container, ...)
-
-### factory(container, { instanceIdentifier }) {:#factory_6581aeb}
-
-<b>Signature:</b>
-
-```typescript
-export declare function factory(container: ComponentContainer, { instanceIdentifier }: InstanceFactoryOptions): AIService;
-```
-
-#### Parameters
-
-|  Parameter | Type | Description |
-|  --- | --- | --- |
-|  container | ComponentContainer |  |
-|  { instanceIdentifier } | InstanceFactoryOptions |  |
-
-<b>Returns:</b>
-
-AIService
 
 ## function(liveSession, ...)
 

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -43,7 +43,7 @@ declare global {
   }
 }
 
-export function factory(
+function factory(
   container: ComponentContainer,
   { instanceIdentifier }: InstanceFactoryOptions
 ): AIService {


### PR DESCRIPTION
Bug introduced by https://github.com/firebase/firebase-js-sdk/pull/9201

Accidentally exported `factory` causing it to also export `AIService` and expose some references to internal-only typings, which breaks a strict typescript compile.

Fixes https://github.com/firebase/firebase-js-sdk/issues/9231