### PR TITLE
chore: Add a dependabot.yml to better configure its behavior

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,9 @@ updates:
       - "/e2e/*"
       - "/repo-scripts/**/*"
     exclude-paths:
-      - "/packages/auth/demo"
-      - "/packages/auth/cordova/demo"
-      - "/packages/auth-compat/demo"
+      - "packages/auth/demo"
+      - "packages/auth/cordova/demo"
+      - "packages/auth-compat/demo"
     schedule:
       interval: "daily"
 


### PR DESCRIPTION
See https://docs.github.com/en/code-security/concepts/supply-chain-security/about-the-dependabot-yml-file

This allows configuring dependabot beyond the Github defaults. I'm using this to exclude the auth demo packages as they aren't used in production and are cluttering up dependabot PRs. (We use both Renovate and Dependabot - we've already excluded these directories in the Renovate config.)