### PR TITLE
feat(data-connect): add automatic disconnect and cleanup logic to streaming, harden error handling

### DIFF
--- a/packages/data-connect/src/core/query/QueryManager.ts
+++ b/packages/data-connect/src/core/query/QueryManager.ts
@@ -436,6 +436,22 @@ export class QueryManager {
             stringified
         );
         this.publishErrorToSubscribers(key, error);
+
+        // cleanup subscriptions in query layer by unsubscribing all ONLY if it's a disconnect
+        const isDisconnect = response.errors.some(
+          e =>
+            e &&
+            typeof e === 'object' &&
+            'message' in e &&
+            e.message === 'WebSocket disconnected externally'
+        );
+
+        if (isDisconnect) {
+          const callbacks = this.callbacks.get(key);
+          if (callbacks) {
+            [...callbacks].forEach(cb => cb.unsubscribe());
+          }
+        }
         return;
       }
       const fetchTime = Date.now().toString();

--- a/packages/data-connect/src/core/query/QueryManager.ts
+++ b/packages/data-connect/src/core/query/QueryManager.ts
@@ -429,7 +429,21 @@ export class QueryManager {
     });
     return async response => {
       if (response.errors && response.errors.length > 0) {
-        const stringified = JSON.stringify(response.errors);
+        const stringified = JSON.stringify(
+          response.errors.map(e => {
+            if (e && typeof e === 'object' && 'message' in e) {
+              const code =
+                'code' in e
+                  ? (e as unknown as Record<string, unknown>)['code']
+                  : undefined;
+              const message = (e as unknown as Record<string, unknown>)[
+                'message'
+              ];
+              return { message, code };
+            }
+            return e;
+          })
+        );
         const error = new DataConnectError(
           Code.OTHER,
           'DataConnect error received from subscribe notification: ' +

--- a/packages/data-connect/src/core/query/QueryManager.ts
+++ b/packages/data-connect/src/core/query/QueryManager.ts
@@ -451,6 +451,7 @@ export class QueryManager {
         );
         this.publishErrorToSubscribers(key, error);
 
+        // TODO(stephenarosaj) use more robust error checking to see if this is a disconnect. categorize your errors!!!
         // cleanup subscriptions in query layer by unsubscribing all ONLY if it's a disconnect
         const isDisconnect = response.errors.some(
           e =>

--- a/packages/data-connect/src/network/rest/fetch.ts
+++ b/packages/data-connect/src/network/rest/fetch.ts
@@ -106,16 +106,24 @@ export async function dcFetch<Data, Variables>(
   try {
     response = await connectFetch(url, fetchOptions);
   } catch (err) {
-    throw new DataConnectError(
-      Code.OTHER,
-      'Failed to fetch: ' + JSON.stringify(err)
-    );
+    const message =
+      err && typeof err === 'object' && 'message' in err
+        ? (err as unknown as Record<string, unknown>)['message']
+        : String(err);
+    throw new DataConnectError(Code.OTHER, 'Failed to fetch: ' + message);
   }
   let jsonResponse: JsonResponse<Data>;
   try {
     jsonResponse = await response.json();
   } catch (e) {
-    throw new DataConnectError(Code.OTHER, JSON.stringify(e));
+    const message =
+      e && typeof e === 'object' && 'message' in e
+        ? (e as unknown as Record<string, unknown>)['message']
+        : String(e);
+    throw new DataConnectError(
+      Code.OTHER,
+      'Failed to parse JSON response: ' + message
+    );
   }
   const message = getErrorMessage(jsonResponse);
   if (response.status >= 400) {

--- a/packages/data-connect/src/network/stream/streamTransport.ts
+++ b/packages/data-connect/src/network/stream/streamTransport.ts
@@ -66,9 +66,9 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
 
   /** Is the stream currently waiting to close connection? */
   get isPendingClose(): boolean {
-    return this._pendingClose;
+    return this.pendingClose;
   }
-  private _pendingClose = false;
+  private pendingClose = false;
 
   // TODO(stephenarosaj): determine this based on the underlying transport when implementing resilience / fallback / disconnects / retries
   get isUnableToConnect(): boolean {
@@ -166,6 +166,13 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     string,
     SubscribeNotificationHook<unknown>
   >();
+
+  /** current close timeout from setTimeout(), if any */
+  private closeTimeout: NodeJS.Timeout | null = null;
+  /** has the close timeout finished? */
+  private closeTimeoutFinished = false;
+  /** current auth uid. used to detect if a different user logs in */
+  private authUid: string | null | undefined;
 
   /**
    * Tracks a query execution request, storing the request body and creating and storing a promise that
@@ -328,6 +335,77 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
   }
 
   /**
+   * Begin closing the connection. Waits for and cleans up all active requests, and waits for 1 minute.
+   * Will be called when there are no more active subscriptions.
+   */
+  private prepareToClose(): void {
+    if (this.pendingClose) {
+      return;
+    }
+    this.pendingClose = true;
+
+    this.activeSubscribeRequests.forEach(requestBody => {
+      this.invokeUnsubscribe(
+        requestBody.subscribe.operationName,
+        requestBody.subscribe.variables
+      );
+    });
+
+    const waitTime = 1000 * 60; // 1 minute
+    this.closeTimeout = setTimeout(async () => {
+      this.closeTimeoutFinished = true;
+      await this.attemptClose();
+    }, waitTime);
+  }
+
+  /**
+   * Attempt to close the connection. Will only close if there are no active requests preventing it
+   * from doing so.
+   */
+  private async attemptClose(): Promise<void> {
+    if (this.hasActiveSubscriptions || this.hasActiveExecuteRequests) {
+      return;
+    }
+    await this.closeConnection();
+    this.onGracefulStreamClose?.();
+  }
+
+  /**
+   * Cancel closing the connection.
+   */
+  private cancelClose(): void {
+    if (this.closeTimeout) {
+      clearTimeout(this.closeTimeout);
+    }
+    this.pendingClose = false;
+    this.closeTimeoutFinished = false;
+  }
+
+  /**
+   * Reject all pending execute promises and subscribe hooks with the given error. Clear active request
+   * tracking maps without cancelling or re-invoking any requests.
+   */
+  private rejectAllPendingRequests(error: DataConnectError): void {
+    this.activeQueryExecuteRequests.clear();
+    this.activeMutationExecuteRequests.clear();
+    this.activeSubscribeRequests.clear();
+
+    for (const [requestId, { rejectFn }] of this.executeRequestPromises) {
+      this.executeRequestPromises.delete(requestId);
+      rejectFn(error);
+    }
+
+    for (const [requestId, notifyHook] of this.subscribeNotificationHooks) {
+      this.subscribeNotificationHooks.delete(requestId);
+      notifyHook({
+        data: undefined,
+        errors: [error],
+        extensions: {}
+      });
+    }
+  }
+
+  /**
    * Prepares a stream request message by adding necessary headers and metadata.
    * If this is the first message on the stream, it includes the resource name, auth token, and App Check token.
    * If the auth token has refreshed since the last message, it includes the new auth token.
@@ -478,15 +556,19 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
   /**
    * @inheritdoc
    * @remarks
-   * This method synchronously updates the request tracking data structures before sending any message.
-   * If any asynchronous functionality is added to this function, it MUST be done in a way that
-   * preserves the synchronous update of the tracking data structures before the method returns.
+   * This method synchronously updates the request tracking data structures before sending any message
+   * or cancelling the closing of the stream. If any asynchronous functionality is added to this function,
+   * it MUST be done in a way that preserves the synchronous update of the tracking data structures
+   * before the method returns.
    */
   invokeSubscribe<Data, Variables>(
     notifyQueryManager: SubscribeNotificationHook<Data>,
     queryName: string,
     variables: Variables
   ): void {
+    // if we are waiting to close the stream, cancel closing!
+    this.cancelClose();
+
     const requestId = this.nextRequestId();
     const activeRequestKey = { operationName: queryName, variables };
     const mapKey = this.getMapKey(queryName, variables);
@@ -510,6 +592,9 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
         errors: [err instanceof Error ? err : new Error(String(err))]
       });
       this.cleanupSubscribeRequest(requestId, mapKey);
+      if (!this.hasActiveSubscriptions) {
+        this.prepareToClose();
+      }
     });
   }
 
@@ -537,12 +622,40 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     // asynchronous, fire and forget
     this.sendRequestMessage(cancelBody).catch(err => {
       logError(`Stream Transport failed to send unsubscribe message: ${err}`);
+    }).finally(() => {
+      if (!this.hasActiveSubscriptions) {
+        this.prepareToClose();
+      }
     });
   }
 
+
   onAuthTokenChanged(newToken: string | null): void {
+    const oldAuthToken = this._authToken;
     this._authToken = newToken;
+
+    const oldAuthUid = this.authUid;
+    const newAuthUid = this.authProvider?.getAuth().getUid();
+    this.authUid = newAuthUid;
+
+    if (
+      (oldAuthToken && newToken === null) ||
+      (oldAuthUid && newAuthUid !== oldAuthUid) ||
+      (!oldAuthUid && newAuthUid)
+    ) {
+      // (user logged out) || (new user is logged in) || (user logged in)
+      if (this.hasActiveSubscriptions || this.hasActiveExecuteRequests) {
+        this.rejectAllPendingRequests(
+          new DataConnectError(
+            Code.UNAUTHORIZED,
+            'Stream disconnected due to auth change.'
+          )
+        );
+        void this.attemptClose();
+      }
+    }
   }
+
 
   /**
    * Handle a response message from the server. Called by the connection-specific implementation after

--- a/packages/data-connect/src/network/stream/streamTransport.ts
+++ b/packages/data-connect/src/network/stream/streamTransport.ts
@@ -622,11 +622,11 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     // asynchronous, fire and forget
     this.sendRequestMessage(cancelBody).catch(err => {
       logError(`Stream Transport failed to send unsubscribe message: ${err}`);
-    }).finally(() => {
-      if (!this.hasActiveSubscriptions) {
-        this.prepareToClose();
-      }
     });
+
+    if (!this.hasActiveSubscriptions) {
+      this.prepareToClose();
+    }
   }
 
 

--- a/packages/data-connect/src/network/stream/streamTransport.ts
+++ b/packages/data-connect/src/network/stream/streamTransport.ts
@@ -41,6 +41,9 @@ import {
 /** The request id of the first request over the stream */
 const FIRST_REQUEST_ID = 1;
 
+/** Time to wait before closing an idle connection (no active subscriptions) */
+const IDLE_CONNECTION_TIMEOUT_MS = 60 * 1000; // 1 minute
+
 /**
  * A promise that is settled for a request is received, and the functions that resolve or reject it.
  */
@@ -335,8 +338,9 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
   }
 
   /**
-   * Begin closing the connection. Waits for and cleans up all active requests, and waits for 1 minute.
-   * Will be called when there are no more active subscriptions.
+   * Begin closing the connection. Waits for and cleans up all active requests, and waits for
+   * {@link IDLE_CONNECTION_TIMEOUT_MS}. Will be called when there are no more active
+   * subscriptions.
    */
   private prepareToClose(): void {
     if (this.pendingClose) {
@@ -351,11 +355,10 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       );
     });
 
-    const waitTime = 1000 * 60; // 1 minute
     this.closeTimeout = setTimeout(async () => {
       this.closeTimeoutFinished = true;
       await this.attemptClose();
-    }, waitTime);
+    }, IDLE_CONNECTION_TIMEOUT_MS);
   }
 
   /**
@@ -634,15 +637,14 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     this._authToken = newToken;
 
     const oldAuthUid = this.authUid;
-    const newAuthUid = this.authProvider?.getAuth().getUid();
+    const newAuthUid = this.authProvider?.getAuth()?.getUid();
     this.authUid = newAuthUid;
 
     if (
-      (oldAuthToken && newToken === null) ||
-      (oldAuthUid && newAuthUid !== oldAuthUid) ||
-      (!oldAuthUid && newAuthUid)
+      (oldAuthToken && newToken === null) || // user logged out
+      (!oldAuthUid && newAuthUid) || // user logged in
+      (oldAuthUid && newAuthUid !== oldAuthUid) // logged in user changed
     ) {
-      // (user logged out) || (new user is logged in) || (user logged in)
       this.rejectAllActiveRequests(
         new DataConnectError(
           Code.UNAUTHORIZED,

--- a/packages/data-connect/src/network/stream/streamTransport.ts
+++ b/packages/data-connect/src/network/stream/streamTransport.ts
@@ -643,15 +643,13 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       (!oldAuthUid && newAuthUid)
     ) {
       // (user logged out) || (new user is logged in) || (user logged in)
-      if (this.hasActiveSubscriptions || this.hasActiveExecuteRequests) {
-        this.rejectAllActiveRequests(
-          new DataConnectError(
-            Code.UNAUTHORIZED,
-            'Stream disconnected due to auth change.'
-          )
-        );
-        void this.attemptClose();
-      }
+      this.rejectAllActiveRequests(
+        new DataConnectError(
+          Code.UNAUTHORIZED,
+          'Stream disconnected due to auth change.'
+        )
+      );
+      void this.attemptClose();
     }
   }
 

--- a/packages/data-connect/src/network/stream/streamTransport.ts
+++ b/packages/data-connect/src/network/stream/streamTransport.ts
@@ -382,10 +382,10 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
   }
 
   /**
-   * Reject all pending execute promises and subscribe hooks with the given error. Clear active request
-   * tracking maps without cancelling or re-invoking any requests.
+   * Reject all active execute promises and notify all subscribe hooks with the given error. 
+   * Clear active request tracking maps without cancelling or re-invoking any requests.
    */
-  private rejectAllPendingRequests(error: DataConnectError): void {
+  protected rejectAllActiveRequests(error: DataConnectError): void {
     this.activeQueryExecuteRequests.clear();
     this.activeMutationExecuteRequests.clear();
     this.activeSubscribeRequests.clear();
@@ -645,7 +645,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     ) {
       // (user logged out) || (new user is logged in) || (user logged in)
       if (this.hasActiveSubscriptions || this.hasActiveExecuteRequests) {
-        this.rejectAllPendingRequests(
+        this.rejectAllActiveRequests(
           new DataConnectError(
             Code.UNAUTHORIZED,
             'Stream disconnected due to auth change.'

--- a/packages/data-connect/src/network/stream/streamTransport.ts
+++ b/packages/data-connect/src/network/stream/streamTransport.ts
@@ -347,6 +347,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       return;
     }
     this.pendingClose = true;
+    this.closeTimeoutFinished = false;
     this.closeTimeout = setTimeout(() => {
       this.closeTimeoutFinished = true;
       void this.attemptClose();
@@ -361,6 +362,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     if (this.hasActiveSubscriptions || this.hasActiveExecuteRequests) {
       return;
     }
+    this.cancelClose();
     await this.closeConnection();
     this.onGracefulStreamClose?.();
   }
@@ -506,14 +508,14 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       mapKey,
       executeBody
     );
-    responsePromise = responsePromise.finally(async () => {
+    responsePromise = responsePromise.finally(() => {
       this.cleanupQueryExecuteRequest(requestId, mapKey);
       if (
         !this.hasActiveSubscriptions &&
         !this.hasActiveExecuteRequests &&
         this.closeTimeoutFinished
       ) {
-        await this.attemptClose();
+        void this.attemptClose();
       }
     });
 

--- a/packages/data-connect/src/network/stream/streamTransport.ts
+++ b/packages/data-connect/src/network/stream/streamTransport.ts
@@ -382,7 +382,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
   }
 
   /**
-   * Reject all active execute promises and notify all subscribe hooks with the given error. 
+   * Reject all active execute promises and notify all subscribe hooks with the given error.
    * Clear active request tracking maps without cancelling or re-invoking any requests.
    */
   protected rejectAllActiveRequests(error: DataConnectError): void {
@@ -629,7 +629,6 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     }
   }
 
-
   onAuthTokenChanged(newToken: string | null): void {
     const oldAuthToken = this._authToken;
     this._authToken = newToken;
@@ -655,7 +654,6 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       }
     }
   }
-
 
   /**
    * Handle a response message from the server. Called by the connection-specific implementation after

--- a/packages/data-connect/src/network/stream/streamTransport.ts
+++ b/packages/data-connect/src/network/stream/streamTransport.ts
@@ -339,25 +339,17 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
 
   /**
    * Begin closing the connection. Waits for and cleans up all active requests, and waits for
-   * {@link IDLE_CONNECTION_TIMEOUT_MS}. Will be called when there are no more active
-   * subscriptions.
+   * {@link IDLE_CONNECTION_TIMEOUT_MS}. This is a graceful close - it will be called when there are
+   * no more active subscriptions, so there's no need to cleanup.
    */
-  private prepareToClose(): void {
+  private prepareToCloseGracefully(): void {
     if (this.pendingClose) {
       return;
     }
     this.pendingClose = true;
-
-    this.activeSubscribeRequests.forEach(requestBody => {
-      this.invokeUnsubscribe(
-        requestBody.subscribe.operationName,
-        requestBody.subscribe.variables
-      );
-    });
-
-    this.closeTimeout = setTimeout(async () => {
+    this.closeTimeout = setTimeout(() => {
       this.closeTimeoutFinished = true;
-      await this.attemptClose();
+      void this.attemptClose();
     }, IDLE_CONNECTION_TIMEOUT_MS);
   }
 
@@ -514,9 +506,16 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       mapKey,
       executeBody
     );
-    responsePromise = responsePromise.finally(() =>
-      this.cleanupQueryExecuteRequest(requestId, mapKey)
-    );
+    responsePromise = responsePromise.finally(async () => {
+      this.cleanupQueryExecuteRequest(requestId, mapKey);
+      if (
+        !this.hasActiveSubscriptions &&
+        !this.hasActiveExecuteRequests &&
+        this.closeTimeoutFinished
+      ) {
+        await this.attemptClose();
+      }
+    });
 
     // asynchronous, fire and forget
     this.sendRequestMessage<Variables>(executeBody).catch(err => {
@@ -549,9 +548,16 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       mapKey,
       executeBody
     );
-    responsePromise = responsePromise.finally(() =>
-      this.cleanupMutationExecuteRequest(requestId, mapKey)
-    );
+    responsePromise = responsePromise.finally(() => {
+      this.cleanupMutationExecuteRequest(requestId, mapKey);
+      if (
+        !this.hasActiveSubscriptions &&
+        !this.hasActiveExecuteRequests &&
+        this.closeTimeoutFinished
+      ) {
+        void this.attemptClose();
+      }
+    });
 
     // asynchronous, fire and forget
     this.sendRequestMessage<Variables>(executeBody).catch(err => {
@@ -600,7 +606,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       });
       this.cleanupSubscribeRequest(requestId, mapKey);
       if (!this.hasActiveSubscriptions) {
-        this.prepareToClose();
+        this.prepareToCloseGracefully();
       }
     });
   }
@@ -632,7 +638,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     });
 
     if (!this.hasActiveSubscriptions) {
-      this.prepareToClose();
+      this.prepareToCloseGracefully();
     }
   }
 
@@ -643,6 +649,13 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     const oldAuthUid = this.authUid;
     const newAuthUid = this.authProvider?.getAuth()?.getUid();
     this.authUid = newAuthUid;
+
+    // onAuthTokenChanged gets called by the auth provider once it initializes, so we must make sure
+    // we don't prematurely disconnect the stream if this is the initial call.
+    const isInitialAuth = oldAuthUid === undefined;
+    if (isInitialAuth) {
+      return;
+    }
 
     if (
       (oldAuthToken && newToken === null) || // user logged out

--- a/packages/data-connect/src/network/stream/streamTransport.ts
+++ b/packages/data-connect/src/network/stream/streamTransport.ts
@@ -387,6 +387,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
   /**
    * Reject all active execute promises and notify all subscribe hooks with the given error.
    * Clear active request tracking maps without cancelling or re-invoking any requests.
+   * Called by concrete implementations when the connection fails to open, or when the connection is closed.
    */
   protected rejectAllActiveRequests(error: DataConnectError): void {
     this.activeQueryExecuteRequests.clear();
@@ -508,12 +509,12 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       execute: activeRequestKey
     };
 
-    const { responsePromise, rejectFn } = this.trackQueryExecuteRequest<Data>(
+    let { responsePromise, rejectFn } = this.trackQueryExecuteRequest<Data>(
       requestId,
       mapKey,
       executeBody
     );
-    void responsePromise.finally(() =>
+    responsePromise = responsePromise.finally(() =>
       this.cleanupQueryExecuteRequest(requestId, mapKey)
     );
 
@@ -543,9 +544,12 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       execute: activeRequestKey
     };
 
-    const { responsePromise, rejectFn } =
-      this.trackMutationExecuteRequest<Data>(requestId, mapKey, executeBody);
-    void responsePromise.finally(() =>
+    let { responsePromise, rejectFn } = this.trackMutationExecuteRequest<Data>(
+      requestId,
+      mapKey,
+      executeBody
+    );
+    responsePromise = responsePromise.finally(() =>
       this.cleanupMutationExecuteRequest(requestId, mapKey)
     );
 

--- a/packages/data-connect/src/network/stream/websocket.ts
+++ b/packages/data-connect/src/network/stream/websocket.ts
@@ -140,54 +140,50 @@ export class WebSocketTransport extends AbstractDataConnectStreamTransport {
   }
 
   protected ensureConnection(): Promise<void> {
-    if (this.streamIsReady) {
-      return Promise.resolve();
-    }
-    if (this.connectionAttempt) {
-      return this.connectionAttempt;
-    }
-    this.connectionAttempt = new Promise<void>((resolve, reject) => {
-      if (!connectWebSocket) {
-        throw new DataConnectError(
-          Code.OTHER,
-          'No WebSocket Implementation detected!'
-        );
+    try {
+      if (this.streamIsReady) {
+        return Promise.resolve();
       }
-      const ws = new connectWebSocket(this.endpointUrl);
-      this.connection = ws;
-      this.connection!.binaryType = 'arraybuffer';
-      ws.onopen = () => {
-        this.onConnectionReady();
-        resolve();
-      };
-      ws.onerror = event => {
-        this.connectionAttempt = null;
-        reject(`Could not open websocket connection`);
-      };
-      ws.onmessage = ev =>
-        this.handleWebSocketMessage(ev).catch(async reason => {
-          logError(
-            `DataConnect WebSocket protocol error, closing stream: ${reason}`
+      if (this.connectionAttempt) {
+        return this.connectionAttempt;
+      }
+      this.connectionAttempt = new Promise<void>((resolve, reject) => {
+        if (!connectWebSocket) {
+          throw new DataConnectError(
+            Code.OTHER,
+            'No WebSocket Implementation detected!'
           );
-          if (this.connection) {
-            // TODO(stephenarosaj): Node environments only support close codes 1000 or 3000-4999 - update to use 3000-4999 range to specify why we're closing
-            if (reason instanceof WebSocketDataConnectError) {
-              this.connection.close(
-                WebSocketCloseCode.GRACEFUL_CLOSE,
-                reason.message
-              );
-            } else {
-              this.connection.close(
-                WebSocketCloseCode.GRACEFUL_CLOSE,
-                'Protocol Error'
-              );
-            }
-          }
-        });
-      ws.onclose = ev => this.handleWebsocketDisconnect(ev);
-    });
+        }
+        const ws = new connectWebSocket(this.endpointUrl);
+        this.connection = ws;
+        this.connection!.binaryType = 'arraybuffer';
 
-    return this.connectionAttempt;
+        ws.onopen = () => {
+          this.onConnectionReady();
+          resolve();
+        };
+
+        ws.onerror = event => {
+          this.connectionAttempt = null;
+          this.handleError(
+            `Error using WebSocket connection, closing WebSocket`
+          );
+          reject(`Error using WebSocket connection, closing WebSocket`);
+        };
+
+        ws.onmessage = ev =>
+          this.handleWebSocketMessage(ev).catch(async reason => {
+            this.handleError(reason);
+          });
+
+        ws.onclose = ev => this.handleWebsocketDisconnect(ev);
+      });
+
+      return this.connectionAttempt;
+    } catch (error) {
+      this.handleError(error);
+      throw error;
+    }
   }
 
   protected openConnection(): Promise<void> {
@@ -199,13 +195,14 @@ export class WebSocketTransport extends AbstractDataConnectStreamTransport {
     });
   }
 
-  protected closeConnection(): Promise<void> {
+  protected closeConnection(code?: number, reason?: string): Promise<void> {
     if (!this.connection) {
+      this.connectionAttempt = null;
       return Promise.resolve();
     }
     let error;
     try {
-      this.connection.close();
+      this.connection.close(code, reason);
     } catch (e) {
       error = e;
     } finally {
@@ -230,6 +227,19 @@ export class WebSocketTransport extends AbstractDataConnectStreamTransport {
     );
   }
 
+  /**
+   * Handle an error that occurred on the WebSocket. Close the connection and reject all active requests.
+   */
+  private handleError(error?: unknown): void {
+    logError(`DataConnect WebSocket error, closing stream: ${error}`);
+    const code = WebSocketCloseCode.GRACEFUL_CLOSE;
+    let reason = 'Protocol Error';
+    if (error instanceof WebSocketDataConnectError) {
+      reason = error.message;
+    }
+    void this.closeConnection(code, reason);
+  }
+
   protected sendMessage<Variables>(
     requestBody: DataConnectStreamRequest<Variables>
   ): Promise<void> {
@@ -238,6 +248,7 @@ export class WebSocketTransport extends AbstractDataConnectStreamTransport {
         this.connection!.send(JSON.stringify(requestBody));
         return Promise.resolve();
       } catch (err) {
+        this.handleError(err);
         throw new DataConnectError(
           Code.OTHER,
           `Failed to send message: ${String(err)}`

--- a/packages/data-connect/src/network/stream/websocket.ts
+++ b/packages/data-connect/src/network/stream/websocket.ts
@@ -226,10 +226,7 @@ export class WebSocketTransport extends AbstractDataConnectStreamTransport {
     this.connection = undefined;
     this.connectionAttempt = null;
     this.rejectAllActiveRequests(
-      new DataConnectError(
-        Code.OTHER,
-        'WebSocket disconnected externally'
-      )
+      new DataConnectError(Code.OTHER, 'WebSocket disconnected externally')
     );
   }
 

--- a/packages/data-connect/src/network/stream/websocket.ts
+++ b/packages/data-connect/src/network/stream/websocket.ts
@@ -225,7 +225,12 @@ export class WebSocketTransport extends AbstractDataConnectStreamTransport {
   private handleWebsocketDisconnect(ev: CloseEvent): void {
     this.connection = undefined;
     this.connectionAttempt = null;
-    // TODO(stephenarosaj): check code, alert manager if need be, initiate reconnection, cleanup, etc.
+    this.rejectAllActiveRequests(
+      new DataConnectError(
+        Code.OTHER,
+        'WebSocket disconnected externally'
+      )
+    );
   }
 
   protected sendMessage<Variables>(

--- a/packages/data-connect/src/network/transport.ts
+++ b/packages/data-connect/src/network/transport.ts
@@ -152,7 +152,9 @@ export interface DataConnectTransportInterface {
   useEmulator(host: string, port?: number, sslEnabled?: boolean): void;
 
   /**
-   * Callback invoked when the Firebase Auth token is refreshed or changed.
+   * Callback invoked when the Firebase Auth token is refreshed or changed. Note that this callback
+   * is called immediately asynchronously when the Auth Provider is initialized to provide
+   * the initial auth state.
    * @param token The new access token or null if signed out.
    */
   onAuthTokenChanged: (token: string | null) => void;

--- a/packages/data-connect/test/unit/streamTransport.test.ts
+++ b/packages/data-connect/test/unit/streamTransport.test.ts
@@ -110,7 +110,7 @@ interface TransportWithInternals {
   _setCallerSdkType(type: CallerSdkType): void;
   invokeOnAuthTokenChanged(token: string | null): void;
   setAuthToken(token: string | null): void;
-  authProvider: { getAuth: () => { getUid: () => string } };
+  authProvider: { getAuth: () => { getUid(): string | null } };
   setAppCheckToken(token: string | null): void;
   nextRequestId(): string;
   triggerOnConnectionReady(): void;
@@ -1088,11 +1088,14 @@ describe('AbstractDataConnectStreamTransport', () => {
         const hook = sinon.spy();
 
         transport.setAuthToken(null);
+        const getAuthStub = sinon.stub(transport.authProvider, 'getAuth');
+        getAuthStub.returns({ getUid: () => null });
         transport.invokeOnAuthTokenChanged(null); // Establish baseline (unauth)
 
         transport.invokeSubscribe(hook, queryName1, variables1);
 
         transport.setAuthToken('new-token');
+        getAuthStub.returns({ getUid: () => 'some-uid' });
         transport.invokeOnAuthTokenChanged('new-token'); // Change (login)
 
         expect(closeSpy).to.have.been.calledOnce;
@@ -1103,11 +1106,14 @@ describe('AbstractDataConnectStreamTransport', () => {
         const hook = sinon.spy();
 
         transport.setAuthToken('initial-token');
+        const getAuthStub = sinon.stub(transport.authProvider, 'getAuth');
+        getAuthStub.returns({ getUid: () => 'some-uid' });
         transport.invokeOnAuthTokenChanged('initial-token'); // Establish baseline (auth)
 
         transport.invokeSubscribe(hook, queryName1, variables1);
 
         transport.setAuthToken(null);
+        getAuthStub.returns({ getUid: () => null });
         transport.invokeOnAuthTokenChanged(null); // Change (logout)
 
         expect(closeSpy).to.have.been.calledOnce;
@@ -1118,17 +1124,38 @@ describe('AbstractDataConnectStreamTransport', () => {
         const hook = sinon.spy();
 
         transport.setAuthToken('token-a');
+        const getAuthStub = sinon.stub(transport.authProvider, 'getAuth');
+        getAuthStub.returns({ getUid: () => 'user-a' });
         transport.invokeOnAuthTokenChanged('token-a'); // Establish baseline (user A)
 
         transport.invokeSubscribe(hook, queryName1, variables1);
 
-        sinon
-          .stub(transport.authProvider, 'getAuth')
-          .returns({ getUid: () => 'new-uid' });
-
-        transport.invokeOnAuthTokenChanged('new-token'); // Change (user B)
+        transport.setAuthToken('token-b');
+        getAuthStub.returns({ getUid: () => 'user-b' });
+        transport.invokeOnAuthTokenChanged('token-b'); // Change (user B)
 
         expect(closeSpy).to.have.been.calledOnce;
+      });
+
+      it('should NOT close stream on valid auth token refresh (same user)', async () => {
+        const closeSpy = sinon.spy(transport, 'closeConnection');
+        const hook = sinon.spy();
+
+        transport.setAuthToken('initial-token');
+
+        // Stub getUid to return the same user ID regardless of token
+        sinon
+          .stub(transport.authProvider, 'getAuth')
+          .returns({ getUid: () => 'same-user' });
+
+        transport.invokeOnAuthTokenChanged('initial-token'); // Establish baseline
+
+        transport.invokeSubscribe(hook, queryName1, variables1);
+
+        transport.setAuthToken('refreshed-token');
+        transport.invokeOnAuthTokenChanged('refreshed-token'); // Refresh
+
+        expect(closeSpy).to.not.have.been.called;
       });
     });
   });

--- a/packages/data-connect/test/unit/streamTransport.test.ts
+++ b/packages/data-connect/test/unit/streamTransport.test.ts
@@ -1040,15 +1040,60 @@ describe('AbstractDataConnectStreamTransport', () => {
       expect(closeSpy).to.have.been.calledOnce;
     });
 
+    it('should not close connection if there are active execute requests', async () => {
+      const closeSpy = sinon.spy(transport, 'closeConnection');
+      sinon.stub(transport, 'sendMessage').resolves();
+      const hook = sinon.spy();
+
+      await transport.invokeSubscribe(hook, queryName1, variables1);
+      await transport.invokeUnsubscribe(queryName1, variables1);
+
+      void transport.invokeQuery(queryName2, variables2);
+
+      clock.tick(1000 * 65);
+      expect(closeSpy).to.not.have.been.called;
+    });
+
+    it('should close connection when last execute request finishes after idle timeout', async () => {
+      const closeSpy = sinon.spy(transport, 'closeConnection');
+      sinon.stub(transport, 'sendMessage').resolves();
+      const hook = sinon.spy();
+
+      await transport.invokeSubscribe(hook, queryName1, variables1);
+      await transport.invokeUnsubscribe(queryName1, variables1);
+
+      const queryPromise = transport.invokeQuery(queryName2, variables2);
+
+      clock.tick(1000 * 65);
+      expect(closeSpy).to.not.have.been.called;
+
+      const expectedKey = transport.getMapKey(queryName2, variables2);
+      const request = transport.activeQueryExecuteRequests.get(expectedKey);
+      const requestId = (request as ExecuteStreamRequest<unknown>).requestId;
+
+      const dummyResponse = {
+        data: { result: 'result' },
+        errors: [],
+        extensions: {}
+      };
+      await transport.invokeHandleResponse(requestId, dummyResponse);
+      await queryPromise;
+
+      expect(closeSpy).to.have.been.calledOnce;
+    });
+
     describe('Auth Disconnects', () => {
       it('should close stream immediately on illegal auth change (login)', async () => {
         const closeSpy = sinon.spy(transport, 'closeConnection');
         const hook = sinon.spy();
+
         transport.setAuthToken(null);
+        transport.invokeOnAuthTokenChanged(null); // Establish baseline (unauth)
 
         transport.invokeSubscribe(hook, queryName1, variables1);
 
-        transport.invokeOnAuthTokenChanged('new-token');
+        transport.setAuthToken('new-token');
+        transport.invokeOnAuthTokenChanged('new-token'); // Change (login)
 
         expect(closeSpy).to.have.been.calledOnce;
       });
@@ -1057,9 +1102,13 @@ describe('AbstractDataConnectStreamTransport', () => {
         const closeSpy = sinon.spy(transport, 'closeConnection');
         const hook = sinon.spy();
 
+        transport.setAuthToken('initial-token');
+        transport.invokeOnAuthTokenChanged('initial-token'); // Establish baseline (auth)
+
         transport.invokeSubscribe(hook, queryName1, variables1);
 
-        transport.invokeOnAuthTokenChanged(null);
+        transport.setAuthToken(null);
+        transport.invokeOnAuthTokenChanged(null); // Change (logout)
 
         expect(closeSpy).to.have.been.calledOnce;
       });
@@ -1068,13 +1117,16 @@ describe('AbstractDataConnectStreamTransport', () => {
         const closeSpy = sinon.spy(transport, 'closeConnection');
         const hook = sinon.spy();
 
+        transport.setAuthToken('token-a');
+        transport.invokeOnAuthTokenChanged('token-a'); // Establish baseline (user A)
+
         transport.invokeSubscribe(hook, queryName1, variables1);
 
         sinon
           .stub(transport.authProvider, 'getAuth')
           .returns({ getUid: () => 'new-uid' });
 
-        transport.invokeOnAuthTokenChanged('new-token');
+        transport.invokeOnAuthTokenChanged('new-token'); // Change (user B)
 
         expect(closeSpy).to.have.been.calledOnce;
       });

--- a/packages/data-connect/test/unit/streamTransport.test.ts
+++ b/packages/data-connect/test/unit/streamTransport.test.ts
@@ -22,6 +22,7 @@ import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 
 import { DataConnectOptions } from '../../src/api/DataConnect';
+import { AuthTokenProvider } from '../../src/core/FirebaseAuthProvider';
 import * as logger from '../../src/logger';
 import {
   CallerSdkType,
@@ -67,30 +68,29 @@ class TestStreamTransport extends AbstractDataConnectStreamTransport {
     return Promise.resolve();
   }
 
-  /**
-   * Manually trigger onConnectionReady for testing purposes.
-   */
+  /** Manually trigger onConnectionReady for testing purposes. */
   triggerOnConnectionReady(): void {
     this.onConnectionReady();
   }
 
-  /**
-   * Manually set auth token for testing purposes.
-   */
-  setAuthToken(token: string | null): void {
+  /** Manually invoke token change for testing purposes. */
+  invokeOnAuthTokenChanged(token: string | null): void {
     this.onAuthTokenChanged(token);
   }
 
-  /**
-   * Manually set app check token for testing purposes.
-   */
+  /** Manually set auth token for testing purposes. */
+  setAuthToken(token: string | null): void {
+    this._authToken = token;
+  }
+
+  authProvider = { getAuth: () => ({ getUid: () => this._authToken }) } as AuthTokenProvider;
+
+  /** Manually set app check token for testing purposes. */
   setAppCheckToken(token: string | null): void {
     this._appCheckToken = token;
   }
 
-  /**
-   * Manually resolve a request for testing purposes.
-   */
+  /** Manually resolve a request for testing purposes. */
   invokeHandleResponse<Data>(
     requestId: string,
     response: DataConnectResponse<Data>
@@ -101,14 +101,19 @@ class TestStreamTransport extends AbstractDataConnectStreamTransport {
 
 /** Interface that exposes some private fields and methods of TestStreamTransport for testing purposes. */
 interface TransportWithInternals {
-  nextRequestId(): string;
   _connectorResourcePath: string;
   _isUsingGen: boolean;
   appId: string | undefined;
   _callerSdkType: CallerSdkType;
   _setCallerSdkType(type: CallerSdkType): void;
+  invokeOnAuthTokenChanged(token: string | null): void;
   setAuthToken(token: string | null): void;
+  authProvider: { getAuth: () => { getUid: () => string } };
   setAppCheckToken(token: string | null): void;
+  nextRequestId(): string;
+  triggerOnConnectionReady(): void;
+  closeConnection(): Promise<void>;
+  cancelClose(): void;
   prepareMessage<
     Variables,
     StreamBody extends DataConnectStreamRequest<Variables>
@@ -180,6 +185,13 @@ describe('AbstractDataConnectStreamTransport', () => {
   const newAppCheckToken = 'new-app-check-token';
   const initialAppId = 'initial-app-id';
   const newAppId = 'new-app-id';
+  const queryName1 = 'testQuery1';
+  const queryName2 = 'testQuery2';
+  const variables1 = { foo: 'bar', num: 1 };
+  const variables2 = { abc: 'xyz', num: 2 };
+  const mutationName1 = 'testMutation1';
+  const mutationName2 = 'testMutation2';
+  const expectedError = new Error('test error');
 
   beforeEach(() => {
     transport = new TestStreamTransport(
@@ -364,7 +376,7 @@ describe('AbstractDataConnectStreamTransport', () => {
       expect(secondMessage.headers?.authToken).to.be.undefined;
 
       // Trigger the physical connection reset
-      (transport as unknown as TestStreamTransport).triggerOnConnectionReady();
+      transport.triggerOnConnectionReady();
 
       // The next message should be treated as a "first" message again
       const thirdMessage = transport.prepareMessage(
@@ -379,14 +391,6 @@ describe('AbstractDataConnectStreamTransport', () => {
   });
 
   describe('Request Tracking', () => {
-    const queryName1 = 'testQuery1';
-    const queryName2 = 'testQuery2';
-    const variables1 = { foo: 'bar', num: 1 };
-    const variables2 = { abc: 'xyz', num: 2 };
-    const mutationName1 = 'testMutation1';
-    const mutationName2 = 'testMutation2';
-    const expectedError = new Error('test error');
-
     it('getMapKey should sort keys consistently for map lookups', () => {
       const queryName = 'sortQuery';
       const variables1 = { a: 1, b: 2, c: 3, d: 4 };
@@ -863,8 +867,8 @@ describe('AbstractDataConnectStreamTransport', () => {
         });
 
         it('should clean map correctly when handleResponse rejects', async () => {
-          transport.invokeMutation(mutationName1, variables1).catch(() => {});
-          transport.invokeMutation(mutationName2, variables2).catch(() => {});
+          transport.invokeMutation(mutationName1, variables1).catch(() => { });
+          transport.invokeMutation(mutationName2, variables2).catch(() => { });
           const expectedKey1 = transport.getMapKey(mutationName1, variables1);
           const expectedKey2 = transport.getMapKey(mutationName2, variables2);
           const activeRequests1 =
@@ -965,6 +969,110 @@ describe('AbstractDataConnectStreamTransport', () => {
           expect(transport.subscribeNotificationHooks.has(requestId2)).to.be
             .true;
         });
+      });
+    });
+  });
+
+  describe('Disconnects', () => {
+    let clock: sinon.SinonFakeTimers;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('should close connection after 60 seconds of idle (no active subscriptions)', async () => {
+      const closeSpy = sinon.spy(transport, 'closeConnection');
+      sinon.stub(transport, 'sendMessage').resolves();
+      const hook = sinon.spy();
+
+      await transport.invokeSubscribe(hook, queryName1, variables1);
+      await transport.invokeUnsubscribe(queryName1, variables1);
+
+      clock.tick(1000 * 59);
+      expect(closeSpy).to.not.have.been.called;
+
+      clock.tick(1000 * 2);
+      expect(closeSpy).to.have.been.calledOnce;
+    });
+
+    it('should cancel close if a new subscription arrives during timeout', async () => {
+      const closeSpy = sinon.spy(transport, 'closeConnection');
+      sinon.stub(transport, 'sendMessage').resolves();
+      const hook = sinon.spy();
+
+      await transport.invokeSubscribe(hook, queryName1, variables1);
+      await transport.invokeUnsubscribe(queryName1, variables1);
+
+      clock.tick(1000 * 30);
+      expect(closeSpy).to.not.have.been.called;
+
+      await transport.invokeSubscribe(hook, queryName2, variables2);
+
+      clock.tick(1000 * 65);
+      expect(closeSpy).to.not.have.been.called;
+    });
+
+    it('should restart close timeout if subscribe fails and leaves no active subscriptions', async () => {
+      const closeSpy = sinon.spy(transport, 'closeConnection');
+      const sendMessageStub = sinon.stub(transport, 'sendMessage');
+      sendMessageStub.resolves();
+      const hook = sinon.spy();
+
+      await transport.invokeSubscribe(hook, queryName1, variables1);
+      await transport.invokeUnsubscribe(queryName1, variables1);
+
+      clock.tick(1000 * 30);
+      expect(closeSpy).to.not.have.been.called;
+
+      sendMessageStub.rejects();
+      await transport.invokeSubscribe(hook, queryName2, variables2);
+
+      clock.tick(1000 * 30);
+      expect(closeSpy).to.not.have.been.called;
+
+      clock.tick(1000 * 35);
+      expect(closeSpy).to.have.been.calledOnce;
+    });
+
+    describe('Auth Disconnects', () => {
+      it('should close stream immediately on illegal auth change (login)', async () => {
+        const closeSpy = sinon.spy(transport, 'closeConnection');
+        const hook = sinon.spy();
+        transport.setAuthToken(null);
+
+        transport.invokeSubscribe(hook, queryName1, variables1);
+
+        transport.invokeOnAuthTokenChanged('new-token');
+
+        expect(closeSpy).to.have.been.calledOnce;
+      });
+
+      it('should close stream immediately on illegal auth change (logout)', async () => {
+        const closeSpy = sinon.spy(transport, 'closeConnection');
+        const hook = sinon.spy();
+
+        transport.invokeSubscribe(hook, queryName1, variables1);
+
+        transport.invokeOnAuthTokenChanged(null);
+
+        expect(closeSpy).to.have.been.calledOnce;
+      });
+
+      it('should close stream immediately on illegal auth change (user change)', async () => {
+        const closeSpy = sinon.spy(transport, 'closeConnection');
+        const hook = sinon.spy();
+
+        transport.invokeSubscribe(hook, queryName1, variables1);
+
+        sinon.stub(transport.authProvider, 'getAuth').returns({ getUid: () => 'new-uid' });
+
+        transport.invokeOnAuthTokenChanged('new-token');
+
+        expect(closeSpy).to.have.been.calledOnce;
       });
     });
   });

--- a/packages/data-connect/test/unit/streamTransport.test.ts
+++ b/packages/data-connect/test/unit/streamTransport.test.ts
@@ -83,7 +83,9 @@ class TestStreamTransport extends AbstractDataConnectStreamTransport {
     this._authToken = token;
   }
 
-  authProvider = { getAuth: () => ({ getUid: () => this._authToken }) } as AuthTokenProvider;
+  authProvider = {
+    getAuth: () => ({ getUid: () => this._authToken })
+  } as AuthTokenProvider;
 
   /** Manually set app check token for testing purposes. */
   setAppCheckToken(token: string | null): void {
@@ -867,8 +869,8 @@ describe('AbstractDataConnectStreamTransport', () => {
         });
 
         it('should clean map correctly when handleResponse rejects', async () => {
-          transport.invokeMutation(mutationName1, variables1).catch(() => { });
-          transport.invokeMutation(mutationName2, variables2).catch(() => { });
+          transport.invokeMutation(mutationName1, variables1).catch(() => {});
+          transport.invokeMutation(mutationName2, variables2).catch(() => {});
           const expectedKey1 = transport.getMapKey(mutationName1, variables1);
           const expectedKey2 = transport.getMapKey(mutationName2, variables2);
           const activeRequests1 =
@@ -1068,7 +1070,9 @@ describe('AbstractDataConnectStreamTransport', () => {
 
         transport.invokeSubscribe(hook, queryName1, variables1);
 
-        sinon.stub(transport.authProvider, 'getAuth').returns({ getUid: () => 'new-uid' });
+        sinon
+          .stub(transport.authProvider, 'getAuth')
+          .returns({ getUid: () => 'new-uid' });
 
         transport.invokeOnAuthTokenChanged('new-token');
 

--- a/packages/data-connect/test/unit/streaming.test.ts
+++ b/packages/data-connect/test/unit/streaming.test.ts
@@ -23,7 +23,9 @@ import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 
 import {
+  Code,
   DataConnect,
+  DataConnectError,
   DataConnectResponse,
   DataConnectResponseWithMaxAge,
   executeMutation,
@@ -359,6 +361,62 @@ describe('Streaming & Query Layer Integration', () => {
       expect(result3.message).to.include(
         'DataConnect error received from subscribe notification'
       );
+    });
+
+    it('should clean up subscriptions in query layer when hook receives a disconnect error', async () => {
+      const q = queryRef<TestData, TestVariables>(dc, queryName, testVariables);
+      const onNextSpy = sinon.spy();
+      const onErrSpy = sinon.spy();
+
+      subscribe(q, { onNext: onNextSpy, onErr: onErrSpy });
+
+      const notificationHook =
+        stubStreamTransport.invokeSubscribe.firstCall.args[0];
+
+      const expectedError = new DataConnectError(
+        Code.OTHER,
+        'WebSocket disconnected externally'
+      );
+      await notificationHook({
+        data: {},
+        errors: [expectedError],
+        extensions: {}
+      });
+
+      expect(onErrSpy).to.have.been.calledOnce;
+      expect(stubStreamTransport.invokeUnsubscribe).to.have.been.calledOnce;
+
+      // Call hook again with data, should not reach subscriber because it was cleaned up
+      await notificationHook({
+        data: { abc: 'new data' },
+        errors: [],
+        extensions: {}
+      });
+      expect(onNextSpy).to.not.have.been.called;
+    });
+
+    it('should NOT clean up subscriptions in query layer when hook receives a non-disconnect error', async () => {
+      const q = queryRef<TestData, TestVariables>(dc, queryName, testVariables);
+      const onNextSpy = sinon.spy();
+      const onErrSpy = sinon.spy();
+
+      subscribe(q, { onNext: onNextSpy, onErr: onErrSpy });
+
+      const hook = stubStreamTransport.invokeSubscribe.firstCall.args[0];
+
+      const expectedError = new Error('test error');
+      await hook({ data: {}, errors: [expectedError], extensions: {} });
+
+      expect(onErrSpy).to.have.been.calledOnce;
+
+      // Call hook again with data, should STILL reach subscriber because it was NOT cleaned up
+      const testData: TestData = { abc: 'new data' };
+      await hook({ data: testData, errors: [], extensions: {} });
+      expect(onNextSpy).to.have.been.calledOnce;
+      expect(onNextSpy.firstCall.args[0].data).to.deep.equal(testData);
+
+      // Verify that invokeUnsubscribe was NOT called
+      expect(stubStreamTransport.invokeUnsubscribe).to.not.have.been.called;
     });
   });
 });

--- a/packages/data-connect/test/unit/transportManager.test.ts
+++ b/packages/data-connect/test/unit/transportManager.test.ts
@@ -410,4 +410,67 @@ describe('DataConnectTransportManager', () => {
       });
     });
   });
+
+  describe('idle timeout routing', () => {
+    let clock: sinon.SinonFakeTimers;
+    let streamTransport: WebSocketTransport;
+    let restInvokeQuerySpy: sinon.SinonStub;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+      streamTransport = manager.initStreamTransport() as WebSocketTransport;
+      const streamTransportPublic = streamTransport as unknown as {
+        openConnection(): Promise<void>;
+        sendMessage(payload: unknown): Promise<void>;
+      };
+      sinon.stub(streamTransportPublic, 'openConnection').resolves();
+      sinon.stub(streamTransportPublic, 'sendMessage').resolves();
+      sinon.stub(streamTransport, 'streamIsReady').get(() => true);
+      restInvokeQuerySpy = sinon
+        .stub(manager.restTransport, 'invokeQuery')
+        .resolves(testResponse);
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('should route to REST during idle timeout and disconnect after 60s', async () => {
+      const hook: SubscribeNotificationHook<TestData> = () => {};
+
+      manager.invokeSubscribe(hook, queryName1, variables1);
+      expect(manager.executeShouldUseStream()).to.be.true;
+
+      manager.invokeUnsubscribe(queryName1, variables1);
+      expect(manager.executeShouldUseStream()).to.be.false;
+
+      // without active streams, should route to REST
+      restInvokeQuerySpy.resetHistory();
+      await manager.invokeQuery(queryName1, variables1);
+      expect(restInvokeQuerySpy).to.have.been.calledOnce;
+
+      await clock.tickAsync(59000);
+      expect(manager.streamTransport).to.exist;
+
+      await manager.invokeQuery(queryName1, variables1);
+      expect(restInvokeQuerySpy).to.have.been.calledTwice;
+
+      await clock.tickAsync(1000);
+      expect(manager.streamTransport).to.be.undefined;
+    });
+
+    it('should route to REST after stream automatically closes', async () => {
+      const hook: SubscribeNotificationHook<TestData> = () => {};
+
+      manager.invokeSubscribe(hook, queryName1, variables1);
+      manager.invokeUnsubscribe(queryName1, variables1);
+
+      await clock.tickAsync(60000);
+      expect(manager.streamTransport).to.be.undefined;
+
+      restInvokeQuerySpy.resetHistory();
+      await manager.invokeQuery(queryName1, variables1);
+      expect(restInvokeQuerySpy).to.have.been.calledOnce;
+    });
+  });
 });

--- a/packages/data-connect/test/unit/transportManager.test.ts
+++ b/packages/data-connect/test/unit/transportManager.test.ts
@@ -472,5 +472,31 @@ describe('DataConnectTransportManager', () => {
       await manager.invokeQuery(queryName1, variables1);
       expect(restInvokeQuerySpy).to.have.been.calledOnce;
     });
+
+    it('should route back to stream after reconnect', async () => {
+      const hook: SubscribeNotificationHook<TestData> = () => {};
+
+      manager.invokeSubscribe(hook, queryName1, variables1);
+      manager.invokeUnsubscribe(queryName1, variables1);
+
+      await clock.tickAsync(60000);
+      expect(manager.streamTransport).to.be.undefined;
+
+      manager.invokeSubscribe(hook, queryName1, variables1);
+      const newStreamTransport = manager.streamTransport!;
+      const newStreamTransportPublic = newStreamTransport as unknown as {
+        openConnection(): Promise<void>;
+        sendMessage(payload: unknown): Promise<void>;
+      };
+      sinon.stub(newStreamTransportPublic, 'openConnection').resolves();
+      sinon.stub(newStreamTransportPublic, 'sendMessage').resolves();
+      sinon.stub(newStreamTransport, 'streamIsReady').get(() => true);
+      const streamExecuteQueryStub = sinon
+        .stub(newStreamTransport, 'invokeQuery')
+        .resolves(testResponse);
+      await manager.invokeQuery(queryName1, variables1);
+      expect(streamExecuteQueryStub).to.have.been.calledOnce;
+      expect(restInvokeQuerySpy).to.have.not.been.called;
+    });
   });
 });

--- a/packages/data-connect/test/unit/websocketTransport.test.ts
+++ b/packages/data-connect/test/unit/websocketTransport.test.ts
@@ -47,6 +47,7 @@ interface TransportWithInternals {
     requestId: string,
     response: DataConnectResponse<Data>
   ): Promise<void>;
+  rejectAllActiveRequests(error: Error): void;
 }
 
 describe('WebSocketTransport', () => {
@@ -177,6 +178,19 @@ describe('WebSocketTransport', () => {
       // simulate server drop / unexpected closure
       await transport.connection!.simulateClose();
       expect(transport.connection).to.be.undefined;
+    });
+
+    it('should call rejectAllActiveRequests and clean up when closed externally', async () => {
+      const openPromise = transport.openConnection();
+      await transport.connection!.simulateOpen();
+      await openPromise;
+      
+      const rejectSpy = sinon.spy(transport, 'rejectAllActiveRequests');
+      
+      await transport.connection!.simulateClose();
+      
+      expect(rejectSpy).to.have.been.calledOnce;
+      expect(rejectSpy.firstCall.args[0].message).to.equal('WebSocket disconnected externally');
     });
   });
 

--- a/packages/data-connect/test/unit/websocketTransport.test.ts
+++ b/packages/data-connect/test/unit/websocketTransport.test.ts
@@ -289,79 +289,83 @@ describe('WebSocketTransport', () => {
       expect(calledResponse.extensions).to.deep.equal({ dataConnect: [] });
     });
 
-    it('should close connection with protocol error if message is not an object', async () => {
+    it('should close connection with error if message is not an object', async () => {
       const openPromise = transport.openConnection();
-      await transport.connection!.simulateOpen();
+      const mockWs = transport.connection!;
+      await mockWs.simulateOpen();
       await openPromise;
 
-      await transport.connection!.simulateMessage(
+      await mockWs.simulateMessage(
         JSON.stringify('this is a string, not an object')
       );
 
-      expect(transport.connection!.close).to.have.been.calledOnceWith(
+      expect(mockWs.close).to.have.been.calledOnceWith(
         WebSocketCloseCode.GRACEFUL_CLOSE,
         'WebSocket message is not an object'
       );
       expect(logErrorStub).to.have.been.calledOnce;
       expect(logErrorStub).to.have.been.calledWithMatch(
-        'DataConnect WebSocket protocol error, closing stream'
+        'DataConnect WebSocket error, closing stream'
       );
     });
 
-    it('should close connection with protocol error if result is missing', async () => {
+    it('should close connection with error if result is missing', async () => {
       const openPromise = transport.openConnection();
-      await transport.connection!.simulateOpen();
+      const mockWs = transport.connection!;
+      await mockWs.simulateOpen();
       await openPromise;
 
       const invalidData = { foo: 'bar' }; // no result object
 
-      await transport.connection!.simulateMessage(JSON.stringify(invalidData));
+      await mockWs.simulateMessage(JSON.stringify(invalidData));
 
-      expect(transport.connection!.close).to.have.been.calledOnceWith(
+      expect(mockWs.close).to.have.been.calledOnceWith(
         WebSocketCloseCode.GRACEFUL_CLOSE,
         'WebSocket message from emulator did not include result'
       );
       expect(logErrorStub).to.have.been.calledOnce;
       expect(logErrorStub).to.have.been.calledWithMatch(
-        'DataConnect WebSocket protocol error, closing stream'
+        'DataConnect WebSocket error, closing stream'
       );
     });
 
-    it('should close connection with protocol error if result is not an object', async () => {
+    it('should close connection with error if result is not an object', async () => {
       const openPromise = transport.openConnection();
-      await transport.connection!.simulateOpen();
+      const mockWs = transport.connection!;
+      await mockWs.simulateOpen();
       await openPromise;
 
       const invalidData = { result: 'string result' };
 
-      await transport.connection!.simulateMessage(JSON.stringify(invalidData));
+      await mockWs.simulateMessage(JSON.stringify(invalidData));
 
-      expect(transport.connection!.close).to.have.been.calledOnceWith(
+      expect(mockWs.close).to.have.been.calledOnceWith(
         WebSocketCloseCode.GRACEFUL_CLOSE,
         'WebSocket message result is not an object'
       );
       expect(logErrorStub).to.have.been.calledOnce;
       expect(logErrorStub).to.have.been.calledWithMatch(
-        'DataConnect WebSocket protocol error, closing stream'
+        'DataConnect WebSocket error, closing stream'
       );
     });
 
-    it('should close connection with protocol error if requestId is missing', async () => {
+    it('should close connection with error if requestId is missing', async () => {
       const openPromise = transport.openConnection();
-      await transport.connection!.simulateOpen();
+      const mockWs = transport.connection!;
+      await mockWs.simulateOpen();
       await openPromise;
 
       const invalidData = { result: { foo: 'bar' } }; // no requestId
 
-      await transport.connection!.simulateMessage(JSON.stringify(invalidData));
+      await mockWs.simulateMessage(JSON.stringify(invalidData));
 
-      expect(transport.connection!.close).to.have.been.calledOnceWith(
+      expect(mockWs.close).to.have.been.calledOnceWith(
         WebSocketCloseCode.GRACEFUL_CLOSE,
         'WebSocket message did not include requestId'
       );
       expect(logErrorStub).to.have.been.calledOnce;
       expect(logErrorStub).to.have.been.calledWithMatch(
-        'DataConnect WebSocket protocol error, closing stream'
+        'DataConnect WebSocket error, closing stream'
       );
     });
   });

--- a/packages/data-connect/test/unit/websocketTransport.test.ts
+++ b/packages/data-connect/test/unit/websocketTransport.test.ts
@@ -184,13 +184,15 @@ describe('WebSocketTransport', () => {
       const openPromise = transport.openConnection();
       await transport.connection!.simulateOpen();
       await openPromise;
-      
+
       const rejectSpy = sinon.spy(transport, 'rejectAllActiveRequests');
-      
+
       await transport.connection!.simulateClose();
-      
+
       expect(rejectSpy).to.have.been.calledOnce;
-      expect(rejectSpy.firstCall.args[0].message).to.equal('WebSocket disconnected externally');
+      expect(rejectSpy.firstCall.args[0].message).to.equal(
+        'WebSocket disconnected externally'
+      );
     });
   });
 


### PR DESCRIPTION
## Description

✨ This PR improves error handling and implements robust cleanup logic for the streaming transport during disconnects and authentication changes.

## Changes

- **Automatic Disconnects**: Automatically disconnect the stream after 60 seconds of no active subscriptions. Wait to close until pending execute requests finish.
- **Stream Cleanup**: Added state cleanup immediately upon disconnect.
- **Error Handling**: Enhanced error generation and logging for stream operations.
- **Auth Changes**: Enforced stream closure on illegal authentication state changes. Every auth state change except for a same-user token refresh will tear down the stream.
- **Query Layer**: Added subscription cleanup when the stream disconnects externally.

## Testing

- Unit tests were added to `websocketTransport.test.ts` and related files to verify disconnect, cleanup, and error behavior.
