### PR TITLE
test(ai): prompt for grep string in debug script

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -190,8 +190,8 @@
     {
       "id": "grepString",
       "type": "promptString",
-      "description": "Enter grep pattern (e.g., 'Google AI gemini-2.0-flash')",
-      "default": "Google AI gemini-2.0-flash"
+      "description": "Enter grep pattern (e.g., 'Google AI gemini-2.0-flash generateContent')",
+      "default": ""
     }
   ]
 }


### PR DESCRIPTION
Mocha lets us filter tests using the `--grep` command-line option. This is useful when debugging the AI integration tests, which run against a grid of backend x model. With this grid there may me multiple redundant test runs, and the tests may take >20 minutes.

With this new config, we can isolate the test we want to debug. Before running, VSCode will prompt us for a regex to use for grepping tests by name.
An example grep string would be
`Google AI gemini-2.0-flash generateContent: google search grounding`.

Without this, I've been manually editing the input test files to be the file with the test I'm running, then manually editing `integration/constants.ts` to remove the additional backends and model names.
