### PR TITLE
fix(storage): correct UploadTask Example 3 docs

### DIFF
--- a/packages/storage/src/public-types.ts
+++ b/packages/storage/src/public-types.ts
@@ -352,15 +352,6 @@ export interface UploadTask {
    *       // Stop after receiving one update.
    *       unsubscribe();
    *     });
-   *
-   * // This code is equivalent to the above.
-   * var handle = uploadTask.on(firebase.storage.TaskEvent.STATE_CHANGED);
-   * unsubscribe = handle(function(snapshot) {
-   *   var percent = snapshot.bytesTransferred / snapshot.totalBytes * 100;
-   *   console.log(percent + "% done");
-   *   // Stop after receiving one update.
-   *   unsubscribe();
-   * });
    * ```
    *
    * @param event - The type of event to listen for.


### PR DESCRIPTION
Fixes #7859

## Summary
Removes the broken "handle" pattern from UploadTask Example 3 that was causing the error "undefined is not an object (evaluating 't.next')".

## Changes
- Removed the incorrect example code that attempted to use `uploadTask.on('state_changed')` as a subscribe function
- The implementation always returns `Unsubscribe` when callbacks are passed, not a `Subscribe` function
- Kept the working example that directly passes callbacks to `on()`

## Testing
- Verified the storage package builds successfully
- This is a documentation-only change (JSDoc comment), no code changes