### PR TITLE
Remove firebaseToken from persistence if tokenRefreshHandler is not s…

### DIFF
--- a/packages/auth/src/core/auth/auth_impl.test.ts
+++ b/packages/auth/src/core/auth/auth_impl.test.ts
@@ -367,6 +367,9 @@ describe('core/auth/auth_impl', () => {
       const token = await auth.getFirebaseAccessToken();
       expect(token).to.be.null;
       expect(exchangeTokenStub).not.to.have.been.called;
+      expect(persistenceStub._remove).to.have.been.calledWith(
+        'firebase:persistence-token:api-key:test-app'
+      );
     });
 
     it('should refresh the token if token is expiring in next 1 minute and a token refresh handler is set', async () => {
@@ -441,6 +444,9 @@ describe('core/auth/auth_impl', () => {
       expect(consoleErrorStub).to.have.been.calledWith(
         'Token refresh failed:',
         sinon.match.instanceOf(Error)
+      );
+      expect(persistenceStub._remove).to.have.been.calledWith(
+        'firebase:persistence-token:api-key:test-app'
       );
     });
 

--- a/packages/auth/src/core/auth/auth_impl.ts
+++ b/packages/auth/src/core/auth/auth_impl.ts
@@ -266,9 +266,9 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
       return firebaseAccessToken.token;
     }
 
+    // Resets the Firebase Access Token to null i.e. logs out the user.
+    await this._updateFirebaseToken(null);
     if (firebaseAccessToken && this.tokenRefreshHandler) {
-      // Resets the Firebase Access Token to null i.e. logs out the user.
-      await this._updateFirebaseToken(null);
       try {
         // Awaits for the callback method to execute. The callback method
         // is responsible for performing the exchangeToken(auth, valid3pIdpToken)


### PR DESCRIPTION
Remove firebaseToken from persistence if tokenRefreshHandler is not set and token is expired

### Testing

  * Added Unit test.

