### PR TITLE
fix(ai): Fix test script broken by #9232

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -35,7 +35,7 @@
     "dev": "rollup -c -w",
     "update-responses": "../../scripts/update_vertexai_responses.sh",
     "testsetup": "yarn update-responses && yarn ts-node ./test-utils/convert-mocks.ts",
-    "test": "run-p --npm-path npm lint test:browser",
+    "test": "run-p --npm-path npm lint type-check test:browser",
     "test:ci": "yarn testsetup && node ../../scripts/run_tests_in_ci.js -s test",
     "test:skip-clone": "karma start",
     "test:browser": "yarn testsetup && karma start",
@@ -44,6 +44,7 @@
     "test:integration:node": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha integration/**/*.test.ts --config ../../config/mocharc.node.js",
     "api-report": "api-extractor run --local --verbose",
     "typings:public": "node ../../scripts/build/use_typings.js ./dist/ai-public.d.ts",
+    "type-check": "yarn tsc --noEmit",
     "trusted-type-check": "tsec -p tsconfig.json --noEmit"
   },
   "peerDependencies": {

--- a/packages/ai/src/factory-browser.ts
+++ b/packages/ai/src/factory-browser.ts
@@ -1,0 +1,34 @@
+
+import { ComponentContainer, InstanceFactoryOptions } from "@firebase/component";
+import { AIError } from "./errors";
+import { decodeInstanceIdentifier } from "./helpers";
+import { chromeAdapterFactory } from "./methods/chrome-adapter";
+import { AIService } from "./service";
+import { AIErrorCode } from "./types";
+
+export function factory(
+  container: ComponentContainer,
+  { instanceIdentifier }: InstanceFactoryOptions
+): AIService {
+  if (!instanceIdentifier) {
+    throw new AIError(
+      AIErrorCode.ERROR,
+      'AIService instance identifier is undefined.'
+    );
+  }
+
+  const backend = decodeInstanceIdentifier(instanceIdentifier);
+
+  // getImmediate for FirebaseApp will always succeed
+  const app = container.getProvider('app').getImmediate();
+  const auth = container.getProvider('auth-internal');
+  const appCheckProvider = container.getProvider('app-check-internal');
+
+  return new AIService(
+    app,
+    backend,
+    auth,
+    appCheckProvider,
+    chromeAdapterFactory
+  );
+}

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -22,52 +22,16 @@
  */
 
 import { registerVersion, _registerComponent } from '@firebase/app';
-import { AIService } from './service';
 import { AI_TYPE } from './constants';
-import {
-  Component,
-  ComponentContainer,
-  ComponentType,
-  InstanceFactoryOptions
-} from '@firebase/component';
+import { Component, ComponentType } from '@firebase/component';
 import { name, version } from '../package.json';
-import { decodeInstanceIdentifier } from './helpers';
-import { AIError } from './api';
-import { AIErrorCode } from './types';
-import { chromeAdapterFactory } from './methods/chrome-adapter';
 import { LanguageModel } from './types/language-model';
+import { factory } from './factory-browser';
 
 declare global {
   interface Window {
     LanguageModel: LanguageModel;
   }
-}
-
-function factory(
-  container: ComponentContainer,
-  { instanceIdentifier }: InstanceFactoryOptions
-): AIService {
-  if (!instanceIdentifier) {
-    throw new AIError(
-      AIErrorCode.ERROR,
-      'AIService instance identifier is undefined.'
-    );
-  }
-
-  const backend = decodeInstanceIdentifier(instanceIdentifier);
-
-  // getImmediate for FirebaseApp will always succeed
-  const app = container.getProvider('app').getImmediate();
-  const auth = container.getProvider('auth-internal');
-  const appCheckProvider = container.getProvider('app-check-internal');
-
-  return new AIService(
-    app,
-    backend,
-    auth,
-    appCheckProvider,
-    chromeAdapterFactory
-  );
 }
 
 function registerAI(): void {

--- a/packages/ai/test-utils/get-fake-firebase-services.ts
+++ b/packages/ai/test-utils/get-fake-firebase-services.ts
@@ -24,7 +24,7 @@ import {
 import { Component, ComponentType } from '@firebase/component';
 import { FirebaseAppCheckInternal } from '@firebase/app-check-interop-types';
 import { AI_TYPE } from '../src/constants';
-import { factory } from '../src';
+import { factory } from '../src/factory-browser';
 
 const fakeConfig = {
   projectId: 'projectId',
@@ -38,7 +38,11 @@ export function getFullApp(fakeAppParams?: {
   appId?: string;
   apiKey?: string;
 }): FirebaseApp {
-  _registerComponent(new Component(AI_TYPE, factory, ComponentType.PUBLIC));
+  _registerComponent(
+    new Component(AI_TYPE, factory, ComponentType.PUBLIC).setMultipleInstances(
+      true
+    )
+  );
   _registerComponent(
     new Component(
       'app-check-internal',


### PR DESCRIPTION
In the emergency fix for https://github.com/firebase/firebase-js-sdk/pull/9232, overlooked that the `factory` export was being used by a test utility. Refactored so that the test utility can use it without exporting it in the public API.

Also added a tsc type check to the tests, that would have caught this.