### PR TITLE
test(firestore): silence stack trace output from `run_tests.ts`

### DIFF
--- a/packages/firestore/scripts/run-tests.ts
+++ b/packages/firestore/scripts/run-tests.ts
@@ -95,11 +95,11 @@ const childProcess = spawnPromise.childProcess;
 spawnPromise.catch(error => {
   // When a test fails, there will be a non-zero error code. Simply exit this process,
   // and don't print a stack trace.
-  if (error.code) {
+  if (typeof error.code === 'number') {
     process.exit(error.code);
   } else {
-    // The error code will be undefined if it was a real crash (e.g., spawn failed to start),
-    // so print the entire stack trace for debugging.
+    // The error code will not be a number for a real crash (e.g., spawn
+    // failed to start), so print the entire stack trace for debugging.
     console.error(error);
     process.exit(1);
   }


### PR DESCRIPTION
When using `run_tests.ts` (e.g., when running Firestore Lite tests), a noisy stack trace is output when tests fail. A stack trace isn't necessary in this case.

This modifies the script to only output a stack trace for real crashes, not test failures.

Before:
```
$ RUN_ENTERPRISE_TESTS=true yarn test:lite:prod --databaseId=enterprise --grep "Regex"
yarn run v1.22.11
$ ts-node ./scripts/run-tests.ts --platform node_lite --main=lite/index.ts 'test/lite/**/*.test.ts' --databaseId=enterprise --grep Regex

  Firestore Pipelines
    function expressions
      ✔ testRegexContains (55ms)
      1) testRegexFind
      ✔ testRegexMatches (65ms)

  2 passing (6s)
  1 failing

  1) Firestore Pipelines
       function expressions
         testRegexFind:
     Function field() called with invalid data. Invalid field path (.oo.). Paths must not be empty, begin with '.', end with '.', or contain '..'

ChildProcessError: `/Users/dlarocque/workspace/firebase-js-sdk/node_modules/.bin/nyc --reporter lcovonly /Users/dlarocque/workspace/firebase-js-sdk/node_modules/.bin/mocha --require /Users/dlarocque/workspace/firebase-js-sdk/packages/firestore/babel-register.js --require lite/index.ts --config ../../config/mocharc.node.js --grep Regex test/lite/**/*.test.ts` failed with code 1
    at ChildProcess.<anonymous> (/Users/dlarocque/workspace/firebase-js-sdk/node_modules/child-process-promise/lib/index.js:132:23)
    at ChildProcess.emit (node:events:518:28)
    at ChildProcess.emit (node:domain:489:12)
    at maybeClose (node:internal/child_process:1104:16)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:304:5) {
  code: 1,
  childProcess: ChildProcess {
    _events: [Object: null prototype] {
      error: [Function (anonymous)],
      close: [Function (anonymous)]
    },
    _eventsCount: 2,
    _maxListeners: undefined,
    _closesNeeded: 1,
    _closesGot: 1,
    connected: false,
    signalCode: null,
    exitCode: 1,
    killed: false,
    spawnfile: '/Users/dlarocque/workspace/firebase-js-sdk/node_modules/.bin/nyc',
    _handle: null,
    spawnargs: [
      '/Users/dlarocque/workspace/firebase-js-sdk/node_modules/.bin/nyc',
      '--reporter',
      'lcovonly',
      '/Users/dlarocque/workspace/firebase-js-sdk/node_modules/.bin/mocha',
      '--require',
      '/Users/dlarocque/workspace/firebase-js-sdk/packages/firestore/babel-register.js',
      '--require',
      'lite/index.ts',
      '--config',
      '../../config/mocharc.node.js',
      '--grep',
      'Regex',
      'test/lite/**/*.test.ts'
    ],
    pid: 14458,
    stdin: null,
    stdout: null,
    stderr: null,
    stdio: [ null, null, null ],
    [Symbol(shapeMode)]: false,
    [Symbol(kCapture)]: false
  },
  stdout: undefined,
  stderr: undefined
}
error Command failed with exit code 1
```

After:
```
$ RUN_ENTERPRISE_TESTS=true yarn test:lite:prod --databaseId=enterprise --grep "Regex"
yarn run v1.22.11
$ ts-node ./scripts/run-tests.ts --platform node_lite --main=lite/index.ts 'test/lite/**/*.test.ts' --databaseId=enterprise --grep Regex

  Firestore Pipelines
    function expressions
      ✔ testRegexContains (73ms)
      1) testRegexFind
      ✔ testRegexMatches (54ms)

  2 passing (5s)
  1 failing

  1) Firestore Pipelines
       function expressions
         testRegexFind:
     Function field() called with invalid data. Invalid field path (.oo.). Paths must not be empty, begin with '.', end with '.', or contain '..'

error Command failed with exit code 1.
```