### PR TITLE
ci: Have renovate ignore typescript

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,8 @@
     "typedoc",
     "@microsoft/tsdoc",
     "idb",
-    "karma-webpack"
+    "karma-webpack",
+    "typescript"
   ],
   "ignorePaths": ["auth/demo", "auth/cordova/demo", "auth-compat/demo"],
   "assignees": ["@hsubox76"],


### PR DESCRIPTION
We want to handle Typescript upgrades manually, not automatically.