### PR TITLE
test(e2e): upgrade model from `gemini-1.5-flash` to `gemini-2.5-flash`

### DIFF
--- a/e2e/smoke-tests/sample-apps/modular.js
+++ b/e2e/smoke-tests/sample-apps/modular.js
@@ -313,7 +313,7 @@ function callPerformance(app) {
 async function callAI(app) {
   console.log('[AI] start');
   const ai = getAI(app, { backend: new VertexAIBackend() });
-  const model = getGenerativeModel(ai, { model: 'gemini-1.5-flash' });
+  const model = getGenerativeModel(ai, { model: 'gemini-2.5-flash' });
   const result = await model.countTokens('abcdefg');
   console.log(`[AI] counted tokens: ${result.totalTokens}`);
 }

--- a/e2e/smoke-tests/tests/modular.test.ts
+++ b/e2e/smoke-tests/tests/modular.test.ts
@@ -314,8 +314,8 @@ describe('MODULAR', () => {
       ai = getAI(app, { backend: new VertexAIBackend() });
     });
     it('getGenerativeModel() and countTokens()', async () => {
-      const model = getGenerativeModel(ai, { model: 'gemini-1.5-flash' });
-      expect(model.model).toMatch(/gemini-1.5-flash$/);
+      const model = getGenerativeModel(ai, { model: 'gemini-2.5-flash' });
+      expect(model.model).toMatch(/gemini-2.5-flash$/);
       const result = await model.countTokens('abcdefg');
       expect(result.totalTokens).toBeTruthy;
     });


### PR DESCRIPTION
Upgrade the model from `gemini-1.5-flash` to `gemini-2.5-flash`, since 1.5-flash is deprecated, and causes the e2e tests to fail.