### PR TITLE
Feat/live structured output

### DIFF
--- a/.changeset/live-structured-output.md
+++ b/.changeset/live-structured-output.md
@@ -1,0 +1,10 @@
+---
+"@firebase/ai": minor
+"firebase": minor
+---
+
+feat(ai): add structured output support to Live API via LiveGenerationConfig
+
+- Add `responseMimeType` and `responseSchema` to `LiveGenerationConfig` so Live sessions can request structured output (e.g., `application/json` or `text/x.enum`).
+- Mirrors non-live `GenerationConfig` behavior and forwards config through the WebSocket setup message.
+- Includes unit test to validate that structured output fields are present in the Live setup payload.

--- a/packages/ai/src/types/requests.ts
+++ b/packages/ai/src/types/requests.ts
@@ -184,6 +184,21 @@ export interface LiveGenerationConfig {
    * The modalities of the response.
    */
   responseModalities?: ResponseModality[];
+  /**
+   * Output response MIME type of the generated text when using live generation.
+   * Supported MIME types include `text/plain` (default), `application/json` (JSON response),
+   * and `text/x.enum`.
+   */
+  responseMimeType?: string;
+  /**
+   * Output response schema used to constrain the live model's response when a schema-capable
+   * MIME type is selected. This can be a class generated with a {@link Schema} static method
+   * like `Schema.string()` or `Schema.object()` or it can be a plain object matching
+   * {@link SchemaRequest}.
+   * <br/>Note: This only applies when the specified `responseMimeType` supports a schema; currently
+   * this is limited to `application/json` and `text/x.enum`.
+   */
+  responseSchema?: TypedSchema | SchemaRequest;
 }
 
 /**


### PR DESCRIPTION
•  Summary
◦  Adds responseMimeType and responseSchema to LiveGenerationConfig to enable structured output during Live sessions (parity with non-live GenerationConfig).
◦  The Live setup message forwards these fields to the backend. Additive, no breaking changes.
◦  This extends a Beta API surface.
•  Motivation
◦  The non-live API supports structured output; the Live/bidirectional API currently does not. This change enables structured output for Live sessions so clients can reliably parse responses (e.g., enums or JSON).
◦  Closes #9295.
•  Implementation
◦  types/requests.ts: Extend LiveGenerationConfig with responseMimeType and responseSchema (TypedSchema | SchemaRequest).
◦  live-generative-model: Setup message already passes generationConfig through; no additional plumbing required.
◦  Tests: Added a unit test ensuring the setup message includes the new fields and schema serialization.
•  Testing
◦  Added test in packages/ai/src/models/live-generative-model.test.ts verifying setup payload contains responseMimeType and responseSchema.
◦  Existing tests unaffected. CI will run full test suite.
•  Docs and formatting
◦  If Formatting Check fails in CI, I will run yarn format and push an update.
◦  If Doc Change Check fails, I will run yarn && yarn docgen:all and commit the generated docs.
◦  Changeset included (minor for @firebase/ai and firebase).
•  Release notes
◦  LiveGenerationConfig: add responseMimeType and responseSchema to request structured output in Live sessions.