### PR TITLE
build(deps): update optional react-native-async-storage peerDependency to v2+

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -116,7 +116,7 @@
   },
   "peerDependencies": {
     "@firebase/app": "0.x",
-    "@react-native-async-storage/async-storage": "^1.18.1"
+    "@react-native-async-storage/async-storage": "^2.2.0"
   },
   "peerDependenciesMeta": {
     "@react-native-async-storage/async-storage": {


### PR DESCRIPTION
### Discussion

v1 of the react-native-async-storage package does not work with modern react-native, and projects that rely on firebase-js-sdk have difficulty overriding this peer dependency to the v2 series that works, because of unrelated issues with the npm package manager

The version I propose is the most recent stable version: 

- https://github.com/react-native-async-storage/async-storage/releases
- https://www.npmjs.com/package/@react-native-async-storage/async-storage?activeTab=versions

The related issue in react-native-firebase where it turns out the transitive from react-native-firebase through firebase-js-sdk to react-native-async-storage is downgraded to v1 by firebase-js-sdk:

- https://github.com/invertase/react-native-firebase/issues/8735
- Issue in this repo, closed before realizing it really was here: #9346

### Testing

  * react-native-firebase uses firebase-js-sdk to implement a "lite" mode for non-native platforms, and our tests pass while using the yarn package manager, which accepts our v2 dependency on react-native-async-storage, with no changes required in firebase-js-sdk to adapt to it, as far as we can tell

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help 
    us make Firebase APIs better, please propose your change in an issue so that we 
    can discuss it together.
