### PR TITLE
fix(firestore): use Firestore instead of FirebaseFirestore in error messages

### DIFF
--- a/packages/firestore/src/lite-api/reference.ts
+++ b/packages/firestore/src/lite-api/reference.ts
@@ -514,7 +514,7 @@ export function collection<AppModelType, DbModelType extends DocumentData>(
       throw new FirestoreError(
         Code.INVALID_ARGUMENT,
         'Expected first argument to collection() to be a CollectionReference, ' +
-          'a DocumentReference or FirebaseFirestore'
+          'a DocumentReference or Firestore'
       );
     }
     const absolutePath = parent._path.child(
@@ -652,7 +652,7 @@ export function doc<AppModelType, DbModelType extends DocumentData>(
       throw new FirestoreError(
         Code.INVALID_ARGUMENT,
         'Expected first argument to doc() to be a CollectionReference, ' +
-          'a DocumentReference or FirebaseFirestore'
+          'a DocumentReference or Firestore'
       );
     }
     const absolutePath = parent._path.child(

--- a/packages/firestore/test/lite/integration.test.ts
+++ b/packages/firestore/test/lite/integration.test.ts
@@ -289,7 +289,7 @@ describe('doc', () => {
         // @ts-expect-error
         doc({}, 'coll/doc')
       ).to.throw(
-        'Expected first argument to doc() to be a CollectionReference, a DocumentReference or FirebaseFirestore'
+        'Expected first argument to doc() to be a CollectionReference, a DocumentReference or Firestore'
       );
       expect(() => doc(db, 'coll')).to.throw(
         'Invalid document reference. Document references must have an even ' +
@@ -307,6 +307,30 @@ describe('doc', () => {
       );
     });
   });
+  it('validates collection path', () => {
+  return withTestDb(db => {
+    expect(() =>
+      // @ts-expect-error
+      collection({}, 'coll')
+    ).to.throw(
+      'Expected first argument to collection() to be a CollectionReference, a DocumentReference or Firestore'
+    );
+
+    expect(() => collection(db, '')).to.throw(
+      'Function collection() cannot be called with an empty path.'
+    );
+
+    expect(() => collection(db, 'coll/doc')).to.throw(
+      'Invalid collection reference. Collection references must have an odd ' +
+        'number of segments, but coll/doc has 2.'
+    );
+
+    expect(() => collection(db, 'coll//doc')).to.throw(
+      'Invalid segment (coll//doc). Paths must not contain // in them.'
+    );
+  });
+});
+
 
   it('supports AutoId', () => {
     return withTestDb(db => {


### PR DESCRIPTION
This PR updates Firestore lite API error messages to use the v9 modular API
type name `Firestore` instead of the legacy v8 name `FirebaseFirestore`.

No behavior changes; string-only fix for consistency and clarity.

Fixes #9434
