### PR TITLE
fix(app-types): Fix "dependency" typo

### DIFF
--- a/.changeset/eighty-cameras-smoke.md
+++ b/.changeset/eighty-cameras-smoke.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app-types': patch
+---
+
+Fix typo in package.json (dependency => dependencies)

--- a/packages/app-types/package.json
+++ b/packages/app-types/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
   },
-  "dependency": {
+  "dependencies": {
     "@firebase/logger": "0.2.6"
   },
   "devDependencies": {

--- a/packages/app-types/package.json
+++ b/packages/app-types/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
   },
   "dependencies": {
-    "@firebase/logger": "0.2.6"
+    "@firebase/logger": "0.5.0"
   },
   "devDependencies": {
     "typescript": "5.5.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1324,6 +1324,11 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
+"@firebase/logger@0.2.6":
+  version "0.2.6"
+  resolved "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.6.tgz#3aa2ca4fe10327cabf7808bd3994e88db26d7989"
+  integrity sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw==
+
 "@gar/promisify@^1.0.1":
   version "1.1.3"
   resolved "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1324,11 +1324,6 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
-"@firebase/logger@0.2.6":
-  version "0.2.6"
-  resolved "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.6.tgz#3aa2ca4fe10327cabf7808bd3994e88db26d7989"
-  integrity sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw==
-
 "@gar/promisify@^1.0.1":
   version "1.1.3"
   resolved "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"


### PR DESCRIPTION
Typo introduced in https://github.com/firebase/firebase-js-sdk/pull/5144 causes errors in package installers.

Fixes #9787