### PR TITLE
feat(ai): Add responseJsonSchema

### DIFF
--- a/.changeset/sharp-kiwis-push.md
+++ b/.changeset/sharp-kiwis-push.md
@@ -1,5 +1,6 @@
 ---
 '@firebase/ai': minor
+'firebase': minor
 ---
 
 Added `responseJsonSchema` to `GenerationConfig`.

--- a/.changeset/sharp-kiwis-push.md
+++ b/.changeset/sharp-kiwis-push.md
@@ -1,0 +1,5 @@
+---
+'@firebase/ai': minor
+---
+
+Added `responseJsonSchema` to `GenerationConfig`.

--- a/common/api-review/ai.api.md
+++ b/common/api-review/ai.api.md
@@ -520,6 +520,9 @@ export interface GenerationConfig {
     maxOutputTokens?: number;
     // (undocumented)
     presencePenalty?: number;
+    responseJsonSchema?: {
+        [key: string]: unknown;
+    };
     responseMimeType?: string;
     // @beta
     responseModalities?: ResponseModality[];

--- a/docs-devsite/ai.generationconfig.md
+++ b/docs-devsite/ai.generationconfig.md
@@ -26,6 +26,7 @@ export interface GenerationConfig
 |  [frequencyPenalty](./ai.generationconfig.md#generationconfigfrequencypenalty) | number |  |
 |  [maxOutputTokens](./ai.generationconfig.md#generationconfigmaxoutputtokens) | number |  |
 |  [presencePenalty](./ai.generationconfig.md#generationconfigpresencepenalty) | number |  |
+|  [responseJsonSchema](./ai.generationconfig.md#generationconfigresponsejsonschema) | { \[key: string\]: unknown; } | Output schema of the generated response. This is an alternative to <code>responseSchema</code> that accepts \[JSON Schema\](https://json-schema.org/).<!-- -->If set, <code>responseSchema</code> must be omitted, but <code>responseMimeType</code> is required and must be set to <code>application/json</code>. |
 |  [responseMimeType](./ai.generationconfig.md#generationconfigresponsemimetype) | string | Output response MIME type of the generated candidate text. Supported MIME types are <code>text/plain</code> (default, text output), <code>application/json</code> (JSON response in the candidates), and <code>text/x.enum</code>. |
 |  [responseModalities](./ai.generationconfig.md#generationconfigresponsemodalities) | [ResponseModality](./ai.md#responsemodality)<!-- -->\[\] | <b><i>(Public Preview)</i></b> Generation modalities to be returned in generation responses. |
 |  [responseSchema](./ai.generationconfig.md#generationconfigresponseschema) | [TypedSchema](./ai.md#typedschema) \| [SchemaRequest](./ai.schemarequest.md#schemarequest_interface) | Output response schema of the generated candidate text. This value can be a class generated with a [Schema](./ai.schema.md#schema_class) static method like <code>Schema.string()</code> or <code>Schema.object()</code> or it can be a plain JS object matching the [SchemaRequest](./ai.schemarequest.md#schemarequest_interface) interface. <br/>Note: This only applies when the specified <code>responseMimeType</code> supports a schema; currently this is limited to <code>application/json</code> and <code>text/x.enum</code>. |
@@ -65,6 +66,20 @@ maxOutputTokens?: number;
 
 ```typescript
 presencePenalty?: number;
+```
+
+## GenerationConfig.responseJsonSchema
+
+Output schema of the generated response. This is an alternative to `responseSchema` that accepts \[JSON Schema\](https://json-schema.org/).
+
+If set, `responseSchema` must be omitted, but `responseMimeType` is required and must be set to `application/json`<!-- -->.
+
+<b>Signature:</b>
+
+```typescript
+responseJsonSchema?: {
+        [key: string]: unknown;
+    };
 ```
 
 ## GenerationConfig.responseMimeType

--- a/packages/ai/src/models/generative-model.ts
+++ b/packages/ai/src/models/generative-model.ts
@@ -201,4 +201,14 @@ function validateGenerationConfig(generationConfig: GenerationConfig): void {
       `Cannot set both thinkingBudget and thinkingLevel in a config.`
     );
   }
+  if (
+    // != allows for null and undefined.
+    generationConfig.responseSchema != null &&
+    generationConfig.responseJsonSchema != null
+  ) {
+    throw new AIError(
+      AIErrorCode.UNSUPPORTED,
+      `Cannot set both responseSchema and responseJsonSchema in a config.`
+    );
+  }
 }

--- a/packages/ai/src/models/generative-model.ts
+++ b/packages/ai/src/models/generative-model.ts
@@ -211,4 +211,14 @@ function validateGenerationConfig(generationConfig: GenerationConfig): void {
       `Cannot set both responseSchema and responseJsonSchema in a config.`
     );
   }
+  if (
+    (generationConfig.responseSchema != null ||
+      generationConfig.responseJsonSchema != null) &&
+    generationConfig.responseMimeType
+  ) {
+    throw new AIError(
+      AIErrorCode.UNSUPPORTED,
+      `responseMimeType must be set if responseSchema or responseJsonSchema are set.`
+    );
+  }
 }

--- a/packages/ai/src/types/requests.ts
+++ b/packages/ai/src/types/requests.ts
@@ -121,6 +121,14 @@ export interface GenerationConfig {
    */
   responseSchema?: TypedSchema | SchemaRequest;
   /**
+   * Output schema of the generated response. This is an alternative to
+   * `responseSchema` that accepts [JSON Schema](https://json-schema.org/).
+   *
+   * If set, `responseSchema` must be omitted, but `responseMimeType`
+   * is required and must be set to `application/json`.
+   */
+  responseJsonSchema?: { [key: string]: unknown };
+  /**
    * Generation modalities to be returned in generation responses.
    *
    * @remarks


### PR DESCRIPTION
Adds `responseJsonSchema` field, which takes an object in JSON Schema format.

Gemini docs examples show how to use the zod library to easily generate this object (https://ai.google.dev/gemini-api/docs/structured-output?example=recipe), and we should follow this with an example of how to do the same, somewhere in the Firebase guides. Maybe this page? https://firebase.google.com/docs/ai-logic/generate-structured-output?api=dev

Tested manually with Developer API and Vertex and both work.

Doc changes: Added text for `responseJsonSchema` and used `@remarks` to remove bulk of text of both `responseSchema` and `responseJsonSchema` from table of contents (full text is still in the section below).

Fixes #9625