### PR TITLE
fix(ai): preserve first urlContextMetadata and ignore duplicates

### DIFF
--- a/packages/ai/src/requests/stream-reader.test.ts
+++ b/packages/ai/src/requests/stream-reader.test.ts
@@ -529,4 +529,60 @@ describe('aggregateResponses', () => {
       );
     }
   });
+  it('preserves first urlContextMetadata and ignores duplicates', () => {
+    const firstMetadata = {
+      urlMetadata: [
+        {
+          retrievedUrl: 'https://example.com',
+          urlRetrievalStatus: 'URL_RETRIEVAL_STATUS_SUCCESS'
+        }
+      ]
+    };
+    const secondMetadata = {
+      urlMetadata: [
+        {
+          retrievedUrl: 'https://different.com',
+          urlRetrievalStatus: 'URL_RETRIEVAL_STATUS_SUCCESS'
+        }
+      ]
+    };
+
+    const responsesToAggregate: GenerateContentResponse[] = [
+      {
+        candidates: [
+          {
+            index: 0,
+            content: {
+              role: 'user',
+              parts: [{ text: 'first chunk' }]
+            },
+            urlContextMetadata: firstMetadata as any
+          }
+        ]
+      },
+      {
+        candidates: [
+          {
+            index: 0,
+            content: {
+              role: 'user',
+              parts: [{ text: 'second chunk' }]
+            },
+            urlContextMetadata: secondMetadata as any
+          }
+        ]
+      }
+    ];
+
+    const response = aggregateResponses(responsesToAggregate);
+    
+    // Should preserve the first metadata
+    expect(response.candidates?.[0].urlContextMetadata).to.deep.equal(
+      firstMetadata
+    );
+    // Verify it's the first one, not the second
+    expect(
+      response.candidates?.[0].urlContextMetadata?.urlMetadata[0].retrievedUrl
+    ).to.equal('https://example.com');
+  });
 });

--- a/packages/ai/src/requests/stream-reader.ts
+++ b/packages/ai/src/requests/stream-reader.ts
@@ -218,9 +218,10 @@ export function aggregateResponses(
         // The urlContextMetadata object is defined in the first chunk of the response stream.
         // In all subsequent chunks, the urlContextMetadata object will be undefined. We need to
         // make sure that we don't overwrite the first value urlContextMetadata object with undefined.
-        // FIXME: What happens if we receive a second, valid urlContextMetadata object?
+        // We preserve the first valid urlContextMetadata and ignore any subsequent ones.
         const urlContextMetadata = candidate.urlContextMetadata as unknown;
         if (
+          !aggregatedResponse.candidates[i].urlContextMetadata &&
           typeof urlContextMetadata === 'object' &&
           urlContextMetadata !== null &&
           Object.keys(urlContextMetadata).length > 0


### PR DESCRIPTION
Fixes #9446

## Description
Fixed the handling of duplicate `urlContextMetadata` objects in the `aggregateResponses` function. The previous implementation would overwrite the first valid metadata if a second valid one was received, potentially causing data loss.

## Changes
- **Implementation:** Added condition to check if `urlContextMetadata` already exists before setting it (first-write-wins strategy)
- **Documentation:** Updated comment to explain the behavior and removed FIXME
- **Testing:** Added test case to verify duplicate metadata handling

### Code Changes
**File:** `packages/ai/src/requests/stream-reader.ts`
- Line 223: Added check `!aggregatedResponse.candidates[i].urlContextMetadata &&` 
- Line 221: Updated comment to explain first-write-wins behavior
- Removed FIXME comment

**File:** `packages/ai/src/requests/stream-reader.test.ts`
- Added test case: `'preserves first urlContextMetadata and ignores duplicates'`
- Verifies that first metadata is preserved
- Verifies that second metadata is ignored

## Behavior
**Before:**
- If two valid `urlContextMetadata` objects arrived, the second would overwrite the first (last-write-wins)

**After:**
- First valid `urlContextMetadata` is preserved
- Subsequent valid metadata objects are ignored (first-write-wins)
- Matches the documented expectation: "The urlContextMetadata object is defined in the first chunk"

## Testing
- Added unit test verifying duplicate handling
- Test creates two responses with different valid metadata
- Asserts that first metadata is preserved
- CI will run full test suite

## Type of Change
- [x] Bug fix (resolves FIXME)
- [x] Adds test coverage

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective
- [x] New and existing tests pass locally