### PR TITLE
fix(firestore): read and write user data on pipeline execute

### DIFF
--- a/.changeset/eleven-carrots-relate.md
+++ b/.changeset/eleven-carrots-relate.md
@@ -2,4 +2,4 @@
 '@firebase/firestore': patch
 ---
 
-**Breaking change**: Defer pipeline user data validation from initialization to `execute()`. This breaking change is allowed in a non-major release since the Firestore Pipelines API is currently in Public Preview.
+**Beta API Breaking change**: Defer pipeline user data validation from initialization to `execute()`. This breaking change is allowed in a non-major release since the Firestore Pipelines API is currently in Public Preview.

--- a/.changeset/eleven-carrots-relate.md
+++ b/.changeset/eleven-carrots-relate.md
@@ -1,0 +1,5 @@
+---
+'@firebase/firestore': patch
+---
+
+**Breaking change**: Defer pipeline user data validation from initialization to `execute()`. This breaking change is allowed in a non-major release since the Firestore Pipelines API is currently in Public Preview.

--- a/common/api-review/firestore-lite-pipelines.api.md
+++ b/common/api-review/firestore-lite-pipelines.api.md
@@ -1156,11 +1156,6 @@ export class Ordering {
 
 // @beta
 export class Pipeline {
-    /* Excluded from this release type: _db */
-    /* Excluded from this release type: userDataReader */
-    /* Excluded from this release type: _userDataWriter */
-    /* Excluded from this release type: stages */
-    /* Excluded from this release type: __constructor */
     addFields(field: Selectable, ...additionalFields: Selectable[]): Pipeline;
     addFields(options: AddFieldsStageOptions): Pipeline;
     aggregate(accumulator: AliasedAggregate, ...additionalAccumulators: AliasedAggregate[]): Pipeline;
@@ -1217,15 +1212,31 @@ export class PipelineSnapshot {
 // @beta
 export class PipelineSource<PipelineType> {
     collection(collection: string | Query): PipelineType;
+    /* Excluded from this release type: _createPipeline */
+    /* Excluded from this release type: __constructor */
     collection(options: CollectionStageOptions): PipelineType;
+    /* Excluded from this release type: _createPipeline */
+    /* Excluded from this release type: __constructor */
     collectionGroup(collectionId: string): PipelineType;
+    /* Excluded from this release type: _createPipeline */
+    /* Excluded from this release type: __constructor */
     collectionGroup(options: CollectionGroupStageOptions): PipelineType;
+    /* Excluded from this release type: _createPipeline */
+    /* Excluded from this release type: __constructor */
     createFrom(query: Query): Pipeline;
+    /* Excluded from this release type: _createPipeline */
+    /* Excluded from this release type: __constructor */
     database(): PipelineType;
+    /* Excluded from this release type: _createPipeline */
+    /* Excluded from this release type: __constructor */
     database(options: DatabaseStageOptions): PipelineType;
+    /* Excluded from this release type: _createPipeline */
+    /* Excluded from this release type: __constructor */
     documents(docs: Array<string | DocumentReference>): PipelineType;
+    /* Excluded from this release type: _createPipeline */
+    /* Excluded from this release type: __constructor */
     documents(options: DocumentsStageOptions): PipelineType;
-    }
+}
 
 // @beta
 export function pow(base: Expression, exponent: Expression): FunctionExpression;

--- a/common/api-review/firestore-pipelines.api.md
+++ b/common/api-review/firestore-pipelines.api.md
@@ -1254,15 +1254,31 @@ export class PipelineSnapshot {
 // @beta
 export class PipelineSource<PipelineType> {
     collection(collection: string | Query): PipelineType;
+    /* Excluded from this release type: _createPipeline */
+    /* Excluded from this release type: __constructor */
     collection(options: CollectionStageOptions): PipelineType;
+    /* Excluded from this release type: _createPipeline */
+    /* Excluded from this release type: __constructor */
     collectionGroup(collectionId: string): PipelineType;
+    /* Excluded from this release type: _createPipeline */
+    /* Excluded from this release type: __constructor */
     collectionGroup(options: CollectionGroupStageOptions): PipelineType;
+    /* Excluded from this release type: _createPipeline */
+    /* Excluded from this release type: __constructor */
     createFrom(query: Query): Pipeline;
+    /* Excluded from this release type: _createPipeline */
+    /* Excluded from this release type: __constructor */
     database(): PipelineType;
+    /* Excluded from this release type: _createPipeline */
+    /* Excluded from this release type: __constructor */
     database(options: DatabaseStageOptions): PipelineType;
+    /* Excluded from this release type: _createPipeline */
+    /* Excluded from this release type: __constructor */
     documents(docs: Array<string | DocumentReference>): PipelineType;
+    /* Excluded from this release type: _createPipeline */
+    /* Excluded from this release type: __constructor */
     documents(options: DocumentsStageOptions): PipelineType;
-    }
+}
 
 // @beta
 export function pow(base: Expression, exponent: Expression): FunctionExpression;

--- a/packages/firestore/src/api/pipeline.ts
+++ b/packages/firestore/src/api/pipeline.ts
@@ -17,8 +17,6 @@
 
 import { Pipeline as LitePipeline } from '../lite-api/pipeline';
 import { Stage } from '../lite-api/stage';
-import { UserDataReader } from '../lite-api/user_data_reader';
-import { AbstractUserDataWriter } from '../lite-api/user_data_writer';
 
 import { Firestore } from './database';
 
@@ -30,18 +28,11 @@ export class Pipeline extends LitePipeline {
    * @internal
    * @private
    * @param db
-   * @param userDataReader
    * @param userDataWriter
    * @param stages
-   * @param converter
    * @protected
    */
-  protected newPipeline(
-    db: Firestore,
-    userDataReader: UserDataReader,
-    userDataWriter: AbstractUserDataWriter,
-    stages: Stage[]
-  ): Pipeline {
-    return new Pipeline(db, userDataReader, userDataWriter, stages);
+  protected newPipeline(db: Firestore, stages: Stage[]): Pipeline {
+    return new Pipeline(db, stages);
   }
 }

--- a/packages/firestore/src/api/pipeline_impl.ts
+++ b/packages/firestore/src/api/pipeline_impl.ts
@@ -28,7 +28,6 @@ import { PipelineExecuteOptions } from '../lite-api/pipeline_options';
 import { Stage } from '../lite-api/stage';
 import {
   newUserDataReader,
-  UserDataReader,
   UserDataSource
 } from '../lite-api/user_data_reader';
 import { cast } from '../util/input_validation';
@@ -140,11 +139,14 @@ export function execute(
   const firestore = cast(pipeline._db, Firestore);
   const client = ensureFirestoreConfigured(firestore);
 
-  const udr = new UserDataReader(
-    firestore._databaseId,
-    /* ignoreUndefinedProperties */ true
+  const userDataReader = newUserDataReader(firestore);
+  const context = userDataReader.createContext(
+    UserDataSource.Argument,
+    'execute'
   );
-  const context = udr.createContext(UserDataSource.Argument, 'execute');
+
+  pipeline._readUserData(context);
+  const userDataWriter = new ExpUserDataWriter(firestore);
 
   const structuredPipelineOptions = new StructuredPipelineOptions(
     rest,
@@ -172,7 +174,7 @@ export function execute(
         .map(
           element =>
             new PipelineResult(
-              pipeline._userDataWriter,
+              userDataWriter,
               element.fields!,
               element.key?.path
                 ? new DocumentReference(firestore, null, element.key)
@@ -198,17 +200,7 @@ export function execute(
  */
 // Augment the Firestore class with the pipeline() factory method
 Firestore.prototype.pipeline = function (): PipelineSource<Pipeline> {
-  const userDataReader = newUserDataReader(this);
-  return new PipelineSource<Pipeline>(
-    this._databaseId,
-    userDataReader,
-    (stages: Stage[]) => {
-      return new Pipeline(
-        this,
-        userDataReader,
-        new ExpUserDataWriter(this),
-        stages
-      );
-    }
-  );
+  return new PipelineSource<Pipeline>(this._databaseId, (stages: Stage[]) => {
+    return new Pipeline(this, stages);
+  });
 };

--- a/packages/firestore/src/lite-api/pipeline-source.ts
+++ b/packages/firestore/src/lite-api/pipeline-source.ts
@@ -40,7 +40,6 @@ import {
   DatabaseStageOptions,
   DocumentsStageOptions
 } from './stage_options';
-import { UserDataReader, UserDataSource } from './user_data_reader';
 
 /**
  * @beta
@@ -55,12 +54,10 @@ export class PipelineSource<PipelineType> {
    * @internal
    * @private
    * @param databaseId
-   * @param userDataReader
    * @param _createPipeline
    */
   constructor(
     private databaseId: DatabaseId,
-    private userDataReader: UserDataReader,
     /**
      * @internal
      * @private
@@ -108,14 +105,6 @@ export class PipelineSource<PipelineType> {
     // Create stage object
     const stage = new CollectionSource(normalizedCollection, options);
 
-    // User data must be read in the context of the API method to
-    // provide contextual errors
-    const parseContext = this.userDataReader.createContext(
-      UserDataSource.Argument,
-      'collection'
-    );
-    stage._readUserData(parseContext);
-
     // Add stage to the pipeline
     return this._createPipeline([stage]);
   }
@@ -148,14 +137,6 @@ export class PipelineSource<PipelineType> {
     // Create stage object
     const stage = new CollectionGroupSource(collectionId, options);
 
-    // User data must be read in the context of the API method to
-    // provide contextual errors
-    const parseContext = this.userDataReader.createContext(
-      UserDataSource.Argument,
-      'collectionGroup'
-    );
-    stage._readUserData(parseContext);
-
     // Add stage to the pipeline
     return this._createPipeline([stage]);
   }
@@ -177,14 +158,6 @@ export class PipelineSource<PipelineType> {
 
     // Create stage object
     const stage = new DatabaseSource(options);
-
-    // User data must be read in the context of the API method to
-    // provide contextual errors
-    const parseContext = this.userDataReader.createContext(
-      UserDataSource.Argument,
-      'database'
-    );
-    stage._readUserData(parseContext);
 
     // Add stage to the pipeline
     return this._createPipeline([stage]);
@@ -235,14 +208,6 @@ export class PipelineSource<PipelineType> {
 
     // Create stage object
     const stage = new DocumentsSource(normalizedDocs, options);
-
-    // User data must be read in the context of the API method to
-    // provide contextual errors
-    const parseContext = this.userDataReader.createContext(
-      UserDataSource.Argument,
-      'documents'
-    );
-    stage._readUserData(parseContext);
 
     // Add stage to the pipeline
     return this._createPipeline([stage]);

--- a/packages/firestore/src/lite-api/pipeline.ts
+++ b/packages/firestore/src/lite-api/pipeline.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { ParseContext } from '../api/parse_context';
 import {
   Pipeline as ProtoPipeline,
   Stage as ProtoStage
@@ -85,8 +86,7 @@ import {
   UnnestStageOptions,
   WhereStageOptions
 } from './stage_options';
-import { UserDataReader, UserDataSource } from './user_data_reader';
-import { AbstractUserDataWriter } from './user_data_writer';
+import { UserData } from './user_data_reader';
 
 /**
  * @beta
@@ -128,13 +128,11 @@ import { AbstractUserDataWriter } from './user_data_writer';
  *     .aggregate(average(field("rating")).as("averageRating")));
  * ```
  */
-export class Pipeline implements ProtoSerializable<ProtoPipeline> {
+export class Pipeline implements ProtoSerializable<ProtoPipeline>, UserData {
   /**
    * @internal
    * @private
    * @param _db
-   * @param userDataReader
-   * @param _userDataWriter
    * @param stages
    */
   constructor(
@@ -147,18 +145,17 @@ export class Pipeline implements ProtoSerializable<ProtoPipeline> {
      * @internal
      * @private
      */
-    private userDataReader: UserDataReader,
-    /**
-     * @internal
-     * @private
-     */
-    public _userDataWriter: AbstractUserDataWriter,
-    /**
-     * @internal
-     * @private
-     */
     private stages: Stage[]
   ) {}
+
+  _readUserData(context: ParseContext): void {
+    this.stages.forEach(stage => {
+      const subContext = context.contextWith({
+        methodName: stage._name
+      });
+      stage._readUserData(subContext);
+    });
+  }
 
   /**
    * @beta
@@ -239,14 +236,6 @@ export class Pipeline implements ProtoSerializable<ProtoPipeline> {
     // Create stage object
     const stage = new AddFields(normalizedFields, options);
 
-    // User data must be read in the context of the API method to
-    // provide contextual errors
-    const parseContext = this.userDataReader.createContext(
-      UserDataSource.Argument,
-      'addFields'
-    );
-    stage._readUserData(parseContext);
-
     // Add stage to the pipeline
     return this._addStage(stage);
   }
@@ -316,12 +305,6 @@ export class Pipeline implements ProtoSerializable<ProtoPipeline> {
 
     // Create stage object
     const stage = new RemoveFields(convertedFields, options);
-
-    // User data must be read in the context of the API method to
-    // provide contextual errors
-    stage._readUserData(
-      this.userDataReader.createContext(UserDataSource.Argument, 'removeFields')
-    );
 
     // Add stage to the pipeline
     return this._addStage(stage);
@@ -421,14 +404,6 @@ export class Pipeline implements ProtoSerializable<ProtoPipeline> {
     // Create stage object
     const stage = new Select(normalizedSelections, options);
 
-    // User data must be read in the context of the API method to
-    // provide contextual errors
-    const parseContext = this.userDataReader.createContext(
-      UserDataSource.Argument,
-      'select'
-    );
-    stage._readUserData(parseContext);
-
     // Add stage to the pipeline
     return this._addStage(stage);
   }
@@ -511,14 +486,6 @@ export class Pipeline implements ProtoSerializable<ProtoPipeline> {
     // Create stage object
     const stage = new Where(condition, options);
 
-    // User data must be read in the context of the API method to
-    // provide contextual errors
-    const parseContext = this.userDataReader.createContext(
-      UserDataSource.Argument,
-      'where'
-    );
-    stage._readUserData(parseContext);
-
     // Add stage to the pipeline
     return this._addStage(stage);
   }
@@ -583,14 +550,6 @@ export class Pipeline implements ProtoSerializable<ProtoPipeline> {
 
     // Create stage object
     const stage = new Offset(offset, options);
-
-    // User data must be read in the context of the API method to
-    // provide contextual errors
-    const parseContext = this.userDataReader.createContext(
-      UserDataSource.Argument,
-      'offset'
-    );
-    stage._readUserData(parseContext);
 
     // Add stage to the pipeline
     return this._addStage(stage);
@@ -661,14 +620,6 @@ export class Pipeline implements ProtoSerializable<ProtoPipeline> {
 
     // Create stage object
     const stage = new Limit(limit, options);
-
-    // User data must be read in the context of the API method to
-    // provide contextual errors
-    const parseContext = this.userDataReader.createContext(
-      UserDataSource.Argument,
-      'limit'
-    );
-    stage._readUserData(parseContext);
 
     // Add stage to the pipeline
     return this._addStage(stage);
@@ -755,14 +706,6 @@ export class Pipeline implements ProtoSerializable<ProtoPipeline> {
 
     // Create stage object
     const stage = new Distinct(convertedGroups, options);
-
-    // User data must be read in the context of the API method to
-    // provide contextual errors
-    const parseContext = this.userDataReader.createContext(
-      UserDataSource.Argument,
-      'distinct'
-    );
-    stage._readUserData(parseContext);
 
     // Add stage to the pipeline
     return this._addStage(stage);
@@ -860,14 +803,6 @@ export class Pipeline implements ProtoSerializable<ProtoPipeline> {
       options
     );
 
-    // User data must be read in the context of the API method to
-    // provide contextual errors
-    const parseContext = this.userDataReader.createContext(
-      UserDataSource.Argument,
-      'aggregate'
-    );
-    stage._readUserData(parseContext);
-
     // Add stage to the pipeline
     return this._addStage(stage);
   }
@@ -918,14 +853,6 @@ export class Pipeline implements ProtoSerializable<ProtoPipeline> {
       options.distanceMeasure,
       internalOptions
     );
-
-    // User data must be read in the context of the API method to
-    // provide contextual errors
-    const parseContext = this.userDataReader.createContext(
-      UserDataSource.Argument,
-      'addFields'
-    );
-    stage._readUserData(parseContext);
 
     // Add stage to the pipeline
     return this._addStage(stage);
@@ -998,14 +925,6 @@ export class Pipeline implements ProtoSerializable<ProtoPipeline> {
 
     // Create stage object
     const stage = new Sort(orderings, options);
-
-    // User data must be read in the context of the API method to
-    // provide contextual errors
-    const parseContext = this.userDataReader.createContext(
-      UserDataSource.Argument,
-      'sort'
-    );
-    stage._readUserData(parseContext);
 
     // Add stage to the pipeline
     return this._addStage(stage);
@@ -1140,14 +1059,6 @@ export class Pipeline implements ProtoSerializable<ProtoPipeline> {
     // Create stage object
     const stage = new Replace(mapExpr, options);
 
-    // User data must be read in the context of the API method to
-    // provide contextual errors
-    const parseContext = this.userDataReader.createContext(
-      UserDataSource.Argument,
-      'replaceWith'
-    );
-    stage._readUserData(parseContext);
-
     // Add stage to the pipeline
     return this._addStage(stage);
   }
@@ -1214,14 +1125,6 @@ export class Pipeline implements ProtoSerializable<ProtoPipeline> {
     // Create stage object
     const stage = new Sample(rate, mode, options);
 
-    // User data must be read in the context of the API method to
-    // provide contextual errors
-    const parseContext = this.userDataReader.createContext(
-      UserDataSource.Argument,
-      'sample'
-    );
-    stage._readUserData(parseContext);
-
     // Add stage to the pipeline
     return this._addStage(stage);
   }
@@ -1281,14 +1184,6 @@ export class Pipeline implements ProtoSerializable<ProtoPipeline> {
 
     // Create stage object
     const stage = new Union(otherPipeline, options);
-
-    // User data must be read in the context of the API method to
-    // provide contextual errors
-    const parseContext = this.userDataReader.createContext(
-      UserDataSource.Argument,
-      'union'
-    );
-    stage._readUserData(parseContext);
 
     // Add stage to the pipeline
     return this._addStage(stage);
@@ -1393,14 +1288,6 @@ export class Pipeline implements ProtoSerializable<ProtoPipeline> {
     // Create stage object
     const stage = new Unnest(alias, expr, options);
 
-    // User data must be read in the context of the API method to
-    // provide contextual errors
-    const parseContext = this.userDataReader.createContext(
-      UserDataSource.Argument,
-      'unnest'
-    );
-    stage._readUserData(parseContext);
-
     // Add stage to the pipeline
     return this._addStage(stage);
   }
@@ -1449,14 +1336,6 @@ export class Pipeline implements ProtoSerializable<ProtoPipeline> {
     // Create stage object
     const stage = new RawStage(name, expressionParams, options ?? {});
 
-    // User data must be read in the context of the API method to
-    // provide contextual errors
-    const parseContext = this.userDataReader.createContext(
-      UserDataSource.Argument,
-      'rawStage'
-    );
-    stage._readUserData(parseContext);
-
     // Add stage to the pipeline
     return this._addStage(stage);
   }
@@ -1475,12 +1354,7 @@ export class Pipeline implements ProtoSerializable<ProtoPipeline> {
   private _addStage(stage: Stage): Pipeline {
     const copy = this.stages.map(s => s);
     copy.push(stage);
-    return this.newPipeline(
-      this._db,
-      this.userDataReader,
-      this._userDataWriter,
-      copy
-    );
+    return this.newPipeline(this._db, copy);
   }
 
   /**
@@ -1492,13 +1366,8 @@ export class Pipeline implements ProtoSerializable<ProtoPipeline> {
    * @param stages
    * @protected
    */
-  protected newPipeline(
-    db: Firestore,
-    userDataReader: UserDataReader,
-    userDataWriter: AbstractUserDataWriter,
-    stages: Stage[]
-  ): Pipeline {
-    return new Pipeline(db, userDataReader, userDataWriter, stages);
+  protected newPipeline(db: Firestore, stages: Stage[]): Pipeline {
+    return new Pipeline(db, stages);
   }
 }
 

--- a/packages/firestore/src/lite-api/pipeline_impl.ts
+++ b/packages/firestore/src/lite-api/pipeline_impl.ts
@@ -20,6 +20,7 @@ import {
   StructuredPipelineOptions
 } from '../core/structured_pipeline';
 import { invokeExecutePipeline } from '../remote/datastore';
+import { cast } from '../util/input_validation';
 
 import { getDatastore } from './components';
 import { Firestore } from './database';
@@ -29,11 +30,7 @@ import { PipelineSource } from './pipeline-source';
 import { DocumentReference } from './reference';
 import { LiteUserDataWriter } from './reference_impl';
 import { Stage } from './stage';
-import {
-  newUserDataReader,
-  UserDataReader,
-  UserDataSource
-} from './user_data_reader';
+import { newUserDataReader, UserDataSource } from './user_data_reader';
 
 declare module './database' {
   interface Firestore {
@@ -86,12 +83,16 @@ declare module './database' {
  */
 export function execute(pipeline: Pipeline): Promise<PipelineSnapshot> {
   const datastore = getDatastore(pipeline._db);
+  const firestore = cast(pipeline._db, Firestore);
 
-  const udr = new UserDataReader(
-    pipeline._db._databaseId,
-    /* ignoreUndefinedProperties */ true
+  const userDataReader = newUserDataReader(firestore);
+  const context = userDataReader.createContext(
+    UserDataSource.Argument,
+    'execute'
   );
-  const context = udr.createContext(UserDataSource.Argument, 'execute');
+
+  pipeline._readUserData(context);
+  const userDataWriter = new LiteUserDataWriter(firestore);
 
   const structuredPipelineOptions = new StructuredPipelineOptions({}, {});
   structuredPipelineOptions._readUserData(context);
@@ -115,7 +116,7 @@ export function execute(pipeline: Pipeline): Promise<PipelineSnapshot> {
       .map(
         element =>
           new PipelineResult(
-            pipeline._userDataWriter,
+            userDataWriter,
             element.fields!,
             element.key?.path
               ? new DocumentReference(pipeline._db, null, element.key)
@@ -139,13 +140,7 @@ export function execute(pipeline: Pipeline): Promise<PipelineSnapshot> {
  * ```
  */
 Firestore.prototype.pipeline = function (): PipelineSource<Pipeline> {
-  const userDataWriter = new LiteUserDataWriter(this);
-  const userDataReader = newUserDataReader(this);
-  return new PipelineSource<Pipeline>(
-    this._databaseId,
-    userDataReader,
-    (stages: Stage[]) => {
-      return new Pipeline(this, userDataReader, userDataWriter, stages);
-    }
-  );
+  return new PipelineSource<Pipeline>(this._databaseId, (stages: Stage[]) => {
+    return new Pipeline(this, stages);
+  });
 };

--- a/packages/firestore/test/lite/pipeline.test.ts
+++ b/packages/firestore/test/lite/pipeline.test.ts
@@ -717,32 +717,50 @@ describe.skipClassic('Firestore Pipelines', () => {
     });
 
     it('throws on undefined in a map', async () => {
-      expect(() => {
-        firestore
-          .pipeline()
-          .collection(randomCol.path)
-          .limit(1)
-          .select(
-            map({
-              'number': 1,
-              undefined
-            }).as('foo')
-          );
-      }).to.throw(
-        'Function map() called with invalid data. Unsupported field value: undefined'
-      );
+      try {
+        await execute(
+          firestore
+            .pipeline()
+            .collection(randomCol.path)
+            .limit(1)
+            .select(
+              map({
+                'number': 1,
+                undefined
+              }).as('foo')
+            )
+        );
+        expect(true, 'should throw').to.be.false;
+      } catch (e: unknown) {
+        expect(e instanceof FirebaseError).to.be.true;
+        const err = e as FirebaseError;
+        expect(err['code']).to.equal('invalid-argument');
+        expect(typeof err['message']).to.equal('string');
+        expect(err['message']).to.equal(
+          'Function map() called with invalid data. Unsupported field value: undefined'
+        );
+      }
     });
 
     it('throws on undefined in an array', async () => {
-      expect(() => {
-        firestore
-          .pipeline()
-          .collection(randomCol.path)
-          .limit(1)
-          .select(array([1, undefined]).as('foo'));
-      }).to.throw(
-        'Function array() called with invalid data. Unsupported field value: undefined'
-      );
+      try {
+        await execute(
+          firestore
+            .pipeline()
+            .collection(randomCol.path)
+            .limit(1)
+            .select(array([1, undefined]).as('foo'))
+        );
+        expect(true, 'should throw').to.be.false;
+      } catch (e: unknown) {
+        expect(e instanceof FirebaseError).to.be.true;
+        const err = e as FirebaseError;
+        expect(err['code']).to.equal('invalid-argument');
+        expect(typeof err['message']).to.equal('string');
+        expect(err['message']).to.equal(
+          'Function array() called with invalid data. Unsupported field value: undefined'
+        );
+      }
     });
 
     it('converts arrays and plain objects to functionValues if the customer intent is unspecified', async () => {


### PR DESCRIPTION
To support standalone stage initializers (such as `subcollection()`), that can be constructed without an existing pipeline, we need to decouple stage initialization and user data validation. Standalone functions do not have access to `Firestore` or `databaseId` context when called, so validation must be deferred until the pipeline is executed with `execute(pipeline)`.

Implementation Details:
1. Removed user data parsing in stage methods (`select`, `where`, `addFields`, ...).
2. Added a `_readUserData()` traversal to `Pipeline` class.
3. Modified `execute()` to trigger `pipeline._readUserData()` before executing the pipeline.

**Breaking Changes:**
1. Validation timing

Errors regarding invalid user data in stages will now be thrown when `execute(pipeline)` is called, rather than during the initialization of the stage (`pipeline.collection().addFields(/* invalid data */)`).
This aligns with the behaviour on both iOS, Android, and Java SDKs.
```typescript
// Previously: error threw here
const ppl = firestore.pipeline().collection('books').select(field, undefined); // undefined is an unsupported field value

// Now: error throws here
await execute(ppl);
```

2. Nested `undefined` on `rawOptions` throws

Inner object properties that are `undefined` inside `rawOptions` will now cause validation to fail, instead of being silently ignored. This is a side effect of execution parsing. Deferring validation allows the context to inherit the active setting for `ignoreUndefinedProperties` (defaulting to `false`) instead of forcing it to `true` as previously done during construction. The reason it only happens for nested properties is a quirk- probably something that should be fixed.

```typescript
execute(pipeline, { 
  rawOptions: {
    custom: { foo: undefined } // now throws "Unsupported field value: undefined"
  }
});
```

3. (Minor) Error message changes

Error message text will report the backend stage naming (`snake_case`) rather than the client naming (`snakeCase`).

Previous: `Function addFields called with invalid data`
New: `Function add_fields called with invalid data`