### PR TITLE
chore(ai): Bump mock responses fetch script to fetch from latest major version

### DIFF
--- a/scripts/update_vertexai_responses.sh
+++ b/scripts/update_vertexai_responses.sh
@@ -17,7 +17,7 @@
 # This script replaces mock response files for Vertex AI unit tests with a fresh
 # clone of the shared repository of Vertex AI test data.
 
-RESPONSES_VERSION='v15.*' # The major version of mock responses to use
+RESPONSES_VERSION='v16.*' # The major version of mock responses to use
 REPO_NAME="vertexai-sdk-test-data"
 REPO_LINK="https://github.com/FirebaseExtended/$REPO_NAME.git"
 


### PR DESCRIPTION
Bump the script to fetch canonical mock responses from the latest major version of the mock responses repo as per warning messages such as https://github.com/firebase/firebase-js-sdk/pull/9816#issuecomment-4201189282