### PR TITLE
test: update AI model name used for e2e tests

### DIFF
--- a/e2e/smoke-tests/sample-apps/modular.js
+++ b/e2e/smoke-tests/sample-apps/modular.js
@@ -313,7 +313,7 @@ function callPerformance(app) {
 async function callAI(app) {
   console.log('[AI] start');
   const ai = getAI(app, { backend: new VertexAIBackend() });
-  const model = getGenerativeModel(ai, { model: 'gemini-1.5-flash' });
+  const model = getGenerativeModel(ai, { model: 'gemini-2.5-flash' });
   const result = await model.countTokens('abcdefg');
   console.log(`[AI] counted tokens: ${result.totalTokens}`);
 }

--- a/e2e/smoke-tests/tests/modular.test.ts
+++ b/e2e/smoke-tests/tests/modular.test.ts
@@ -314,8 +314,8 @@ describe('MODULAR', () => {
       ai = getAI(app, { backend: new VertexAIBackend() });
     });
     it('getGenerativeModel() and countTokens()', async () => {
-      const model = getGenerativeModel(ai, { model: 'gemini-1.5-flash' });
-      expect(model.model).toMatch(/gemini-1.5-flash$/);
+      const model = getGenerativeModel(ai, { model: 'gemini-2.5-flash' });
+      expect(model.model).toMatch(/gemini-2.5-flash$/);
       const result = await model.countTokens('abcdefg');
       expect(result.totalTokens).toBeTruthy;
     });


### PR DESCRIPTION
gemini-1.5-flash has been retired:
https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions#expandable-1