### PR TITLE
test(ai): run prompt templates integration tests against prod endpoint

### DIFF
--- a/packages/ai/integration/constants.ts
+++ b/packages/ai/integration/constants.ts
@@ -100,14 +100,15 @@ export const liveTestConfigs: readonly TestConfig[] = backends.flatMap(
  * do not define a model string.
  * These tests should only run once per backend, rather than once per backend *per model*.
  */
-export const promptTemplatesTestConfigs: readonly TestConfig[] = backends.flatMap(backend => {
-  const ai = getAI(app, { backend });
-  return {
-    ai,
-    model: '', // Unused by prompt templates tests
-    toString: () => formatConfigAsString({ ai, model: '' })
-  };
-});
+export const promptTemplatesTestConfigs: readonly TestConfig[] =
+  backends.flatMap(backend => {
+    const ai = getAI(app, { backend });
+    return {
+      ai,
+      model: '', // Unused by prompt templates tests
+      toString: () => formatConfigAsString({ ai, model: '' }).trim()
+    };
+  });
 
 export const TINY_IMG_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAAApJREFUCNdjYAAAAAIAAeIhvDMAAAAASUVORK5CYII=';

--- a/packages/ai/integration/prompt-templates.test.ts
+++ b/packages/ai/integration/prompt-templates.test.ts
@@ -31,7 +31,7 @@ const templateBackendSuffix = (
 describe('Prompt templates', function () {
   this.timeout(20_000);
   promptTemplatesTestConfigs.forEach(testConfig => {
-    describe(`${promptTemplatesTestConfigs.toString()}`, () => {
+    describe(`${testConfig.toString()}`, () => {
       describe('Generative Model', () => {
         it('successfully generates content', async () => {
           const model = getTemplateGenerativeModel(testConfig.ai);
@@ -53,7 +53,7 @@ describe('Prompt templates', function () {
             )}`,
             { animal: 'Rhino' }
           );
-          expect(images.length).to.equal(1); // We ask for two images in the prompt template
+          expect(images.length).to.equal(1); // The template is configured to generate one image.
         });
       });
     });


### PR DESCRIPTION
- Updates the prompt templates integration tests to use the default endpoint rather than the `STAGING_URL`.
The integration tests were originally written to run against staging. Now that this feature is in prod, we should test against the prod endpoint.
- Added a new set of test configs `promptTemplatesTestConfigs` which are used for the server prompt templates integration tests. These configs don't define a model, since those aren't defined in the client when using server prompt templates. The tests now run only once per endpoint (twice, for Google AI then Vertex AI), rather than once per endpoint *for each model* (Google AI gemini-2.0-flash, Google AI gemini-2.5-flash, ...).