### PR TITLE
fix(auth): export MISSING_PASSWORD in AuthErrorCodes

### DIFF
--- a/packages/auth/src/core/errors.ts
+++ b/packages/auth/src/core/errors.ts
@@ -603,5 +603,6 @@ export const AUTH_ERROR_CODES_MAP_DO_NOT_USE_INTERNALLY = {
   MISSING_RECAPTCHA_VERSION: 'auth/missing-recaptcha-version',
   INVALID_RECAPTCHA_VERSION: 'auth/invalid-recaptcha-version',
   INVALID_REQ_TYPE: 'auth/invalid-req-type',
-  INVALID_HOSTING_LINK_DOMAIN: 'auth/invalid-hosting-link-domain'
+  INVALID_HOSTING_LINK_DOMAIN: 'auth/invalid-hosting-link-domain',
+  MISSING_PASSWORD: 'auth/missing-password'
 } as const;

--- a/packages/auth/test/node/unit/auth_error_codes.test.ts
+++ b/packages/auth/test/node/unit/auth_error_codes.test.ts
@@ -1,0 +1,8 @@
+import { expect } from 'chai';
+import { AuthErrorCodes } from '../../../src';
+
+describe('AuthErrorCodes', () => {
+  it('exports MISSING_PASSWORD', () => {
+    expect(AuthErrorCodes.MISSING_PASSWORD).to.equal('auth/missing-password');
+  });
+});

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": ["mocha", "chai"],
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true
   },
   "exclude": ["dist/**/*", "demo/**/*"]
 }


### PR DESCRIPTION
**Summary**
Export `MISSING_PASSWORD: 'auth/missing-password'` via `AuthErrorCodes` in @firebase/auth.

**Why**
The SDK can throw `auth/missing-password`, but it wasn’t exposed via `AuthErrorCodes`, forcing developers to hardcode the string.

**Tests**
Adds a Node unit test asserting:
`AuthErrorCodes.MISSING_PASSWORD === 'auth/missing-password'`.

**Fixes**
Fixes #9270 

**CLA**
I have signed the Google Contributor License Agreement.
