### PR TITLE
Wire up app check provider to telemetry service

### DIFF
--- a/packages/telemetry/src/register.node.ts
+++ b/packages/telemetry/src/register.node.ts
@@ -30,8 +30,9 @@ export function registerTelemetry(): void {
         // getImmediate for FirebaseApp will always succeed
         const app = container.getProvider('app').getImmediate();
         const loggerProvider = createLoggerProvider();
+        const appCheckProvider = container.getProvider('app-check-internal');
 
-        return new TelemetryService(app, loggerProvider);
+        return new TelemetryService(app, loggerProvider, appCheckProvider);
       },
       ComponentType.PUBLIC
     )

--- a/packages/telemetry/src/register.ts
+++ b/packages/telemetry/src/register.ts
@@ -30,8 +30,9 @@ export function registerTelemetry(): void {
         // getImmediate for FirebaseApp will always succeed
         const app = container.getProvider('app').getImmediate();
         const loggerProvider = createLoggerProvider();
+        const appCheckProvider = container.getProvider('app-check-internal');
 
-        return new TelemetryService(app, loggerProvider);
+        return new TelemetryService(app, loggerProvider, appCheckProvider);
       },
       ComponentType.PUBLIC
     )

--- a/packages/telemetry/src/service.ts
+++ b/packages/telemetry/src/service.ts
@@ -18,9 +18,23 @@
 import { _FirebaseService, FirebaseApp } from '@firebase/app';
 import { Telemetry } from './public-types';
 import { LoggerProvider } from '@opentelemetry/sdk-logs';
+import { Provider } from '@firebase/component';
+import {
+  AppCheckInternalComponentName,
+  FirebaseAppCheckInternal
+} from '@firebase/app-check-interop-types';
 
 export class TelemetryService implements Telemetry, _FirebaseService {
-  constructor(public app: FirebaseApp, public loggerProvider: LoggerProvider) {}
+  appCheck: FirebaseAppCheckInternal | null;
+
+  constructor(
+    public app: FirebaseApp,
+    public loggerProvider: LoggerProvider,
+    appCheckProvider?: Provider<AppCheckInternalComponentName>
+  ) {
+    const appCheck = appCheckProvider?.getImmediate({ optional: true });
+    this.appCheck = appCheck || null;
+  }
 
   _delete(): Promise<void> {
     return Promise.resolve();


### PR DESCRIPTION
Next PR will use the token from the app check provider to pass along as a header.