### PR TITLE
ci(ai): Only run mock responses check on AI PRs

### DIFF
--- a/.github/workflows/check-vertexai-responses.yml
+++ b/.github/workflows/check-vertexai-responses.yml
@@ -14,7 +14,10 @@
 
 name: Check Vertex AI Responses
 
-on: pull_request
+on: 
+  pull_request:
+    paths:
+      - 'packages/ai/**'
 
 jobs:
   check-version:


### PR DESCRIPTION
When the `check-version` job in the `.github/workflows/check-vertexai-responses.yml` workflow fails, the job comments a warning on all PRs, even if they are unrelated to Firebase AI Logic. This is distracting for SDK developers who have no control over the version of the Firebase AI mock responses. I think this job should only add a comment to PRs that make changes to `packages/ai`.