### PR TITLE
fix(ai): Fix responseSchema bug

### DIFF
--- a/.changeset/shiny-papayas-begin.md
+++ b/.changeset/shiny-papayas-begin.md
@@ -1,0 +1,5 @@
+---
+'@firebase/ai': patch
+---
+
+Fixed a bug that causes the model to error if the user specifies `responseSchema` or `responseJsonSchema`.

--- a/packages/ai/src/models/generative-model.test.ts
+++ b/packages/ai/src/models/generative-model.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 import { use, expect } from 'chai';
-import { GenerativeModel } from './generative-model';
+import { GenerativeModel, validateGenerationConfig } from './generative-model';
 import {
   FunctionCallingMode,
   AI,
@@ -955,4 +955,74 @@ describe('GenerativeModel dispatch logic', () => {
       expect(makeRequestStub).to.have.been.calledOnce;
     });
   });
+});
+
+describe('validateGenerationConfig', () => {
+  it('does not allow setting both thinkingBudget and thinkingConfig', () => {
+    expect(() => {
+      validateGenerationConfig({
+        thinkingConfig: {
+          thinkingBudget: 200
+        }
+      });
+    }).to.not.throw();
+    expect(() => {
+      validateGenerationConfig({
+        thinkingConfig: {
+          thinkingLevel: ThinkingLevel.LOW
+        }
+      });
+    }).to.not.throw();
+    expect(() => {
+      validateGenerationConfig({
+        thinkingConfig: {
+          thinkingBudget: 200,
+          thinkingLevel: ThinkingLevel.LOW
+        }
+      });
+    }).to.throw();
+  });
+  it('does not allow setting both responseSchema and responseJsonSchema', () => {
+    expect(() => {
+      validateGenerationConfig({
+        responseSchema: {},
+        responseMimeType: 'application/json'
+      });
+    }).to.not.throw();
+    expect(() => {
+      validateGenerationConfig({
+        responseJsonSchema: {},
+        responseMimeType: 'application/json'
+      });
+    }).to.not.throw();
+    expect(() => {
+      validateGenerationConfig({
+        responseSchema: {},
+        responseJsonSchema: {},
+        responseMimeType: 'application/json'
+      });
+    }).to.throw();
+  });
+  it(
+    'does not allow setting responseSchema or responseJsonSchema' +
+      ' without a responseMimeType',
+    () => {
+      expect(() => {
+        validateGenerationConfig({
+          responseSchema: {}
+        });
+      }).to.throw();
+      expect(() => {
+        validateGenerationConfig({
+          responseJsonSchema: {}
+        });
+      }).to.throw();
+      expect(() => {
+        validateGenerationConfig({
+          responseJsonSchema: {},
+          responseMimeType: 'text/plain'
+        });
+      }).to.throw();
+    }
+  );
 });

--- a/packages/ai/src/models/generative-model.test.ts
+++ b/packages/ai/src/models/generative-model.test.ts
@@ -958,7 +958,7 @@ describe('GenerativeModel dispatch logic', () => {
 });
 
 describe('validateGenerationConfig', () => {
-  it('does not allow setting both thinkingBudget and thinkingConfig', () => {
+  it('does not allow setting both thinkingBudget and thinkingLevel', () => {
     expect(() => {
       validateGenerationConfig({
         thinkingConfig: {
@@ -1004,8 +1004,8 @@ describe('validateGenerationConfig', () => {
     }).to.throw();
   });
   it(
-    'does not allow setting responseSchema or responseJsonSchema' +
-      ' without a responseMimeType',
+    'throws if responseSchema or responseJsonSchema are set' +
+      ' and responseMimeType is not "application/json"',
     () => {
       expect(() => {
         validateGenerationConfig({

--- a/packages/ai/src/models/generative-model.ts
+++ b/packages/ai/src/models/generative-model.ts
@@ -190,7 +190,9 @@ export class GenerativeModel extends AIModel {
  * Client-side validation of some common `GenerationConfig` pitfalls, in order
  * to save the developer a wasted request.
  */
-function validateGenerationConfig(generationConfig: GenerationConfig): void {
+export function validateGenerationConfig(
+  generationConfig: GenerationConfig
+): void {
   if (
     // != allows for null and undefined. 0 is considered "set" by the model
     generationConfig.thinkingConfig?.thinkingBudget != null &&
@@ -214,11 +216,12 @@ function validateGenerationConfig(generationConfig: GenerationConfig): void {
   if (
     (generationConfig.responseSchema != null ||
       generationConfig.responseJsonSchema != null) &&
-    generationConfig.responseMimeType
+    generationConfig.responseMimeType !== 'application/json'
   ) {
     throw new AIError(
       AIErrorCode.UNSUPPORTED,
-      `responseMimeType must be set if responseSchema or responseJsonSchema are set.`
+      `responseMimeType must be set to "application/json" if` +
+        ` responseSchema or responseJsonSchema are set.`
     );
   }
 }


### PR DESCRIPTION
Fix a bug introduced by https://github.com/firebase/firebase-js-sdk/pull/9693

Added unit tests that would catch similar bugs going forward.

Fixes https://github.com/firebase/firebase-js-sdk/issues/9792

Bug description (from comment in PR above):
> @rachelsaunders @DellaBitta @hsubox76 This PR introduces a critical bug which makes it impossible to use responseSchema:
> 
> ```
>     (generationConfig.responseSchema != null ||
>       generationConfig.responseJsonSchema != null) &&
>     generationConfig.responseMimeType
>   ) {
>     throw new AIError(
>       AIErrorCode.UNSUPPORTED,
>       `responseMimeType must be set if responseSchema or responseJsonSchema are set.`
>     );
>   }
> ```
> 
> This block should be checking generationConfig.responseMimeType !== "application/json". Additionally this error message should be explicit about the required value.

