### PR TITLE
fix(firestore): read user data in internal pipeline proto serialization

### DIFF
--- a/.changeset/sour-peaches-attend.md
+++ b/.changeset/sour-peaches-attend.md
@@ -1,0 +1,5 @@
+---
+'@firebase/firestore': patch
+---
+
+Read user data when using internal pipeline proto serialization.

--- a/packages/firestore/src/remote/internal_serializer.ts
+++ b/packages/firestore/src/remote/internal_serializer.ts
@@ -26,6 +26,10 @@ import { AggregateSpec } from '../lite-api/aggregate_types';
 import { getDatastore } from '../lite-api/components';
 import { Pipeline } from '../lite-api/pipeline';
 import { Query } from '../lite-api/reference';
+import {
+  newUserDataReader,
+  UserDataSource
+} from '../lite-api/user_data_reader';
 import { ExecutePipelineRequest as ProtoExecutePipelineRequest } from '../protos/firestore_proto_api';
 import { cast } from '../util/input_validation';
 import { mapToArray } from '../util/obj';
@@ -116,6 +120,15 @@ export function _internalPipelineToExecutePipelineRequestProto(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): any {
   const firestore = cast(pipeline._db, Firestore);
+
+  const userDataReader = newUserDataReader(firestore);
+  const context = userDataReader.createContext(
+    UserDataSource.Argument,
+    '_internalPipelineToExecutePipelineRequestProto'
+  );
+
+  pipeline._readUserData(context);
+
   const datastore = getDatastore(firestore);
   const serializer = datastore.serializer;
   if (serializer === undefined) {


### PR DESCRIPTION
Adds a step to `internalPipelineToExecutePipelineRequestProto` to read user data before serialization. Fixes an in

This function was broken in https://github.com/firebase/firebase-js-sdk/pull/9715, and caused the `console support` tests to fail, which use this method to verify pipelines get serialized as expected. 
```
       console support
         supports pipeline query serialization to proto:
     Error: FIRESTORE (12.10.0) INTERNAL ASSERTION FAILED: Value of this constant has not been serialized to proto value (ID: ed)
      at _fail (src/util/assert.ts:40:1)
      at hardAssert (src/util/assert.ts:61:31)
      at Constant._toProto (src/lite-api/expressions.ts:2449:1)
      at /Users/dlarocque/workspace/sdk/firebase-js-sdk/packages/firestore/src/lite-api/expressions.ts:2573:1
      at Array.map (<anonymous>)
      at FunctionExpression._toProto (src/lite-api/expressions.ts:2573:1)
      at BooleanFunctionExpression._toProto (src/lite-api/expressions.ts:2733:1)
      at Where._toProto (src/lite-api/stage.ts:91:24)
      at /Users/dlarocque/workspace/sdk/firebase-js-sdk/packages/firestore/src/lite-api/pipeline.ts:1027:1
      at Array.map (<anonymous>)
      at Pipeline._toProto (src/lite-api/pipeline.ts:1027:1)
      at StructuredPipeline._toProto (src/core/structured_pipeline.ts:8:1)
      at _internalPipelineToExecutePipelineRequestProto (src/remote/internal_serializer.ts:57:16)
      at Context.<anonymous> (test/integration/api_internal/pipeline.test.ts:71:67)
      at processImmediate (node:internal/timers:478:21)
```

These test failures weren't caught since they weren't run in CI, and were skipped when ran locally with `test:lite` and `test:browser`. I verified these tests now pass using `test:node:prod`.

This is an internal change, so I did not add a changelog entry.
