### PR TITLE
feat(firestore): add timestamp expressions

### DIFF
--- a/.changeset/cool-dragons-compete.md
+++ b/.changeset/cool-dragons-compete.md
@@ -1,0 +1,6 @@
+---
+'firebase': minor
+'@firebase/firestore': minor
+---
+
+Add support for timestamp_trunc, timestamp_diff and timestamp_extract expressions

--- a/common/api-review/firestore-lite-pipelines.api.md
+++ b/common/api-review/firestore-lite-pipelines.api.md
@@ -764,6 +764,14 @@ export abstract class Expression {
     /* Excluded from this release type: _readUserData */
     timestampAdd(unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day', amount: number): FunctionExpression;
     /* Excluded from this release type: _readUserData */
+    timestampDiff(start: Expression, unit: Expression): FunctionExpression;
+    /* Excluded from this release type: _readUserData */
+    timestampDiff(start: string | Expression, unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day'): FunctionExpression;
+    /* Excluded from this release type: _readUserData */
+    timestampExtract(part: TimePart, timezone?: string | Expression): FunctionExpression;
+    /* Excluded from this release type: _readUserData */
+    timestampExtract(part: Expression, timezone?: string | Expression): FunctionExpression;
+    /* Excluded from this release type: _readUserData */
     timestampSubtract(unit: Expression, amount: Expression): FunctionExpression;
     /* Excluded from this release type: _readUserData */
     timestampSubtract(unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day', amount: number): FunctionExpression;
@@ -1476,6 +1484,9 @@ export function sum(fieldName: string): AggregateFunction;
 export type TimeGranularity = 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'week(monday)' | 'week(tuesday)' | 'week(wednesday)' | 'week(thursday)' | 'week(friday)' | 'week(saturday)' | 'week(sunday)' | 'isoWeek' | 'month' | 'quarter' | 'year' | 'isoYear';
 
 // @beta
+export type TimePart = TimeGranularity | 'dayofweek' | 'dayofyear';
+
+// @beta
 export function timestampAdd(timestamp: Expression, unit: Expression, amount: Expression): FunctionExpression;
 
 // @beta
@@ -1483,6 +1494,30 @@ export function timestampAdd(timestamp: Expression, unit: 'microsecond' | 'milli
 
 // @beta
 export function timestampAdd(fieldName: string, unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day', amount: number): FunctionExpression;
+
+// @beta
+export function timestampDiff(endFieldName: string, startFieldName: string, unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | Expression): FunctionExpression;
+
+// @beta
+export function timestampDiff(endFieldName: string, startExpression: Expression, unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | Expression): FunctionExpression;
+
+// @beta
+export function timestampDiff(endExpression: Expression, startFieldName: string, unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | Expression): FunctionExpression;
+
+// @beta
+export function timestampDiff(endExpression: Expression, startExpression: Expression, unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | Expression): FunctionExpression;
+
+// @beta
+export function timestampExtract(fieldName: string, part: TimePart, timezone?: string | Expression): FunctionExpression;
+
+// @beta
+export function timestampExtract(fieldName: string, part: Expression, timezone?: string | Expression): FunctionExpression;
+
+// @beta
+export function timestampExtract(timestampExpression: Expression, part: TimePart, timezone?: string | Expression): FunctionExpression;
+
+// @beta
+export function timestampExtract(timestampExpression: Expression, part: Expression, timezone?: string | Expression): FunctionExpression;
 
 // @beta
 export function timestampSubtract(timestamp: Expression, unit: Expression, amount: Expression): FunctionExpression;

--- a/common/api-review/firestore-pipelines.api.md
+++ b/common/api-review/firestore-pipelines.api.md
@@ -767,6 +767,14 @@ export abstract class Expression {
     /* Excluded from this release type: _readUserData */
     timestampAdd(unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day', amount: number): FunctionExpression;
     /* Excluded from this release type: _readUserData */
+    timestampDiff(start: Expression, unit: Expression): FunctionExpression;
+    /* Excluded from this release type: _readUserData */
+    timestampDiff(start: string | Expression, unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day'): FunctionExpression;
+    /* Excluded from this release type: _readUserData */
+    timestampExtract(part: TimePart, timezone?: string | Expression): FunctionExpression;
+    /* Excluded from this release type: _readUserData */
+    timestampExtract(part: Expression, timezone?: string | Expression): FunctionExpression;
+    /* Excluded from this release type: _readUserData */
     timestampSubtract(unit: Expression, amount: Expression): FunctionExpression;
     /* Excluded from this release type: _readUserData */
     timestampSubtract(unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day', amount: number): FunctionExpression;
@@ -1518,6 +1526,9 @@ export function sum(fieldName: string): AggregateFunction;
 export type TimeGranularity = 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'week(monday)' | 'week(tuesday)' | 'week(wednesday)' | 'week(thursday)' | 'week(friday)' | 'week(saturday)' | 'week(sunday)' | 'isoWeek' | 'month' | 'quarter' | 'year' | 'isoYear';
 
 // @beta
+export type TimePart = TimeGranularity | 'dayofweek' | 'dayofyear';
+
+// @beta
 export function timestampAdd(timestamp: Expression, unit: Expression, amount: Expression): FunctionExpression;
 
 // @beta
@@ -1525,6 +1536,30 @@ export function timestampAdd(timestamp: Expression, unit: 'microsecond' | 'milli
 
 // @beta
 export function timestampAdd(fieldName: string, unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day', amount: number): FunctionExpression;
+
+// @beta
+export function timestampDiff(endFieldName: string, startFieldName: string, unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | Expression): FunctionExpression;
+
+// @beta
+export function timestampDiff(endFieldName: string, startExpression: Expression, unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | Expression): FunctionExpression;
+
+// @beta
+export function timestampDiff(endExpression: Expression, startFieldName: string, unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | Expression): FunctionExpression;
+
+// @beta
+export function timestampDiff(endExpression: Expression, startExpression: Expression, unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | Expression): FunctionExpression;
+
+// @beta
+export function timestampExtract(fieldName: string, part: TimePart, timezone?: string | Expression): FunctionExpression;
+
+// @beta
+export function timestampExtract(fieldName: string, part: Expression, timezone?: string | Expression): FunctionExpression;
+
+// @beta
+export function timestampExtract(timestampExpression: Expression, part: TimePart, timezone?: string | Expression): FunctionExpression;
+
+// @beta
+export function timestampExtract(timestampExpression: Expression, part: Expression, timezone?: string | Expression): FunctionExpression;
 
 // @beta
 export function timestampSubtract(timestamp: Expression, unit: Expression, amount: Expression): FunctionExpression;

--- a/docs-devsite/firestore_lite_pipelines.expression.md
+++ b/docs-devsite/firestore_lite_pipelines.expression.md
@@ -4846,7 +4846,7 @@ timestampDiff(start: Expression, unit: Expression): FunctionExpression;
 
 [FunctionExpression](./firestore_lite_pipelines.functionexpression.md#functionexpression_class)
 
-A new [Expression](./firestore_pipelines.expression.md#expression_class) representing the difference as an int64.
+A new [Expression](./firestore_pipelines.expression.md#expression_class) representing the difference as an integer.
 
 ### Example
 

--- a/docs-devsite/firestore_lite_pipelines.expression.md
+++ b/docs-devsite/firestore_lite_pipelines.expression.md
@@ -180,6 +180,10 @@ export declare abstract class Expression
 |  [sum()](./firestore_lite_pipelines.expression.md#expressionsum) |  | <b><i>(Public Preview)</i></b> Creates an aggregation that calculates the sum of a numeric field across multiple stage inputs. |
 |  [timestampAdd(unit, amount)](./firestore_lite_pipelines.expression.md#expressiontimestampadd) |  | <b><i>(Public Preview)</i></b> Creates an expression that adds a specified amount of time to this timestamp expression. |
 |  [timestampAdd(unit, amount)](./firestore_lite_pipelines.expression.md#expressiontimestampadd) |  | <b><i>(Public Preview)</i></b> Creates an expression that adds a specified amount of time to this timestamp expression. |
+|  [timestampDiff(start, unit)](./firestore_lite_pipelines.expression.md#expressiontimestampdiff) |  | <b><i>(Public Preview)</i></b> Creates an expression that calculates the difference between this timestamp and another timestamp. |
+|  [timestampDiff(start, unit)](./firestore_lite_pipelines.expression.md#expressiontimestampdiff) |  | <b><i>(Public Preview)</i></b> Creates an expression that calculates the difference between this timestamp and another timestamp. |
+|  [timestampExtract(part, timezone)](./firestore_lite_pipelines.expression.md#expressiontimestampextract) |  | <b><i>(Public Preview)</i></b> Creates an expression that extracts a specified part from this timestamp expression. |
+|  [timestampExtract(part, timezone)](./firestore_lite_pipelines.expression.md#expressiontimestampextract) |  | <b><i>(Public Preview)</i></b> Creates an expression that extracts a specified part from this timestamp expression. |
 |  [timestampSubtract(unit, amount)](./firestore_lite_pipelines.expression.md#expressiontimestampsubtract) |  | <b><i>(Public Preview)</i></b> Creates an expression that subtracts a specified amount of time from this timestamp expression. |
 |  [timestampSubtract(unit, amount)](./firestore_lite_pipelines.expression.md#expressiontimestampsubtract) |  | <b><i>(Public Preview)</i></b> Creates an expression that subtracts a specified amount of time from this timestamp expression. |
 |  [timestampToUnixMicros()](./firestore_lite_pipelines.expression.md#expressiontimestamptounixmicros) |  | <b><i>(Public Preview)</i></b> Creates an expression that converts this timestamp expression to the number of microseconds since the Unix epoch (1970-01-01 00:00:00 UTC). |
@@ -4815,6 +4819,146 @@ A new [Expression](./firestore_pipelines.expression.md#expression_class) represe
 ```typescript
 // Add 1 day to the 'timestamp' field.
 field("timestamp").timestampAdd("day", 1);
+
+```
+
+## Expression.timestampDiff()
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Creates an expression that calculates the difference between this timestamp and another timestamp.
+
+<b>Signature:</b>
+
+```typescript
+timestampDiff(start: Expression, unit: Expression): FunctionExpression;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  start | [Expression](./firestore_lite_pipelines.expression.md#expression_class) | The expression evaluating to the starting timestamp. |
+|  unit | [Expression](./firestore_lite_pipelines.expression.md#expression_class) | The expression evaluates to a unit of time, must be one of 'microsecond', 'millisecond', 'second', 'minute', 'hour', 'day'. |
+
+<b>Returns:</b>
+
+[FunctionExpression](./firestore_lite_pipelines.functionexpression.md#functionexpression_class)
+
+A new [Expression](./firestore_pipelines.expression.md#expression_class) representing the difference as an int64.
+
+### Example
+
+
+```typescript
+// Calculate the difference determined by fields 'startTime' and 'unit'.
+field("endTime").timestampDiff(field("startTime"), field("unit"));
+
+```
+
+## Expression.timestampDiff()
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Creates an expression that calculates the difference between this timestamp and another timestamp.
+
+<b>Signature:</b>
+
+```typescript
+timestampDiff(start: string | Expression, unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day'): FunctionExpression;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  start | string \| [Expression](./firestore_lite_pipelines.expression.md#expression_class) | The field name of the starting timestamp. |
+|  unit | 'microsecond' \| 'millisecond' \| 'second' \| 'minute' \| 'hour' \| 'day' | The unit of time for the difference (e.g., "day", "hour"). |
+
+<b>Returns:</b>
+
+[FunctionExpression](./firestore_lite_pipelines.functionexpression.md#functionexpression_class)
+
+A new [Expression](./firestore_pipelines.expression.md#expression_class) representing the difference as an integer.
+
+### Example
+
+
+```typescript
+// Calculate the difference in days between 'endTime' and 'startTime' fields.
+field("endTime").timestampDiff("startTime", "day");
+
+```
+
+## Expression.timestampExtract()
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Creates an expression that extracts a specified part from this timestamp expression.
+
+<b>Signature:</b>
+
+```typescript
+timestampExtract(part: TimePart, timezone?: string | Expression): FunctionExpression;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  part | [TimePart](./firestore_lite_pipelines.md#timepart) | The part to extract from the timestamp (e.g., "year", "month", "day"). |
+|  timezone | string \| [Expression](./firestore_lite_pipelines.expression.md#expression_class) | The timezone to use for extraction. Valid values are from the TZ database (e.g., "America/Los\_Angeles") or in the format "Etc/GMT-1." |
+
+<b>Returns:</b>
+
+[FunctionExpression](./firestore_lite_pipelines.functionexpression.md#functionexpression_class)
+
+A new [Expression](./firestore_pipelines.expression.md#expression_class) representing the extracted part as an integer.
+
+### Example
+
+
+```typescript
+// Extract the year from the 'createdAt' field.
+field('createdAt').timestampExtract('year')
+
+```
+
+## Expression.timestampExtract()
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Creates an expression that extracts a specified part from this timestamp expression.
+
+<b>Signature:</b>
+
+```typescript
+timestampExtract(part: Expression, timezone?: string | Expression): FunctionExpression;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  part | [Expression](./firestore_lite_pipelines.expression.md#expression_class) | The expression evaluating to the part to extract. |
+|  timezone | string \| [Expression](./firestore_lite_pipelines.expression.md#expression_class) | The timezone to use for extraction. Valid values are from the TZ database (e.g., "America/Los\_Angeles") or in the format "Etc/GMT-1." |
+
+<b>Returns:</b>
+
+[FunctionExpression](./firestore_lite_pipelines.functionexpression.md#functionexpression_class)
+
+A new [Expression](./firestore_pipelines.expression.md#expression_class) representing the extracted part as an integer.
+
+### Example
+
+
+```typescript
+// Extract the part specified by the field 'extractionPart' from 'createdAt'.
+field('createdAt').timestampExtract(field('extractionPart'))
 
 ```
 

--- a/docs-devsite/firestore_lite_pipelines.md
+++ b/docs-devsite/firestore_lite_pipelines.md
@@ -73,6 +73,12 @@ https://github.com/firebase/firebase-js-sdk
 |  <b>function(elements, ...)</b> |
 |  [array(elements)](./firestore_lite_pipelines.md#array_7d853aa) | <b><i>(Public Preview)</i></b> Creates an expression that creates a Firestore array value from an input array. |
 |  [map(elements)](./firestore_lite_pipelines.md#map_ce5dee1) | <b><i>(Public Preview)</i></b> Creates an expression that creates a Firestore map value from an input object. |
+|  <b>function(endExpression, ...)</b> |
+|  [timestampDiff(endExpression, startFieldName, unit)](./firestore_lite_pipelines.md#timestampdiff_8cb2a38) | <b><i>(Public Preview)</i></b> Creates an expression that calculates the difference between two timestamps. |
+|  [timestampDiff(endExpression, startExpression, unit)](./firestore_lite_pipelines.md#timestampdiff_33aecb4) | <b><i>(Public Preview)</i></b> Creates an expression that calculates the difference between two timestamps. |
+|  <b>function(endFieldName, ...)</b> |
+|  [timestampDiff(endFieldName, startFieldName, unit)](./firestore_lite_pipelines.md#timestampdiff_c062afd) | <b><i>(Public Preview)</i></b> Creates an expression that calculates the difference between two timestamps. |
+|  [timestampDiff(endFieldName, startExpression, unit)](./firestore_lite_pipelines.md#timestampdiff_8244545) | <b><i>(Public Preview)</i></b> Creates an expression that calculates the difference between two timestamps. |
 |  <b>function(expr, ...)</b> |
 |  [abs(expr)](./firestore_lite_pipelines.md#abs_005f3d4) | <b><i>(Public Preview)</i></b> Creates an expression that computes the absolute value of a numeric value. |
 |  [ascending(expr)](./firestore_lite_pipelines.md#ascending_005f3d4) | <b><i>(Public Preview)</i></b> Creates an [Ordering](./firestore_pipelines.ordering.md#ordering_class) that sorts documents in ascending order based on an expression. |
@@ -249,6 +255,8 @@ https://github.com/firebase/firebase-js-sdk
 |  [subtract(fieldName, value)](./firestore_lite_pipelines.md#subtract_65e2f32) | <b><i>(Public Preview)</i></b> Creates an expression that subtracts a constant value from a field's value. |
 |  [sum(fieldName)](./firestore_lite_pipelines.md#sum_e5b0480) | <b><i>(Public Preview)</i></b> Creates an aggregation that calculates the sum of a field's values across multiple stage inputs. |
 |  [timestampAdd(fieldName, unit, amount)](./firestore_lite_pipelines.md#timestampadd_341fe7d) | <b><i>(Public Preview)</i></b> Creates an expression that adds a specified amount of time to a timestamp represented by a field. |
+|  [timestampExtract(fieldName, part, timezone)](./firestore_lite_pipelines.md#timestampextract_a51c205) | <b><i>(Public Preview)</i></b> Creates an expression that extracts a specified part from a timestamp. |
+|  [timestampExtract(fieldName, part, timezone)](./firestore_lite_pipelines.md#timestampextract_2d51eac) | <b><i>(Public Preview)</i></b> Creates an expression that extracts a specified part from a timestamp. |
 |  [timestampSubtract(fieldName, unit, amount)](./firestore_lite_pipelines.md#timestampsubtract_341fe7d) | <b><i>(Public Preview)</i></b> Creates an expression that subtracts a specified amount of time from a timestamp represented by a field. |
 |  [timestampToUnixMicros(fieldName)](./firestore_lite_pipelines.md#timestamptounixmicros_e5b0480) | <b><i>(Public Preview)</i></b> Creates an expression that converts a timestamp field to the number of microseconds since the Unix epoch (1970-01-01 00:00:00 UTC). |
 |  [timestampToUnixMillis(fieldName)](./firestore_lite_pipelines.md#timestamptounixmillis_e5b0480) | <b><i>(Public Preview)</i></b> Creates an expression that converts a timestamp field to the number of milliseconds since the Unix epoch (1970-01-01 00:00:00 UTC). |
@@ -353,6 +361,8 @@ https://github.com/firebase/firebase-js-sdk
 |  [timestampSubtract(timestamp, unit, amount)](./firestore_lite_pipelines.md#timestampsubtract_98418f9) | <b><i>(Public Preview)</i></b> Creates an expression that subtracts a specified amount of time from a timestamp. |
 |  [timestampSubtract(timestamp, unit, amount)](./firestore_lite_pipelines.md#timestampsubtract_ffe8e57) | <b><i>(Public Preview)</i></b> Creates an expression that subtracts a specified amount of time from a timestamp. |
 |  <b>function(timestampExpression, ...)</b> |
+|  [timestampExtract(timestampExpression, part, timezone)](./firestore_lite_pipelines.md#timestampextract_b2f8f48) | <b><i>(Public Preview)</i></b> Creates an expression that extracts a specified part from a timestamp. |
+|  [timestampExtract(timestampExpression, part, timezone)](./firestore_lite_pipelines.md#timestampextract_73e0311) | <b><i>(Public Preview)</i></b> Creates an expression that extracts a specified part from a timestamp. |
 |  [timestampTruncate(timestampExpression, granularity, timezone)](./firestore_lite_pipelines.md#timestamptruncate_ad5d843) | <b><i>(Public Preview)</i></b> Creates an expression that truncates a timestamp to a specified granularity. |
 |  [timestampTruncate(timestampExpression, granularity, timezone)](./firestore_lite_pipelines.md#timestamptruncate_d6ab2a4) | <b><i>(Public Preview)</i></b> Creates an expression that truncates a timestamp to a specified granularity. |
 |  <b>function(tryExpr, ...)</b> |
@@ -445,6 +455,7 @@ https://github.com/firebase/firebase-js-sdk
 |  [SetOptions](./firestore_lite_pipelines.md#setoptions) | An options object that configures the behavior of [setDoc()](./firestore_lite.md#setdoc_ee215ad)<!-- -->,  and  calls. These calls can be configured to perform granular merges instead of overwriting the target documents in their entirety by providing a <code>SetOptions</code> with <code>merge: true</code>. |
 |  [SortStageOptions](./firestore_lite_pipelines.md#sortstageoptions) | <b><i>(Public Preview)</i></b> Options defining how a SortStage is evaluated. See [Pipeline.sort()](./firestore_pipelines.pipeline.md#pipelinesort)<!-- -->. |
 |  [TimeGranularity](./firestore_lite_pipelines.md#timegranularity) | <b><i>(Public Preview)</i></b> Specify time granularity for expressions. |
+|  [TimePart](./firestore_lite_pipelines.md#timepart) | <b><i>(Public Preview)</i></b> Specify time parts for <code>timestampExtract</code> expressions. |
 |  [Type](./firestore_lite_pipelines.md#type) | <b><i>(Public Preview)</i></b> An enumeration of the different types generated by the Firestore backend.<ul> <li>Numerics evaluate directly to backend representation (<code>int64</code> or <code>float64</code>), not JS <code>number</code>.</li> <li>JavaScript <code>Date</code> and firestore <code>Timestamp</code> objects strictly evaluate to <code>'timestamp'</code>.</li> <li>Advanced configurations parsing backend types (such as <code>decimal128</code>, <code>max_key</code> or <code>min_key</code> from BSON) are also incorporated in this union string type. Note that <code>decimal128</code> is a backend-only numeric type that the JavaScript SDK cannot create natively, but can be evaluated in pipelines.</li> </ul> |
 |  [UnionStageOptions](./firestore_lite_pipelines.md#unionstageoptions) | <b><i>(Public Preview)</i></b> Options defining how a UnionStage is evaluated. See [Pipeline.union()](./firestore_pipelines.pipeline.md#pipelineunion)<!-- -->. |
 |  [UnnestStageOptions](./firestore_lite_pipelines.md#unneststageoptions) | <b><i>(Public Preview)</i></b> Represents the specific options available for configuring an <code>UnnestStage</code> within a pipeline. |
@@ -2059,6 +2070,154 @@ A new [Expression](./firestore_pipelines.expression.md#expression_class) represe
 ```typescript
 // Create a map from the input object and reference the 'baz' field value from the input document.
 map({foo: 'bar', baz: field('baz')}).as('data');
+
+```
+
+## function(endExpression, ...)
+
+### timestampDiff(endExpression, startFieldName, unit) {:#timestampdiff_8cb2a38}
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Creates an expression that calculates the difference between two timestamps.
+
+<b>Signature:</b>
+
+```typescript
+export declare function timestampDiff(endExpression: Expression, startFieldName: string, unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | Expression): FunctionExpression;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  endExpression | [Expression](./firestore_lite_pipelines.expression.md#expression_class) | The ending timestamp for the difference calculation. |
+|  startFieldName | string | The name of the field representing the starting timestamp. |
+|  unit | 'microsecond' \| 'millisecond' \| 'second' \| 'minute' \| 'hour' \| 'day' \| [Expression](./firestore_lite_pipelines.expression.md#expression_class) | The unit of time for the difference (e.g., "day", "hour"). |
+
+<b>Returns:</b>
+
+[FunctionExpression](./firestore_lite_pipelines.functionexpression.md#functionexpression_class)
+
+A new `Expression` representing the difference as an integer.
+
+### Example
+
+
+```typescript
+// Calculate the difference in days between an ending timestamp expression and 'startTime' field.
+timestampDiff(field('endTime'), 'startTime', 'day')
+
+```
+
+### timestampDiff(endExpression, startExpression, unit) {:#timestampdiff_33aecb4}
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Creates an expression that calculates the difference between two timestamps.
+
+<b>Signature:</b>
+
+```typescript
+export declare function timestampDiff(endExpression: Expression, startExpression: Expression, unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | Expression): FunctionExpression;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  endExpression | [Expression](./firestore_lite_pipelines.expression.md#expression_class) | The ending timestamp for the difference calculation. |
+|  startExpression | [Expression](./firestore_lite_pipelines.expression.md#expression_class) | The starting timestamp for the difference calculation. |
+|  unit | 'microsecond' \| 'millisecond' \| 'second' \| 'minute' \| 'hour' \| 'day' \| [Expression](./firestore_lite_pipelines.expression.md#expression_class) | The unit of time for the difference (e.g., "day", "hour"). |
+
+<b>Returns:</b>
+
+[FunctionExpression](./firestore_lite_pipelines.functionexpression.md#functionexpression_class)
+
+A new `Expression` representing the difference as an integer.
+
+### Example
+
+
+```typescript
+// Calculate the difference in days between two timestamp expressions.
+timestampDiff(field('endTime'), field('startTime'), 'day')
+
+```
+
+## function(endFieldName, ...)
+
+### timestampDiff(endFieldName, startFieldName, unit) {:#timestampdiff_c062afd}
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Creates an expression that calculates the difference between two timestamps.
+
+<b>Signature:</b>
+
+```typescript
+export declare function timestampDiff(endFieldName: string, startFieldName: string, unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | Expression): FunctionExpression;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  endFieldName | string | The name of the field representing the ending timestamp. |
+|  startFieldName | string | The name of the field representing the starting timestamp. |
+|  unit | 'microsecond' \| 'millisecond' \| 'second' \| 'minute' \| 'hour' \| 'day' \| [Expression](./firestore_lite_pipelines.expression.md#expression_class) | The unit of time for the difference (e.g., "day", "hour"). |
+
+<b>Returns:</b>
+
+[FunctionExpression](./firestore_lite_pipelines.functionexpression.md#functionexpression_class)
+
+A new `Expression` representing the difference as an integer.
+
+### Example
+
+
+```typescript
+// Calculate the difference in days between 'endTime' and 'startTime' fields.
+timestampDiff('endTime', 'startTime', 'day')
+
+```
+
+### timestampDiff(endFieldName, startExpression, unit) {:#timestampdiff_8244545}
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Creates an expression that calculates the difference between two timestamps.
+
+<b>Signature:</b>
+
+```typescript
+export declare function timestampDiff(endFieldName: string, startExpression: Expression, unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | Expression): FunctionExpression;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  endFieldName | string | The name of the field representing the ending timestamp. |
+|  startExpression | [Expression](./firestore_lite_pipelines.expression.md#expression_class) | The starting timestamp for the difference calculation. |
+|  unit | 'microsecond' \| 'millisecond' \| 'second' \| 'minute' \| 'hour' \| 'day' \| [Expression](./firestore_lite_pipelines.expression.md#expression_class) | The unit of time for the difference (e.g., "day", "hour"). |
+
+<b>Returns:</b>
+
+[FunctionExpression](./firestore_lite_pipelines.functionexpression.md#functionexpression_class)
+
+A new `Expression` representing the difference as an integer.
+
+### Example
+
+
+```typescript
+// Calculate the difference in days between 'endTime' field and a starting timestamp expression.
+timestampDiff('endTime', field('startTime'), 'day')
 
 ```
 
@@ -8023,6 +8182,78 @@ timestampAdd("timestamp", "day", 1);
 
 ```
 
+### timestampExtract(fieldName, part, timezone) {:#timestampextract_a51c205}
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Creates an expression that extracts a specified part from a timestamp.
+
+<b>Signature:</b>
+
+```typescript
+export declare function timestampExtract(fieldName: string, part: TimePart, timezone?: string | Expression): FunctionExpression;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  fieldName | string | The name of the field representing the timestamp. |
+|  part | [TimePart](./firestore_lite_pipelines.md#timepart) | The part to extract from the timestamp (e.g., "year", "month", "day"). |
+|  timezone | string \| [Expression](./firestore_lite_pipelines.expression.md#expression_class) | The timezone to use for extraction. Valid values are from the TZ database (e.g., "America/Los\_Angeles") or in the format "Etc/GMT-1." |
+
+<b>Returns:</b>
+
+[FunctionExpression](./firestore_lite_pipelines.functionexpression.md#functionexpression_class)
+
+A new `Expression` representing the extracted part as an integer.
+
+### Example
+
+
+```typescript
+// Extract the year from the 'createdAt' timestamp.
+timestampExtract('createdAt', 'year')
+
+```
+
+### timestampExtract(fieldName, part, timezone) {:#timestampextract_2d51eac}
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Creates an expression that extracts a specified part from a timestamp.
+
+<b>Signature:</b>
+
+```typescript
+export declare function timestampExtract(fieldName: string, part: Expression, timezone?: string | Expression): FunctionExpression;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  fieldName | string | The name of the field representing the timestamp. |
+|  part | [Expression](./firestore_lite_pipelines.expression.md#expression_class) | The expression evaluating to the part to extract. |
+|  timezone | string \| [Expression](./firestore_lite_pipelines.expression.md#expression_class) | The timezone to use for extraction. Valid values are from the TZ database (e.g., "America/Los\_Angeles") or in the format "Etc/GMT-1." |
+
+<b>Returns:</b>
+
+[FunctionExpression](./firestore_lite_pipelines.functionexpression.md#functionexpression_class)
+
+A new `Expression` representing the extracted part as an integer.
+
+### Example
+
+
+```typescript
+// Extract the part specified by the field 'part' from 'createdAt'.
+timestampExtract('createdAt', field('part'))
+
+```
+
 ### timestampSubtract(fieldName, unit, amount) {:#timestampsubtract_341fe7d}
 
 > This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
@@ -8193,7 +8424,7 @@ A new `Expression` representing the truncated timestamp.
 
 ```typescript
 // Truncate the 'createdAt' timestamp to the beginning of the day.
-field('createdAt').timestampTruncate('day')
+timestampTruncate('createdAt', 'day')
 
 ```
 
@@ -8229,7 +8460,7 @@ A new `Expression` representing the truncated timestamp.
 
 ```typescript
 // Truncate the 'createdAt' timestamp to the granularity specified in the field 'granularity'.
-field('createdAt').timestampTruncate(field('granularity'))
+timestampTruncate('createdAt', field('granularity'))
 
 ```
 
@@ -11087,6 +11318,78 @@ timestampSubtract(field("timestamp"), "day", 1);
 
 ## function(timestampExpression, ...)
 
+### timestampExtract(timestampExpression, part, timezone) {:#timestampextract_b2f8f48}
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Creates an expression that extracts a specified part from a timestamp.
+
+<b>Signature:</b>
+
+```typescript
+export declare function timestampExtract(timestampExpression: Expression, part: TimePart, timezone?: string | Expression): FunctionExpression;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  timestampExpression | [Expression](./firestore_lite_pipelines.expression.md#expression_class) | The expression evaluating to the timestamp. |
+|  part | [TimePart](./firestore_lite_pipelines.md#timepart) | The part to extract from the timestamp (e.g., "year", "month", "day"). |
+|  timezone | string \| [Expression](./firestore_lite_pipelines.expression.md#expression_class) | The timezone to use for extraction. Valid values are from the TZ database (e.g., "America/Los\_Angeles") or in the format "Etc/GMT-1." |
+
+<b>Returns:</b>
+
+[FunctionExpression](./firestore_lite_pipelines.functionexpression.md#functionexpression_class)
+
+A new `Expression` representing the extracted part as an integer.
+
+### Example
+
+
+```typescript
+// Extract the year from the timestamp returned by the expression.
+timestampExtract(field('createdAt'), 'year')
+
+```
+
+### timestampExtract(timestampExpression, part, timezone) {:#timestampextract_73e0311}
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Creates an expression that extracts a specified part from a timestamp.
+
+<b>Signature:</b>
+
+```typescript
+export declare function timestampExtract(timestampExpression: Expression, part: Expression, timezone?: string | Expression): FunctionExpression;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  timestampExpression | [Expression](./firestore_lite_pipelines.expression.md#expression_class) | The expression evaluating to the timestamp. |
+|  part | [Expression](./firestore_lite_pipelines.expression.md#expression_class) | The expression evaluating to the part to extract. |
+|  timezone | string \| [Expression](./firestore_lite_pipelines.expression.md#expression_class) | The timezone to use for extraction. Valid values are from the TZ database (e.g., "America/Los\_Angeles") or in the format "Etc/GMT-1." |
+
+<b>Returns:</b>
+
+[FunctionExpression](./firestore_lite_pipelines.functionexpression.md#functionexpression_class)
+
+A new `Expression` representing the extracted part as an integer.
+
+### Example
+
+
+```typescript
+// Extract the part specified by the field 'part' from the timestamp.
+timestampExtract(field('createdAt'), field('part'))
+
+```
+
 ### timestampTruncate(timestampExpression, granularity, timezone) {:#timestamptruncate_ad5d843}
 
 > This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
@@ -11119,7 +11422,7 @@ A new `Expression` representing the truncated timestamp.
 
 ```typescript
 // Truncate the 'createdAt' timestamp to the beginning of the day.
-field('createdAt').timestampTruncate('day')
+timestampTruncate(field('createdAt'), 'day')
 
 ```
 
@@ -11155,7 +11458,7 @@ A new `Expression` representing the truncated timestamp.
 
 ```typescript
 // Truncate the 'createdAt' timestamp to the granularity specified in the field 'granularity'.
-field('createdAt').timestampTruncate(field('granularity'))
+timestampTruncate(field('createdAt'), field('granularity'))
 
 ```
 
@@ -12195,6 +12498,19 @@ Specify time granularity for expressions.
 
 ```typescript
 export declare type TimeGranularity = 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'week(monday)' | 'week(tuesday)' | 'week(wednesday)' | 'week(thursday)' | 'week(friday)' | 'week(saturday)' | 'week(sunday)' | 'isoWeek' | 'month' | 'quarter' | 'year' | 'isoYear';
+```
+
+## TimePart
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Specify time parts for `timestampExtract` expressions.
+
+<b>Signature:</b>
+
+```typescript
+export declare type TimePart = TimeGranularity | 'dayofweek' | 'dayofyear';
 ```
 
 ## Type

--- a/docs-devsite/firestore_pipelines.expression.md
+++ b/docs-devsite/firestore_pipelines.expression.md
@@ -4846,7 +4846,7 @@ timestampDiff(start: Expression, unit: Expression): FunctionExpression;
 
 [FunctionExpression](./firestore_pipelines.functionexpression.md#functionexpression_class)
 
-A new [Expression](./firestore_pipelines.expression.md#expression_class) representing the difference as an int64.
+A new [Expression](./firestore_pipelines.expression.md#expression_class) representing the difference as an integer.
 
 ### Example
 

--- a/docs-devsite/firestore_pipelines.expression.md
+++ b/docs-devsite/firestore_pipelines.expression.md
@@ -180,6 +180,10 @@ export declare abstract class Expression
 |  [sum()](./firestore_pipelines.expression.md#expressionsum) |  | <b><i>(Public Preview)</i></b> Creates an aggregation that calculates the sum of a numeric field across multiple stage inputs. |
 |  [timestampAdd(unit, amount)](./firestore_pipelines.expression.md#expressiontimestampadd) |  | <b><i>(Public Preview)</i></b> Creates an expression that adds a specified amount of time to this timestamp expression. |
 |  [timestampAdd(unit, amount)](./firestore_pipelines.expression.md#expressiontimestampadd) |  | <b><i>(Public Preview)</i></b> Creates an expression that adds a specified amount of time to this timestamp expression. |
+|  [timestampDiff(start, unit)](./firestore_pipelines.expression.md#expressiontimestampdiff) |  | <b><i>(Public Preview)</i></b> Creates an expression that calculates the difference between this timestamp and another timestamp. |
+|  [timestampDiff(start, unit)](./firestore_pipelines.expression.md#expressiontimestampdiff) |  | <b><i>(Public Preview)</i></b> Creates an expression that calculates the difference between this timestamp and another timestamp. |
+|  [timestampExtract(part, timezone)](./firestore_pipelines.expression.md#expressiontimestampextract) |  | <b><i>(Public Preview)</i></b> Creates an expression that extracts a specified part from this timestamp expression. |
+|  [timestampExtract(part, timezone)](./firestore_pipelines.expression.md#expressiontimestampextract) |  | <b><i>(Public Preview)</i></b> Creates an expression that extracts a specified part from this timestamp expression. |
 |  [timestampSubtract(unit, amount)](./firestore_pipelines.expression.md#expressiontimestampsubtract) |  | <b><i>(Public Preview)</i></b> Creates an expression that subtracts a specified amount of time from this timestamp expression. |
 |  [timestampSubtract(unit, amount)](./firestore_pipelines.expression.md#expressiontimestampsubtract) |  | <b><i>(Public Preview)</i></b> Creates an expression that subtracts a specified amount of time from this timestamp expression. |
 |  [timestampToUnixMicros()](./firestore_pipelines.expression.md#expressiontimestamptounixmicros) |  | <b><i>(Public Preview)</i></b> Creates an expression that converts this timestamp expression to the number of microseconds since the Unix epoch (1970-01-01 00:00:00 UTC). |
@@ -4815,6 +4819,146 @@ A new [Expression](./firestore_pipelines.expression.md#expression_class) represe
 ```typescript
 // Add 1 day to the 'timestamp' field.
 field("timestamp").timestampAdd("day", 1);
+
+```
+
+## Expression.timestampDiff()
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Creates an expression that calculates the difference between this timestamp and another timestamp.
+
+<b>Signature:</b>
+
+```typescript
+timestampDiff(start: Expression, unit: Expression): FunctionExpression;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  start | [Expression](./firestore_pipelines.expression.md#expression_class) | The expression evaluating to the starting timestamp. |
+|  unit | [Expression](./firestore_pipelines.expression.md#expression_class) | The expression evaluates to a unit of time, must be one of 'microsecond', 'millisecond', 'second', 'minute', 'hour', 'day'. |
+
+<b>Returns:</b>
+
+[FunctionExpression](./firestore_pipelines.functionexpression.md#functionexpression_class)
+
+A new [Expression](./firestore_pipelines.expression.md#expression_class) representing the difference as an int64.
+
+### Example
+
+
+```typescript
+// Calculate the difference determined by fields 'startTime' and 'unit'.
+field("endTime").timestampDiff(field("startTime"), field("unit"));
+
+```
+
+## Expression.timestampDiff()
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Creates an expression that calculates the difference between this timestamp and another timestamp.
+
+<b>Signature:</b>
+
+```typescript
+timestampDiff(start: string | Expression, unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day'): FunctionExpression;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  start | string \| [Expression](./firestore_pipelines.expression.md#expression_class) | The field name of the starting timestamp. |
+|  unit | 'microsecond' \| 'millisecond' \| 'second' \| 'minute' \| 'hour' \| 'day' | The unit of time for the difference (e.g., "day", "hour"). |
+
+<b>Returns:</b>
+
+[FunctionExpression](./firestore_pipelines.functionexpression.md#functionexpression_class)
+
+A new [Expression](./firestore_pipelines.expression.md#expression_class) representing the difference as an integer.
+
+### Example
+
+
+```typescript
+// Calculate the difference in days between 'endTime' and 'startTime' fields.
+field("endTime").timestampDiff("startTime", "day");
+
+```
+
+## Expression.timestampExtract()
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Creates an expression that extracts a specified part from this timestamp expression.
+
+<b>Signature:</b>
+
+```typescript
+timestampExtract(part: TimePart, timezone?: string | Expression): FunctionExpression;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  part | [TimePart](./firestore_pipelines.md#timepart) | The part to extract from the timestamp (e.g., "year", "month", "day"). |
+|  timezone | string \| [Expression](./firestore_pipelines.expression.md#expression_class) | The timezone to use for extraction. Valid values are from the TZ database (e.g., "America/Los\_Angeles") or in the format "Etc/GMT-1." |
+
+<b>Returns:</b>
+
+[FunctionExpression](./firestore_pipelines.functionexpression.md#functionexpression_class)
+
+A new [Expression](./firestore_pipelines.expression.md#expression_class) representing the extracted part as an integer.
+
+### Example
+
+
+```typescript
+// Extract the year from the 'createdAt' field.
+field('createdAt').timestampExtract('year')
+
+```
+
+## Expression.timestampExtract()
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Creates an expression that extracts a specified part from this timestamp expression.
+
+<b>Signature:</b>
+
+```typescript
+timestampExtract(part: Expression, timezone?: string | Expression): FunctionExpression;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  part | [Expression](./firestore_pipelines.expression.md#expression_class) | The expression evaluating to the part to extract. |
+|  timezone | string \| [Expression](./firestore_pipelines.expression.md#expression_class) | The timezone to use for extraction. Valid values are from the TZ database (e.g., "America/Los\_Angeles") or in the format "Etc/GMT-1." |
+
+<b>Returns:</b>
+
+[FunctionExpression](./firestore_pipelines.functionexpression.md#functionexpression_class)
+
+A new [Expression](./firestore_pipelines.expression.md#expression_class) representing the extracted part as an integer.
+
+### Example
+
+
+```typescript
+// Extract the part specified by the field 'extractionPart' from 'createdAt'.
+field('createdAt').timestampExtract(field('extractionPart'))
 
 ```
 

--- a/docs-devsite/firestore_pipelines.md
+++ b/docs-devsite/firestore_pipelines.md
@@ -73,6 +73,12 @@ https://github.com/firebase/firebase-js-sdk
 |  <b>function(elements, ...)</b> |
 |  [array(elements)](./firestore_pipelines.md#array_7d853aa) | <b><i>(Public Preview)</i></b> Creates an expression that creates a Firestore array value from an input array. |
 |  [map(elements)](./firestore_pipelines.md#map_ce5dee1) | <b><i>(Public Preview)</i></b> Creates an expression that creates a Firestore map value from an input object. |
+|  <b>function(endExpression, ...)</b> |
+|  [timestampDiff(endExpression, startFieldName, unit)](./firestore_pipelines.md#timestampdiff_8cb2a38) | <b><i>(Public Preview)</i></b> Creates an expression that calculates the difference between two timestamps. |
+|  [timestampDiff(endExpression, startExpression, unit)](./firestore_pipelines.md#timestampdiff_33aecb4) | <b><i>(Public Preview)</i></b> Creates an expression that calculates the difference between two timestamps. |
+|  <b>function(endFieldName, ...)</b> |
+|  [timestampDiff(endFieldName, startFieldName, unit)](./firestore_pipelines.md#timestampdiff_c062afd) | <b><i>(Public Preview)</i></b> Creates an expression that calculates the difference between two timestamps. |
+|  [timestampDiff(endFieldName, startExpression, unit)](./firestore_pipelines.md#timestampdiff_8244545) | <b><i>(Public Preview)</i></b> Creates an expression that calculates the difference between two timestamps. |
 |  <b>function(expr, ...)</b> |
 |  [abs(expr)](./firestore_pipelines.md#abs_005f3d4) | <b><i>(Public Preview)</i></b> Creates an expression that computes the absolute value of a numeric value. |
 |  [ascending(expr)](./firestore_pipelines.md#ascending_005f3d4) | <b><i>(Public Preview)</i></b> Creates an [Ordering](./firestore_pipelines.ordering.md#ordering_class) that sorts documents in ascending order based on an expression. |
@@ -249,6 +255,8 @@ https://github.com/firebase/firebase-js-sdk
 |  [subtract(fieldName, value)](./firestore_pipelines.md#subtract_65e2f32) | <b><i>(Public Preview)</i></b> Creates an expression that subtracts a constant value from a field's value. |
 |  [sum(fieldName)](./firestore_pipelines.md#sum_e5b0480) | <b><i>(Public Preview)</i></b> Creates an aggregation that calculates the sum of a field's values across multiple stage inputs. |
 |  [timestampAdd(fieldName, unit, amount)](./firestore_pipelines.md#timestampadd_341fe7d) | <b><i>(Public Preview)</i></b> Creates an expression that adds a specified amount of time to a timestamp represented by a field. |
+|  [timestampExtract(fieldName, part, timezone)](./firestore_pipelines.md#timestampextract_a51c205) | <b><i>(Public Preview)</i></b> Creates an expression that extracts a specified part from a timestamp. |
+|  [timestampExtract(fieldName, part, timezone)](./firestore_pipelines.md#timestampextract_2d51eac) | <b><i>(Public Preview)</i></b> Creates an expression that extracts a specified part from a timestamp. |
 |  [timestampSubtract(fieldName, unit, amount)](./firestore_pipelines.md#timestampsubtract_341fe7d) | <b><i>(Public Preview)</i></b> Creates an expression that subtracts a specified amount of time from a timestamp represented by a field. |
 |  [timestampToUnixMicros(fieldName)](./firestore_pipelines.md#timestamptounixmicros_e5b0480) | <b><i>(Public Preview)</i></b> Creates an expression that converts a timestamp field to the number of microseconds since the Unix epoch (1970-01-01 00:00:00 UTC). |
 |  [timestampToUnixMillis(fieldName)](./firestore_pipelines.md#timestamptounixmillis_e5b0480) | <b><i>(Public Preview)</i></b> Creates an expression that converts a timestamp field to the number of milliseconds since the Unix epoch (1970-01-01 00:00:00 UTC). |
@@ -356,6 +364,8 @@ https://github.com/firebase/firebase-js-sdk
 |  [timestampSubtract(timestamp, unit, amount)](./firestore_pipelines.md#timestampsubtract_98418f9) | <b><i>(Public Preview)</i></b> Creates an expression that subtracts a specified amount of time from a timestamp. |
 |  [timestampSubtract(timestamp, unit, amount)](./firestore_pipelines.md#timestampsubtract_ffe8e57) | <b><i>(Public Preview)</i></b> Creates an expression that subtracts a specified amount of time from a timestamp. |
 |  <b>function(timestampExpression, ...)</b> |
+|  [timestampExtract(timestampExpression, part, timezone)](./firestore_pipelines.md#timestampextract_b2f8f48) | <b><i>(Public Preview)</i></b> Creates an expression that extracts a specified part from a timestamp. |
+|  [timestampExtract(timestampExpression, part, timezone)](./firestore_pipelines.md#timestampextract_73e0311) | <b><i>(Public Preview)</i></b> Creates an expression that extracts a specified part from a timestamp. |
 |  [timestampTruncate(timestampExpression, granularity, timezone)](./firestore_pipelines.md#timestamptruncate_ad5d843) | <b><i>(Public Preview)</i></b> Creates an expression that truncates a timestamp to a specified granularity. |
 |  [timestampTruncate(timestampExpression, granularity, timezone)](./firestore_pipelines.md#timestamptruncate_d6ab2a4) | <b><i>(Public Preview)</i></b> Creates an expression that truncates a timestamp to a specified granularity. |
 |  <b>function(tryExpr, ...)</b> |
@@ -451,6 +461,7 @@ https://github.com/firebase/firebase-js-sdk
 |  [SetOptions](./firestore_pipelines.md#setoptions) | An options object that configures the behavior of [setDoc()](./firestore_lite.md#setdoc_ee215ad)<!-- -->,  and  calls. These calls can be configured to perform granular merges instead of overwriting the target documents in their entirety by providing a <code>SetOptions</code> with <code>merge: true</code>. |
 |  [SortStageOptions](./firestore_pipelines.md#sortstageoptions) | <b><i>(Public Preview)</i></b> Options defining how a SortStage is evaluated. See [Pipeline.sort()](./firestore_pipelines.pipeline.md#pipelinesort)<!-- -->. |
 |  [TimeGranularity](./firestore_pipelines.md#timegranularity) | <b><i>(Public Preview)</i></b> Specify time granularity for expressions. |
+|  [TimePart](./firestore_pipelines.md#timepart) | <b><i>(Public Preview)</i></b> Specify time parts for <code>timestampExtract</code> expressions. |
 |  [Type](./firestore_pipelines.md#type) | <b><i>(Public Preview)</i></b> An enumeration of the different types generated by the Firestore backend.<ul> <li>Numerics evaluate directly to backend representation (<code>int64</code> or <code>float64</code>), not JS <code>number</code>.</li> <li>JavaScript <code>Date</code> and firestore <code>Timestamp</code> objects strictly evaluate to <code>'timestamp'</code>.</li> <li>Advanced configurations parsing backend types (such as <code>decimal128</code>, <code>max_key</code> or <code>min_key</code> from BSON) are also incorporated in this union string type. Note that <code>decimal128</code> is a backend-only numeric type that the JavaScript SDK cannot create natively, but can be evaluated in pipelines.</li> </ul> |
 |  [UnionStageOptions](./firestore_pipelines.md#unionstageoptions) | <b><i>(Public Preview)</i></b> Options defining how a UnionStage is evaluated. See [Pipeline.union()](./firestore_pipelines.pipeline.md#pipelineunion)<!-- -->. |
 |  [UnnestStageOptions](./firestore_pipelines.md#unneststageoptions) | <b><i>(Public Preview)</i></b> Represents the specific options available for configuring an <code>UnnestStage</code> within a pipeline. |
@@ -2065,6 +2076,154 @@ A new [Expression](./firestore_pipelines.expression.md#expression_class) represe
 ```typescript
 // Create a map from the input object and reference the 'baz' field value from the input document.
 map({foo: 'bar', baz: field('baz')}).as('data');
+
+```
+
+## function(endExpression, ...)
+
+### timestampDiff(endExpression, startFieldName, unit) {:#timestampdiff_8cb2a38}
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Creates an expression that calculates the difference between two timestamps.
+
+<b>Signature:</b>
+
+```typescript
+export declare function timestampDiff(endExpression: Expression, startFieldName: string, unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | Expression): FunctionExpression;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  endExpression | [Expression](./firestore_pipelines.expression.md#expression_class) | The ending timestamp for the difference calculation. |
+|  startFieldName | string | The name of the field representing the starting timestamp. |
+|  unit | 'microsecond' \| 'millisecond' \| 'second' \| 'minute' \| 'hour' \| 'day' \| [Expression](./firestore_pipelines.expression.md#expression_class) | The unit of time for the difference (e.g., "day", "hour"). |
+
+<b>Returns:</b>
+
+[FunctionExpression](./firestore_pipelines.functionexpression.md#functionexpression_class)
+
+A new `Expression` representing the difference as an integer.
+
+### Example
+
+
+```typescript
+// Calculate the difference in days between an ending timestamp expression and 'startTime' field.
+timestampDiff(field('endTime'), 'startTime', 'day')
+
+```
+
+### timestampDiff(endExpression, startExpression, unit) {:#timestampdiff_33aecb4}
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Creates an expression that calculates the difference between two timestamps.
+
+<b>Signature:</b>
+
+```typescript
+export declare function timestampDiff(endExpression: Expression, startExpression: Expression, unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | Expression): FunctionExpression;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  endExpression | [Expression](./firestore_pipelines.expression.md#expression_class) | The ending timestamp for the difference calculation. |
+|  startExpression | [Expression](./firestore_pipelines.expression.md#expression_class) | The starting timestamp for the difference calculation. |
+|  unit | 'microsecond' \| 'millisecond' \| 'second' \| 'minute' \| 'hour' \| 'day' \| [Expression](./firestore_pipelines.expression.md#expression_class) | The unit of time for the difference (e.g., "day", "hour"). |
+
+<b>Returns:</b>
+
+[FunctionExpression](./firestore_pipelines.functionexpression.md#functionexpression_class)
+
+A new `Expression` representing the difference as an integer.
+
+### Example
+
+
+```typescript
+// Calculate the difference in days between two timestamp expressions.
+timestampDiff(field('endTime'), field('startTime'), 'day')
+
+```
+
+## function(endFieldName, ...)
+
+### timestampDiff(endFieldName, startFieldName, unit) {:#timestampdiff_c062afd}
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Creates an expression that calculates the difference between two timestamps.
+
+<b>Signature:</b>
+
+```typescript
+export declare function timestampDiff(endFieldName: string, startFieldName: string, unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | Expression): FunctionExpression;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  endFieldName | string | The name of the field representing the ending timestamp. |
+|  startFieldName | string | The name of the field representing the starting timestamp. |
+|  unit | 'microsecond' \| 'millisecond' \| 'second' \| 'minute' \| 'hour' \| 'day' \| [Expression](./firestore_pipelines.expression.md#expression_class) | The unit of time for the difference (e.g., "day", "hour"). |
+
+<b>Returns:</b>
+
+[FunctionExpression](./firestore_pipelines.functionexpression.md#functionexpression_class)
+
+A new `Expression` representing the difference as an integer.
+
+### Example
+
+
+```typescript
+// Calculate the difference in days between 'endTime' and 'startTime' fields.
+timestampDiff('endTime', 'startTime', 'day')
+
+```
+
+### timestampDiff(endFieldName, startExpression, unit) {:#timestampdiff_8244545}
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Creates an expression that calculates the difference between two timestamps.
+
+<b>Signature:</b>
+
+```typescript
+export declare function timestampDiff(endFieldName: string, startExpression: Expression, unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | Expression): FunctionExpression;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  endFieldName | string | The name of the field representing the ending timestamp. |
+|  startExpression | [Expression](./firestore_pipelines.expression.md#expression_class) | The starting timestamp for the difference calculation. |
+|  unit | 'microsecond' \| 'millisecond' \| 'second' \| 'minute' \| 'hour' \| 'day' \| [Expression](./firestore_pipelines.expression.md#expression_class) | The unit of time for the difference (e.g., "day", "hour"). |
+
+<b>Returns:</b>
+
+[FunctionExpression](./firestore_pipelines.functionexpression.md#functionexpression_class)
+
+A new `Expression` representing the difference as an integer.
+
+### Example
+
+
+```typescript
+// Calculate the difference in days between 'endTime' field and a starting timestamp expression.
+timestampDiff('endTime', field('startTime'), 'day')
 
 ```
 
@@ -8029,6 +8188,78 @@ timestampAdd("timestamp", "day", 1);
 
 ```
 
+### timestampExtract(fieldName, part, timezone) {:#timestampextract_a51c205}
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Creates an expression that extracts a specified part from a timestamp.
+
+<b>Signature:</b>
+
+```typescript
+export declare function timestampExtract(fieldName: string, part: TimePart, timezone?: string | Expression): FunctionExpression;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  fieldName | string | The name of the field representing the timestamp. |
+|  part | [TimePart](./firestore_pipelines.md#timepart) | The part to extract from the timestamp (e.g., "year", "month", "day"). |
+|  timezone | string \| [Expression](./firestore_pipelines.expression.md#expression_class) | The timezone to use for extraction. Valid values are from the TZ database (e.g., "America/Los\_Angeles") or in the format "Etc/GMT-1." |
+
+<b>Returns:</b>
+
+[FunctionExpression](./firestore_pipelines.functionexpression.md#functionexpression_class)
+
+A new `Expression` representing the extracted part as an integer.
+
+### Example
+
+
+```typescript
+// Extract the year from the 'createdAt' timestamp.
+timestampExtract('createdAt', 'year')
+
+```
+
+### timestampExtract(fieldName, part, timezone) {:#timestampextract_2d51eac}
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Creates an expression that extracts a specified part from a timestamp.
+
+<b>Signature:</b>
+
+```typescript
+export declare function timestampExtract(fieldName: string, part: Expression, timezone?: string | Expression): FunctionExpression;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  fieldName | string | The name of the field representing the timestamp. |
+|  part | [Expression](./firestore_pipelines.expression.md#expression_class) | The expression evaluating to the part to extract. |
+|  timezone | string \| [Expression](./firestore_pipelines.expression.md#expression_class) | The timezone to use for extraction. Valid values are from the TZ database (e.g., "America/Los\_Angeles") or in the format "Etc/GMT-1." |
+
+<b>Returns:</b>
+
+[FunctionExpression](./firestore_pipelines.functionexpression.md#functionexpression_class)
+
+A new `Expression` representing the extracted part as an integer.
+
+### Example
+
+
+```typescript
+// Extract the part specified by the field 'part' from 'createdAt'.
+timestampExtract('createdAt', field('part'))
+
+```
+
 ### timestampSubtract(fieldName, unit, amount) {:#timestampsubtract_341fe7d}
 
 > This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
@@ -8199,7 +8430,7 @@ A new `Expression` representing the truncated timestamp.
 
 ```typescript
 // Truncate the 'createdAt' timestamp to the beginning of the day.
-field('createdAt').timestampTruncate('day')
+timestampTruncate('createdAt', 'day')
 
 ```
 
@@ -8235,7 +8466,7 @@ A new `Expression` representing the truncated timestamp.
 
 ```typescript
 // Truncate the 'createdAt' timestamp to the granularity specified in the field 'granularity'.
-field('createdAt').timestampTruncate(field('granularity'))
+timestampTruncate('createdAt', field('granularity'))
 
 ```
 
@@ -11162,6 +11393,78 @@ timestampSubtract(field("timestamp"), "day", 1);
 
 ## function(timestampExpression, ...)
 
+### timestampExtract(timestampExpression, part, timezone) {:#timestampextract_b2f8f48}
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Creates an expression that extracts a specified part from a timestamp.
+
+<b>Signature:</b>
+
+```typescript
+export declare function timestampExtract(timestampExpression: Expression, part: TimePart, timezone?: string | Expression): FunctionExpression;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  timestampExpression | [Expression](./firestore_pipelines.expression.md#expression_class) | The expression evaluating to the timestamp. |
+|  part | [TimePart](./firestore_pipelines.md#timepart) | The part to extract from the timestamp (e.g., "year", "month", "day"). |
+|  timezone | string \| [Expression](./firestore_pipelines.expression.md#expression_class) | The timezone to use for extraction. Valid values are from the TZ database (e.g., "America/Los\_Angeles") or in the format "Etc/GMT-1." |
+
+<b>Returns:</b>
+
+[FunctionExpression](./firestore_pipelines.functionexpression.md#functionexpression_class)
+
+A new `Expression` representing the extracted part as an integer.
+
+### Example
+
+
+```typescript
+// Extract the year from the timestamp returned by the expression.
+timestampExtract(field('createdAt'), 'year')
+
+```
+
+### timestampExtract(timestampExpression, part, timezone) {:#timestampextract_73e0311}
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Creates an expression that extracts a specified part from a timestamp.
+
+<b>Signature:</b>
+
+```typescript
+export declare function timestampExtract(timestampExpression: Expression, part: Expression, timezone?: string | Expression): FunctionExpression;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  timestampExpression | [Expression](./firestore_pipelines.expression.md#expression_class) | The expression evaluating to the timestamp. |
+|  part | [Expression](./firestore_pipelines.expression.md#expression_class) | The expression evaluating to the part to extract. |
+|  timezone | string \| [Expression](./firestore_pipelines.expression.md#expression_class) | The timezone to use for extraction. Valid values are from the TZ database (e.g., "America/Los\_Angeles") or in the format "Etc/GMT-1." |
+
+<b>Returns:</b>
+
+[FunctionExpression](./firestore_pipelines.functionexpression.md#functionexpression_class)
+
+A new `Expression` representing the extracted part as an integer.
+
+### Example
+
+
+```typescript
+// Extract the part specified by the field 'part' from the timestamp.
+timestampExtract(field('createdAt'), field('part'))
+
+```
+
 ### timestampTruncate(timestampExpression, granularity, timezone) {:#timestamptruncate_ad5d843}
 
 > This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
@@ -11194,7 +11497,7 @@ A new `Expression` representing the truncated timestamp.
 
 ```typescript
 // Truncate the 'createdAt' timestamp to the beginning of the day.
-field('createdAt').timestampTruncate('day')
+timestampTruncate(field('createdAt'), 'day')
 
 ```
 
@@ -11230,7 +11533,7 @@ A new `Expression` representing the truncated timestamp.
 
 ```typescript
 // Truncate the 'createdAt' timestamp to the granularity specified in the field 'granularity'.
-field('createdAt').timestampTruncate(field('granularity'))
+timestampTruncate(field('createdAt'), field('granularity'))
 
 ```
 
@@ -12270,6 +12573,19 @@ Specify time granularity for expressions.
 
 ```typescript
 export declare type TimeGranularity = 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'week(monday)' | 'week(tuesday)' | 'week(wednesday)' | 'week(thursday)' | 'week(friday)' | 'week(saturday)' | 'week(sunday)' | 'isoWeek' | 'month' | 'quarter' | 'year' | 'isoYear';
+```
+
+## TimePart
+
+> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+Specify time parts for `timestampExtract` expressions.
+
+<b>Signature:</b>
+
+```typescript
+export declare type TimePart = TimeGranularity | 'dayofweek' | 'dayofyear';
 ```
 
 ## Type

--- a/packages/firestore/lite/pipelines/pipelines.ts
+++ b/packages/firestore/lite/pipelines/pipelines.ts
@@ -184,6 +184,7 @@ export {
   timestampToUnixSeconds,
   timestampAdd,
   timestampSubtract,
+  timestampDiff,
   ascending,
   descending,
   abs,
@@ -210,6 +211,7 @@ export {
   arraySum,
   split,
   timestampTruncate,
+  timestampExtract,
   AliasedExpression,
   Field,
   Constant,
@@ -221,5 +223,6 @@ export {
   BooleanExpression,
   AggregateFunction,
   TimeGranularity,
+  TimePart,
   Type
 } from '../../src/lite-api/expressions';

--- a/packages/firestore/src/api_pipelines.ts
+++ b/packages/firestore/src/api_pipelines.ts
@@ -145,6 +145,7 @@ export {
   timestampToUnixSeconds,
   timestampAdd,
   timestampSubtract,
+  timestampDiff,
   ascending,
   descending,
   countIf,
@@ -178,6 +179,7 @@ export {
   log10,
   arraySum,
   timestampTruncate,
+  timestampExtract,
   split,
   Expression,
   AliasedExpression,
@@ -190,6 +192,7 @@ export {
   AliasedAggregate,
   Selectable,
   TimeGranularity,
+  TimePart,
   Type
 } from './lite-api/expressions';
 

--- a/packages/firestore/src/lite-api/expressions.ts
+++ b/packages/firestore/src/lite-api/expressions.ts
@@ -2652,13 +2652,7 @@ export abstract class Expression implements ProtoValueSerializable, UserData {
    */
   timestampDiff(
     start: string | Expression,
-    unit:
-      | 'microsecond'
-      | 'millisecond'
-      | 'second'
-      | 'minute'
-      | 'hour'
-      | 'day'
+    unit: 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day'
   ): FunctionExpression;
   timestampDiff(
     start: string | Expression,

--- a/packages/firestore/src/lite-api/expressions.ts
+++ b/packages/firestore/src/lite-api/expressions.ts
@@ -2632,7 +2632,7 @@ export abstract class Expression implements ProtoValueSerializable, UserData {
    *
    * @param start - The expression evaluating to the starting timestamp.
    * @param unit - The expression evaluates to a unit of time, must be one of 'microsecond', 'millisecond', 'second', 'minute', 'hour', 'day'.
-   * @returns A new {@link @firebase/firestore/pipelines#Expression} representing the difference as an int64.
+   * @returns A new {@link @firebase/firestore/pipelines#Expression} representing the difference as an integer.
    */
   timestampDiff(start: Expression, unit: Expression): FunctionExpression;
 

--- a/packages/firestore/src/lite-api/expressions.ts
+++ b/packages/firestore/src/lite-api/expressions.ts
@@ -2622,6 +2622,119 @@ export abstract class Expression implements ProtoValueSerializable, UserData {
 
   /**
    * @beta
+   * Creates an expression that calculates the difference between this timestamp and another timestamp.
+   *
+   * @example
+   * ```typescript
+   * // Calculate the difference determined by fields 'startTime' and 'unit'.
+   * field("endTime").timestampDiff(field("startTime"), field("unit"));
+   * ```
+   *
+   * @param start - The expression evaluating to the starting timestamp.
+   * @param unit - The expression evaluates to a unit of time, must be one of 'microsecond', 'millisecond', 'second', 'minute', 'hour', 'day'.
+   * @returns A new {@link @firebase/firestore/pipelines#Expression} representing the difference as an int64.
+   */
+  timestampDiff(start: Expression, unit: Expression): FunctionExpression;
+
+  /**
+   * @beta
+   * Creates an expression that calculates the difference between this timestamp and another timestamp.
+   *
+   * @example
+   * ```typescript
+   * // Calculate the difference in days between 'endTime' and 'startTime' fields.
+   * field("endTime").timestampDiff("startTime", "day");
+   * ```
+   *
+   * @param start - The field name of the starting timestamp.
+   * @param unit - The unit of time for the difference (e.g., "day", "hour").
+   * @returns A new {@link @firebase/firestore/pipelines#Expression} representing the difference as an integer.
+   */
+  timestampDiff(
+    start: string | Expression,
+    unit:
+      | 'microsecond'
+      | 'millisecond'
+      | 'second'
+      | 'minute'
+      | 'hour'
+      | 'day'
+  ): FunctionExpression;
+  timestampDiff(
+    start: string | Expression,
+    unit:
+      | 'microsecond'
+      | 'millisecond'
+      | 'second'
+      | 'minute'
+      | 'hour'
+      | 'day'
+      | Expression
+  ): FunctionExpression {
+    return new FunctionExpression(
+      'timestamp_diff',
+      [this, fieldOrExpression(start), valueToDefaultExpr(unit)],
+      'timestampDiff'
+    );
+  }
+
+  /**
+   * @beta
+   * Creates an expression that extracts a specified part from this timestamp expression.
+   *
+   * @example
+   * ```typescript
+   * // Extract the year from the 'createdAt' field.
+   * field('createdAt').timestampExtract('year')
+   * ```
+   *
+   * @param part - The part to extract from the timestamp (e.g., "year", "month", "day").
+   * @param timezone - The timezone to use for extraction. Valid values are from
+   * the TZ database (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1."
+   * @returns A new {@link @firebase/firestore/pipelines#Expression} representing the extracted part as an integer.
+   */
+  timestampExtract(
+    part: TimePart,
+    timezone?: string | Expression
+  ): FunctionExpression;
+
+  /**
+   * @beta
+   * Creates an expression that extracts a specified part from this timestamp expression.
+   *
+   * @example
+   * ```typescript
+   * // Extract the part specified by the field 'extractionPart' from 'createdAt'.
+   * field('createdAt').timestampExtract(field('extractionPart'))
+   * ```
+   *
+   * @param part - The expression evaluating to the part to extract.
+   * @param timezone - The timezone to use for extraction. Valid values are from
+   * the TZ database (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1."
+   * @returns A new {@link @firebase/firestore/pipelines#Expression} representing the extracted part as an integer.
+   */
+  timestampExtract(
+    part: Expression,
+    timezone?: string | Expression
+  ): FunctionExpression;
+  timestampExtract(
+    part: TimePart | Expression,
+    timezone?: string | Expression
+  ): FunctionExpression {
+    const internalPart = isString(part) ? part.toLowerCase() : part;
+    const args = [this, valueToDefaultExpr(internalPart)];
+    if (timezone) {
+      args.push(valueToDefaultExpr(timezone));
+    }
+    return new FunctionExpression(
+      'timestamp_extract',
+      args,
+      'timestampExtract'
+    );
+  }
+
+  /**
+   * @beta
    *
    * Creates an expression that returns the document ID from a path.
    *
@@ -3384,6 +3497,12 @@ export type TimeGranularity =
   | 'quarter'
   | 'year'
   | 'isoYear';
+
+/**
+ * @beta
+ * Specify time parts for `timestampExtract` expressions.
+ */
+export type TimePart = TimeGranularity | 'dayofweek' | 'dayofyear';
 
 /**
  * @beta
@@ -10763,7 +10882,7 @@ export function split(
  * @example
  * ```typescript
  * // Truncate the 'createdAt' timestamp to the beginning of the day.
- * field('createdAt').timestampTruncate('day')
+ * timestampTruncate('createdAt', 'day')
  * ```
  *
  * @param fieldName - Truncate the timestamp value contained in this field.
@@ -10785,7 +10904,7 @@ export function timestampTruncate(
  * @example
  * ```typescript
  * // Truncate the 'createdAt' timestamp to the granularity specified in the field 'granularity'.
- * field('createdAt').timestampTruncate(field('granularity'))
+ * timestampTruncate('createdAt', field('granularity'))
  * ```
  *
  * @param fieldName - Truncate the timestamp value contained in this field.
@@ -10807,7 +10926,7 @@ export function timestampTruncate(
  * @example
  * ```typescript
  * // Truncate the 'createdAt' timestamp to the beginning of the day.
- * field('createdAt').timestampTruncate('day')
+ * timestampTruncate(field('createdAt'), 'day')
  * ```
  *
  * @param timestampExpression - Truncate the timestamp value that is returned by this expression.
@@ -10829,7 +10948,7 @@ export function timestampTruncate(
  * @example
  * ```typescript
  * // Truncate the 'createdAt' timestamp to the granularity specified in the field 'granularity'.
- * field('createdAt').timestampTruncate(field('granularity'))
+ * timestampTruncate(field('createdAt'), field('granularity'))
  * ```
  *
  * @param timestampExpression - Truncate the timestamp value that is returned by this expression.
@@ -10853,6 +10972,233 @@ export function timestampTruncate(
     : granularity;
   return fieldOrExpression(fieldNameOrExpression).timestampTruncate(
     internalGranularity,
+    timezone
+  );
+}
+
+/**
+ * @beta
+ * Creates an expression that calculates the difference between two timestamps.
+ *
+ * @example
+ * ```typescript
+ * // Calculate the difference in days between 'endTime' and 'startTime' fields.
+ * timestampDiff('endTime', 'startTime', 'day')
+ * ```
+ *
+ * @param endFieldName - The name of the field representing the ending timestamp.
+ * @param startFieldName - The name of the field representing the starting timestamp.
+ * @param unit - The unit of time for the difference (e.g., "day", "hour").
+ * @returns A new `Expression` representing the difference as an integer.
+ */
+export function timestampDiff(
+  endFieldName: string,
+  startFieldName: string,
+  unit:
+    | 'microsecond'
+    | 'millisecond'
+    | 'second'
+    | 'minute'
+    | 'hour'
+    | 'day'
+    | Expression
+): FunctionExpression;
+
+/**
+ * @beta
+ * Creates an expression that calculates the difference between two timestamps.
+ *
+ * @example
+ * ```typescript
+ * // Calculate the difference in days between 'endTime' field and a starting timestamp expression.
+ * timestampDiff('endTime', field('startTime'), 'day')
+ * ```
+ *
+ * @param endFieldName - The name of the field representing the ending timestamp.
+ * @param startExpression - The starting timestamp for the difference calculation.
+ * @param unit - The unit of time for the difference (e.g., "day", "hour").
+ * @returns A new `Expression` representing the difference as an integer.
+ */
+export function timestampDiff(
+  endFieldName: string,
+  startExpression: Expression,
+  unit:
+    | 'microsecond'
+    | 'millisecond'
+    | 'second'
+    | 'minute'
+    | 'hour'
+    | 'day'
+    | Expression
+): FunctionExpression;
+
+/**
+ * @beta
+ * Creates an expression that calculates the difference between two timestamps.
+ *
+ * @example
+ * ```typescript
+ * // Calculate the difference in days between an ending timestamp expression and 'startTime' field.
+ * timestampDiff(field('endTime'), 'startTime', 'day')
+ * ```
+ *
+ * @param endExpression - The ending timestamp for the difference calculation.
+ * @param startFieldName - The name of the field representing the starting timestamp.
+ * @param unit - The unit of time for the difference (e.g., "day", "hour").
+ * @returns A new `Expression` representing the difference as an integer.
+ */
+export function timestampDiff(
+  endExpression: Expression,
+  startFieldName: string,
+  unit:
+    | 'microsecond'
+    | 'millisecond'
+    | 'second'
+    | 'minute'
+    | 'hour'
+    | 'day'
+    | Expression
+): FunctionExpression;
+
+/**
+ * @beta
+ * Creates an expression that calculates the difference between two timestamps.
+ *
+ * @example
+ * ```typescript
+ * // Calculate the difference in days between two timestamp expressions.
+ * timestampDiff(field('endTime'), field('startTime'), 'day')
+ * ```
+ *
+ * @param endExpression - The ending timestamp for the difference calculation.
+ * @param startExpression - The starting timestamp for the difference calculation.
+ * @param unit - The unit of time for the difference (e.g., "day", "hour").
+ * @returns A new `Expression` representing the difference as an integer.
+ */
+export function timestampDiff(
+  endExpression: Expression,
+  startExpression: Expression,
+  unit:
+    | 'microsecond'
+    | 'millisecond'
+    | 'second'
+    | 'minute'
+    | 'hour'
+    | 'day'
+    | Expression
+): FunctionExpression;
+export function timestampDiff(
+  endFieldNameOrExpression: string | Expression,
+  startFieldNameOrExpression: string | Expression,
+  unit:
+    | 'microsecond'
+    | 'millisecond'
+    | 'second'
+    | 'minute'
+    | 'hour'
+    | 'day'
+    | Expression
+): FunctionExpression {
+  const normalizedEnd = fieldOrExpression(endFieldNameOrExpression);
+  const normalizedStart = fieldOrExpression(startFieldNameOrExpression);
+  const normalizedUnit = valueToDefaultExpr(unit);
+  return normalizedEnd.timestampDiff(normalizedStart, normalizedUnit);
+}
+
+/**
+ * @beta
+ * Creates an expression that extracts a specified part from a timestamp.
+ *
+ * @example
+ * ```typescript
+ * // Extract the year from the 'createdAt' timestamp.
+ * timestampExtract('createdAt', 'year')
+ * ```
+ *
+ * @param fieldName - The name of the field representing the timestamp.
+ * @param part - The part to extract from the timestamp (e.g., "year", "month", "day").
+ * @param timezone - The timezone to use for extraction. Valid values are from
+ * the TZ database (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1."
+ * @returns A new `Expression` representing the extracted part as an integer.
+ */
+export function timestampExtract(
+  fieldName: string,
+  part: TimePart,
+  timezone?: string | Expression
+): FunctionExpression;
+
+/**
+ * @beta
+ * Creates an expression that extracts a specified part from a timestamp.
+ *
+ * @example
+ * ```typescript
+ * // Extract the part specified by the field 'part' from 'createdAt'.
+ * timestampExtract('createdAt', field('part'))
+ * ```
+ *
+ * @param fieldName - The name of the field representing the timestamp.
+ * @param part - The expression evaluating to the part to extract.
+ * @param timezone - The timezone to use for extraction. Valid values are from
+ * the TZ database (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1."
+ * @returns A new `Expression` representing the extracted part as an integer.
+ */
+export function timestampExtract(
+  fieldName: string,
+  part: Expression,
+  timezone?: string | Expression
+): FunctionExpression;
+
+/**
+ * @beta
+ * Creates an expression that extracts a specified part from a timestamp.
+ *
+ * @example
+ * ```typescript
+ * // Extract the year from the timestamp returned by the expression.
+ * timestampExtract(field('createdAt'), 'year')
+ * ```
+ *
+ * @param timestampExpression - The expression evaluating to the timestamp.
+ * @param part - The part to extract from the timestamp (e.g., "year", "month", "day").
+ * @param timezone - The timezone to use for extraction. Valid values are from
+ * the TZ database (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1."
+ * @returns A new `Expression` representing the extracted part as an integer.
+ */
+export function timestampExtract(
+  timestampExpression: Expression,
+  part: TimePart,
+  timezone?: string | Expression
+): FunctionExpression;
+
+/**
+ * @beta
+ * Creates an expression that extracts a specified part from a timestamp.
+ *
+ * @example
+ * ```typescript
+ * // Extract the part specified by the field 'part' from the timestamp.
+ * timestampExtract(field('createdAt'), field('part'))
+ * ```
+ *
+ * @param timestampExpression - The expression evaluating to the timestamp.
+ * @param part - The expression evaluating to the part to extract.
+ * @param timezone - The timezone to use for extraction. Valid values are from
+ * the TZ database (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1."
+ * @returns A new `Expression` representing the extracted part as an integer.
+ */
+export function timestampExtract(
+  timestampExpression: Expression,
+  part: Expression,
+  timezone?: string | Expression
+): FunctionExpression;
+export function timestampExtract(
+  fieldNameOrExpression: string | Expression,
+  part: TimePart | Expression,
+  timezone?: string | Expression
+): FunctionExpression {
+  return fieldOrExpression(fieldNameOrExpression).timestampExtract(
+    valueToDefaultExpr(isString(part) ? part.toLowerCase() : part),
     timezone
   );
 }

--- a/packages/firestore/test/integration/api/pipeline.test.ts
+++ b/packages/firestore/test/integration/api/pipeline.test.ts
@@ -168,6 +168,8 @@ import {
   arraySum,
   PipelineSnapshot,
   timestampTruncate,
+  timestampDiff,
+  timestampExtract,
   split,
   type,
   isType
@@ -5105,6 +5107,75 @@ apiDescribe.skipClassic('Pipelines', persistence => {
         'trunc_second': new Timestamp(Date.UTC(2025, 10, 30, 1, 2, 3) / 1000, 0)
       });
     });
+
+    it('supports timestamp difference', async () => {
+      const snapshot = await execute(
+        firestore
+          .pipeline()
+          .collection(randomCol)
+          .limit(1)
+          .select(
+            constant(new Timestamp(1741437296, 123456789)).as('end'),
+            constant(new Timestamp(1741428000, 0)).as('start')
+          )
+          .select(
+            timestampDiff(field('end'), field('start'), 'hour').as('diff_hour'),
+            field('end')
+              .timestampDiff(field('start'), 'minute')
+              .as('diff_minute'),
+            field('end')
+              .timestampDiff(field('start'), 'second')
+              .as('diff_second'),
+            field('start')
+              .timestampDiff(field('end'), 'hour')
+              .as('diff_hour_neg')
+          )
+      );
+
+      expectResults(snapshot, {
+        diff_hour: 2,
+        diff_minute: 154,
+        diff_second: 9296,
+        diff_hour_neg: -2
+      });
+    }).timeout(10000);
+
+    it('supports timestamp extraction', async () => {
+      const snapshot = await execute(
+        firestore
+          .pipeline()
+          .collection(randomCol)
+          .limit(1)
+          .select(constant(new Timestamp(1741437296, 123456789)).as('ts'))
+          .select(
+            timestampExtract(field('ts'), 'year').as('year'),
+            field('ts').timestampExtract('month').as('month'),
+            timestampExtract(field('ts'), 'day').as('day'),
+            field('ts').timestampExtract('hour').as('hour'),
+            timestampExtract(field('ts'), 'minute').as('minute'),
+            field('ts').timestampExtract('second').as('second'),
+            timestampExtract(field('ts'), 'millisecond').as('millis'),
+            field('ts').timestampExtract('microsecond').as('micros'),
+            timestampExtract(field('ts'), 'dayofyear').as('day_of_year'),
+            field('ts')
+              .timestampExtract('hour', 'America/Los_Angeles')
+              .as('hour_la')
+          )
+      );
+
+      expectResults(snapshot, {
+        year: 2025,
+        month: 3,
+        day: 8,
+        hour: 12,
+        minute: 34,
+        second: 56,
+        millis: 123,
+        micros: 123456,
+        day_of_year: 67,
+        hour_la: 4
+      });
+    }).timeout(10000);
 
     it('supports split', async () => {
       const results = await execute(

--- a/packages/firestore/test/integration/api/pipeline.test.ts
+++ b/packages/firestore/test/integration/api/pipeline.test.ts
@@ -5119,24 +5119,24 @@ apiDescribe.skipClassic('Pipelines', persistence => {
             constant(new Timestamp(1741428000, 0)).as('start')
           )
           .select(
-            timestampDiff(field('end'), field('start'), 'hour').as('diff_hour'),
+            timestampDiff(field('end'), field('start'), 'hour').as('diffHour'),
             field('end')
               .timestampDiff(field('start'), 'minute')
-              .as('diff_minute'),
+              .as('diffMinute'),
             field('end')
               .timestampDiff(field('start'), 'second')
-              .as('diff_second'),
+              .as('diffSecond'),
             field('start')
               .timestampDiff(field('end'), 'hour')
-              .as('diff_hour_neg')
+              .as('diffHourNeg')
           )
       );
 
       expectResults(snapshot, {
-        diff_hour: 2,
-        diff_minute: 154,
-        diff_second: 9296,
-        diff_hour_neg: -2
+        diffHour: 2,
+        diffMinute: 154,
+        diffSecond: 9296,
+        diffHourNeg: -2
       });
     }).timeout(10000);
 
@@ -5156,10 +5156,10 @@ apiDescribe.skipClassic('Pipelines', persistence => {
             field('ts').timestampExtract('second').as('second'),
             timestampExtract(field('ts'), 'millisecond').as('millis'),
             field('ts').timestampExtract('microsecond').as('micros'),
-            timestampExtract(field('ts'), 'dayofyear').as('day_of_year'),
+            timestampExtract(field('ts'), 'dayofyear').as('dayOfYear'),
             field('ts')
               .timestampExtract('hour', 'America/Los_Angeles')
-              .as('hour_la')
+              .as('hourLa')
           )
       );
 
@@ -5172,8 +5172,8 @@ apiDescribe.skipClassic('Pipelines', persistence => {
         second: 56,
         millis: 123,
         micros: 123456,
-        day_of_year: 67,
-        hour_la: 4
+        dayOfYear: 67,
+        hourLa: 4
       });
     }).timeout(10000);
 

--- a/packages/firestore/test/integration/api/pipeline.test.ts
+++ b/packages/firestore/test/integration/api/pipeline.test.ts
@@ -5126,9 +5126,7 @@ apiDescribe.skipClassic('Pipelines', persistence => {
             field('end')
               .timestampDiff(field('start'), 'second')
               .as('diffSecond'),
-            field('start')
-              .timestampDiff(field('end'), 'hour')
-              .as('diffHourNeg')
+            field('start').timestampDiff(field('end'), 'hour').as('diffHourNeg')
           )
       );
 

--- a/packages/firestore/test/lite/pipeline.test.ts
+++ b/packages/firestore/test/lite/pipeline.test.ts
@@ -3940,9 +3940,11 @@ describe.skipClassic('Firestore Pipelines', () => {
             constant(new Timestamp(1741437296, 123456789)).as('timestamp')
           )
           .select(
-            timestampTruncate(field('timestamp'), 'day', 'America/Los_Angeles').as(
-              'trunc_day_la'
-            )
+            timestampTruncate(
+              field('timestamp'),
+              'day',
+              'America/Los_Angeles'
+            ).as('trunc_day_la')
           )
       );
 

--- a/packages/firestore/test/lite/pipeline.test.ts
+++ b/packages/firestore/test/lite/pipeline.test.ts
@@ -3971,9 +3971,7 @@ describe.skipClassic('Firestore Pipelines', () => {
             field('end')
               .timestampDiff(field('start'), 'second')
               .as('diffSecond'),
-            field('start')
-              .timestampDiff(field('end'), 'hour')
-              .as('diffHourNeg')
+            field('start').timestampDiff(field('end'), 'hour').as('diffHourNeg')
           )
       );
 

--- a/packages/firestore/test/lite/pipeline.test.ts
+++ b/packages/firestore/test/lite/pipeline.test.ts
@@ -3911,22 +3911,22 @@ describe.skipClassic('Firestore Pipelines', () => {
             constant(new Timestamp(1741437296, 123456789)).as('timestamp')
           )
           .select(
-            timestampTruncate(field('timestamp'), 'year').as('trunc_year'),
-            timestampTruncate(field('timestamp'), 'month').as('trunc_month'),
-            timestampTruncate(field('timestamp'), 'day').as('trunc_day'),
-            timestampTruncate(field('timestamp'), 'hour').as('trunc_hour'),
-            timestampTruncate(field('timestamp'), 'minute').as('trunc_minute'),
-            timestampTruncate(field('timestamp'), 'second').as('trunc_second')
+            timestampTruncate(field('timestamp'), 'year').as('truncYear'),
+            timestampTruncate(field('timestamp'), 'month').as('truncMonth'),
+            timestampTruncate(field('timestamp'), 'day').as('truncDay'),
+            timestampTruncate(field('timestamp'), 'hour').as('truncHour'),
+            timestampTruncate(field('timestamp'), 'minute').as('truncMinute'),
+            timestampTruncate(field('timestamp'), 'second').as('truncSecond')
           )
       );
 
       expectResults(snapshot, {
-        trunc_year: new Timestamp(1735689600, 0),
-        trunc_month: new Timestamp(1740787200, 0),
-        trunc_day: new Timestamp(1741392000, 0),
-        trunc_hour: new Timestamp(1741435200, 0),
-        trunc_minute: new Timestamp(1741437240, 0),
-        trunc_second: new Timestamp(1741437296, 0)
+        truncYear: new Timestamp(1735689600, 0),
+        truncMonth: new Timestamp(1740787200, 0),
+        truncDay: new Timestamp(1741392000, 0),
+        truncHour: new Timestamp(1741435200, 0),
+        truncMinute: new Timestamp(1741437240, 0),
+        truncSecond: new Timestamp(1741437296, 0)
       });
     }).timeout(10000);
 
@@ -3944,12 +3944,12 @@ describe.skipClassic('Firestore Pipelines', () => {
               field('timestamp'),
               'day',
               'America/Los_Angeles'
-            ).as('trunc_day_la')
+            ).as('truncDayLa')
           )
       );
 
       expectResults(snapshot, {
-        trunc_day_la: new Timestamp(1741420800, 0)
+        truncDayLa: new Timestamp(1741420800, 0)
       });
     }).timeout(10000);
 
@@ -3964,24 +3964,24 @@ describe.skipClassic('Firestore Pipelines', () => {
             constant(new Timestamp(1741428000, 0)).as('start')
           )
           .select(
-            timestampDiff(field('end'), field('start'), 'hour').as('diff_hour'),
+            timestampDiff(field('end'), field('start'), 'hour').as('diffHour'),
             field('end')
               .timestampDiff(field('start'), 'minute')
-              .as('diff_minute'),
+              .as('diffMinute'),
             field('end')
               .timestampDiff(field('start'), 'second')
-              .as('diff_second'),
+              .as('diffSecond'),
             field('start')
               .timestampDiff(field('end'), 'hour')
-              .as('diff_hour_neg')
+              .as('diffHourNeg')
           )
       );
 
       expectResults(snapshot, {
-        diff_hour: 2,
-        diff_minute: 154,
-        diff_second: 9296,
-        diff_hour_neg: -2
+        diffHour: 2,
+        diffMinute: 154,
+        diffSecond: 9296,
+        diffHourNeg: -2
       });
     }).timeout(10000);
 
@@ -4001,10 +4001,10 @@ describe.skipClassic('Firestore Pipelines', () => {
             field('ts').timestampExtract('second').as('second'),
             timestampExtract(field('ts'), 'millisecond').as('millis'),
             field('ts').timestampExtract('microsecond').as('micros'),
-            timestampExtract(field('ts'), 'dayofyear').as('day_of_year'),
+            timestampExtract(field('ts'), 'dayofyear').as('dayOfYear'),
             field('ts')
               .timestampExtract('hour', 'America/Los_Angeles')
-              .as('hour_la')
+              .as('hourLa')
           )
       );
 
@@ -4017,8 +4017,8 @@ describe.skipClassic('Firestore Pipelines', () => {
         second: 56,
         millis: 123,
         micros: 123456,
-        day_of_year: 67,
-        hour_la: 4
+        dayOfYear: 67,
+        hourLa: 4
       });
     }).timeout(10000);
 

--- a/packages/firestore/test/lite/pipeline.test.ts
+++ b/packages/firestore/test/lite/pipeline.test.ts
@@ -3916,7 +3916,8 @@ describe.skipClassic('Firestore Pipelines', () => {
             timestampTruncate(field('timestamp'), 'day').as('truncDay'),
             timestampTruncate(field('timestamp'), 'hour').as('truncHour'),
             timestampTruncate(field('timestamp'), 'minute').as('truncMinute'),
-            timestampTruncate(field('timestamp'), 'second').as('truncSecond')
+            timestampTruncate(field('timestamp'), 'second').as('truncSecond'),
+            timestampTruncate(field('timestamp'), 'isoWeek').as('truncIsoWeek')
           )
       );
 
@@ -3926,7 +3927,8 @@ describe.skipClassic('Firestore Pipelines', () => {
         truncDay: new Timestamp(1741392000, 0),
         truncHour: new Timestamp(1741435200, 0),
         truncMinute: new Timestamp(1741437240, 0),
-        truncSecond: new Timestamp(1741437296, 0)
+        truncSecond: new Timestamp(1741437296, 0),
+        truncIsoWeek: new Timestamp(1740960000, 0)
       });
     }).timeout(10000);
 

--- a/packages/firestore/test/lite/pipeline.test.ts
+++ b/packages/firestore/test/lite/pipeline.test.ts
@@ -121,6 +121,9 @@ import {
   timestampToUnixSeconds,
   timestampAdd,
   timestampSubtract,
+  timestampTruncate,
+  timestampDiff,
+  timestampExtract,
   ascending,
   descending,
   FunctionExpression,
@@ -3895,6 +3898,125 @@ describe.skipClassic('Firestore Pipelines', () => {
         minus10seconds: new Timestamp(1741380225, 0),
         minus10micros: new Timestamp(1741380234, 999990000),
         minus10millis: new Timestamp(1741380234, 990000000)
+      });
+    }).timeout(10000);
+
+    it('supports timestamp truncation', async () => {
+      const snapshot = await execute(
+        firestore
+          .pipeline()
+          .collection(randomCol)
+          .limit(1)
+          .select(
+            constant(new Timestamp(1741437296, 123456789)).as('timestamp')
+          )
+          .select(
+            timestampTruncate(field('timestamp'), 'year').as('trunc_year'),
+            timestampTruncate(field('timestamp'), 'month').as('trunc_month'),
+            timestampTruncate(field('timestamp'), 'day').as('trunc_day'),
+            timestampTruncate(field('timestamp'), 'hour').as('trunc_hour'),
+            timestampTruncate(field('timestamp'), 'minute').as('trunc_minute'),
+            timestampTruncate(field('timestamp'), 'second').as('trunc_second')
+          )
+      );
+
+      expectResults(snapshot, {
+        trunc_year: new Timestamp(1735689600, 0),
+        trunc_month: new Timestamp(1740787200, 0),
+        trunc_day: new Timestamp(1741392000, 0),
+        trunc_hour: new Timestamp(1741435200, 0),
+        trunc_minute: new Timestamp(1741437240, 0),
+        trunc_second: new Timestamp(1741437296, 0)
+      });
+    }).timeout(10000);
+
+    it('supports timestamp truncation with timezone', async () => {
+      const snapshot = await execute(
+        firestore
+          .pipeline()
+          .collection(randomCol)
+          .limit(1)
+          .select(
+            constant(new Timestamp(1741437296, 123456789)).as('timestamp')
+          )
+          .select(
+            timestampTruncate(field('timestamp'), 'day', 'America/Los_Angeles').as(
+              'trunc_day_la'
+            )
+          )
+      );
+
+      expectResults(snapshot, {
+        trunc_day_la: new Timestamp(1741420800, 0)
+      });
+    }).timeout(10000);
+
+    it('supports timestamp difference', async () => {
+      const snapshot = await execute(
+        firestore
+          .pipeline()
+          .collection(randomCol)
+          .limit(1)
+          .select(
+            constant(new Timestamp(1741437296, 123456789)).as('end'),
+            constant(new Timestamp(1741428000, 0)).as('start')
+          )
+          .select(
+            timestampDiff(field('end'), field('start'), 'hour').as('diff_hour'),
+            field('end')
+              .timestampDiff(field('start'), 'minute')
+              .as('diff_minute'),
+            field('end')
+              .timestampDiff(field('start'), 'second')
+              .as('diff_second'),
+            field('start')
+              .timestampDiff(field('end'), 'hour')
+              .as('diff_hour_neg')
+          )
+      );
+
+      expectResults(snapshot, {
+        diff_hour: 2,
+        diff_minute: 154,
+        diff_second: 9296,
+        diff_hour_neg: -2
+      });
+    }).timeout(10000);
+
+    it('supports timestamp extraction', async () => {
+      const snapshot = await execute(
+        firestore
+          .pipeline()
+          .collection(randomCol)
+          .limit(1)
+          .select(constant(new Timestamp(1741437296, 123456789)).as('ts'))
+          .select(
+            timestampExtract(field('ts'), 'year').as('year'),
+            field('ts').timestampExtract('month').as('month'),
+            timestampExtract(field('ts'), 'day').as('day'),
+            field('ts').timestampExtract('hour').as('hour'),
+            timestampExtract(field('ts'), 'minute').as('minute'),
+            field('ts').timestampExtract('second').as('second'),
+            timestampExtract(field('ts'), 'millisecond').as('millis'),
+            field('ts').timestampExtract('microsecond').as('micros'),
+            timestampExtract(field('ts'), 'dayofyear').as('day_of_year'),
+            field('ts')
+              .timestampExtract('hour', 'America/Los_Angeles')
+              .as('hour_la')
+          )
+      );
+
+      expectResults(snapshot, {
+        year: 2025,
+        month: 3,
+        day: 8,
+        hour: 12,
+        minute: 34,
+        second: 56,
+        millis: 123,
+        micros: 123456,
+        day_of_year: 67,
+        hour_la: 4
       });
     }).timeout(10000);
 


### PR DESCRIPTION
Add new timestamp expressions `timestamp_diff`  and `timestamp_extract` and integration tests for the expressions

The expression `timestamp_trunc` was already ported in the repo with integration tests in firebase-js-sdk/packages/firestore/test/integration/api/pipeline.test.ts 
Add extra integration tests for `timestamp_trunc` in firebase-js-sdk/packages/firestore/test/lite/pipeline.test.ts and amend the example usage documentation for standalone methods

Both `timestamp_trunc` and `timestamp_extract` use overload implementation and have timeZone as optional argument