### PR TITLE
fix(firestore): Read user data from pipeline in union stage

### DIFF
--- a/.changeset/stupid-turtles-grow.md
+++ b/.changeset/stupid-turtles-grow.md
@@ -1,0 +1,5 @@
+---
+'@firebase/firestore': patch
+---
+
+Read user data from pipeline in union stage. Fixes [GitHub Issue #9764](https://github.com/firebase/firebase-js-sdk/issues/9764)

--- a/packages/firestore/src/lite-api/stage.ts
+++ b/packages/firestore/src/lite-api/stage.ts
@@ -626,6 +626,9 @@ export class Union extends Stage {
   }
 
   _readUserData(context: ParseContext): void {
+    if (this.other) {
+      this.other._readUserData(context);
+    }
     super._readUserData(context);
   }
 }

--- a/packages/firestore/src/lite-api/stage.ts
+++ b/packages/firestore/src/lite-api/stage.ts
@@ -626,9 +626,7 @@ export class Union extends Stage {
   }
 
   _readUserData(context: ParseContext): void {
-    if (this.other) {
-      this.other._readUserData(context);
-    }
+    this.other._readUserData(context);
     super._readUserData(context);
   }
 }

--- a/packages/firestore/test/integration/api/pipeline.test.ts
+++ b/packages/firestore/test/integration/api/pipeline.test.ts
@@ -1926,8 +1926,8 @@ apiDescribe.skipClassic('Pipelines', persistence => {
         expectResults(
           snapshot,
           'book1',
-          'book10',
           'book1',
+          'book10',
           'book2',
           'book3',
           'book4',

--- a/packages/firestore/test/integration/api/pipeline.test.ts
+++ b/packages/firestore/test/integration/api/pipeline.test.ts
@@ -1910,6 +1910,35 @@ apiDescribe.skipClassic('Pipelines', persistence => {
         );
       });
 
+      it('run pipeline with user data with union', async () => {
+        const snapshot = await execute(
+          firestore
+            .pipeline()
+            .collection(randomCol.path)
+            .union(
+              firestore
+                .pipeline()
+                .collection(randomCol.path)
+                .where(equal('title', "The Hitchhiker's Guide to the Galaxy"))
+            )
+            .sort(field(documentIdFieldPath()).ascending())
+        );
+        expectResults(
+          snapshot,
+          'book1',
+          'book10',
+          'book1',
+          'book2',
+          'book3',
+          'book4',
+          'book5',
+          'book6',
+          'book7',
+          'book8',
+          'book9'
+        );
+      });
+
       it('supports options', async () => {
         const snapshot = await execute(
           firestore

--- a/packages/firestore/test/lite/pipeline.test.ts
+++ b/packages/firestore/test/lite/pipeline.test.ts
@@ -1898,6 +1898,35 @@ describe.skipClassic('Firestore Pipelines', () => {
         );
       });
 
+      it('run pipeline with user data with union', async () => {
+        const snapshot = await execute(
+          firestore
+            .pipeline()
+            .collection(randomCol.path)
+            .union(
+              firestore
+                .pipeline()
+                .collection(randomCol.path)
+                .where(equal('title', "The Hitchhiker's Guide to the Galaxy"))
+            )
+            .sort(field(documentIdFieldPath()).ascending())
+        );
+        expectResults(
+          snapshot,
+          'book1',
+          'book1',
+          'book10',
+          'book2',
+          'book3',
+          'book4',
+          'book5',
+          'book6',
+          'book7',
+          'book8',
+          'book9'
+        );
+      });
+
       it('supports options', async () => {
         const snapshot = await execute(
           firestore


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/9764.

This bug was introduced in https://github.com/firebase/firebase-js-sdk/commit/4e99d4ba66a9a28558cd504826ae04fd07251c1b.

Reading user data in a pipeline has been deferred from stage initialization to when `execute(pipeline)` is called. An inner pipeline in a union stage never had it's user data read after this change. 

This fix calls `readUserData` on the pipeline passed to the union stage when `readUserData` is called on the outer pipeline.