### PR TITLE
Update dependencies for Coveralls workflow 

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -269,7 +269,7 @@ jobs:
 
   coveralls-finish:
     name: Finalize Coveralls
-    needs: [test-the-rest-coverage, test-auth-coverage, test-firestore-coverage]
+    needs: [test-the-rest, test-auth, test-firestore]
     runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished


### PR DESCRIPTION
The coveralls job dependencies needs to point to job IDs not flag names, otherwise the workflow will fail.

Hey there! So you want to contribute to a Firebase SDK? 
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here. 
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * Changes that affect the public API will require internal review. Before making a
    PR that changes the public API, we would suggest first proposing your change in an
    issue so that we can discuss it together.
