### PR TITLE
docs(auth): remove deprecated Google Sign-In reference

### DIFF
--- a/packages/auth/src/core/providers/google.ts
+++ b/packages/auth/src/core/providers/google.ts
@@ -82,7 +82,7 @@ export class GoogleAuthProvider extends BaseOAuthProvider {
    *
    * @example
    * ```javascript
-   * // \`googleUser\` from the onsuccess Google Sign In callback.
+   * // ID token obtained from Google Identity Services (GIS) sign-in flow.
    * const credential = GoogleAuthProvider.credential(googleUser.getAuthResponse().id_token);
    * const result = await signInWithCredential(credential);
    * ```


### PR DESCRIPTION
This PR removes a deprecated Google Sign-In reference from the GoogleAuthProvider documentation example.

The change updates outdated wording to avoid confusion with the deprecated Google Sign-In JavaScript platform library.

No functional code changes were made — documentation only.
