### PR TITLE
Snapshot of crashlytics tracing feature

### DIFF
--- a/common/api-review/crashlytics-angular.api.md
+++ b/common/api-review/crashlytics-angular.api.md
@@ -16,6 +16,7 @@ export interface Crashlytics {
 export interface CrashlyticsOptions {
     appVersion?: string;
     endpointUrl?: string;
+    tracingUrl?: string;
 }
 
 // @public

--- a/common/api-review/crashlytics-react-router.api.md
+++ b/common/api-review/crashlytics-react-router.api.md
@@ -17,6 +17,7 @@ export interface Crashlytics {
 export interface CrashlyticsOptions {
     appVersion?: string;
     endpointUrl?: string;
+    tracingUrl?: string;
 }
 
 // @public

--- a/common/api-review/crashlytics-react.api.md
+++ b/common/api-review/crashlytics-react.api.md
@@ -15,6 +15,7 @@ export interface Crashlytics {
 export interface CrashlyticsOptions {
     appVersion?: string;
     endpointUrl?: string;
+    tracingUrl?: string;
 }
 
 // @public

--- a/common/api-review/crashlytics.api.md
+++ b/common/api-review/crashlytics.api.md
@@ -17,6 +17,7 @@ export interface Crashlytics {
 export interface CrashlyticsOptions {
     appVersion?: string;
     endpointUrl?: string;
+    tracingUrl?: string;
 }
 
 // @public

--- a/docs-devsite/crashlytics_.crashlyticsoptions.md
+++ b/docs-devsite/crashlytics_.crashlyticsoptions.md
@@ -24,6 +24,7 @@ export interface CrashlyticsOptions
 |  --- | --- | --- |
 |  [appVersion](./crashlytics_.crashlyticsoptions.md#crashlyticsoptionsappversion) | string | The version of the application. This should be a unique string that identifies the snapshot of code to be deployed, such as "1.0.2". If not specified, other default locations will be checked for an identifier. Setting a value here takes precedence over any other values. |
 |  [endpointUrl](./crashlytics_.crashlyticsoptions.md#crashlyticsoptionsendpointurl) | string | The URL for the endpoint to which Crashlytics data should be sent, in the OpenTelemetry format. By default, data will be sent to Firebase. |
+|  [tracingUrl](./crashlytics_.crashlyticsoptions.md#crashlyticsoptionstracingurl) | string | The URL for the endpoint to which Crashlytics traces should be sent, in the OpenTelemetry format. By default, data will be sent to Firebase. |
 
 ## CrashlyticsOptions.appVersion
 
@@ -43,4 +44,14 @@ The URL for the endpoint to which Crashlytics data should be sent, in the OpenTe
 
 ```typescript
 endpointUrl?: string;
+```
+
+## CrashlyticsOptions.tracingUrl
+
+The URL for the endpoint to which Crashlytics traces should be sent, in the OpenTelemetry format. By default, data will be sent to Firebase.
+
+<b>Signature:</b>
+
+```typescript
+tracingUrl?: string;
 ```

--- a/docs-devsite/crashlytics_angular.crashlyticsoptions.md
+++ b/docs-devsite/crashlytics_angular.crashlyticsoptions.md
@@ -24,6 +24,7 @@ export interface CrashlyticsOptions
 |  --- | --- | --- |
 |  [appVersion](./crashlytics_angular.crashlyticsoptions.md#crashlyticsoptionsappversion) | string | The version of the application. This should be a unique string that identifies the snapshot of code to be deployed, such as "1.0.2". If not specified, other default locations will be checked for an identifier. Setting a value here takes precedence over any other values. |
 |  [endpointUrl](./crashlytics_angular.crashlyticsoptions.md#crashlyticsoptionsendpointurl) | string | The URL for the endpoint to which Crashlytics data should be sent, in the OpenTelemetry format. By default, data will be sent to Firebase. |
+|  [tracingUrl](./crashlytics_angular.crashlyticsoptions.md#crashlyticsoptionstracingurl) | string | The URL for the endpoint to which Crashlytics traces should be sent, in the OpenTelemetry format. By default, data will be sent to Firebase. |
 
 ## CrashlyticsOptions.appVersion
 
@@ -43,4 +44,14 @@ The URL for the endpoint to which Crashlytics data should be sent, in the OpenTe
 
 ```typescript
 endpointUrl?: string;
+```
+
+## CrashlyticsOptions.tracingUrl
+
+The URL for the endpoint to which Crashlytics traces should be sent, in the OpenTelemetry format. By default, data will be sent to Firebase.
+
+<b>Signature:</b>
+
+```typescript
+tracingUrl?: string;
 ```

--- a/docs-devsite/crashlytics_react-router.crashlyticsoptions.md
+++ b/docs-devsite/crashlytics_react-router.crashlyticsoptions.md
@@ -24,6 +24,7 @@ export interface CrashlyticsOptions
 |  --- | --- | --- |
 |  [appVersion](./crashlytics_react-router.crashlyticsoptions.md#crashlyticsoptionsappversion) | string | The version of the application. This should be a unique string that identifies the snapshot of code to be deployed, such as "1.0.2". If not specified, other default locations will be checked for an identifier. Setting a value here takes precedence over any other values. |
 |  [endpointUrl](./crashlytics_react-router.crashlyticsoptions.md#crashlyticsoptionsendpointurl) | string | The URL for the endpoint to which Crashlytics data should be sent, in the OpenTelemetry format. By default, data will be sent to Firebase. |
+|  [tracingUrl](./crashlytics_react-router.crashlyticsoptions.md#crashlyticsoptionstracingurl) | string | The URL for the endpoint to which Crashlytics traces should be sent, in the OpenTelemetry format. By default, data will be sent to Firebase. |
 
 ## CrashlyticsOptions.appVersion
 
@@ -43,4 +44,14 @@ The URL for the endpoint to which Crashlytics data should be sent, in the OpenTe
 
 ```typescript
 endpointUrl?: string;
+```
+
+## CrashlyticsOptions.tracingUrl
+
+The URL for the endpoint to which Crashlytics traces should be sent, in the OpenTelemetry format. By default, data will be sent to Firebase.
+
+<b>Signature:</b>
+
+```typescript
+tracingUrl?: string;
 ```

--- a/docs-devsite/crashlytics_react-router.md
+++ b/docs-devsite/crashlytics_react-router.md
@@ -15,7 +15,7 @@ https://github.com/firebase/firebase-js-sdk
 
 |  Function | Description |
 |  --- | --- |
-|  [CrashlyticsRoutes({ firebaseApp, crashlyticsOptions, children, ...props })](./crashlytics_react-router.md#crashlyticsroutes_707e4a5) | A wrapper around  that automatically captures errors in route components.<!-- -->This component acts as a replacement for <code>Routes</code> from <code>react-router-dom</code>. It wraps the routes in an error boundary that captures errors thrown during rendering and reports them to Crashlytics. The error boundary is reset on navigation (path changes). |
+|  [CrashlyticsRoutes({ firebaseApp, crashlyticsOptions, children, ...props })](./crashlytics_react-router.md#crashlyticsroutes_707e4a5) | A wrapper around <code>Routes</code> from <code>react-router-dom</code> that automatically captures errors in route components.<!-- -->This component acts as a replacement for <code>Routes</code> from <code>react-router-dom</code>. It wraps the routes in an error boundary that captures errors thrown during rendering and reports them to Crashlytics. The error boundary is reset on navigation (path changes). |
 
 ## Interfaces
 
@@ -28,7 +28,7 @@ https://github.com/firebase/firebase-js-sdk
 
 ### CrashlyticsRoutes({ firebaseApp, crashlyticsOptions, children, ...props }) {:#crashlyticsroutes_707e4a5}
 
-A wrapper around  that automatically captures errors in route components.
+A wrapper around `Routes` from `react-router-dom` that automatically captures errors in route components.
 
 This component acts as a replacement for `Routes` from `react-router-dom`<!-- -->. It wraps the routes in an error boundary that captures errors thrown during rendering and reports them to Crashlytics. The error boundary is reset on navigation (path changes).
 

--- a/docs-devsite/crashlytics_react.crashlyticsoptions.md
+++ b/docs-devsite/crashlytics_react.crashlyticsoptions.md
@@ -24,6 +24,7 @@ export interface CrashlyticsOptions
 |  --- | --- | --- |
 |  [appVersion](./crashlytics_react.crashlyticsoptions.md#crashlyticsoptionsappversion) | string | The version of the application. This should be a unique string that identifies the snapshot of code to be deployed, such as "1.0.2". If not specified, other default locations will be checked for an identifier. Setting a value here takes precedence over any other values. |
 |  [endpointUrl](./crashlytics_react.crashlyticsoptions.md#crashlyticsoptionsendpointurl) | string | The URL for the endpoint to which Crashlytics data should be sent, in the OpenTelemetry format. By default, data will be sent to Firebase. |
+|  [tracingUrl](./crashlytics_react.crashlyticsoptions.md#crashlyticsoptionstracingurl) | string | The URL for the endpoint to which Crashlytics traces should be sent, in the OpenTelemetry format. By default, data will be sent to Firebase. |
 
 ## CrashlyticsOptions.appVersion
 
@@ -43,4 +44,14 @@ The URL for the endpoint to which Crashlytics data should be sent, in the OpenTe
 
 ```typescript
 endpointUrl?: string;
+```
+
+## CrashlyticsOptions.tracingUrl
+
+The URL for the endpoint to which Crashlytics traces should be sent, in the OpenTelemetry format. By default, data will be sent to Firebase.
+
+<b>Signature:</b>
+
+```typescript
+tracingUrl?: string;
 ```

--- a/packages/crashlytics/package.json
+++ b/packages/crashlytics/package.json
@@ -88,6 +88,7 @@
     "@firebase/app": "0.x",
     "@firebase/app-types": "0.x",
     "@types/react": ">= 16.8.0",
+    "next": ">= 13.0.0",
     "react": ">= 16.8.0",
     "react-router-dom": ">= 6.0.0"
   },
@@ -106,20 +107,30 @@
     },
     "react-router-dom": {
       "optional": true
+    },
+    "next": {
+      "optional": true
     }
   },
   "dependencies": {
     "@firebase/component": "0.7.2",
     "@firebase/installations": "0.6.21",
     "@opentelemetry/api": "1.9.0",
-    "@opentelemetry/api-logs": "0.203.0",
-    "@opentelemetry/core": "2.2.0",
-    "@opentelemetry/exporter-logs-otlp-http": "0.203.0",
-    "@opentelemetry/otlp-exporter-base": "0.205.0",
-    "@opentelemetry/otlp-transformer": "0.205.0",
-    "@opentelemetry/resources": "2.0.1",
-    "@opentelemetry/sdk-logs": "0.203.0",
-    "@opentelemetry/semantic-conventions": "1.36.0",
+    "@opentelemetry/api-logs": "0.212.0",
+    "@opentelemetry/context-zone": "2.5.1",
+    "@opentelemetry/core": "2.5.1",
+    "@opentelemetry/exporter-logs-otlp-http": "0.212.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.212.0",
+    "@opentelemetry/instrumentation": "0.212.0",
+    "@opentelemetry/instrumentation-fetch": "0.212.0",
+    "@opentelemetry/instrumentation-xml-http-request": "0.213.0",
+    "@opentelemetry/otlp-exporter-base": "0.212.0",
+    "@opentelemetry/otlp-transformer": "0.212.0",
+    "@opentelemetry/resources": "2.5.1",
+    "@opentelemetry/sdk-logs": "0.212.0",
+    "@opentelemetry/sdk-trace-base": "2.5.1",
+    "@opentelemetry/sdk-trace-web": "2.5.1",
+    "@opentelemetry/semantic-conventions": "1.39.0",
     "tslib": "^2.1.0"
   },
   "license": "Apache-2.0",

--- a/packages/crashlytics/src/api.test.ts
+++ b/packages/crashlytics/src/api.test.ts
@@ -17,13 +17,9 @@
 
 import { expect } from 'chai';
 import { LoggerProvider } from '@opentelemetry/sdk-logs';
-import { trace } from '@opentelemetry/api';
+import { trace, TracerProvider } from '@opentelemetry/api';
 import { Logger, LogRecord, SeverityNumber } from '@opentelemetry/api-logs';
-import {
-  InMemorySpanExporter,
-  SimpleSpanProcessor,
-  WebTracerProvider
-} from '@opentelemetry/sdk-trace-web';
+import sinon from 'sinon';
 import {
   FirebaseApp,
   initializeApp,
@@ -66,6 +62,18 @@ const fakeLoggerProvider = {
   shutdown: () => Promise.resolve()
 } as unknown as LoggerProvider;
 
+const fakeTracingProvider = {
+  getTracer: () => ({
+    startActiveSpan: (name: string, fn: (span: any) => any) =>
+      fn({
+        end: () => {},
+        spanContext: () => ({ traceId: 'my-trace', spanId: 'my-span' })
+      })
+  }),
+  register: () => {},
+  shutdown: () => Promise.resolve()
+} as unknown as TracerProvider;
+
 const fakeCrashlytics: CrashlyticsInternal = {
   app: {
     name: 'DEFAULT',
@@ -75,7 +83,8 @@ const fakeCrashlytics: CrashlyticsInternal = {
       appId: APP_ID
     }
   },
-  loggerProvider: fakeLoggerProvider
+  loggerProvider: fakeLoggerProvider,
+  tracingProvider: fakeTracingProvider
 };
 
 describe('Top level API', () => {
@@ -246,34 +255,34 @@ describe('Top level API', () => {
       });
     });
 
-    it('should propagate trace context', async () => {
-      const provider = new WebTracerProvider({
-        spanProcessors: [new SimpleSpanProcessor(new InMemorySpanExporter())]
-      });
-      provider.register();
+    it('should propagate trace context', () => {
+      const getActiveSpanStub = sinon.stub(trace, 'getActiveSpan').returns({
+        spanContext: () => ({
+          traceId: 'my-trace',
+          spanId: 'my-span',
+          traceFlags: 0,
+          isRemote: false
+        })
+      } as any);
 
-      trace.getTracer('test-tracer').startActiveSpan('test-span', span => {
+      try {
         const error = new Error('This is a test error');
         error.stack = '...stack trace...';
         error.name = 'TestError';
 
-        span.spanContext().traceId = 'my-trace';
-        span.spanContext().spanId = 'my-span';
-
         recordError(fakeCrashlytics, error);
-        span.end();
-      });
 
-      await provider.shutdown();
-
-      expect(emittedLogs[0].attributes).to.deep.equal({
-        'error.type': 'TestError',
-        'error.stack': '...stack trace...',
-        [LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
-        'logging.googleapis.com/trace': `projects/${PROJECT_ID}/traces/my-trace`,
-        'logging.googleapis.com/spanId': `my-span`,
-        [LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
-      });
+        expect(emittedLogs[0].attributes).to.deep.equal({
+          'error.type': 'TestError',
+          'error.stack': '...stack trace...',
+          [LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
+          'logging.googleapis.com/trace': `my-trace`,
+          'logging.googleapis.com/spanId': `my-span`,
+          [LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
+        });
+      } finally {
+        getActiveSpanStub.restore();
+      }
     });
 
     it('should propagate custom attributes', () => {
@@ -310,7 +319,8 @@ describe('Top level API', () => {
       AUTO_CONSTANTS.appVersion = '1.2.3'; // Unused
       const crashlytics = new CrashlyticsService(
         fakeCrashlytics.app,
-        fakeLoggerProvider
+        fakeLoggerProvider,
+        fakeTracingProvider
       );
       crashlytics.options = {
         appVersion: '1.0.0'

--- a/packages/crashlytics/src/api.ts
+++ b/packages/crashlytics/src/api.ts
@@ -95,12 +95,11 @@ export function recordError(
 
   // Add trace metadata
   const activeSpanContext = trace.getActiveSpan()?.spanContext();
-  if (crashlytics.app.options.projectId && activeSpanContext?.traceId) {
-    customAttributes[
-      'logging.googleapis.com/trace'
-    ] = `projects/${crashlytics.app.options.projectId}/traces/${activeSpanContext.traceId}`;
+  if (activeSpanContext?.traceId) {
+    customAttributes[LOG_ENTRY_ATTRIBUTE_KEYS.TRACE_ID] =
+      activeSpanContext.traceId;
     if (activeSpanContext?.spanId) {
-      customAttributes['logging.googleapis.com/spanId'] =
+      customAttributes[LOG_ENTRY_ATTRIBUTE_KEYS.SPAN_ID] =
         activeSpanContext.spanId;
     }
   }

--- a/packages/crashlytics/src/auto-constants.ts
+++ b/packages/crashlytics/src/auto-constants.ts
@@ -20,5 +20,4 @@
  * The supported keys are:
  * - appVersion: string indicating the version of source code being deployed (eg. git commit hash)
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const AUTO_CONSTANTS: any = {};
+export const AUTO_CONSTANTS: Record<string, string> = {};

--- a/packages/crashlytics/src/constants.ts
+++ b/packages/crashlytics/src/constants.ts
@@ -25,7 +25,9 @@ export const CRASHLYTICS_SESSION_ID_KEY = 'firebasecrashlytics.sessionid';
 export const LOG_ENTRY_ATTRIBUTE_KEYS = {
   APP_VERSION: 'app_version',
   SESSION_ID: 'session_id',
-  USER_ID: 'user_id'
+  USER_ID: 'user_id',
+  TRACE_ID: 'logging.googleapis.com/trace',
+  SPAN_ID: 'logging.googleapis.com/spanId'
 };
 
 /**

--- a/packages/crashlytics/src/helpers.test.ts
+++ b/packages/crashlytics/src/helpers.test.ts
@@ -18,6 +18,7 @@
 import { expect } from 'chai';
 import { LoggerProvider } from '@opentelemetry/sdk-logs';
 import { Logger, LogRecord } from '@opentelemetry/api-logs';
+import { TracerProvider } from '@opentelemetry/api';
 import { isNode } from '@firebase/util';
 import { registerListeners, startNewSession } from './helpers';
 import {
@@ -36,6 +37,7 @@ describe('helpers', () => {
   let storage: Record<string, string> = {};
   let emittedLogs: LogRecord[] = [];
   let flushed = false;
+  let spanEnded = false;
 
   const fakeLoggerProvider = {
     getLogger: (): Logger => {
@@ -52,6 +54,27 @@ describe('helpers', () => {
     shutdown: () => Promise.resolve()
   } as unknown as LoggerProvider;
 
+  const fakeTracingProvider = {
+    getTracer: () => ({
+      startSpan: () => ({
+        setAttribute: () => {},
+        end: () => {
+          spanEnded = true;
+        },
+        spanContext: () => ({ traceId: 'my-trace', spanId: 'my-span' })
+      }),
+      startActiveSpan: (name: string, fn: (span: any) => any) =>
+        fn({
+          end: () => {
+            spanEnded = true;
+          },
+          spanContext: () => ({ traceId: 'my-trace', spanId: 'my-span' })
+        })
+    }),
+    register: () => {},
+    shutdown: () => Promise.resolve()
+  } as unknown as TracerProvider;
+
   const fakeCrashlytics: CrashlyticsInternal = {
     app: {
       name: 'DEFAULT',
@@ -61,12 +84,14 @@ describe('helpers', () => {
         appId: 'my-appid'
       }
     },
-    loggerProvider: fakeLoggerProvider
+    loggerProvider: fakeLoggerProvider,
+    tracingProvider: fakeTracingProvider
   };
 
   beforeEach(() => {
     emittedLogs = [];
     flushed = false;
+    spanEnded = false;
     storage = {};
     // @ts-ignore
     originalSessionStorage = global.sessionStorage;
@@ -119,7 +144,9 @@ describe('helpers', () => {
       expect(emittedLogs.length).to.equal(1);
       expect(emittedLogs[0].attributes).to.deep.equal({
         [LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID,
-        [LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION]: 'unset'
+        [LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
+        [LOG_ENTRY_ATTRIBUTE_KEYS.TRACE_ID]: 'my-trace',
+        [LOG_ENTRY_ATTRIBUTE_KEYS.SPAN_ID]: 'my-span'
       });
     });
 
@@ -129,14 +156,17 @@ describe('helpers', () => {
 
       expect(emittedLogs[0].attributes).to.deep.equal({
         [LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID,
-        [LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION]: '1.2.3'
+        [LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION]: '1.2.3',
+        [LOG_ENTRY_ATTRIBUTE_KEYS.TRACE_ID]: 'my-trace',
+        [LOG_ENTRY_ATTRIBUTE_KEYS.SPAN_ID]: 'my-span'
       });
     });
 
     it('should log app version from telemetry options', () => {
       const telemetryWithVersion = new CrashlyticsService(
         fakeCrashlytics.app,
-        fakeLoggerProvider
+        fakeLoggerProvider,
+        fakeTracingProvider
       );
       telemetryWithVersion.options = { appVersion: '9.9.9' };
 
@@ -144,7 +174,9 @@ describe('helpers', () => {
 
       expect(emittedLogs[0].attributes).to.deep.equal({
         [LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID,
-        [LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION]: '9.9.9'
+        [LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION]: '9.9.9',
+        [LOG_ENTRY_ATTRIBUTE_KEYS.TRACE_ID]: 'my-trace',
+        [LOG_ENTRY_ATTRIBUTE_KEYS.SPAN_ID]: 'my-span'
       });
     });
   });
@@ -159,6 +191,7 @@ describe('helpers', () => {
         registerListeners(fakeCrashlytics);
 
         expect(flushed).to.be.false;
+        expect(spanEnded).to.be.false;
 
         Object.defineProperty(document, 'visibilityState', {
           value: 'hidden',
@@ -167,16 +200,20 @@ describe('helpers', () => {
         window.dispatchEvent(new Event('visibilitychange'));
 
         expect(flushed).to.be.true;
+        expect(spanEnded).to.be.true;
       });
 
       it('should flush logs when the pagehide event fires', () => {
+        startNewSession(fakeCrashlytics);
         registerListeners(fakeCrashlytics);
 
         expect(flushed).to.be.false;
+        expect(spanEnded).to.be.false;
 
         window.dispatchEvent(new Event('pagehide'));
 
         expect(flushed).to.be.true;
+        expect(spanEnded).to.be.true;
       });
     }
   });

--- a/packages/crashlytics/src/helpers.ts
+++ b/packages/crashlytics/src/helpers.ts
@@ -24,6 +24,7 @@ import {
 import { Crashlytics } from './public-types';
 import { CrashlyticsService } from './service';
 import { CrashlyticsInternal } from './types';
+import { sessionContextManager } from './tracing/session-context-manager';
 
 /**
  * Returns the app version from the provided Telemetry instance, if available.
@@ -57,7 +58,9 @@ export function getSessionId(): string | undefined {
  */
 export function startNewSession(crashlytics: Crashlytics): void {
   // Cast to CrashlyticsInternal to access internal loggerProvider
-  const { loggerProvider } = crashlytics as CrashlyticsInternal;
+  const { loggerProvider, tracingProvider } =
+    crashlytics as CrashlyticsInternal;
+
   if (
     typeof sessionStorage !== 'undefined' &&
     typeof crypto?.randomUUID === 'function'
@@ -66,6 +69,15 @@ export function startNewSession(crashlytics: Crashlytics): void {
       const sessionId = crypto.randomUUID();
       sessionStorage.setItem(CRASHLYTICS_SESSION_ID_KEY, sessionId);
 
+      const tracer = tracingProvider.getTracer('session-tracer');
+      const span = tracer.startSpan('session-start');
+      span.setAttribute(LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID, sessionId);
+      span.setAttribute(
+        LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION,
+        getAppVersion(crashlytics)
+      );
+      sessionContextManager.setSessionSpan(span);
+
       // Emit session creation log
       const logger = loggerProvider.getLogger('session-logger');
       logger.emit({
@@ -73,7 +85,9 @@ export function startNewSession(crashlytics: Crashlytics): void {
         body: 'Session created',
         attributes: {
           [LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID]: sessionId,
-          [LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION]: getAppVersion(crashlytics)
+          [LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION]: getAppVersion(crashlytics),
+          [LOG_ENTRY_ATTRIBUTE_KEYS.TRACE_ID]: `${span.spanContext().traceId}`,
+          [LOG_ENTRY_ATTRIBUTE_KEYS.SPAN_ID]: `${span.spanContext().spanId}`
         }
       });
     } catch (e) {
@@ -90,10 +104,12 @@ export function registerListeners(crashlytics: Crashlytics): void {
   if (typeof window !== 'undefined' && typeof document !== 'undefined') {
     window.addEventListener('visibilitychange', async () => {
       if (document.visibilityState === 'hidden') {
+        sessionContextManager.getSessionSpan()?.end();
         await flush(crashlytics);
       }
     });
     window.addEventListener('pagehide', async () => {
+      sessionContextManager.getSessionSpan()?.end();
       await flush(crashlytics);
     });
   }

--- a/packages/crashlytics/src/logging/logger-provider.ts
+++ b/packages/crashlytics/src/logging/logger-provider.ts
@@ -68,8 +68,7 @@ export function createLoggerProvider(
 
   return new LoggerProvider({
     resource,
-    processors: [new BatchLogRecordProcessor(logExporter)],
-    logRecordLimits: {}
+    processors: [new BatchLogRecordProcessor(logExporter)]
   });
 }
 
@@ -93,7 +92,11 @@ class OTLPLogExporter
         JsonLogsSerializer,
         new FetchTransport({
           url: config.url!,
-          headers: new Headers(config.headers),
+          headers: new Headers(
+            typeof config.headers === 'object'
+              ? (config.headers as Record<string, string>)
+              : {}
+          ),
           dynamicHeaderProviders
         })
       )
@@ -118,5 +121,15 @@ class OTLPLogExporter
       });
     }
     super.export(logs, resultCallback);
+  }
+
+  async shutdown(): Promise<void> {
+    // Basic implementation of shutdown for interface compliance
+    console.log('OTLPLogExporter: shutdown called');
+  }
+
+  async forceFlush(): Promise<void> {
+    // Basic implementation of forceFlush for interface compliance
+    console.log('OTLPLogExporter: forceFlush called');
   }
 }

--- a/packages/crashlytics/src/next.ts
+++ b/packages/crashlytics/src/next.ts
@@ -17,7 +17,6 @@
 
 import { getApp } from '@firebase/app';
 import { recordError, getCrashlytics } from './api';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Instrumentation } from 'next';
 import { CrashlyticsOptions } from './public-types';
 import {

--- a/packages/crashlytics/src/public-types.ts
+++ b/packages/crashlytics/src/public-types.ts
@@ -44,6 +44,12 @@ export interface CrashlyticsOptions {
   endpointUrl?: string;
 
   /**
+   * The URL for the endpoint to which Crashlytics traces should be sent, in the OpenTelemetry format.
+   * By default, data will be sent to Firebase.
+   */
+  tracingUrl?: string;
+
+  /**
    * The version of the application. This should be a unique string that identifies the snapshot of
    * code to be deployed, such as "1.0.2". If not specified, other default locations will be checked
    * for an identifier. Setting a value here takes precedence over any other values.

--- a/packages/crashlytics/src/react-router/index.ts
+++ b/packages/crashlytics/src/react-router/index.ts
@@ -35,7 +35,7 @@ registerCrashlytics();
 export * from '../public-types';
 
 /**
- * A wrapper around {@link react-router-dom#Routes} that automatically captures errors in route components.
+ * A wrapper around `Routes` from `react-router-dom` that automatically captures errors in route components.
  *
  * This component acts as a replacement for `Routes` from `react-router-dom`. It wraps the routes
  * in an error boundary that captures errors thrown during rendering and reports them to Crashlytics.

--- a/packages/crashlytics/src/register.node.ts
+++ b/packages/crashlytics/src/register.node.ts
@@ -21,6 +21,7 @@ import { CRASHLYTICS_TYPE } from './constants';
 import { name, version } from '../package.json';
 import { CrashlyticsService } from './service';
 import { createLoggerProvider } from './logging/logger-provider';
+import { createTracingProvider } from './tracing/tracing-provider';
 
 export function registerCrashlytics(): void {
   _registerComponent(
@@ -34,13 +35,15 @@ export function registerCrashlytics(): void {
         }
 
         // TODO: change to default endpoint once it exists
-        const endpointUrl = instanceIdentifier || 'http://localhost';
+        const loggingUrl = instanceIdentifier || 'http://localhost';
+        const tracingUrl = instanceIdentifier || 'http://localhost';
 
         // getImmediate for FirebaseApp will always succeed
         const app = container.getProvider('app').getImmediate();
-        const loggerProvider = createLoggerProvider(app, endpointUrl);
+        const loggerProvider = createLoggerProvider(app, loggingUrl);
+        const tracingProvider = createTracingProvider(app, tracingUrl);
 
-        return new CrashlyticsService(app, loggerProvider);
+        return new CrashlyticsService(app, loggerProvider, tracingProvider);
       },
       ComponentType.PUBLIC
     ).setMultipleInstances(true)

--- a/packages/crashlytics/src/service.ts
+++ b/packages/crashlytics/src/service.ts
@@ -18,12 +18,17 @@
 import { _FirebaseService, FirebaseApp } from '@firebase/app';
 import { Crashlytics, CrashlyticsOptions } from './public-types';
 import { LoggerProvider } from '@opentelemetry/sdk-logs';
+import { TracerProvider } from '@opentelemetry/api';
 
 export class CrashlyticsService implements Crashlytics, _FirebaseService {
   private _options?: CrashlyticsOptions;
   private _frameworkAttributesProvider?: () => Record<string, string>;
 
-  constructor(public app: FirebaseApp, public loggerProvider: LoggerProvider) {}
+  constructor(
+    public app: FirebaseApp,
+    public loggerProvider: LoggerProvider,
+    public tracingProvider: TracerProvider | null
+  ) {}
 
   _delete(): Promise<void> {
     return Promise.resolve();

--- a/packages/crashlytics/src/tracing/firebase-span-processor.test.ts
+++ b/packages/crashlytics/src/tracing/firebase-span-processor.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { Span } from '@opentelemetry/api';
+import { FirebaseSpanProcessor } from './firebase-span-processor';
+import {
+  CRASHLYTICS_SESSION_ID_KEY,
+  LOG_ENTRY_ATTRIBUTE_KEYS
+} from '../constants';
+
+const MOCK_SESSION_ID = 'mock-session-id';
+
+describe('FirebaseSpanProcessor', () => {
+  let processor: FirebaseSpanProcessor;
+  let mockSpan: any;
+  let originalSessionStorage: Storage | undefined;
+  let storage: Record<string, string> = {};
+
+  beforeEach(() => {
+    storage = {};
+    originalSessionStorage = global.sessionStorage;
+    const sessionStorageMock: Partial<Storage> = {
+      getItem: (key: string) => storage[key] || null,
+      setItem: (key: string, value: string) => {
+        storage[key] = value;
+      }
+    };
+    Object.defineProperty(global, 'sessionStorage', {
+      value: sessionStorageMock,
+      writable: true
+    });
+
+    processor = new FirebaseSpanProcessor();
+    mockSpan = {
+      attributes: {},
+      setAttribute: (key: string, value: string) => {
+        mockSpan.attributes[key] = value;
+      }
+    };
+  });
+
+  afterEach(() => {
+    Object.defineProperty(global, 'sessionStorage', {
+      value: originalSessionStorage,
+      writable: true
+    });
+  });
+
+  it('should add session id to span if present in storage', () => {
+    storage[CRASHLYTICS_SESSION_ID_KEY] = MOCK_SESSION_ID;
+    processor.onStart(mockSpan as Span, {} as any);
+    expect(mockSpan.attributes[LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID]).to.equal(
+      MOCK_SESSION_ID
+    );
+  });
+
+  it('should not add session id if not present in storage', () => {
+    processor.onStart(mockSpan as Span, {} as any);
+    expect(mockSpan.attributes[LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID]).to.be
+      .undefined;
+  });
+});

--- a/packages/crashlytics/src/tracing/firebase-span-processor.ts
+++ b/packages/crashlytics/src/tracing/firebase-span-processor.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Context, Span } from '@opentelemetry/api';
+import { SpanProcessor, ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { getSessionId } from '../helpers';
+import { LOG_ENTRY_ATTRIBUTE_KEYS } from '../constants';
+
+/**
+ * A SpanProcessor that adds Firebase-specific attributes to spans.
+ */
+export class FirebaseSpanProcessor implements SpanProcessor {
+  forceFlush(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  onStart(span: Span, _parentContext: Context): void {
+    const sessionId = getSessionId();
+    if (sessionId) {
+      span.setAttribute(LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID, sessionId);
+    }
+  }
+
+  onEnd(_span: ReadableSpan): void {}
+
+  shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/packages/crashlytics/src/tracing/session-context-manager.ts
+++ b/packages/crashlytics/src/tracing/session-context-manager.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Context, Span, trace } from '@opentelemetry/api';
+import { ZoneContextManager } from '@opentelemetry/context-zone';
+
+/**
+ * A custom ContextManager that ensures the session span is the default parent.
+ */
+class SessionContextManager extends ZoneContextManager {
+  private _sessionSpan: Span | undefined;
+
+  setSessionSpan(span: Span | undefined): void {
+    this._sessionSpan = span;
+  }
+
+  getSessionSpan(): Span | undefined {
+    return this._sessionSpan;
+  }
+
+  override active(): Context {
+    const context = super.active();
+    if (this._sessionSpan && !trace.getSpan(context)) {
+      return trace.setSpan(context, this._sessionSpan);
+    }
+    return context;
+  }
+}
+
+/**
+ * Global instance of the SessionContextManager.
+ * @internal
+ */
+export const sessionContextManager = new SessionContextManager();

--- a/packages/crashlytics/src/tracing/tracing-provider.ts
+++ b/packages/crashlytics/src/tracing/tracing-provider.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { resourceFromAttributes } from '@opentelemetry/resources';
+import {
+  CompositePropagator,
+  W3CTraceContextPropagator
+} from '@opentelemetry/core';
+import { TracerProvider, trace } from '@opentelemetry/api';
+import {
+  WebTracerProvider,
+  BatchSpanProcessor,
+  SimpleSpanProcessor,
+  ConsoleSpanExporter
+} from '@opentelemetry/sdk-trace-web';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
+import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
+import { FirebaseApp } from '@firebase/app';
+import { FirebaseSpanProcessor } from './firebase-span-processor';
+import { sessionContextManager } from './session-context-manager';
+
+/**
+ * Create a tracing provider for the current execution environment.
+ *
+ * @internal
+ */
+export function createTracingProvider(
+  app: FirebaseApp,
+  tracingUrl: string
+): TracerProvider {
+  if (typeof window === 'undefined') {
+    return trace.getTracerProvider();
+  }
+
+  const { projectId, appId, apiKey } = app.options;
+
+  const resource = resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: appId,
+    'gcp.project_id': projectId,
+    'cloud.provider': 'gcp'
+  });
+
+  if (tracingUrl.endsWith('/')) {
+    tracingUrl = tracingUrl.slice(0, -1);
+  }
+
+  const otlpEndpoint = `${tracingUrl}/v1/projects/${projectId}/apps/${appId}/traces`;
+
+  const traceExporter = new OTLPTraceExporter({
+    url: otlpEndpoint,
+    headers: {
+      'X-Goog-User-Project': projectId || '',
+      ...(apiKey ? { 'X-Goog-Api-Key': apiKey } : {})
+    }
+  });
+
+  const provider = new WebTracerProvider({
+    resource,
+    spanProcessors: [
+      new FirebaseSpanProcessor(),
+      // TODO: Remove console exporter before we ship
+      new SimpleSpanProcessor(new ConsoleSpanExporter()),
+      new BatchSpanProcessor(traceExporter)
+    ]
+  });
+
+  provider.register({
+    contextManager: sessionContextManager,
+    propagator: new CompositePropagator({
+      propagators: [new W3CTraceContextPropagator()]
+    })
+  });
+
+  registerInstrumentations({
+    instrumentations: [
+      new FetchInstrumentation(),
+      new XMLHttpRequestInstrumentation()
+    ]
+  });
+
+  return provider;
+}

--- a/packages/crashlytics/src/types.ts
+++ b/packages/crashlytics/src/types.ts
@@ -16,6 +16,7 @@
  */
 
 import { LoggerProvider } from '@opentelemetry/sdk-logs';
+import { TracerProvider } from '@opentelemetry/api';
 import { Crashlytics } from './public-types';
 
 /**
@@ -25,6 +26,7 @@ import { Crashlytics } from './public-types';
  */
 export interface CrashlyticsInternal extends Crashlytics {
   loggerProvider: LoggerProvider;
+  tracingProvider: TracerProvider;
 }
 
 type KeyValuePair = [key: string, value: string];

--- a/packages/crashlytics/tsconfig.json
+++ b/packages/crashlytics/tsconfig.json
@@ -2,7 +2,16 @@
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "jsx": "react"
+    "jsx": "react",
+    "baseUrl": ".",
+    "paths": {}
   },
-  "exclude": ["dist/**/*"]
+  "exclude": [
+    "dist/**/*"
+  ],
+  "include": [
+    "src/**/*",
+    "index.ts",
+    "index.node.ts"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2793,17 +2793,17 @@
   dependencies:
     "@octokit/openapi-types" "^12.11.0"
 
-"@opentelemetry/api-logs@0.203.0":
-  version "0.203.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.203.0.tgz#3309a76c51a848ea820cd7f00ee62daf36b06380"
-  integrity sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==
+"@opentelemetry/api-logs@0.212.0":
+  version "0.212.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.212.0.tgz#ec66a0951b84b1f082e13fd8a027b9f9d65a3f7a"
+  integrity sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==
   dependencies:
     "@opentelemetry/api" "^1.3.0"
 
-"@opentelemetry/api-logs@0.205.0":
-  version "0.205.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.205.0.tgz#7d334958c0eaa0725a1fe51aadc9b39ed7d4b6f2"
-  integrity sha512-wBlPk1nFB37Hsm+3Qy73yQSobVn28F4isnWIBvKpd5IUH/eat8bwcL02H9yzmHyyPmukeccSl2mbN5sDQZYnPg==
+"@opentelemetry/api-logs@0.213.0":
+  version "0.213.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.213.0.tgz#c7abc7d3c4586cfbfd737c0a2fcfb2323a9def75"
+  integrity sha512-zRM5/Qj6G84Ej3F1yt33xBVY/3tnMxtL1fiDIxYbDWYaZ/eudVw3/PBiZ8G7JwUxXxjW8gU4g6LnOyfGKYHYgw==
   dependencies:
     "@opentelemetry/api" "^1.3.0"
 
@@ -2812,162 +2812,182 @@
   resolved "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
   integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
 
-"@opentelemetry/core@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz#44e1149d5666a4743cde943ef89841db3ce0f8bc"
-  integrity sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==
+"@opentelemetry/context-zone-peer-dep@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-2.5.1.tgz#c1fb818d61aca1758b8abcb5d430cb91e7782104"
+  integrity sha512-xyBDA9BIjlAeawNawFZtwJp4BUznGrR5Sm7ldK/94qWtYde9+1y61tAqBep0/5B46WpbEadZGbpa2MCKAZwvxA==
+
+"@opentelemetry/context-zone@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.npmjs.org/@opentelemetry/context-zone/-/context-zone-2.5.1.tgz#c226ca4bbfea94f7fafe61cb9db9f857130b8062"
+  integrity sha512-v4HORgtvdnDAdFsP43H5P2fTSzCE/22UrxszSeDyEJmKldpEh2Dyp6tT/5GXYBBVFaTnFvkGv81U0pXV4z41Jg==
+  dependencies:
+    "@opentelemetry/context-zone-peer-dep" "2.5.1"
+    zone.js "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0 || ^0.16.0"
+
+"@opentelemetry/core@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.1.tgz#b5d830ab499bc13e29f6efa88a165630f25d2ad2"
+  integrity sha512-Dwlc+3HAZqpgTYq0MUyZABjFkcrKTePwuiFVLjahGD8cx3enqihmpAmdgNFO1R4m/sIe5afjJrA25Prqy4NXlA==
   dependencies:
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
-"@opentelemetry/core@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz#5539f04eb9e5245e000b0c3f77bdfaa07557e3a7"
-  integrity sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==
+"@opentelemetry/core@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz#719c829ed98bd7af808a2d2c83374df1fd1f3c66"
+  integrity sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==
   dependencies:
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
-"@opentelemetry/core@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz#2f857d7790ff160a97db3820889b5f4cade6eaee"
-  integrity sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==
+"@opentelemetry/exporter-logs-otlp-http@0.212.0":
+  version "0.212.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.212.0.tgz#78071c1f17371e3eb7577e7fa877b21f0ba267aa"
+  integrity sha512-JidJasLwG/7M9RTxV/64xotDKmFAUSBc9SNlxI32QYuUMK5rVKhHNWMPDzC7E0pCAL3cu+FyiKvsTwLi2KqPYw==
   dependencies:
+    "@opentelemetry/api-logs" "0.212.0"
+    "@opentelemetry/core" "2.5.1"
+    "@opentelemetry/otlp-exporter-base" "0.212.0"
+    "@opentelemetry/otlp-transformer" "0.212.0"
+    "@opentelemetry/sdk-logs" "0.212.0"
+
+"@opentelemetry/exporter-trace-otlp-proto@0.212.0":
+  version "0.212.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.212.0.tgz#ac2eaac1a0d24aa84bc6c21fd5f10d5ac830e3ed"
+  integrity sha512-d1ivqPT0V+i0IVOOdzGaLqonjtlk5jYrW7ItutWzXL/Mk+PiYb59dymy/i2reot9dDnBFWfrsvxyqdutGF5Vig==
+  dependencies:
+    "@opentelemetry/core" "2.5.1"
+    "@opentelemetry/otlp-exporter-base" "0.212.0"
+    "@opentelemetry/otlp-transformer" "0.212.0"
+    "@opentelemetry/resources" "2.5.1"
+    "@opentelemetry/sdk-trace-base" "2.5.1"
+
+"@opentelemetry/instrumentation-fetch@0.212.0":
+  version "0.212.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.212.0.tgz#9a147d45b628d02a99207a36a4974ff0c3328b8b"
+  integrity sha512-qHcv+4fVvT1PGSLLiwK4UjfXlbpg1KDVZWJyle3VoH6uMfyeQSirS23u4WewwNdRPorfDX8bhQ7RCWItwWvZtA==
+  dependencies:
+    "@opentelemetry/core" "2.5.1"
+    "@opentelemetry/instrumentation" "0.212.0"
+    "@opentelemetry/sdk-trace-web" "2.5.1"
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
-"@opentelemetry/exporter-logs-otlp-http@0.203.0":
-  version "0.203.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.203.0.tgz#cdecb5c5b39561aa8520c8bb78347c6e11c91a81"
-  integrity sha512-s0hys1ljqlMTbXx2XiplmMJg9wG570Z5lH7wMvrZX6lcODI56sG4HL03jklF63tBeyNwK2RV1/ntXGo3HgG4Qw==
+"@opentelemetry/instrumentation-xml-http-request@0.213.0":
+  version "0.213.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.213.0.tgz#bbf74cdd89aa5fd7921f639b61c68367a8855dfe"
+  integrity sha512-Swuigd0YX5zQANch6lC0vSx63Z9ilB8/fJPn9iYBSif/SwPGmecHLawXpMM78PuxO/hIn8rSWP1gSWhBthLTKw==
   dependencies:
-    "@opentelemetry/api-logs" "0.203.0"
-    "@opentelemetry/core" "2.0.1"
-    "@opentelemetry/otlp-exporter-base" "0.203.0"
-    "@opentelemetry/otlp-transformer" "0.203.0"
-    "@opentelemetry/sdk-logs" "0.203.0"
-
-"@opentelemetry/otlp-exporter-base@0.203.0":
-  version "0.203.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.203.0.tgz#8a9c2916b5a87467fd85950c054cecf9a97aec26"
-  integrity sha512-Wbxf7k+87KyvxFr5D7uOiSq/vHXWommvdnNE7vECO3tAhsA2GfOlpWINCMWUEPdHZ7tCXxw6Epp3vgx3jU7llQ==
-  dependencies:
-    "@opentelemetry/core" "2.0.1"
-    "@opentelemetry/otlp-transformer" "0.203.0"
-
-"@opentelemetry/otlp-exporter-base@0.205.0":
-  version "0.205.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.205.0.tgz#3a4a09382e517af88d152c2f31e47ac16a84b43c"
-  integrity sha512-2MN0C1IiKyo34M6NZzD6P9Nv9Dfuz3OJ3rkZwzFmF6xzjDfqqCTatc9v1EpNfaP55iDOCLHFyYNCgs61FFgtUQ==
-  dependencies:
-    "@opentelemetry/core" "2.1.0"
-    "@opentelemetry/otlp-transformer" "0.205.0"
-
-"@opentelemetry/otlp-transformer@0.203.0":
-  version "0.203.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.203.0.tgz#e93220ed56aae573640c85e158221094d1f2905b"
-  integrity sha512-Y8I6GgoCna0qDQ2W6GCRtaF24SnvqvA8OfeTi7fqigD23u8Jpb4R5KFv/pRvrlGagcCLICMIyh9wiejp4TXu/A==
-  dependencies:
-    "@opentelemetry/api-logs" "0.203.0"
-    "@opentelemetry/core" "2.0.1"
-    "@opentelemetry/resources" "2.0.1"
-    "@opentelemetry/sdk-logs" "0.203.0"
-    "@opentelemetry/sdk-metrics" "2.0.1"
-    "@opentelemetry/sdk-trace-base" "2.0.1"
-    protobufjs "^7.3.0"
-
-"@opentelemetry/otlp-transformer@0.205.0":
-  version "0.205.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.205.0.tgz#bf53729676a3f80a701141762ed6e3c92ec82963"
-  integrity sha512-KmObgqPtk9k/XTlWPJHdMbGCylRAmMJNXIRh6VYJmvlRDMfe+DonH41G7eenG8t4FXn3fxOGh14o/WiMRR6vPg==
-  dependencies:
-    "@opentelemetry/api-logs" "0.205.0"
-    "@opentelemetry/core" "2.1.0"
-    "@opentelemetry/resources" "2.1.0"
-    "@opentelemetry/sdk-logs" "0.205.0"
-    "@opentelemetry/sdk-metrics" "2.1.0"
-    "@opentelemetry/sdk-trace-base" "2.1.0"
-    protobufjs "^7.3.0"
-
-"@opentelemetry/resources@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.1.tgz#0365d134291c0ed18d96444a1e21d0e6a481c840"
-  integrity sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==
-  dependencies:
-    "@opentelemetry/core" "2.0.1"
+    "@opentelemetry/core" "2.6.0"
+    "@opentelemetry/instrumentation" "0.213.0"
+    "@opentelemetry/sdk-trace-web" "2.6.0"
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
-"@opentelemetry/resources@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz#11772e732af4f27953cf55567a6630d8b4d8282d"
-  integrity sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==
+"@opentelemetry/instrumentation@0.212.0":
+  version "0.212.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.212.0.tgz#238b6e3e2131217ff4acfe7e8e7b6ce1f0ac0ba0"
+  integrity sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg==
   dependencies:
-    "@opentelemetry/core" "2.1.0"
+    "@opentelemetry/api-logs" "0.212.0"
+    import-in-the-middle "^2.0.6"
+    require-in-the-middle "^8.0.0"
+
+"@opentelemetry/instrumentation@0.213.0":
+  version "0.213.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.213.0.tgz#55362569efd0cba00aab9921a78dd20dfddf70b6"
+  integrity sha512-3i9NdkET/KvQomeh7UaR/F4r9P25Rx6ooALlWXPIjypcEOUxksCmVu0zA70NBJWlrMW1rPr/LRidFAflLI+s/w==
+  dependencies:
+    "@opentelemetry/api-logs" "0.213.0"
+    import-in-the-middle "^3.0.0"
+    require-in-the-middle "^8.0.0"
+
+"@opentelemetry/otlp-exporter-base@0.212.0":
+  version "0.212.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.212.0.tgz#c1aab3d2a9c4a10bcc1116ef7e230b5d3b732819"
+  integrity sha512-HoMv5pQlzbuxiMS0hN7oiUtg8RsJR5T7EhZccumIWxYfNo/f4wFc7LPDfFK6oHdG2JF/+qTocfqIHoom+7kLpw==
+  dependencies:
+    "@opentelemetry/core" "2.5.1"
+    "@opentelemetry/otlp-transformer" "0.212.0"
+
+"@opentelemetry/otlp-transformer@0.212.0":
+  version "0.212.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.212.0.tgz#ceef3f0b18fcf6565b21dbc6eaa2f049bf1ad7f1"
+  integrity sha512-bj7zYFOg6Db7NUwsRZQ/WoVXpAf41WY2gsd3kShSfdpZQDRKHWJiRZIg7A8HvWsf97wb05rMFzPbmSHyjEl9tw==
+  dependencies:
+    "@opentelemetry/api-logs" "0.212.0"
+    "@opentelemetry/core" "2.5.1"
+    "@opentelemetry/resources" "2.5.1"
+    "@opentelemetry/sdk-logs" "0.212.0"
+    "@opentelemetry/sdk-metrics" "2.5.1"
+    "@opentelemetry/sdk-trace-base" "2.5.1"
+    protobufjs "8.0.0"
+
+"@opentelemetry/resources@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.1.tgz#90ccc27cea02b543f20a7db9834852ec11784c1a"
+  integrity sha512-BViBCdE/GuXRlp9k7nS1w6wJvY5fnFX5XvuEtWsTAOQFIO89Eru7lGW3WbfbxtCuZ/GbrJfAziXG0w0dpxL7eQ==
+  dependencies:
+    "@opentelemetry/core" "2.5.1"
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
-"@opentelemetry/sdk-logs@0.203.0":
-  version "0.203.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.203.0.tgz#01bc7c0549929d2864af2ab0ba23fd5ce02b5b0a"
-  integrity sha512-vM2+rPq0Vi3nYA5akQD2f3QwossDnTDLvKbea6u/A2NZ3XDkPxMfo/PNrDoXhDUD/0pPo2CdH5ce/thn9K0kLw==
+"@opentelemetry/resources@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.0.tgz#1a945dbb8986043d8b593c358d5d8e3de6becf5a"
+  integrity sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==
   dependencies:
-    "@opentelemetry/api-logs" "0.203.0"
-    "@opentelemetry/core" "2.0.1"
-    "@opentelemetry/resources" "2.0.1"
-
-"@opentelemetry/sdk-logs@0.205.0":
-  version "0.205.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.205.0.tgz#4a302b1507e753d2c4d9bddb5243aecf5eb7156b"
-  integrity sha512-nyqhNQ6eEzPWQU60Nc7+A5LIq8fz3UeIzdEVBQYefB4+msJZ2vuVtRuk9KxPMw1uHoHDtYEwkr2Ct0iG29jU8w==
-  dependencies:
-    "@opentelemetry/api-logs" "0.205.0"
-    "@opentelemetry/core" "2.1.0"
-    "@opentelemetry/resources" "2.1.0"
-
-"@opentelemetry/sdk-metrics@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.1.tgz#efb6e9349e8a9038ac622e172692bfcdcad8010b"
-  integrity sha512-wf8OaJoSnujMAHWR3g+/hGvNcsC16rf9s1So4JlMiFaFHiE4HpIA3oUh+uWZQ7CNuK8gVW/pQSkgoa5HkkOl0g==
-  dependencies:
-    "@opentelemetry/core" "2.0.1"
-    "@opentelemetry/resources" "2.0.1"
-
-"@opentelemetry/sdk-metrics@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.1.0.tgz#fbb9b270ee56c29feba885062e5c0418213fccf2"
-  integrity sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==
-  dependencies:
-    "@opentelemetry/core" "2.1.0"
-    "@opentelemetry/resources" "2.1.0"
-
-"@opentelemetry/sdk-trace-base@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz#25808bb6a3d08a501ad840249e4d43d3493eb6e5"
-  integrity sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==
-  dependencies:
-    "@opentelemetry/core" "2.0.1"
-    "@opentelemetry/resources" "2.0.1"
+    "@opentelemetry/core" "2.6.0"
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
-"@opentelemetry/sdk-trace-base@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz#9d31474824e9ed215f94bf71260d5321f64d402a"
-  integrity sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==
+"@opentelemetry/sdk-logs@0.212.0":
+  version "0.212.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.212.0.tgz#0ed756044ed8201a8620a39e7535fe8b34d54be5"
+  integrity sha512-qglb5cqTf0mOC1sDdZ7nfrPjgmAqs2OxkzOPIf2+Rqx8yKBK0pS7wRtB1xH30rqahBIut9QJDbDePyvtyqvH/Q==
   dependencies:
-    "@opentelemetry/core" "2.1.0"
-    "@opentelemetry/resources" "2.1.0"
+    "@opentelemetry/api-logs" "0.212.0"
+    "@opentelemetry/core" "2.5.1"
+    "@opentelemetry/resources" "2.5.1"
+
+"@opentelemetry/sdk-metrics@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.5.1.tgz#b6eeb57f5474d6a47dda255c3375573364166ea4"
+  integrity sha512-RKMn3QKi8nE71ULUo0g/MBvq1N4icEBo7cQSKnL3URZT16/YH3nSVgWegOjwx7FRBTrjOIkMJkCUn/ZFIEfn4A==
+  dependencies:
+    "@opentelemetry/core" "2.5.1"
+    "@opentelemetry/resources" "2.5.1"
+
+"@opentelemetry/sdk-trace-base@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.5.1.tgz#4f55f37e18ac3f971936d4717b6bfd43cfd72d61"
+  integrity sha512-iZH3Gw8cxQn0gjpOjJMmKLd9GIaNh/E3v3ST67vyzLSxHBs14HsG4dy7jMYyC5WXGdBVEcM7U/XTF5hCQxjDMw==
+  dependencies:
+    "@opentelemetry/core" "2.5.1"
+    "@opentelemetry/resources" "2.5.1"
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
-"@opentelemetry/sdk-trace-web@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.1.0.tgz#5765729ad975a8611eb863d40778d644eda4ae54"
-  integrity sha512-2F6ZuZFmJg4CdhRPP8+60DkvEwGLCiU3ffAkgnnqe/ALGEBqGa0HrZaNWFGprXWVivrYHpXhr7AEfasgLZD71g==
+"@opentelemetry/sdk-trace-base@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.0.tgz#d7e752a0906f2bcae3c1261e224aef3e3b3746f9"
+  integrity sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==
   dependencies:
-    "@opentelemetry/core" "2.1.0"
-    "@opentelemetry/sdk-trace-base" "2.1.0"
+    "@opentelemetry/core" "2.6.0"
+    "@opentelemetry/resources" "2.6.0"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
 
-"@opentelemetry/semantic-conventions@1.36.0":
-  version "1.36.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.36.0.tgz#149449bd4df4d0464220915ad4164121e0d75d4d"
-  integrity sha512-TtxJSRD8Ohxp6bKkhrm27JRHAxPczQA7idtcTOMYI+wQRRrfgqxHv1cFbCApcSnNjtXkmzFozn6jQtFrOmbjPQ==
+"@opentelemetry/sdk-trace-web@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.5.1.tgz#8d4f46f752e29eac94e1b25b5780b428afa45871"
+  integrity sha512-4PWFtMJ5nqWMP2YqgKjcMlQlUeN1imUYSXdhy6Xl/3bnO0/Ryo5Y3/kWG8T66uMHo2RpTQLloZjoQACKdbHbxg==
+  dependencies:
+    "@opentelemetry/core" "2.5.1"
+    "@opentelemetry/sdk-trace-base" "2.5.1"
 
-"@opentelemetry/semantic-conventions@^1.29.0":
+"@opentelemetry/sdk-trace-web@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.6.0.tgz#dba26c354879bc0cebe9b0082464b1a144e31bca"
+  integrity sha512-xyYmLFatwUeYnB7NtQ2Ydl9Y8uiblN+EDo5YEjnk7ZRMhGFyt1wgPqb8EYvATLuDiRVtxid1fJsL6RH1fCQMIA==
+  dependencies:
+    "@opentelemetry/core" "2.6.0"
+    "@opentelemetry/sdk-trace-base" "2.6.0"
+
+"@opentelemetry/semantic-conventions@1.39.0", "@opentelemetry/semantic-conventions@^1.29.0":
   version "1.39.0"
   resolved "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz#f653b2752171411feb40310b8a8953d7e5c543b7"
   integrity sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==
@@ -4178,6 +4198,11 @@ accepts@~1.3.4, accepts@~1.3.8:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
+acorn-import-attributes@^1.9.5:
+  version "1.9.5"
+  resolved "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz#7eb1557b1ba05ef18b5ed0ec67591bfab04688ef"
+  integrity sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -4199,6 +4224,11 @@ acorn@^8.11.0, acorn@^8.14.0, acorn@^8.4.1, acorn@^8.8.2, acorn@^8.9.0:
   version "8.14.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz#063e2c70cac5fb4f6467f0b11152e04c682795b0"
   integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
+
+acorn@^8.15.0:
+  version "8.16.0"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
+  integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -5742,6 +5772,11 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   dependencies:
     inherits "^2.0.4"
     safe-buffer "^5.2.1"
+
+cjs-module-lexer@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz#b3ca5101843389259ade7d88c77bd06ce55849ca"
+  integrity sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==
 
 cjson@^0.3.1:
   version "0.3.3"
@@ -9557,6 +9592,26 @@ import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
+import-in-the-middle@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz#1972337bfe020d05f6b5e020c13334567436324f"
+  integrity sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==
+  dependencies:
+    acorn "^8.15.0"
+    acorn-import-attributes "^1.9.5"
+    cjs-module-lexer "^2.2.0"
+    module-details-from-path "^1.0.4"
+
+import-in-the-middle@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.0.tgz#720c12b4c07ea58b32a54667e70a022e18cc36a3"
+  integrity sha512-OnGy+eYT7wVejH2XWgLRgbmzujhhVIATQH0ztIeRilwHBjTeG3pD+XnH3PKX0r9gJ0BuJmJ68q/oh9qgXnNDQg==
+  dependencies:
+    acorn "^8.15.0"
+    acorn-import-attributes "^1.9.5"
+    cjs-module-lexer "^2.2.0"
+    module-details-from-path "^1.0.4"
+
 import-lazy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
@@ -12269,6 +12324,11 @@ modify-values@^1.0.0:
   resolved "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
+module-details-from-path@^1.0.3, module-details-from-path@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz#b662fdcd93f6c83d3f25289da0ce81c8d9685b94"
+  integrity sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==
+
 moment@~2.30.1:
   version "2.30.1"
   resolved "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
@@ -14006,10 +14066,10 @@ protobufjs@7.4.0, protobufjs@^7.2.5, protobufjs@^7.3.2:
     "@types/node" ">=13.7.0"
     long "^5.0.0"
 
-protobufjs@^7.3.0:
-  version "7.5.4"
-  resolved "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz#885d31fe9c4b37f25d1bb600da30b1c5b37d286a"
-  integrity sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==
+protobufjs@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.0.tgz#d884102c1fe8d0b1e2493789ad37bc7ea47c0893"
+  integrity sha512-jx6+sE9h/UryaCZhsJWbJtTEy47yXoGNYI4z8ZaRncM0zBKeRqjO2JEcOUYwrYGb1WLhXM1FfMzW3annvFv0rw==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"
@@ -14722,6 +14782,14 @@ require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
+require-in-the-middle@^8.0.0:
+  version "8.0.1"
+  resolved "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz#dbde2587f669398626d56b20c868ab87bf01cce4"
+  integrity sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==
+  dependencies:
+    debug "^4.3.5"
+    module-details-from-path "^1.0.3"
 
 require-main-filename@^1.0.1:
   version "1.0.1"
@@ -18204,3 +18272,8 @@ zone.js@0.15.1:
   version "0.15.1"
   resolved "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz#1e109adb75f80e9e004ee8e0d4a0a52e0a336481"
   integrity sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==
+
+"zone.js@^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0 || ^0.16.0":
+  version "0.16.1"
+  resolved "https://registry.npmjs.org/zone.js/-/zone.js-0.16.1.tgz#ca91f0889e46b1c252aab6c75332e36840916227"
+  integrity sha512-dpvY17vxYIW3+bNrP0ClUlaiY0CiIRK3tnoLaGoQsQcY9/I/NpzIWQ7tQNhbV7LacQMpCII6wVzuL3tuWOyfuA==


### PR DESCRIPTION
* To once and for all deal with complex commit merge/revert history in the `crashlytics` branch, created a new feature branch for traces and rebased/copied all tracing related changes from `crashlytics-tracing` on top of the most recent `crashlytics` branch.
* Manually reverted extraneous changes (e.g. accidental changes to eslint) that happened in the legacy `crashlytics-tracing` that were unnecessary for the tracing feature.
* Addressed presubmit errors around formatting. There are a few more presubmit errors around module resolution that will be handled in a follow up.
* Finally, ran the playground app locally and verified tracing is working and writing to Cloud via the proxy server.