### PR TITLE
test(firestore): Enable `forceIndex` tests

### DIFF
--- a/packages/firestore/test/integration/api/pipeline.test.ts
+++ b/packages/firestore/test/integration/api/pipeline.test.ts
@@ -6011,27 +6011,33 @@ apiDescribe.skipClassic('Pipelines', persistence => {
 
   describe('stage options', () => {
     describe('forceIndex', () => {
-      // SKIP: requires pre-existing index
-      // eslint-disable-next-line no-restricted-properties
-      it.skip('Collection Stage', async () => {
+      it('Collection Stage', async () => {
         const snapshot = await execute(
           firestore.pipeline().collection({
             collection: randomCol,
-            forceIndex: 'unknown'
+            forceIndex: 'primary'
           })
         );
+        expect(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (snapshot as any)._pipeline.stages[0].optionsProto.force_index
+            .stringValue
+        ).equal('primary');
         expect(snapshot.results.length).to.equal(10);
       });
 
-      // SKIP: requires pre-existing index
-      // eslint-disable-next-line no-restricted-properties
-      it.skip('CollectionGroup Stage', async () => {
+      it('CollectionGroup Stage', async () => {
         const snapshot = await execute(
           firestore.pipeline().collectionGroup({
             collectionId: randomCol.id,
-            forceIndex: 'unknown'
+            forceIndex: 'primary'
           })
         );
+        expect(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (snapshot as any)._pipeline.stages[0].optionsProto.force_index
+            .stringValue
+        ).equal('primary');
         expect(snapshot.results.length).to.equal(10);
       });
     });

--- a/packages/firestore/test/lite/pipeline.test.ts
+++ b/packages/firestore/test/lite/pipeline.test.ts
@@ -5883,27 +5883,33 @@ describe.skipClassic('Firestore Pipelines', () => {
 
   describe('stage options', () => {
     describe('forceIndex', () => {
-      // SKIP: requires pre-existing index
-      // eslint-disable-next-line no-restricted-properties
-      it.skip('Collection Stage', async () => {
+      it('Collection Stage', async () => {
         const snapshot = await execute(
           firestore.pipeline().collection({
             collection: randomCol,
-            forceIndex: 'unknown'
+            forceIndex: 'primary'
           })
         );
+        expect(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (snapshot as any)._pipeline.stages[0].optionsProto.force_index
+            .stringValue
+        ).equal('primary');
         expect(snapshot.results.length).to.equal(10);
       });
 
-      // SKIP: requires pre-existing index
-      // eslint-disable-next-line no-restricted-properties
-      it.skip('CollectionGroup Stage', async () => {
+      it('CollectionGroup Stage', async () => {
         const snapshot = await execute(
           firestore.pipeline().collectionGroup({
             collectionId: randomCol.id,
-            forceIndex: 'unknown'
+            forceIndex: 'primary'
           })
         );
+        expect(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (snapshot as any)._pipeline.stages[0].optionsProto.force_index
+            .stringValue
+        ).equal('primary');
         expect(snapshot.results.length).to.equal(10);
       });
     });


### PR DESCRIPTION
Enables the `forceIndex` tests. They set the `forceIndex` option to `"primary"` and simply assert that the snapshot contains an expected number of documents, and that the stage option has the `forceIndex` set as expected.

Question: Is there a better way to validate that the request correctly used the index specified by `forceIndex`?