### PR TITLE
fix(ai): Update code execution and URL context doc comments to reflect they are public now

### DIFF
--- a/.changeset/silent-trains-bake.md
+++ b/.changeset/silent-trains-bake.md
@@ -1,0 +1,5 @@
+---
+'@firebase/ai': patch
+---
+
+Update code execution and URL context features to reflect that they are generally available and no longer public preview.

--- a/common/api-review/ai.api.md
+++ b/common/api-review/ai.api.md
@@ -219,7 +219,7 @@ export interface CodeExecutionResultPart {
     thoughtSignature?: never;
 }
 
-// @beta
+// @public
 export interface CodeExecutionTool {
     codeExecution: {};
 }
@@ -1407,9 +1407,6 @@ export const ThinkingLevel: {
 // @public
 export type ThinkingLevel = (typeof ThinkingLevel)[keyof typeof ThinkingLevel];
 
-// Warning: (ae-incompatible-release-tags) The symbol "Tool" is marked as @public, but its signature references "CodeExecutionTool" which is marked as @beta
-// Warning: (ae-incompatible-release-tags) The symbol "Tool" is marked as @public, but its signature references "URLContextTool" which is marked as @beta
-//
 // @public
 export type Tool = FunctionDeclarationsTool | GoogleSearchTool | CodeExecutionTool | URLContextTool;
 
@@ -1427,7 +1424,7 @@ export interface Transcription {
 // @public
 export type TypedSchema = IntegerSchema | NumberSchema | StringSchema | BooleanSchema | ObjectSchema | ArraySchema | AnyOfSchema;
 
-// @beta
+// @public
 export interface URLContext {
 }
 
@@ -1436,7 +1433,7 @@ export interface URLContextMetadata {
     urlMetadata: URLMetadata[];
 }
 
-// @beta
+// @public
 export interface URLContextTool {
     urlContext: URLContext;
 }

--- a/docs-devsite/ai.codeexecutiontool.md
+++ b/docs-devsite/ai.codeexecutiontool.md
@@ -22,11 +22,11 @@ export interface CodeExecutionTool
 
 |  Property | Type | Description |
 |  --- | --- | --- |
-|  [codeExecution](./ai.codeexecutiontool.md#codeexecutiontoolcodeexecution) | {} | Specifies the Google Search configuration. Currently, this is an empty object, but it's reserved for future configuration options. |
+|  [codeExecution](./ai.codeexecutiontool.md#codeexecutiontoolcodeexecution) | {} | Currently, this is an empty object, but it's reserved for future configuration options. |
 
 ## CodeExecutionTool.codeExecution
 
-Specifies the Google Search configuration. Currently, this is an empty object, but it's reserved for future configuration options.
+Currently, this is an empty object, but it's reserved for future configuration options.
 
 <b>Signature:</b>
 

--- a/docs-devsite/ai.codeexecutiontool.md
+++ b/docs-devsite/ai.codeexecutiontool.md
@@ -10,9 +10,6 @@ https://github.com/firebase/firebase-js-sdk
 {% endcomment %}
 
 # CodeExecutionTool interface
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
-> 
-
 A tool that enables the model to use code execution.
 
 <b>Signature:</b>
@@ -25,12 +22,9 @@ export interface CodeExecutionTool
 
 |  Property | Type | Description |
 |  --- | --- | --- |
-|  [codeExecution](./ai.codeexecutiontool.md#codeexecutiontoolcodeexecution) | {} | <b><i>(Public Preview)</i></b> Specifies the Google Search configuration. Currently, this is an empty object, but it's reserved for future configuration options. |
+|  [codeExecution](./ai.codeexecutiontool.md#codeexecutiontoolcodeexecution) | {} | Specifies the Google Search configuration. Currently, this is an empty object, but it's reserved for future configuration options. |
 
 ## CodeExecutionTool.codeExecution
-
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
-> 
 
 Specifies the Google Search configuration. Currently, this is an empty object, but it's reserved for future configuration options.
 

--- a/docs-devsite/ai.md
+++ b/docs-devsite/ai.md
@@ -67,7 +67,7 @@ The Firebase AI Web SDK.
 |  [CitationMetadata](./ai.citationmetadata.md#citationmetadata_interface) | Citation metadata that may be found on a [GenerateContentCandidate](./ai.generatecontentcandidate.md#generatecontentcandidate_interface)<!-- -->. |
 |  [CodeExecutionResult](./ai.codeexecutionresult.md#codeexecutionresult_interface) | The results of code execution run by the model. |
 |  [CodeExecutionResultPart](./ai.codeexecutionresultpart.md#codeexecutionresultpart_interface) | Represents the code execution result from the model. |
-|  [CodeExecutionTool](./ai.codeexecutiontool.md#codeexecutiontool_interface) | <b><i>(Public Preview)</i></b> A tool that enables the model to use code execution. |
+|  [CodeExecutionTool](./ai.codeexecutiontool.md#codeexecutiontool_interface) | A tool that enables the model to use code execution. |
 |  [Content](./ai.content.md#content_interface) | Content type for both prompts and response candidates. |
 |  [CountTokensRequest](./ai.counttokensrequest.md#counttokensrequest_interface) | Params for calling [GenerativeModel.countTokens()](./ai.generativemodel.md#generativemodelcounttokens) |
 |  [CountTokensResponse](./ai.counttokensresponse.md#counttokensresponse_interface) | Response from calling [GenerativeModel.countTokens()](./ai.generativemodel.md#generativemodelcounttokens)<!-- -->. |
@@ -142,9 +142,9 @@ The Firebase AI Web SDK.
 |  [ThinkingConfig](./ai.thinkingconfig.md#thinkingconfig_interface) | Configuration for "thinking" behavior of compatible Gemini models.<!-- -->Certain models utilize a thinking process before generating a response. This allows them to reason through complex problems and plan a more coherent and accurate answer. |
 |  [ToolConfig](./ai.toolconfig.md#toolconfig_interface) | Tool config. This config is shared for all tools provided in the request. |
 |  [Transcription](./ai.transcription.md#transcription_interface) | <b><i>(Public Preview)</i></b> Transcription of audio. This can be returned from a [LiveGenerativeModel](./ai.livegenerativemodel.md#livegenerativemodel_class) if transcription is enabled with the <code>inputAudioTranscription</code> or <code>outputAudioTranscription</code> properties on the [LiveGenerationConfig](./ai.livegenerationconfig.md#livegenerationconfig_interface)<!-- -->. |
-|  [URLContext](./ai.urlcontext.md#urlcontext_interface) | <b><i>(Public Preview)</i></b> Specifies the URL Context configuration. |
+|  [URLContext](./ai.urlcontext.md#urlcontext_interface) | Specifies the URL Context configuration. |
 |  [URLContextMetadata](./ai.urlcontextmetadata.md#urlcontextmetadata_interface) | Metadata related to [URLContextTool](./ai.urlcontexttool.md#urlcontexttool_interface)<!-- -->. |
-|  [URLContextTool](./ai.urlcontexttool.md#urlcontexttool_interface) | <b><i>(Public Preview)</i></b> A tool that allows you to provide additional context to the models in the form of public web URLs. By including URLs in your request, the Gemini model will access the content from those pages to inform and enhance its response. |
+|  [URLContextTool](./ai.urlcontexttool.md#urlcontexttool_interface) | A tool that allows you to provide additional context to the models in the form of public web URLs. By including URLs in your request, the Gemini model will access the content from those pages to inform and enhance its response. |
 |  [URLMetadata](./ai.urlmetadata.md#urlmetadata_interface) | Metadata for a single URL retrieved by the [URLContextTool](./ai.urlcontexttool.md#urlcontexttool_interface) tool. |
 |  [UsageMetadata](./ai.usagemetadata.md#usagemetadata_interface) | Usage metadata about a [GenerateContentResponse](./ai.generatecontentresponse.md#generatecontentresponse_interface)<!-- -->. |
 |  [VideoMetadata](./ai.videometadata.md#videometadata_interface) | Describes the input video content. |

--- a/docs-devsite/ai.urlcontext.md
+++ b/docs-devsite/ai.urlcontext.md
@@ -10,9 +10,6 @@ https://github.com/firebase/firebase-js-sdk
 {% endcomment %}
 
 # URLContext interface
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
-> 
-
 Specifies the URL Context configuration.
 
 <b>Signature:</b>

--- a/docs-devsite/ai.urlcontexttool.md
+++ b/docs-devsite/ai.urlcontexttool.md
@@ -10,9 +10,6 @@ https://github.com/firebase/firebase-js-sdk
 {% endcomment %}
 
 # URLContextTool interface
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
-> 
-
 A tool that allows you to provide additional context to the models in the form of public web URLs. By including URLs in your request, the Gemini model will access the content from those pages to inform and enhance its response.
 
 <b>Signature:</b>
@@ -25,12 +22,9 @@ export interface URLContextTool
 
 |  Property | Type | Description |
 |  --- | --- | --- |
-|  [urlContext](./ai.urlcontexttool.md#urlcontexttoolurlcontext) | [URLContext](./ai.urlcontext.md#urlcontext_interface) | <b><i>(Public Preview)</i></b> Specifies the URL Context configuration. |
+|  [urlContext](./ai.urlcontexttool.md#urlcontexttoolurlcontext) | [URLContext](./ai.urlcontext.md#urlcontext_interface) | Specifies the URL Context configuration. |
 
 ## URLContextTool.urlContext
-
-> This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
-> 
 
 Specifies the URL Context configuration.
 

--- a/packages/ai/src/types/requests.ts
+++ b/packages/ai/src/types/requests.ts
@@ -388,7 +388,6 @@ export interface GoogleSearchTool {
  */
 export interface CodeExecutionTool {
   /**
-   * Specifies the Google Search configuration.
    * Currently, this is an empty object, but it's reserved for future configuration options.
    */
   codeExecution: {};

--- a/packages/ai/src/types/requests.ts
+++ b/packages/ai/src/types/requests.ts
@@ -384,7 +384,7 @@ export interface GoogleSearchTool {
 /**
  * A tool that enables the model to use code execution.
  *
- * @beta
+ * @public
  */
 export interface CodeExecutionTool {
   /**
@@ -408,7 +408,7 @@ export interface GoogleSearch {}
  * URLs. By including URLs in your request, the Gemini model will access the content from those
  * pages to inform and enhance its response.
  *
- * @beta
+ * @public
  */
 export interface URLContextTool {
   /**
@@ -420,7 +420,7 @@ export interface URLContextTool {
 /**
  * Specifies the URL Context configuration.
  *
- * @beta
+ * @public
  */
 export interface URLContext {}
 


### PR DESCRIPTION
Update code execution and URL context features to reflect that they are generally available and no longer public preview. This happened some time ago and we are catching up in the docs.

Also removed a stray sentence referencing the wrong feature.