### PR TITLE
Add onRegistered and onUnregistered API

### DIFF
--- a/common/api-review/messaging-sw.api.md
+++ b/common/api-review/messaging-sw.api.md
@@ -62,6 +62,12 @@ export { Observer }
 // @public
 export function onBackgroundMessage(messaging: Messaging, nextOrObserver: NextFn<MessagePayload> | Observer<MessagePayload>): Unsubscribe;
 
+// @public
+export function onRegistered(messaging: Messaging, nextOrObserver: NextFn<string> | Observer<string>): Unsubscribe;
+
+// @public
+export function onUnregistered(messaging: Messaging, nextOrObserver: NextFn<string> | Observer<string>): Unsubscribe;
+
 export { Unsubscribe }
 
 

--- a/common/api-review/messaging.api.md
+++ b/common/api-review/messaging.api.md
@@ -65,6 +65,12 @@ export { Observer }
 // @public
 export function onMessage(messaging: Messaging, nextOrObserver: NextFn<MessagePayload> | Observer<MessagePayload>): Unsubscribe;
 
+// @public
+export function onRegistered(messaging: Messaging, nextOrObserver: NextFn<string> | Observer<string>): Unsubscribe;
+
+// @public
+export function onUnregistered(messaging: Messaging, nextOrObserver: NextFn<string> | Observer<string>): Unsubscribe;
+
 export { Unsubscribe }
 
 

--- a/docs-devsite/messaging_.md
+++ b/docs-devsite/messaging_.md
@@ -21,6 +21,8 @@ https://github.com/firebase/firebase-js-sdk
 |  [deleteToken(messaging)](./messaging_.md#deletetoken_3fae4b1) | Deletes the registration token associated with this [Messaging](./messaging_.messaging.md#messaging_interface) instance and unsubscribes the [Messaging](./messaging_.messaging.md#messaging_interface) instance from the push subscription. |
 |  [getToken(messaging, options)](./messaging_.md#gettoken_b538f38) | Subscribes the [Messaging](./messaging_.messaging.md#messaging_interface) instance to push notifications. Returns a Firebase Cloud Messaging registration token that can be used to send push messages to that [Messaging](./messaging_.messaging.md#messaging_interface) instance.<!-- -->If notification permission isn't already granted, this method asks the user for permission. The returned promise rejects if the user does not allow the app to show notifications. |
 |  [onMessage(messaging, nextOrObserver)](./messaging_.md#onmessage_b9887da) | When a push message is received and the user is currently on a page for your origin, the message is passed to the page and an <code>onMessage()</code> event is dispatched with the payload of the push message. |
+|  [onRegistered(messaging, nextOrObserver)](./messaging_.md#onregistered_f8a466e) | Subscribes to FID (Firebase Installation ID) registration events. The observer is invoked when an FID is delivered after an explicit register() call or automatic SDK refresh. Use this to upload the installationId to your application server upon receipt. |
+|  [onUnregistered(messaging, nextOrObserver)](./messaging_.md#onunregistered_f8a466e) | Subscribes to FID (Firebase Installation ID) unregistration events. The observer is dispatched after a successful unregister() call with the FID that is no longer active. Use this to notify your backend to remove this FID to prevent 404 errors on send. |
 |  <b>function()</b> |
 |  [isSupported()](./messaging_.md#issupported) | Checks if all required APIs exist in the browser. |
 
@@ -129,6 +131,52 @@ export declare function onMessage(messaging: Messaging, nextOrObserver: NextFn<M
 [Unsubscribe](./util.md#unsubscribe)
 
 To stop listening for messages execute this returned function.
+
+### onRegistered(messaging, nextOrObserver) {:#onregistered_f8a466e}
+
+Subscribes to FID (Firebase Installation ID) registration events. The observer is invoked when an FID is delivered after an explicit register() call or automatic SDK refresh. Use this to upload the installationId to your application server upon receipt.
+
+<b>Signature:</b>
+
+```typescript
+export declare function onRegistered(messaging: Messaging, nextOrObserver: NextFn<string> | Observer<string>): Unsubscribe;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  messaging | [Messaging](./messaging_.messaging.md#messaging_interface) | The [Messaging](./messaging_.messaging.md#messaging_interface) instance. |
+|  nextOrObserver | [NextFn](./util.md#nextfn)<!-- -->&lt;string&gt; \| [Observer](./util.observer.md#observer_interface)<!-- -->&lt;string&gt; | A function or observer object called when an FID is registered. |
+
+<b>Returns:</b>
+
+[Unsubscribe](./util.md#unsubscribe)
+
+Unsubscribe function to stop listening.
+
+### onUnregistered(messaging, nextOrObserver) {:#onunregistered_f8a466e}
+
+Subscribes to FID (Firebase Installation ID) unregistration events. The observer is dispatched after a successful unregister() call with the FID that is no longer active. Use this to notify your backend to remove this FID to prevent 404 errors on send.
+
+<b>Signature:</b>
+
+```typescript
+export declare function onUnregistered(messaging: Messaging, nextOrObserver: NextFn<string> | Observer<string>): Unsubscribe;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  messaging | [Messaging](./messaging_.messaging.md#messaging_interface) | The [Messaging](./messaging_.messaging.md#messaging_interface) instance. |
+|  nextOrObserver | [NextFn](./util.md#nextfn)<!-- -->&lt;string&gt; \| [Observer](./util.observer.md#observer_interface)<!-- -->&lt;string&gt; | A function or observer object called with the unregistered FID. |
+
+<b>Returns:</b>
+
+[Unsubscribe](./util.md#unsubscribe)
+
+Unsubscribe function to stop listening.
 
 ## function()
 

--- a/docs-devsite/messaging_.md
+++ b/docs-devsite/messaging_.md
@@ -21,8 +21,8 @@ https://github.com/firebase/firebase-js-sdk
 |  [deleteToken(messaging)](./messaging_.md#deletetoken_3fae4b1) | Deletes the registration token associated with this [Messaging](./messaging_.messaging.md#messaging_interface) instance and unsubscribes the [Messaging](./messaging_.messaging.md#messaging_interface) instance from the push subscription. |
 |  [getToken(messaging, options)](./messaging_.md#gettoken_b538f38) | Subscribes the [Messaging](./messaging_.messaging.md#messaging_interface) instance to push notifications. Returns a Firebase Cloud Messaging registration token that can be used to send push messages to that [Messaging](./messaging_.messaging.md#messaging_interface) instance.<!-- -->If notification permission isn't already granted, this method asks the user for permission. The returned promise rejects if the user does not allow the app to show notifications. |
 |  [onMessage(messaging, nextOrObserver)](./messaging_.md#onmessage_b9887da) | When a push message is received and the user is currently on a page for your origin, the message is passed to the page and an <code>onMessage()</code> event is dispatched with the payload of the push message. |
-|  [onRegistered(messaging, nextOrObserver)](./messaging_.md#onregistered_f8a466e) | Subscribes to FID (Firebase Installation ID) registration events. The observer is invoked when an FID is delivered after an explicit register() call or automatic SDK refresh. Use this to upload the installationId to your application server upon receipt. |
-|  [onUnregistered(messaging, nextOrObserver)](./messaging_.md#onunregistered_f8a466e) | Subscribes to FID (Firebase Installation ID) unregistration events. The observer is dispatched after a successful unregister() call with the FID that is no longer active. Use this to notify your backend to remove this FID to prevent 404 errors on send. |
+|  [onRegistered(messaging, nextOrObserver)](./messaging_.md#onregistered_f8a466e) | Subscribes to an event that the app instance is registered with FCM via FID. Use the FID passed to the callback to upload it to your application server. |
+|  [onUnregistered(messaging, nextOrObserver)](./messaging_.md#onunregistered_f8a466e) | Subscribes to an event that the app instance is unregistered from FCM (FID no longer active). Use this to notify your backend to remove this FID to prevent 404 errors on send. |
 |  <b>function()</b> |
 |  [isSupported()](./messaging_.md#issupported) | Checks if all required APIs exist in the browser. |
 
@@ -134,7 +134,7 @@ To stop listening for messages execute this returned function.
 
 ### onRegistered(messaging, nextOrObserver) {:#onregistered_f8a466e}
 
-Subscribes to FID (Firebase Installation ID) registration events. The observer is invoked when an FID is delivered after an explicit register() call or automatic SDK refresh. Use this to upload the installationId to your application server upon receipt.
+Subscribes to an event that the app instance is registered with FCM via FID. Use the FID passed to the callback to upload it to your application server.
 
 <b>Signature:</b>
 
@@ -157,7 +157,7 @@ Unsubscribe function to stop listening.
 
 ### onUnregistered(messaging, nextOrObserver) {:#onunregistered_f8a466e}
 
-Subscribes to FID (Firebase Installation ID) unregistration events. The observer is dispatched after a successful unregister() call with the FID that is no longer active. Use this to notify your backend to remove this FID to prevent 404 errors on send.
+Subscribes to an event that the app instance is unregistered from FCM (FID no longer active). Use this to notify your backend to remove this FID to prevent 404 errors on send.
 
 <b>Signature:</b>
 

--- a/docs-devsite/messaging_sw.md
+++ b/docs-devsite/messaging_sw.md
@@ -20,6 +20,8 @@ https://github.com/firebase/firebase-js-sdk
 |  <b>function(messaging, ...)</b> |
 |  [experimentalSetDeliveryMetricsExportedToBigQueryEnabled(messaging, enable)](./messaging_sw.md#experimentalsetdeliverymetricsexportedtobigqueryenabled_f3e53bd) | Enables or disables Firebase Cloud Messaging message delivery metrics export to BigQuery. By default, message delivery metrics are not exported to BigQuery. Use this method to enable or disable the export at runtime. |
 |  [onBackgroundMessage(messaging, nextOrObserver)](./messaging_sw.md#onbackgroundmessage_b9887da) | Called when a message is received while the app is in the background. An app is considered to be in the background if no active window is displayed. |
+|  [onRegistered(messaging, nextOrObserver)](./messaging_sw.md#onregistered_f8a466e) | Subscribes to FID (Firebase Installation ID) registration events. The observer is invoked when an FID is delivered after an explicit register() call or automatic SDK refresh. Use this to upload the installationId to your application server upon receipt. |
+|  [onUnregistered(messaging, nextOrObserver)](./messaging_sw.md#onunregistered_f8a466e) | Subscribes to FID (Firebase Installation ID) unregistration events. The observer is dispatched after a successful unregister() call with the FID that is no longer active. Use this to notify your backend to remove this FID to prevent 404 errors on send. |
 |  <b>function()</b> |
 |  [isSupported()](./messaging_sw.md#issupported) | Checks whether all required APIs exist within SW Context |
 
@@ -102,6 +104,52 @@ export declare function onBackgroundMessage(messaging: Messaging, nextOrObserver
 [Unsubscribe](./util.md#unsubscribe)
 
 To stop listening for messages execute this returned function
+
+### onRegistered(messaging, nextOrObserver) {:#onregistered_f8a466e}
+
+Subscribes to FID (Firebase Installation ID) registration events. The observer is invoked when an FID is delivered after an explicit register() call or automatic SDK refresh. Use this to upload the installationId to your application server upon receipt.
+
+<b>Signature:</b>
+
+```typescript
+export declare function onRegistered(messaging: Messaging, nextOrObserver: NextFn<string> | Observer<string>): Unsubscribe;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  messaging | [Messaging](./messaging_.messaging.md#messaging_interface) | The [Messaging](./messaging_.messaging.md#messaging_interface) instance. |
+|  nextOrObserver | [NextFn](./util.md#nextfn)<!-- -->&lt;string&gt; \| [Observer](./util.observer.md#observer_interface)<!-- -->&lt;string&gt; | A function or observer object called when an FID is registered. |
+
+<b>Returns:</b>
+
+[Unsubscribe](./util.md#unsubscribe)
+
+Unsubscribe function to stop listening.
+
+### onUnregistered(messaging, nextOrObserver) {:#onunregistered_f8a466e}
+
+Subscribes to FID (Firebase Installation ID) unregistration events. The observer is dispatched after a successful unregister() call with the FID that is no longer active. Use this to notify your backend to remove this FID to prevent 404 errors on send.
+
+<b>Signature:</b>
+
+```typescript
+export declare function onUnregistered(messaging: Messaging, nextOrObserver: NextFn<string> | Observer<string>): Unsubscribe;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  messaging | [Messaging](./messaging_.messaging.md#messaging_interface) | The [Messaging](./messaging_.messaging.md#messaging_interface) instance. |
+|  nextOrObserver | [NextFn](./util.md#nextfn)<!-- -->&lt;string&gt; \| [Observer](./util.observer.md#observer_interface)<!-- -->&lt;string&gt; | A function or observer object called with the unregistered FID. |
+
+<b>Returns:</b>
+
+[Unsubscribe](./util.md#unsubscribe)
+
+Unsubscribe function to stop listening.
 
 ## function()
 

--- a/docs-devsite/messaging_sw.md
+++ b/docs-devsite/messaging_sw.md
@@ -20,8 +20,8 @@ https://github.com/firebase/firebase-js-sdk
 |  <b>function(messaging, ...)</b> |
 |  [experimentalSetDeliveryMetricsExportedToBigQueryEnabled(messaging, enable)](./messaging_sw.md#experimentalsetdeliverymetricsexportedtobigqueryenabled_f3e53bd) | Enables or disables Firebase Cloud Messaging message delivery metrics export to BigQuery. By default, message delivery metrics are not exported to BigQuery. Use this method to enable or disable the export at runtime. |
 |  [onBackgroundMessage(messaging, nextOrObserver)](./messaging_sw.md#onbackgroundmessage_b9887da) | Called when a message is received while the app is in the background. An app is considered to be in the background if no active window is displayed. |
-|  [onRegistered(messaging, nextOrObserver)](./messaging_sw.md#onregistered_f8a466e) | Subscribes to FID (Firebase Installation ID) registration events. The observer is invoked when an FID is delivered after an explicit register() call or automatic SDK refresh. Use this to upload the installationId to your application server upon receipt. |
-|  [onUnregistered(messaging, nextOrObserver)](./messaging_sw.md#onunregistered_f8a466e) | Subscribes to FID (Firebase Installation ID) unregistration events. The observer is dispatched after a successful unregister() call with the FID that is no longer active. Use this to notify your backend to remove this FID to prevent 404 errors on send. |
+|  [onRegistered(messaging, nextOrObserver)](./messaging_sw.md#onregistered_f8a466e) | Subscribes to an event that the app instance is registered with FCM via FID. Use the FID passed to the callback to upload it to your application server. |
+|  [onUnregistered(messaging, nextOrObserver)](./messaging_sw.md#onunregistered_f8a466e) | Subscribes to an event that the app instance is unregistered from FCM (FID no longer active). Use this to notify your backend to remove this FID to prevent 404 errors on send. |
 |  <b>function()</b> |
 |  [isSupported()](./messaging_sw.md#issupported) | Checks whether all required APIs exist within SW Context |
 
@@ -107,7 +107,7 @@ To stop listening for messages execute this returned function
 
 ### onRegistered(messaging, nextOrObserver) {:#onregistered_f8a466e}
 
-Subscribes to FID (Firebase Installation ID) registration events. The observer is invoked when an FID is delivered after an explicit register() call or automatic SDK refresh. Use this to upload the installationId to your application server upon receipt.
+Subscribes to an event that the app instance is registered with FCM via FID. Use the FID passed to the callback to upload it to your application server.
 
 <b>Signature:</b>
 
@@ -130,7 +130,7 @@ Unsubscribe function to stop listening.
 
 ### onUnregistered(messaging, nextOrObserver) {:#onunregistered_f8a466e}
 
-Subscribes to FID (Firebase Installation ID) unregistration events. The observer is dispatched after a successful unregister() call with the FID that is no longer active. Use this to notify your backend to remove this FID to prevent 404 errors on send.
+Subscribes to an event that the app instance is unregistered from FCM (FID no longer active). Use this to notify your backend to remove this FID to prevent 404 errors on send.
 
 <b>Signature:</b>
 

--- a/packages/messaging/src/api.ts
+++ b/packages/messaging/src/api.ts
@@ -160,7 +160,7 @@ export function onMessage(
  * @param nextOrObserver - This function, or observer object with `next` defined, is called when a
  * message is received and the app is currently in the background.
  *
- * @returns To stop listening for messages execute this returned function
+ * @returns To stop listening for messages execute this returned function.
  *
  * @public
  */
@@ -173,9 +173,8 @@ export function onBackgroundMessage(
 }
 
 /**
- * Subscribes to FID (Firebase Installation ID) registration events. The observer is invoked
- * when an FID is delivered after an explicit register() call or automatic SDK refresh.
- * Use this to upload the installationId to your application server upon receipt.
+ * Subscribes to an event that the app instance is registered with FCM via Firebase Installation ID (FID).
+ * Use the FID passed to the callback to upload it to your application server.
  *
  * @param messaging - The {@link Messaging} instance.
  * @param nextOrObserver - A function or observer object called when an FID is registered.
@@ -192,8 +191,7 @@ export function onRegistered(
 }
 
 /**
- * Subscribes to FID (Firebase Installation ID) unregistration events. The observer is
- * dispatched after a successful unregister() call with the FID that is no longer active.
+ * Subscribes to an event that the app instance is unregistered from FCM (FID no longer active).
  * Use this to notify your backend to remove this FID to prevent 404 errors on send.
  *
  * @param messaging - The {@link Messaging} instance.

--- a/packages/messaging/src/api.ts
+++ b/packages/messaging/src/api.ts
@@ -35,6 +35,8 @@ import { deleteToken as _deleteToken } from './api/deleteToken';
 import { getToken as _getToken } from './api/getToken';
 import { onBackgroundMessage as _onBackgroundMessage } from './api/onBackgroundMessage';
 import { onMessage as _onMessage } from './api/onMessage';
+import { onRegistered as _onRegistered } from './api/onRegistered';
+import { onUnregistered as _onUnregistered } from './api/onUnregistered';
 import { _setDeliveryMetricsExportedToBigQueryEnabled } from './api/setDeliveryMetricsExportedToBigQueryEnabled';
 
 /**
@@ -168,6 +170,44 @@ export function onBackgroundMessage(
 ): Unsubscribe {
   messaging = getModularInstance(messaging);
   return _onBackgroundMessage(messaging as MessagingService, nextOrObserver);
+}
+
+/**
+ * Subscribes to FID (Firebase Installation ID) registration events. The observer is invoked
+ * when an FID is delivered after an explicit register() call or automatic SDK refresh.
+ * Use this to upload the installationId to your application server upon receipt.
+ *
+ * @param messaging - The {@link Messaging} instance.
+ * @param nextOrObserver - A function or observer object called when an FID is registered.
+ * @returns Unsubscribe function to stop listening.
+ *
+ * @public
+ */
+export function onRegistered(
+  messaging: Messaging,
+  nextOrObserver: NextFn<string> | Observer<string>
+): Unsubscribe {
+  messaging = getModularInstance(messaging);
+  return _onRegistered(messaging as MessagingService, nextOrObserver);
+}
+
+/**
+ * Subscribes to FID (Firebase Installation ID) unregistration events. The observer is
+ * dispatched after a successful unregister() call with the FID that is no longer active.
+ * Use this to notify your backend to remove this FID to prevent 404 errors on send.
+ *
+ * @param messaging - The {@link Messaging} instance.
+ * @param nextOrObserver - A function or observer object called with the unregistered FID.
+ * @returns Unsubscribe function to stop listening.
+ *
+ * @public
+ */
+export function onUnregistered(
+  messaging: Messaging,
+  nextOrObserver: NextFn<string> | Observer<string>
+): Unsubscribe {
+  messaging = getModularInstance(messaging);
+  return _onUnregistered(messaging as MessagingService, nextOrObserver);
 }
 
 /**

--- a/packages/messaging/src/api/onRegistered.ts
+++ b/packages/messaging/src/api/onRegistered.ts
@@ -19,9 +19,8 @@ import { NextFn, Observer, Unsubscribe } from '../interfaces/public-types';
 import { MessagingService } from '../messaging-service';
 
 /**
- * Subscribes to FID (Firebase Installation ID) registration events. The observer is invoked
- * when an FID is delivered after an explicit register() call or automatic SDK refresh.
- * Use this to upload the installationId to your application server upon receipt.
+ * Subscribes to an event that the app instance is registered with FCM via Firebase Installation ID (FID).
+ * Use the FID passed to the callback to upload it to your application server.
  *
  * @param messaging - The {@link MessagingService} instance.
  * @param nextOrObserver - A function or observer object called when an FID is registered.
@@ -34,6 +33,8 @@ export function onRegistered(
   messaging.onRegisteredHandler = nextOrObserver;
 
   return () => {
-    messaging.onRegisteredHandler = null;
+    if (messaging.onRegisteredHandler === nextOrObserver) {
+      messaging.onRegisteredHandler = null;
+    }
   };
 }

--- a/packages/messaging/src/api/onRegistered.ts
+++ b/packages/messaging/src/api/onRegistered.ts
@@ -15,11 +15,7 @@
  * limitations under the License.
  */
 
-import {
-  NextFn,
-  Observer,
-  Unsubscribe
-} from '../interfaces/public-types';
+import { NextFn, Observer, Unsubscribe } from '../interfaces/public-types';
 import { MessagingService } from '../messaging-service';
 
 /**

--- a/packages/messaging/src/api/onRegistered.ts
+++ b/packages/messaging/src/api/onRegistered.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  NextFn,
+  Observer,
+  Unsubscribe
+} from '../interfaces/public-types';
+import { MessagingService } from '../messaging-service';
+
+/**
+ * Subscribes to FID (Firebase Installation ID) registration events. The observer is invoked
+ * when an FID is delivered after an explicit register() call or automatic SDK refresh.
+ * Use this to upload the installationId to your application server upon receipt.
+ *
+ * @param messaging - The {@link MessagingService} instance.
+ * @param nextOrObserver - A function or observer object called when an FID is registered.
+ * @returns Unsubscribe function to stop listening.
+ */
+export function onRegistered(
+  messaging: MessagingService,
+  nextOrObserver: NextFn<string> | Observer<string>
+): Unsubscribe {
+  messaging.onRegisteredHandler = nextOrObserver;
+
+  return () => {
+    messaging.onRegisteredHandler = null;
+  };
+}

--- a/packages/messaging/src/api/onUnregistered.ts
+++ b/packages/messaging/src/api/onUnregistered.ts
@@ -19,8 +19,7 @@ import { NextFn, Observer, Unsubscribe } from '../interfaces/public-types';
 import { MessagingService } from '../messaging-service';
 
 /**
- * Subscribes to FID (Firebase Installation ID) unregistration events. The observer is
- * dispatched after a successful unregister() call with the FID that is no longer active.
+ * Subscribes to an event that the app instance is unregistered from FCM (FID no longer active).
  * Use this to notify your backend to remove this FID to prevent 404 errors on send.
  *
  * @param messaging - The {@link MessagingService} instance.
@@ -34,6 +33,8 @@ export function onUnregistered(
   messaging.onUnregisteredHandler = nextOrObserver;
 
   return () => {
-    messaging.onUnregisteredHandler = null;
+    if (messaging.onUnregisteredHandler === nextOrObserver) {
+      messaging.onUnregisteredHandler = null;
+    }
   };
 }

--- a/packages/messaging/src/api/onUnregistered.ts
+++ b/packages/messaging/src/api/onUnregistered.ts
@@ -15,11 +15,7 @@
  * limitations under the License.
  */
 
-import {
-  NextFn,
-  Observer,
-  Unsubscribe
-} from '../interfaces/public-types';
+import { NextFn, Observer, Unsubscribe } from '../interfaces/public-types';
 import { MessagingService } from '../messaging-service';
 
 /**

--- a/packages/messaging/src/api/onUnregistered.ts
+++ b/packages/messaging/src/api/onUnregistered.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  NextFn,
+  Observer,
+  Unsubscribe
+} from '../interfaces/public-types';
+import { MessagingService } from '../messaging-service';
+
+/**
+ * Subscribes to FID (Firebase Installation ID) unregistration events. The observer is
+ * dispatched after a successful unregister() call with the FID that is no longer active.
+ * Use this to notify your backend to remove this FID to prevent 404 errors on send.
+ *
+ * @param messaging - The {@link MessagingService} instance.
+ * @param nextOrObserver - A function or observer object called with the unregistered FID.
+ * @returns Unsubscribe function to stop listening.
+ */
+export function onUnregistered(
+  messaging: MessagingService,
+  nextOrObserver: NextFn<string> | Observer<string>
+): Unsubscribe {
+  messaging.onUnregisteredHandler = nextOrObserver;
+
+  return () => {
+    messaging.onUnregisteredHandler = null;
+  };
+}

--- a/packages/messaging/src/index.sw.ts
+++ b/packages/messaging/src/index.sw.ts
@@ -23,6 +23,8 @@ import { registerMessagingInSw } from './helpers/register';
 export * from './interfaces/public-types';
 export {
   onBackgroundMessage,
+  onRegistered,
+  onUnregistered,
   getMessagingInSw as getMessaging,
   experimentalSetDeliveryMetricsExportedToBigQueryEnabled
 } from './api';

--- a/packages/messaging/src/index.ts
+++ b/packages/messaging/src/index.ts
@@ -31,6 +31,8 @@ export {
   getToken,
   deleteToken,
   onMessage,
+  onRegistered,
+  onUnregistered,
   getMessagingInWindow as getMessaging
 } from './api';
 export { isWindowSupported as isSupported } from './api/isSupported';

--- a/packages/messaging/src/messaging-service.ts
+++ b/packages/messaging/src/messaging-service.ts
@@ -42,10 +42,10 @@ export class MessagingService implements _FirebaseService {
   onMessageHandler: NextFn<MessagePayload> | Observer<MessagePayload> | null =
     null;
 
-  /** Observer for FID delivered after register() or automatic refresh. */
+  /** Observer for the event that the app instance is registered with FCM via Firebase Installation ID (FID). */
   onRegisteredHandler: NextFn<string> | Observer<string> | null = null;
 
-  /** Observer for FID that is no longer active after unregister(). */
+  /** Observer for the event that the app instance is unregistered from FCM (FID no longer active). */
   onUnregisteredHandler: NextFn<string> | Observer<string> | null = null;
 
   logEvents: LogEvent[] = [];

--- a/packages/messaging/src/messaging-service.ts
+++ b/packages/messaging/src/messaging-service.ts
@@ -42,6 +42,12 @@ export class MessagingService implements _FirebaseService {
   onMessageHandler: NextFn<MessagePayload> | Observer<MessagePayload> | null =
     null;
 
+  /** Observer for FID delivered after register() or automatic refresh. */
+  onRegisteredHandler: NextFn<string> | Observer<string> | null = null;
+
+  /** Observer for FID that is no longer active after unregister(). */
+  onUnregisteredHandler: NextFn<string> | Observer<string> | null = null;
+
   logEvents: LogEvent[] = [];
   isLogServiceStarted: boolean = false;
 


### PR DESCRIPTION
## Summary

This PR adds **Phase 1** of FCM Web SDK modernization (token → FID): observer APIs for FID registration and unregistration.

**New APIs**
- **`onRegistered(messaging, nextOrObserver)`** — Subscribes to FID registration events (after `register()` or automatic refresh). Use to upload the `installationId` (FID) to your app server.
- **`onUnregistered(messaging, nextOrObserver)`** — Subscribes to unregistration events (after `unregister()`). Use to tell your backend to remove the FID to avoid 404s on send.

Both accept `NextFn<string> | Observer<string>` and return `Unsubscribe`.

**Changes**
- New: `api/onRegistered.ts`, `api/onUnregistered.ts`
- Wired in: `api.ts`, `index.ts`, `index.sw.ts`, `messaging-service.ts`
- API review + docs-devsite updated.


---

## Next steps (future PRs → `feat/messaging-api-series`)

| Phase | Focus |
|-------|--------|
| **Phase 2** | Wrapper service (legacy token + FID); call `register()`; backend FID target support. |
| **Phase 3** | 404 handling (trigger `register()`); unified identity payload (TOKEN vs FID). |
| **Phase 4** | Encapsulate legacy (`getToken` / `deleteToken`) in `LegacyMessaging`|

After the series is merged into `feat/messaging-api-series`, one final PR will merge that branch into `main`.