### PR TITLE
fix(ai): deprecate topK and temperature for hybrid

### DIFF
--- a/.changeset/gold-chefs-jam.md
+++ b/.changeset/gold-chefs-jam.md
@@ -1,0 +1,6 @@
+---
+'@firebase/ai': minor
+'firebase': minor
+---
+
+Deprecate topK and temperature properties for hybrid inference mode.

--- a/.changeset/gold-chefs-jam.md
+++ b/.changeset/gold-chefs-jam.md
@@ -3,4 +3,4 @@
 'firebase': minor
 ---
 
-Deprecate topK and temperature properties for hybrid inference mode.
+Deprecate `topK` and `temperature` properties for hybrid inference mode.

--- a/common/api-review/ai.api.md
+++ b/common/api-review/ai.api.md
@@ -896,9 +896,9 @@ export type Language = (typeof Language)[keyof typeof Language];
 export interface LanguageModelCreateCoreOptions {
     // (undocumented)
     expectedInputs?: LanguageModelExpected[];
-    // (undocumented)
+    // @deprecated (undocumented)
     temperature?: number;
-    // (undocumented)
+    // @deprecated (undocumented)
     topK?: number;
 }
 

--- a/docs-devsite/ai.languagemodelcreatecoreoptions.md
+++ b/docs-devsite/ai.languagemodelcreatecoreoptions.md
@@ -45,6 +45,10 @@ expectedInputs?: LanguageModelExpected[];
 > This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
+> Warning: This API is now obsolete.
+> 
+> 
+
 <b>Signature:</b>
 
 ```typescript
@@ -54,6 +58,10 @@ temperature?: number;
 ## LanguageModelCreateCoreOptions.topK
 
 > This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
+
+> Warning: This API is now obsolete.
+> 
 > 
 
 <b>Signature:</b>

--- a/packages/ai/src/types/language-model.ts
+++ b/packages/ai/src/types/language-model.ts
@@ -54,7 +54,13 @@ export enum Availability {
  * @beta
  */
 export interface LanguageModelCreateCoreOptions {
+  /**
+   * @deprecated
+   */
   topK?: number;
+  /**
+   * @deprecated
+   */
   temperature?: number;
   expectedInputs?: LanguageModelExpected[];
 }


### PR DESCRIPTION
Mark these properties as deprecated to match Chrome deprecating them in their Prompt API: https://b.corp.google.com/issues/481013139 (internal link)