### PR TITLE
test(auth): Disable flaky totp tests

### DIFF
--- a/packages/auth/test/integration/flows/totp.test.ts
+++ b/packages/auth/test/integration/flows/totp.test.ts
@@ -52,7 +52,13 @@ let totpTimestamp: Date;
 let emulatorUrl: string | null;
 let mfaUser: MultiFactorUser | null;
 
-describe(' Integration tests: Mfa enrollment using totp', () => {
+/**
+ * TOTP tests disabled until they can be rewritten without requiring a
+ * permanent account.
+ */
+
+// eslint-disable-next-line no-restricted-properties
+describe.skip(' Integration tests: Mfa enrollment using totp', () => {
   beforeEach(async () => {
     emulatorUrl = getEmulatorUrl();
     if (!emulatorUrl) {
@@ -122,7 +128,8 @@ describe(' Integration tests: Mfa enrollment using totp', () => {
   });
 });
 
-describe('Integration tests: sign-in for mfa-enrolled users', () => {
+// eslint-disable-next-line no-restricted-properties
+describe.skip('Integration tests: sign-in for mfa-enrolled users', () => {
   beforeEach(async () => {
     emulatorUrl = getEmulatorUrl();
     mfaUser = null;


### PR DESCRIPTION
TOTP tests currently require a pre-created test user to exist in the JS SDK project, and for that account to be configured properly. Every so often, at unpredictable intervals, the test user account ends up stuck in a state that causes tests to fail, and this user needs to be manually deleted and recreated by an SDK team member.

Disabling these tests until an alternative method can be found to test TOTP that avoids this issue. Using `describe.skip` allows contributors to easily re-enable the tests locally in order to run them manually.