### PR TITLE
test(ai): do not run browser tests when debugging node tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
         "src/index.node.ts",
         "--timeout",
         "5000",
-        "src/**/*.test.ts"
+        "'src/**/!(*-browser)*.test.ts"
       ],
       "env": {
         "TS_NODE_COMPILER_OPTIONS": "{\"module\":\"commonjs\"}"


### PR DESCRIPTION
Follow-up to https://github.com/firebase/firebase-js-sdk/commit/6e0e303173c93646c07b9138c7bed8749b514e8f

The node tests should not run tests that have `browser` in the file name. We fixed the `test:node` script in `package.json`. This adds this to the VSCode debug config.