### PR TITLE
fix(ai): Add a warning when setting top-level params in hybrid mode

### DIFF
--- a/packages/ai/src/api.test.ts
+++ b/packages/ai/src/api.test.ts
@@ -167,6 +167,7 @@ describe('Top level API', () => {
     expect(genModel).to.be.an.instanceOf(GenerativeModel);
     expect(warnStub).to.be.calledWithMatch(InferenceMode.PREFER_ON_DEVICE);
     expect(warnStub).to.be.calledWithMatch('generationConfig');
+    warnStub.restore();
   });
   it('getImagenModel throws if no model is provided', () => {
     try {

--- a/packages/ai/src/api.ts
+++ b/packages/ai/src/api.ts
@@ -118,6 +118,12 @@ export function getAI(app: FirebaseApp = getApp(), options?: AIOptions): AI {
   return aiInstance;
 }
 
+const hybridParamKeys: Array<keyof HybridParams> = [
+  'mode',
+  'onDeviceParams',
+  'inCloudParams'
+];
+
 /**
  * Returns a {@link GenerativeModel} class with methods for inference
  * and other functionality.
@@ -133,12 +139,7 @@ export function getGenerativeModel(
   const hybridParams = modelParams as HybridParams;
   let inCloudParams: ModelParams;
   if (hybridParams.mode) {
-    const hybridParamKeys: Array<keyof HybridParams> = [
-      'mode',
-      'onDeviceParams',
-      'inCloudParams'
-    ];
-    for (const param in modelParams) {
+    for (const param of Object.keys(modelParams)) {
       if (!hybridParamKeys.includes(param as keyof HybridParams)) {
         logger.warn(
           `When a hybrid inference mode is specified (mode is currently set` +


### PR DESCRIPTION
When using hybrid mode, top level params will be ignored (see comments in code)

```
const model = getGenerativeModel(ai, {
  mode: InferenceMode.PREFER_ON_DEVICE,
  // this will be ignored
  generationConfig: {},
  // this will be used (when doing device inference)
  onDeviceParams: {
    createOptions: {
      expectedInputs: [{ type: "image" }],
    },
  },
  // this will be used (when doing cloud inference)
  inCloudParams: {
    model: "gemini-2.5-flash-lite",
    generationConfig: {
      maxOutputTokens: 3,
    },
  },
});
```

Adding a warning so developers are aware and will not be confused why those settings are doing nothing.