### PR TITLE
fix(firestore): record pending target requests at stream-start time

### DIFF
--- a/.changeset/fix-pending-target-bookkeeping.md
+++ b/.changeset/fix-pending-target-bookkeeping.md
@@ -1,6 +1,5 @@
 ---
 '@firebase/firestore': patch
-'firebase': patch
 ---
 
-Fixed watch stream pending target bookkeeping to prevent crashes during rapid unlisten/listen cycles (e.g. React 19 StrictMode).
+Fix watch stream pending target bookkeeping to prevent fatal crash caused by React 19 StrictMode double-invoking effects during stream reconnection.

--- a/.changeset/fix-pending-target-bookkeeping.md
+++ b/.changeset/fix-pending-target-bookkeeping.md
@@ -1,0 +1,6 @@
+---
+'@firebase/firestore': patch
+'firebase': patch
+---
+
+Fixed watch stream pending target bookkeeping to prevent crashes during rapid unlisten/listen cycles (e.g. React 19 StrictMode).

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -143,6 +143,16 @@ class RemoteStoreImpl implements RemoteStore {
   watchChangeAggregator?: WatchChangeAggregator;
 
   /**
+   * Set of target IDs whose pending responses were pre-recorded when
+   * startWatchStream was called. Used by onWatchStreamOpen to avoid
+   * double-counting pending responses for targets that existed at
+   * stream-start time.
+   *
+   * See: https://github.com/firebase/firebase-js-sdk/issues/9729
+   */
+  pendingTargetsForWatchOpen?: Set<TargetId>;
+
+  /**
    * A set of reasons for why the RemoteStore may be offline. If empty, the
    * RemoteStore may start its network connections.
    */
@@ -349,6 +359,28 @@ function sendWatchRequest(
 }
 
 /**
+ * Sends a watch request on the wire without recording a pending target
+ * request. Used by onWatchStreamOpen for targets whose pending requests
+ * were already recorded in startWatchStream.
+ */
+function sendWatchMessage(
+  remoteStoreImpl: RemoteStoreImpl,
+  targetData: TargetData
+): void {
+  if (
+    targetData.resumeToken.approximateByteSize() > 0 ||
+    targetData.snapshotVersion.compareTo(SnapshotVersion.min()) > 0
+  ) {
+    const expectedCount = remoteStoreImpl.remoteSyncer.getRemoteKeysForTarget!(
+      targetData.targetId
+    ).size;
+    targetData = targetData.withExpectedCount(expectedCount);
+  }
+
+  ensureWatchStream(remoteStoreImpl).watch(targetData);
+}
+
+/**
  * We need to increment the expected number of pending responses we're due
  * from watch so we wait for the removal on the server before we process any
  * messages from this target.
@@ -378,6 +410,19 @@ function startWatchStream(remoteStoreImpl: RemoteStoreImpl): void {
       remoteStoreImpl.listenTargets.get(targetId) || null,
     getDatabaseId: () => remoteStoreImpl.datastore.serializer.databaseId
   });
+
+  // Record pending target requests for all current listen targets immediately,
+  // rather than deferring to onWatchStreamOpen. This prevents a bookkeeping
+  // mismatch when targets are removed/re-added between stream start and open
+  // (e.g. React StrictMode double-invoking effects, or rapid navigation during
+  // network reconnection).
+  // See: https://github.com/firebase/firebase-js-sdk/issues/9729
+  remoteStoreImpl.pendingTargetsForWatchOpen = new Set<TargetId>();
+  remoteStoreImpl.listenTargets.forEach((_, targetId) => {
+    remoteStoreImpl.watchChangeAggregator!.recordPendingTargetRequest(targetId);
+    remoteStoreImpl.pendingTargetsForWatchOpen!.add(targetId);
+  });
+
   ensureWatchStream(remoteStoreImpl).start();
   remoteStoreImpl.onlineStateTracker.handleWatchStreamStart();
 }
@@ -401,6 +446,7 @@ export function canUseNetwork(remoteStore: RemoteStore): boolean {
 
 function cleanUpWatchStreamState(remoteStoreImpl: RemoteStoreImpl): void {
   remoteStoreImpl.watchChangeAggregator = undefined;
+  remoteStoreImpl.pendingTargetsForWatchOpen = undefined;
 }
 
 async function onWatchStreamConnected(
@@ -413,9 +459,30 @@ async function onWatchStreamConnected(
 async function onWatchStreamOpen(
   remoteStoreImpl: RemoteStoreImpl
 ): Promise<void> {
+  const preRecorded = remoteStoreImpl.pendingTargetsForWatchOpen;
+  remoteStoreImpl.pendingTargetsForWatchOpen = undefined;
+
   remoteStoreImpl.listenTargets.forEach((targetData, targetId) => {
-    sendWatchRequest(remoteStoreImpl, targetData);
+    if (preRecorded?.has(targetId)) {
+      // Pending request was already recorded in startWatchStream.
+      // Just send the wire message without re-recording.
+      sendWatchMessage(remoteStoreImpl, targetData);
+    } else {
+      // Target was added after startWatchStream. Record pending + send.
+      sendWatchRequest(remoteStoreImpl, targetData);
+    }
   });
+
+  // Clean up pre-recorded targets that were removed before the stream opened.
+  // Their pending requests were recorded but no wire message was sent, so no
+  // server response will arrive. Remove their orphaned target state.
+  if (preRecorded) {
+    for (const targetId of preRecorded) {
+      if (!remoteStoreImpl.listenTargets.has(targetId)) {
+        remoteStoreImpl.watchChangeAggregator!.removeTarget(targetId);
+      }
+    }
+  }
 }
 
 async function onWatchStreamClose(

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -334,17 +334,14 @@ export function remoteStoreUnlisten(
 }
 
 /**
- * We need to increment the expected number of pending responses we're due
- * from watch so we wait for the ack to process any messages from this target.
+ * Sends a watch request on the wire, attaching the expected count when the
+ * target carries a resume token or snapshot version. This shared helper is
+ * used by both {@link sendWatchRequest} and {@link sendWatchMessage}.
  */
-function sendWatchRequest(
+function writeWatchTarget(
   remoteStoreImpl: RemoteStoreImpl,
   targetData: TargetData
 ): void {
-  remoteStoreImpl.watchChangeAggregator!.recordPendingTargetRequest(
-    targetData.targetId
-  );
-
   if (
     targetData.resumeToken.approximateByteSize() > 0 ||
     targetData.snapshotVersion.compareTo(SnapshotVersion.min()) > 0
@@ -359,6 +356,20 @@ function sendWatchRequest(
 }
 
 /**
+ * We need to increment the expected number of pending responses we're due
+ * from watch so we wait for the ack to process any messages from this target.
+ */
+function sendWatchRequest(
+  remoteStoreImpl: RemoteStoreImpl,
+  targetData: TargetData
+): void {
+  remoteStoreImpl.watchChangeAggregator!.recordPendingTargetRequest(
+    targetData.targetId
+  );
+  writeWatchTarget(remoteStoreImpl, targetData);
+}
+
+/**
  * Sends a watch request on the wire without recording a pending target
  * request. Used by onWatchStreamOpen for targets whose pending requests
  * were already recorded in startWatchStream.
@@ -367,17 +378,7 @@ function sendWatchMessage(
   remoteStoreImpl: RemoteStoreImpl,
   targetData: TargetData
 ): void {
-  if (
-    targetData.resumeToken.approximateByteSize() > 0 ||
-    targetData.snapshotVersion.compareTo(SnapshotVersion.min()) > 0
-  ) {
-    const expectedCount = remoteStoreImpl.remoteSyncer.getRemoteKeysForTarget!(
-      targetData.targetId
-    ).size;
-    targetData = targetData.withExpectedCount(expectedCount);
-  }
-
-  ensureWatchStream(remoteStoreImpl).watch(targetData);
+  writeWatchTarget(remoteStoreImpl, targetData);
 }
 
 /**

--- a/packages/firestore/src/remote/watch_change.ts
+++ b/packages/firestore/src/remote/watch_change.ts
@@ -240,12 +240,23 @@ class TargetState {
 
   recordTargetResponse(): void {
     this.pendingResponses -= 1;
-    hardAssert(
-      this.pendingResponses >= 0,
-      0x0ca9,
-      '`pendingResponses` is less than 0. This indicates that the SDK received more target acks from the server than expected. The SDK should not continue to operate.',
-      { pendingResponses: this.pendingResponses }
-    );
+    if (this.pendingResponses < 0) {
+      // It is possible for pendingResponses to go negative in environments
+      // where effects are double-invoked (e.g. React 19 StrictMode). A rapid
+      // listen/unlisten/re-listen cycle can cause the server to send more
+      // target acks than the client has recorded pending requests. Rather
+      // than fatally crashing the entire SDK instance (which is
+      // unrecoverable), we clamp to zero and continue.
+      // See: https://github.com/firebase/firebase-js-sdk/issues/9729
+      logWarn(
+        'Received more target responses than pending target requests ' +
+          '(pendingResponses=' +
+          this.pendingResponses +
+          '). This may happen in environments that re-invoke effects ' +
+          '(e.g. React StrictMode).'
+      );
+      this.pendingResponses = 0;
+    }
   }
 
   markCurrent(): void {

--- a/packages/firestore/test/unit/remote/remote_event.test.ts
+++ b/packages/firestore/test/unit/remote/remote_event.test.ts
@@ -697,4 +697,85 @@ describe('RemoteEvent', () => {
     // Doc3 is only in the non-limbo target, therefore not tracked as limbo
     expect(event.resolvedLimboDocuments.has(doc3.key)).to.be.false;
   });
+
+  it('does not crash when receiving more target responses than pending requests', () => {
+    // Regression test for https://github.com/firebase/firebase-js-sdk/issues/9729
+    //
+    // React 19 StrictMode double-invokes effects, which can cause
+    // listen/unlisten/re-listen sequences that result in the server sending
+    // more target acks than the client expects. The old hardAssert in
+    // recordTargetResponse() would permanently crash the Firestore SDK
+    // instance in this scenario.
+    //
+    // Scenario:
+    //   1. Client sends watch request (pendingResponses = 1)
+    //   2. StrictMode cleanup sends unwatch + rewatch, but the watch stream
+    //      may be recreated, losing track of the first pending request
+    //   3. Server responds with Added for a target that has 0 pending requests
+    //   4. pendingResponses goes to -1 → hardAssert fires → SDK poisoned
+
+    // Set up target 1 with only 1 outstanding response
+    const targets = listens(1);
+    const outstandingResponses = { 1: 1 };
+
+    const doc1 = doc('docs/1', 1, { value: 1 });
+
+    // First response: Removed (consumes the 1 pending response → 0)
+    const change1 = new WatchTargetChange(WatchTargetChangeState.Removed, [1]);
+    // Second response: Added (would decrement to -1, triggering the crash)
+    const change2 = new WatchTargetChange(WatchTargetChangeState.Added, [1]);
+    // A document arrives after the re-add
+    const change3 = new DocumentWatchChange([1], [], doc1.key, doc1);
+
+    // This should NOT throw. Before the fix, hardAssert would fire with
+    // "pendingResponses is less than 0" and permanently break the SDK.
+    const event = createRemoteEvent({
+      snapshotVersion: 3,
+      targets,
+      outstandingResponses,
+      changes: [change1, change2, change3]
+    });
+
+    expectEqual(event.snapshotVersion, version(3));
+    // The document should be tracked after the target is re-added
+    expect(event.documentUpdates.size).to.equal(1);
+    expectEqual(event.documentUpdates.get(doc1.key), doc1);
+  });
+
+  it('handles rapid listen/unlisten/re-listen without fatal assertion', () => {
+    // Additional regression test for #9729: simulates the full
+    // React 19 StrictMode sequence where a getDoc() effect fires,
+    // cleans up, and re-fires, resulting in 3 pending requests but
+    // potentially 4 responses if the server acks overlap.
+    const targets = listens(1);
+    // Simulate: watch(1), unwatch(1), watch(1) = 3 pending requests
+    const outstandingResponses = { 1: 3 };
+
+    const doc1 = doc('docs/1', 1, { value: 1 });
+
+    // Server responds to all three + an extra overlapping ack:
+    // Response 1: Added for original watch   (3 → 2)
+    // Response 2: Removed for unwatch         (2 → 1)
+    // Response 3: Added for re-watch          (1 → 0)
+    // Response 4: Spurious Added from overlap (0 → -1, crash before fix)
+    const changes = [
+      new WatchTargetChange(WatchTargetChangeState.Added, [1]),
+      new WatchTargetChange(WatchTargetChangeState.Removed, [1]),
+      new WatchTargetChange(WatchTargetChangeState.Added, [1]),
+      new WatchTargetChange(WatchTargetChangeState.Added, [1]), // spurious
+      new DocumentWatchChange([1], [], doc1.key, doc1)
+    ];
+
+    // Should not throw
+    const event = createRemoteEvent({
+      snapshotVersion: 3,
+      targets,
+      outstandingResponses,
+      changes
+    });
+
+    expectEqual(event.snapshotVersion, version(3));
+    expect(event.documentUpdates.size).to.equal(1);
+    expectEqual(event.documentUpdates.get(doc1.key), doc1);
+  });
 });

--- a/packages/firestore/test/unit/specs/remote_store_spec.test.ts
+++ b/packages/firestore/test/unit/specs/remote_store_spec.test.ts
@@ -115,4 +115,196 @@ describeSpec('Remote store:', [], () => {
       );
     }
   );
+
+  // Regression tests for https://github.com/firebase/firebase-js-sdk/issues/9729
+  //
+  // These tests exercise the watch stream reconnection path with rapid
+  // unlisten/listen cycles, validating that pending target request
+  // bookkeeping remains correct across stream restarts.
+
+  specTest(
+    'Handles unlisten/listen after stream reconnect',
+    [],
+    () => {
+      // Exercises the startWatchStream → onWatchStreamOpen code path after a
+      // network drop, followed by a rapid unlisten/listen cycle (the pattern
+      // caused by React StrictMode double-invoking effects).
+      const query1 = query('collection');
+      const doc1 = doc('collection/a', 1000, { key: 'a' });
+      const doc1v2 = doc('collection/a', 2000, { key: 'a', updated: true });
+      return (
+        spec()
+          .ensureManualLruGC()
+          // Establish an active listen
+          .userListens(query1)
+          .watchAcksFull(query1, 1000, doc1)
+          .expectEvents(query1, { added: [doc1] })
+
+          // Network drops and comes back
+          .disableNetwork()
+          .expectEvents(query1, { fromCache: true })
+          .enableNetwork()
+          .restoreListen(query1, 'resume-token-1000')
+
+          // After reconnect, simulate StrictMode: unlisten then re-listen.
+          // The re-listen uses the cached resume token from the prior ack.
+          .userUnlistens(query1)
+          .userListens(query1, { resumeToken: 'resume-token-1000' })
+          .expectEvents(query1, {
+            added: [doc1],
+            fromCache: true
+          })
+
+          // Server acks the restore, then the unlisten, then the new listen.
+          // Each server response decrements pendingResponses by 1:
+          // restore(3→2), remove(2→1), ackFull(1→0) → events raised.
+          .watchAcks(query1)
+          .watchRemoves(query1)
+          .watchAcksFull(query1, 2000, doc1v2)
+          .expectEvents(query1, { modified: [doc1v2] })
+      );
+    }
+  );
+
+  specTest(
+    'Handles multiple unlisten/listen cycles after stream reconnect',
+    [],
+    () => {
+      // Same as above but with multiple rapid cycles, similar to the
+      // "Waits for watch to ack last target add" test but after a
+      // stream reconnect which creates a new WatchChangeAggregator.
+      const query1 = query('collection');
+      const doc1 = doc('collection/a', 1000, { key: 'a' });
+      const doc1v2 = doc('collection/a', 2000, { key: 'a', updated: true });
+      return (
+        spec()
+          .ensureManualLruGC()
+          .userListens(query1)
+          .watchAcksFull(query1, 1000, doc1)
+          .expectEvents(query1, { added: [doc1] })
+
+          // Network drops and comes back
+          .disableNetwork()
+          .expectEvents(query1, { fromCache: true })
+          .enableNetwork()
+          .restoreListen(query1, 'resume-token-1000')
+
+          // Multiple rapid unlisten/listen cycles (e.g. multiple StrictMode
+          // components or rapid navigation)
+          .userUnlistens(query1)
+          .userListens(query1, { resumeToken: 'resume-token-1000' })
+          .expectEvents(query1, {
+            added: [doc1],
+            fromCache: true
+          })
+          .userUnlistens(query1)
+          .userListens(query1, { resumeToken: 'resume-token-1000' })
+          .expectEvents(query1, {
+            added: [doc1],
+            fromCache: true
+          })
+
+          // Server processes all the acks in order:
+          // 5 pending (restore + unlisten + re-listen + unlisten + re-listen)
+          // Need 5 responses to reach pendingResponses = 0.
+          .watchAcks(query1)
+          .watchRemoves(query1)
+          .watchAcks(query1)
+          .watchRemoves(query1)
+          .watchAcksFull(query1, 2000, doc1v2)
+          .expectEvents(query1, { modified: [doc1v2] })
+      );
+    }
+  );
+
+  specTest(
+    'Handles unlisten during stream startup before open',
+    [],
+    () => {
+      // Exercises the code path where a target is removed from listenTargets
+      // and a new one added during a network disruption. With the structural
+      // fix, startWatchStream pre-records the pending request and
+      // onWatchStreamOpen cleans up the orphaned target state.
+      const query1 = query('collection');
+      const query2 = query('other');
+      const doc1 = doc('collection/a', 1000, { key: 'a' });
+      const doc2 = doc('other/b', 1000, { key: 'b' });
+      return (
+        spec()
+          .ensureManualLruGC()
+          .userListens(query1)
+          .watchAcksFull(query1, 1000, doc1)
+          .expectEvents(query1, { added: [doc1] })
+
+          // Network drops
+          .disableNetwork()
+          .expectEvents(query1, { fromCache: true })
+
+          // While offline, remove the first query and add a second
+          .userUnlistens(query1)
+          .userListens(query2)
+          .expectEvents(query2, { fromCache: true })
+
+          // Bring network back
+          .enableNetwork()
+
+          // Now only query2 should be active
+          .watchAcksFull(query2, 2000, doc2)
+          .expectEvents(query2, { added: [doc2] })
+      );
+    }
+  );
+
+  specTest(
+    'Handles listen/unlisten/listen with two targets after reconnect',
+    [],
+    () => {
+      // Tests that the pending count bookkeeping is correct per-target when
+      // one target has a rapid unlisten/listen cycle and another is stable.
+      const query1 = query('collection');
+      const query2 = query('other');
+      const doc1 = doc('collection/a', 1000, { key: 'a' });
+      const doc2 = doc('other/b', 1000, { key: 'b' });
+      const doc1v2 = doc('collection/a', 2000, { key: 'a', updated: true });
+      const doc2v2 = doc('other/b', 2000, { key: 'b', updated: true });
+      return (
+        spec()
+          .ensureManualLruGC()
+          // Establish two active listens
+          .userListens(query1)
+          .watchAcksFull(query1, 1000, doc1)
+          .expectEvents(query1, { added: [doc1] })
+          .userListens(query2)
+          .watchAcksFull(query2, 1000, doc2)
+          .expectEvents(query2, { added: [doc2] })
+
+          // Network drops and comes back
+          .disableNetwork()
+          .expectEvents(query1, { fromCache: true })
+          .expectEvents(query2, { fromCache: true })
+          .enableNetwork()
+          .restoreListen(query1, 'resume-token-1000')
+          .restoreListen(query2, 'resume-token-1000')
+
+          // After reconnect, query1 does unlisten/listen (StrictMode),
+          // query2 stays stable
+          .userUnlistens(query1)
+          .userListens(query1, { resumeToken: 'resume-token-1000' })
+          .expectEvents(query1, {
+            added: [doc1],
+            fromCache: true
+          })
+
+          // Server acks: query2 restore+data, query1 restore+remove+re-add.
+          // query2 has 1 pending (restore) → ackFull consumes it.
+          // query1 has 3 pending (restore + unlisten + re-listen).
+          .watchAcksFull(query2, 2000, doc2v2)
+          .expectEvents(query2, { modified: [doc2v2] })
+          .watchAcks(query1)
+          .watchRemoves(query1)
+          .watchAcksFull(query1, 2000, doc1v2)
+          .expectEvents(query1, { modified: [doc1v2] })
+      );
+    }
+  );
 });

--- a/packages/firestore/test/unit/specs/remote_store_spec.test.ts
+++ b/packages/firestore/test/unit/specs/remote_store_spec.test.ts
@@ -122,49 +122,45 @@ describeSpec('Remote store:', [], () => {
   // unlisten/listen cycles, validating that pending target request
   // bookkeeping remains correct across stream restarts.
 
-  specTest(
-    'Handles unlisten/listen after stream reconnect',
-    [],
-    () => {
-      // Exercises the startWatchStream → onWatchStreamOpen code path after a
-      // network drop, followed by a rapid unlisten/listen cycle (the pattern
-      // caused by React StrictMode double-invoking effects).
-      const query1 = query('collection');
-      const doc1 = doc('collection/a', 1000, { key: 'a' });
-      const doc1v2 = doc('collection/a', 2000, { key: 'a', updated: true });
-      return (
-        spec()
-          .ensureManualLruGC()
-          // Establish an active listen
-          .userListens(query1)
-          .watchAcksFull(query1, 1000, doc1)
-          .expectEvents(query1, { added: [doc1] })
+  specTest('Handles unlisten/listen after stream reconnect', [], () => {
+    // Exercises the startWatchStream → onWatchStreamOpen code path after a
+    // network drop, followed by a rapid unlisten/listen cycle (the pattern
+    // caused by React StrictMode double-invoking effects).
+    const query1 = query('collection');
+    const doc1 = doc('collection/a', 1000, { key: 'a' });
+    const doc1v2 = doc('collection/a', 2000, { key: 'a', updated: true });
+    return (
+      spec()
+        .ensureManualLruGC()
+        // Establish an active listen
+        .userListens(query1)
+        .watchAcksFull(query1, 1000, doc1)
+        .expectEvents(query1, { added: [doc1] })
 
-          // Network drops and comes back
-          .disableNetwork()
-          .expectEvents(query1, { fromCache: true })
-          .enableNetwork()
-          .restoreListen(query1, 'resume-token-1000')
+        // Network drops and comes back
+        .disableNetwork()
+        .expectEvents(query1, { fromCache: true })
+        .enableNetwork()
+        .restoreListen(query1, 'resume-token-1000')
 
-          // After reconnect, simulate StrictMode: unlisten then re-listen.
-          // The re-listen uses the cached resume token from the prior ack.
-          .userUnlistens(query1)
-          .userListens(query1, { resumeToken: 'resume-token-1000' })
-          .expectEvents(query1, {
-            added: [doc1],
-            fromCache: true
-          })
+        // After reconnect, simulate StrictMode: unlisten then re-listen.
+        // The re-listen uses the cached resume token from the prior ack.
+        .userUnlistens(query1)
+        .userListens(query1, { resumeToken: 'resume-token-1000' })
+        .expectEvents(query1, {
+          added: [doc1],
+          fromCache: true
+        })
 
-          // Server acks the restore, then the unlisten, then the new listen.
-          // Each server response decrements pendingResponses by 1:
-          // restore(3→2), remove(2→1), ackFull(1→0) → events raised.
-          .watchAcks(query1)
-          .watchRemoves(query1)
-          .watchAcksFull(query1, 2000, doc1v2)
-          .expectEvents(query1, { modified: [doc1v2] })
-      );
-    }
-  );
+        // Server acks the restore, then the unlisten, then the new listen.
+        // Each server response decrements pendingResponses by 1:
+        // restore(3→2), remove(2→1), ackFull(1→0) → events raised.
+        .watchAcks(query1)
+        .watchRemoves(query1)
+        .watchAcksFull(query1, 2000, doc1v2)
+        .expectEvents(query1, { modified: [doc1v2] })
+    );
+  });
 
   specTest(
     'Handles multiple unlisten/listen cycles after stream reconnect',
@@ -217,43 +213,39 @@ describeSpec('Remote store:', [], () => {
     }
   );
 
-  specTest(
-    'Handles unlisten during stream startup before open',
-    [],
-    () => {
-      // Exercises the code path where a target is removed from listenTargets
-      // and a new one added during a network disruption. With the structural
-      // fix, startWatchStream pre-records the pending request and
-      // onWatchStreamOpen cleans up the orphaned target state.
-      const query1 = query('collection');
-      const query2 = query('other');
-      const doc1 = doc('collection/a', 1000, { key: 'a' });
-      const doc2 = doc('other/b', 1000, { key: 'b' });
-      return (
-        spec()
-          .ensureManualLruGC()
-          .userListens(query1)
-          .watchAcksFull(query1, 1000, doc1)
-          .expectEvents(query1, { added: [doc1] })
+  specTest('Handles unlisten during stream startup before open', [], () => {
+    // Exercises the code path where a target is removed from listenTargets
+    // and a new one added during a network disruption. With the structural
+    // fix, startWatchStream pre-records the pending request and
+    // onWatchStreamOpen cleans up the orphaned target state.
+    const query1 = query('collection');
+    const query2 = query('other');
+    const doc1 = doc('collection/a', 1000, { key: 'a' });
+    const doc2 = doc('other/b', 1000, { key: 'b' });
+    return (
+      spec()
+        .ensureManualLruGC()
+        .userListens(query1)
+        .watchAcksFull(query1, 1000, doc1)
+        .expectEvents(query1, { added: [doc1] })
 
-          // Network drops
-          .disableNetwork()
-          .expectEvents(query1, { fromCache: true })
+        // Network drops
+        .disableNetwork()
+        .expectEvents(query1, { fromCache: true })
 
-          // While offline, remove the first query and add a second
-          .userUnlistens(query1)
-          .userListens(query2)
-          .expectEvents(query2, { fromCache: true })
+        // While offline, remove the first query and add a second
+        .userUnlistens(query1)
+        .userListens(query2)
+        .expectEvents(query2, { fromCache: true })
 
-          // Bring network back
-          .enableNetwork()
+        // Bring network back
+        .enableNetwork()
 
-          // Now only query2 should be active
-          .watchAcksFull(query2, 2000, doc2)
-          .expectEvents(query2, { added: [doc2] })
-      );
-    }
-  );
+        // Now only query2 should be active
+        .watchAcksFull(query2, 2000, doc2)
+        .expectEvents(query2, { added: [doc2] })
+    );
+  });
 
   specTest(
     'Handles listen/unlisten/listen with two targets after reconnect',


### PR DESCRIPTION
Move the pendingResponses bookkeeping for restored targets from
onWatchStreamOpen into startWatchStream, closing the timing window
where a rapid unlisten/listen cycle (e.g. React 19 StrictMode
double-invoking effects) could fire before the stream opens and
leave the counter in an inconsistent state.

Adds 4 spec tests covering:
- unlisten/listen after stream reconnect
- multiple unlisten/listen cycles after reconnect
- unlisten during stream startup before open
- multi-target reconnect with one target cycling

Fixes https://github.com/firebase/firebase-js-sdk/issues/9729