### PR TITLE
Update closure-net dependency to the latest release

### DIFF
--- a/packages/webchannel-wrapper/package.json
+++ b/packages/webchannel-wrapper/package.json
@@ -31,7 +31,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "closure-net": "git+https://github.com/google/closure-net.git#0412666",
+    "closure-net": "git+https://github.com/google/closure-net.git#6f48f578d3e80fe7a85e530a5d95b9351433d135",
     "@rollup/plugin-commonjs": "21.1.0",
     "rollup": "2.79.2",
     "rollup-plugin-copy": "3.5.0",


### PR DESCRIPTION
This release of closure includes two fixes:

1. Increased the buffering-proxy detection timeout to minimize the false-positive rate
2. Updating WebChannel to ignore duplicate messages received from the server.