### PR TITLE
re-register on FID change 

### DIFF
--- a/packages/messaging/src/api/register.ts
+++ b/packages/messaging/src/api/register.ts
@@ -70,11 +70,9 @@ export async function register(
       return;
     }
 
-    // TODO: refresh weekly
     await registerFcmRegistrationWithFid(messaging);
     messaging.lastNotifiedFid = fid;
 
-    // TODO: callback per fid change
     const handler = messaging.onRegisteredHandler;
     if (!handler) {
       return;

--- a/packages/messaging/src/api/register.ts
+++ b/packages/messaging/src/api/register.ts
@@ -57,7 +57,8 @@ export async function register(
   if (!messaging.onRegisteredHandler) {
     throw ERROR_FACTORY.create(ErrorCode.INVALID_ON_REGISTERED_HANDLER);
   }
-
+  
+  // TODO: refresh weekly
   await updateVapidKey(messaging, options?.vapidKey);
   await updateSwReg(messaging, options?.serviceWorkerRegistration);
 

--- a/packages/messaging/src/api/register.ts
+++ b/packages/messaging/src/api/register.ts
@@ -71,6 +71,7 @@ export async function register(
       return;
     }
 
+    // TODO: refresh weekly
     await registerFcmRegistrationWithFid(messaging);
     messaging.lastNotifiedFid = fid;
 

--- a/packages/messaging/src/helpers/fid-change-registration.test.ts
+++ b/packages/messaging/src/helpers/fid-change-registration.test.ts
@@ -21,75 +21,119 @@ import { subscribeFidChangeRegistration } from './fid-change-registration';
 import { MessagingService } from '../messaging-service';
 import {
   getFakeAnalyticsProvider,
-  getFakeApp,
-  getFakeInstallations
+  getFakeApp
 } from '../testing/fakes/firebase-dependencies';
 import { FakeServiceWorkerRegistration } from '../testing/fakes/service-worker';
 import { stub } from 'sinon';
 import { expect } from 'chai';
-import * as registerModule from '../api/register';
 import * as installationsApi from '@firebase/installations';
+import * as requestsModule from '../internals/requests';
 import { Stub } from '../testing/sinon-types';
+import { _FirebaseInstallationsInternal } from '@firebase/installations';
 
 describe('subscribeFidChangeRegistration', () => {
   let messaging: MessagingService;
+  /** Same object as `messaging.firebaseDependencies.installations`; `getId` tracks simulated rotation. */
+  let installationsInternal: _FirebaseInstallationsInternal;
+  let currentFid: string;
+  let installations: installationsApi.Installations;
   let onIdChangeStub: Stub<typeof installationsApi.onIdChange>;
-  let registerStub: Stub<typeof registerModule.register>;
+  let requestCreateRegistrationStub: Stub<
+    typeof requestsModule.requestCreateRegistration
+  >;
   let fidChangeCallback: installationsApi.IdChangeCallbackFn | undefined;
+  let unsubscribeStub: ReturnType<typeof stub>;
 
   beforeEach(() => {
     stub(Notification, 'permission').value('granted');
+    const app = getFakeApp();
+    currentFid = 'fid-before-rotation';
+    installationsInternal = {
+      getId: async () => currentFid,
+      getToken: async () => 'authToken'
+    };
+    installations = { app } as installationsApi.Installations;
     messaging = new MessagingService(
-      getFakeApp(),
-      getFakeInstallations(),
+      app,
+      installationsInternal,
       getFakeAnalyticsProvider()
     );
     messaging.vapidKey = 'dmFwaWQta2V5LXZhbHVl';
-    messaging.swRegistration = new FakeServiceWorkerRegistration();
+    // Test-only: Fake registration is structurally compatible for our usage here.
+    messaging.swRegistration =
+      new FakeServiceWorkerRegistration() as unknown as ServiceWorkerRegistration;
 
     fidChangeCallback = undefined;
+    unsubscribeStub = stub();
     onIdChangeStub = stub(installationsApi, 'onIdChange').callsFake(
       (_installations, cb: installationsApi.IdChangeCallbackFn) => {
         fidChangeCallback = cb;
-        return () => {};
+        return unsubscribeStub;
       }
     ) as Stub<typeof installationsApi.onIdChange>;
 
-    registerStub = stub(registerModule, 'register').resolves() as Stub<
-      typeof registerModule.register
-    >;
+    requestCreateRegistrationStub = stub(
+      requestsModule,
+      'requestCreateRegistration'
+    ).resolves() as Stub<typeof requestsModule.requestCreateRegistration>;
   });
 
   afterEach(() => {
     onIdChangeStub.restore();
-    registerStub.restore();
+    requestCreateRegistrationStub.restore();
   });
 
-  it('calls register when Installations invokes the FID change callback and onRegistered is set', async () => {
-    messaging.onRegisteredHandler = stub();
+  it('runs real register when Installations invokes the FID change callback and delivers the new FID via onRegistered', async () => {
+    const onRegisteredSpy = stub();
+    messaging.onRegisteredHandler = onRegisteredSpy;
+    messaging.lastNotifiedFid = 'fid-before-rotation';
 
-    subscribeFidChangeRegistration(
-      messaging,
-      {} as installationsApi.Installations
-    );
+    subscribeFidChangeRegistration(messaging, installations);
 
-    fidChangeCallback!('new-fid');
+    currentFid = 'fid-after-rotation';
+    fidChangeCallback!('fid-after-rotation');
 
-    await Promise.resolve();
+    // `register()` only assigns `_registerNotifyChain` after updateVapidKey/updateSwReg; wait for
+    // that chain (and the inner getId/registerFcm work) to finish.
+    await new Promise<void>(resolve => setTimeout(resolve, 0));
+    await messaging._registerNotifyChain;
 
-    expect(registerStub).to.have.been.calledOnceWith(messaging);
+    expect(onRegisteredSpy).to.have.been.calledOnceWith('fid-after-rotation');
+    expect(requestCreateRegistrationStub).to.have.been.calledOnce;
   });
 
-  it('does not call register when onRegistered handler is not set', () => {
+  it('does not call register when onRegistered handler is not set', async () => {
     messaging.onRegisteredHandler = null;
 
-    subscribeFidChangeRegistration(
-      messaging,
-      {} as installationsApi.Installations
-    );
+    subscribeFidChangeRegistration(messaging, installations);
 
+    currentFid = 'new-fid';
     fidChangeCallback!('new-fid');
 
-    expect(registerStub).to.not.have.been.called;
+    await new Promise<void>(resolve => setTimeout(resolve, 0));
+    await messaging._registerNotifyChain;
+
+    expect(requestCreateRegistrationStub).to.not.have.been.called;
+  });
+
+  it('does not call the unsubscribe function when FID changes (unsubscribe is only for teardown)', async () => {
+    messaging.onRegisteredHandler = stub();
+
+    const unsubscribe = subscribeFidChangeRegistration(
+      messaging,
+      installations
+    );
+    expect(unsubscribe).to.equal(unsubscribeStub);
+
+    messaging.lastNotifiedFid = 'a';
+    currentFid = 'b';
+    fidChangeCallback!('b');
+    currentFid = 'c';
+    fidChangeCallback!('c');
+
+    await new Promise<void>(resolve => setTimeout(resolve, 0));
+    await messaging._registerNotifyChain;
+
+    expect(unsubscribeStub).to.not.have.been.called;
   });
 });

--- a/packages/messaging/src/helpers/fid-change-registration.test.ts
+++ b/packages/messaging/src/helpers/fid-change-registration.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '../testing/setup';
+
+import { subscribeFidChangeRegistration } from './fid-change-registration';
+import { MessagingService } from '../messaging-service';
+import {
+  getFakeAnalyticsProvider,
+  getFakeApp,
+  getFakeInstallations
+} from '../testing/fakes/firebase-dependencies';
+import { FakeServiceWorkerRegistration } from '../testing/fakes/service-worker';
+import { stub } from 'sinon';
+import { expect } from 'chai';
+import * as registerModule from '../api/register';
+import * as installationsApi from '@firebase/installations';
+import { Stub } from '../testing/sinon-types';
+
+describe('subscribeFidChangeRegistration', () => {
+  let messaging: MessagingService;
+  let onIdChangeStub: Stub<typeof installationsApi.onIdChange>;
+  let registerStub: Stub<typeof registerModule.register>;
+  let fidChangeCallback: installationsApi.IdChangeCallbackFn | undefined;
+
+  beforeEach(() => {
+    stub(Notification, 'permission').value('granted');
+    messaging = new MessagingService(
+      getFakeApp(),
+      getFakeInstallations(),
+      getFakeAnalyticsProvider()
+    );
+    messaging.vapidKey = 'dmFwaWQta2V5LXZhbHVl';
+    messaging.swRegistration = new FakeServiceWorkerRegistration();
+
+    fidChangeCallback = undefined;
+    onIdChangeStub = stub(installationsApi, 'onIdChange').callsFake(
+      (_installations, cb: installationsApi.IdChangeCallbackFn) => {
+        fidChangeCallback = cb;
+        return () => {};
+      }
+    ) as Stub<typeof installationsApi.onIdChange>;
+
+    registerStub = stub(registerModule, 'register').resolves() as Stub<
+      typeof registerModule.register
+    >;
+  });
+
+  afterEach(() => {
+    onIdChangeStub.restore();
+    registerStub.restore();
+  });
+
+  it('calls register when Installations invokes the FID change callback and onRegistered is set', async () => {
+    messaging.onRegisteredHandler = stub();
+
+    subscribeFidChangeRegistration(
+      messaging,
+      {} as installationsApi.Installations
+    );
+
+    fidChangeCallback!('new-fid');
+
+    await Promise.resolve();
+
+    expect(registerStub).to.have.been.calledOnceWith(messaging);
+  });
+
+  it('does not call register when onRegistered handler is not set', () => {
+    messaging.onRegisteredHandler = null;
+
+    subscribeFidChangeRegistration(
+      messaging,
+      {} as installationsApi.Installations
+    );
+
+    fidChangeCallback!('new-fid');
+
+    expect(registerStub).to.not.have.been.called;
+  });
+});

--- a/packages/messaging/src/helpers/fid-change-registration.ts
+++ b/packages/messaging/src/helpers/fid-change-registration.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  IdChangeUnsubscribeFn,
+  Installations,
+  onIdChange
+} from '@firebase/installations';
+import { register } from '../api/register';
+import { MessagingService } from '../messaging-service';
+
+/**
+ * When the Firebase Installation ID changes, re-run `register()` so FCM registration and
+ * onRegistered run for the new FID. No-op if no onRegistered handler is set.
+ */
+export function subscribeFidChangeRegistration(
+  messaging: MessagingService,
+  installations: Installations
+): IdChangeUnsubscribeFn {
+  return onIdChange(installations, () => {
+    if (!messaging.onRegisteredHandler) {
+      return;
+    }
+    void register(messaging).catch(() => {
+      // Best-effort: permission may be revoked or SW unavailable after FID rotation.
+    });
+  });
+}

--- a/packages/messaging/src/helpers/register.ts
+++ b/packages/messaging/src/helpers/register.ts
@@ -34,6 +34,7 @@ import { ServiceWorkerGlobalScope } from '../util/sw-types';
 import { _registerComponent, registerVersion } from '@firebase/app';
 import { getToken } from '../api/getToken';
 import { register } from '../api/register';
+import { subscribeFidChangeRegistration } from './fid-change-registration';
 import { messageEventListener } from '../listeners/window-listener';
 
 import { name, version } from '../../package.json';
@@ -49,6 +50,11 @@ const WindowMessagingFactory: InstanceFactory<'messaging'> = (
 
   navigator.serviceWorker.addEventListener('message', e =>
     messageEventListener(messaging as MessagingService, e)
+  );
+
+  messaging._fidChangeUnsubscribe = subscribeFidChangeRegistration(
+    messaging as MessagingService,
+    container.getProvider('installations').getImmediate()
   );
 
   return messaging;

--- a/packages/messaging/src/messaging-service.ts
+++ b/packages/messaging/src/messaging-service.ts
@@ -22,7 +22,10 @@ import { FirebaseAnalyticsInternalName } from '@firebase/analytics-interop-types
 import { FirebaseInternalDependencies } from './interfaces/internal-dependencies';
 import { LogEvent } from './interfaces/logging-types';
 import { Provider } from '@firebase/component';
-import { _FirebaseInstallationsInternal } from '@firebase/installations';
+import {
+  _FirebaseInstallationsInternal,
+  IdChangeUnsubscribeFn
+} from '@firebase/installations';
 import { extractAppConfig } from './helpers/extract-app-config';
 
 export class MessagingService implements _FirebaseService {
@@ -57,6 +60,9 @@ export class MessagingService implements _FirebaseService {
    */
   _registerNotifyChain: Promise<void> = Promise.resolve();
 
+  /** Unsubscribe from Installations `onIdChange` when messaging is deleted. */
+  _fidChangeUnsubscribe: IdChangeUnsubscribeFn | null = null;
+
   logEvents: LogEvent[] = [];
   isLogServiceStarted: boolean = false;
 
@@ -66,7 +72,6 @@ export class MessagingService implements _FirebaseService {
     analyticsProvider: Provider<FirebaseAnalyticsInternalName>
   ) {
     const appConfig = extractAppConfig(app);
-
     this.firebaseDependencies = {
       app,
       appConfig,
@@ -76,6 +81,10 @@ export class MessagingService implements _FirebaseService {
   }
 
   _delete(): Promise<void> {
+    if (this._fidChangeUnsubscribe) {
+      this._fidChangeUnsubscribe();
+      this._fidChangeUnsubscribe = null;
+    }
     return Promise.resolve();
   }
 }


### PR DESCRIPTION
## Summary

When the Firebase Installation ID (FID) changes, the Messaging SDK now listens via Firebase Installations `onIdChange` (including cross-tab updates) and calls `register()` when an `onRegistered` handler is set. That re-runs FCM FID registration and delivers the new FID through `onRegistered`, without requiring the app to poll `getId()`.

## Implementation

- `subscribeFidChangeRegistration()` uses `onIdChange` from `@firebase/installations`.
- Wired in the window `MessagingService` factory; unsubscribe stored on `MessagingService` and cleared in `_delete()`.
- If no `onRegistered` handler is registered, the FID-change path does not call `register()` (avoids `invalid-on-registered-handler`).
- Errors from `register()` in this path are swallowed to avoid unhandled rejections (e.g. revoked permission).
