### PR TITLE
test(firestore): Accept `grep` as an argument to `run_tests.ts`

### DIFF
--- a/packages/firestore/scripts/run-tests.ts
+++ b/packages/firestore/scripts/run-tests.ts
@@ -80,7 +80,6 @@ if (argv.databaseId) {
 }
 
 if (argv.grep) {
-  console.log('found grep argument. forwarding.');
   args.push('--grep', argv.grep);
 }
 


### PR DESCRIPTION
Added a `grep` flag to `run_tests.ts`.

We want to be able to filter tests when running `run_tests.ts`. Test filtering is done in Mocha using the `--grep` command line flag. Since `run_tests.ts` swallows all command line arguments and does not forward them all, we cannot pass additional flags.

This allows us to filter tests using regular expressions where we use `run_tests.ts`- specifically when testing Firestore Lite.

Example: `yarn test:lite:prod --grep "aggregateQuerySnapshotEqual"`