### PR TITLE
fix(ai): correct typo 'seperate' to 'separate' in imagen internal types

### DIFF
--- a/packages/ai/src/types/imagen/internal.ts
+++ b/packages/ai/src/types/imagen/internal.ts
@@ -76,7 +76,7 @@ export interface ImagenResponseInternal {
  * The parameters to be sent in the request body of the HTTP call
  * to the Vertex AI backend.
  *
- * We need a seperate internal-only interface for this because the REST
+ * We need a separate internal-only interface for this because the REST
  * API expects different parameter names than what we show to our users.
  *
  * Sample request body JSON:


### PR DESCRIPTION
Fixes #9437.

- Fixed spelling error in comment at line 79
- Changed 'seperate' to 'separate' in packages/ai/src/types/imagen/internal.ts

### Discussion

See Issue #9437.

### Testing

CI.

### API Changes

N/A