### PR TITLE
Expose setUserProperties from internal analytics instance

### DIFF
--- a/.changeset/young-timers-jump.md
+++ b/.changeset/young-timers-jump.md
@@ -1,0 +1,6 @@
+---
+'@firebase/analytics-interop-types': patch
+'@firebase/analytics': patch
+---
+
+Expose `setUserProperties` on internal Analytics instance.

--- a/packages/analytics-interop-types/index.d.ts
+++ b/packages/analytics-interop-types/index.d.ts
@@ -31,7 +31,7 @@ export interface FirebaseAnalyticsInternal {
   ): void;
   setUserProperties: (
     properties: { [key: string]: unknown },
-    options: AnalyticsCallOptions
+    options?: AnalyticsCallOptions
   ) => void;
 }
 

--- a/packages/analytics-interop-types/index.d.ts
+++ b/packages/analytics-interop-types/index.d.ts
@@ -29,6 +29,10 @@ export interface FirebaseAnalyticsInternal {
     eventParams?: { [key: string]: unknown },
     options?: AnalyticsCallOptions
   ): void;
+  setUserProperties: (
+    properties: { [key: string]: unknown },
+    options: AnalyticsCallOptions
+  ) => void;
 }
 
 export interface AnalyticsCallOptions {

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -82,7 +82,7 @@ function registerAnalytics(): void {
         ) => logEvent(analytics, eventName, eventParams, options),
         setUserProperties: (
           properties: CustomParams,
-          options: AnalyticsCallOptions
+          options?: AnalyticsCallOptions
         ) => setUserProperties(analytics, properties, options)
       };
     } catch (e) {

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -33,9 +33,9 @@ import {
   InstanceFactoryOptions
 } from '@firebase/component';
 import { ERROR_FACTORY, AnalyticsError } from './errors';
-import { logEvent } from './api';
+import { logEvent, setUserProperties } from './api';
 import { name, version } from '../package.json';
-import { AnalyticsCallOptions } from './public-types';
+import { AnalyticsCallOptions, CustomParams } from './public-types';
 import '@firebase/installations';
 
 declare global {
@@ -79,7 +79,11 @@ function registerAnalytics(): void {
           eventName: string,
           eventParams?: { [key: string]: unknown },
           options?: AnalyticsCallOptions
-        ) => logEvent(analytics, eventName, eventParams, options)
+        ) => logEvent(analytics, eventName, eventParams, options),
+        setUserProperties: (
+          properties: CustomParams,
+          options: AnalyticsCallOptions
+        ) => setUserProperties(analytics, properties, options)
       };
     } catch (e) {
       throw ERROR_FACTORY.create(AnalyticsError.INTEROP_COMPONENT_REG_FAILED, {

--- a/packages/messaging/src/testing/fakes/firebase-dependencies.ts
+++ b/packages/messaging/src/testing/fakes/firebase-dependencies.ts
@@ -68,7 +68,8 @@ export function getFakeInstallations(): _FirebaseInstallationsInternal {
 
 export function getFakeAnalyticsProvider(): Provider<FirebaseAnalyticsInternalName> {
   const analytics: FirebaseAnalyticsInternal = {
-    logEvent() {}
+    logEvent() {},
+    setUserProperties() {}
   };
 
   return {


### PR DESCRIPTION
This allows other Firebase product packages to call the Analytics method `setUserProperties()` internally in the same way they can currently call `logEvent()`. This will be needed for an upcoming Remote Config feature.

Tested this by temporarily adding some code to messaging (the only other product SDK that currently depends on the internal analytics instance) so that it calls `setUserProperties()` (then removing it after the test). This succeeded.

Edit: No changeset for messaging because it's only a test change.