### PR TITLE
chore(firestore): spec test that reproduces the race condition leading to ca9 pendingResponses < 0

### DIFF
--- a/packages/firestore/scripts/run-tests.ts
+++ b/packages/firestore/scripts/run-tests.ts
@@ -45,7 +45,7 @@ const argv = yargs
     grep: {
       type: 'string',
       description: 'Filter tests by name (regex)'
-    },
+    }
   })
   .parseSync();
 

--- a/packages/firestore/test/unit/specs/remote_store_spec.test.ts
+++ b/packages/firestore/test/unit/specs/remote_store_spec.test.ts
@@ -115,4 +115,18 @@ describeSpec('Remote store:', [], () => {
       );
     }
   );
+
+  specTest('Handles removal of old target after re-listen', [], () => {
+    const query1 = query('collection');
+    return spec()
+      .ensureManualLruGC()
+      .userListens(query1)
+      .watchAcks(query1)
+      .userUnlistens(query1)
+      .userListens(query1)
+      // Use numerical code 8 for RESOURCE_EXHAUSTED
+      .watchRemoves(query1, { code: 8 })
+      .expectEvents(query1, { errorCode: Code.RESOURCE_EXHAUSTED })
+      .watchAcks(query1);
+  });
 });

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -265,6 +265,15 @@ export class SpecBuilder {
     return this;
   }
 
+  allowUnlistedTargetRemoval(): this {
+    debugAssert(
+      !this.currentStep,
+      'allowUnlistedTargetRemoval() must be called before all spec steps.'
+    );
+    (this.config as any).allowUnlistedTargetRemoval = true;
+    return this;
+  }
+
   withMaxConcurrentLimboResolutions(value?: number): this {
     this.config.maxConcurrentLimboResolutions = value;
     return this;
@@ -782,7 +791,9 @@ export class SpecBuilder {
       watchRemove: { targetIds: [this.getTargetId(query)], cause }
     };
     if (cause) {
-      delete this.activeTargets[this.getTargetId(query)];
+      if (!(this.config as any).allowUnlistedTargetRemoval) {
+        delete this.activeTargets[this.getTargetId(query)];
+      }
       this.currentStep.expectedState = {
         activeTargets: { ...this.activeTargets }
       };

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -270,7 +270,7 @@ abstract class TestRunner {
   constructor(
     private sharedWrites: SharedWriteTracker,
     clientIndex: number,
-    config: SpecConfig
+    protected config: SpecConfig
   ) {
     this.clientId = `client${clientIndex}`;
     this.databaseInfo = new DatabaseInfo(
@@ -672,10 +672,12 @@ abstract class TestRunner {
       // with a server-side removal), but we want to pay extra careful
       // attention in tests that we only remove targets we listened too.
       removed.targetIds.forEach(targetId => {
-        expect(
-          this.connection.activeTargets[targetId],
-          'Removing a non-active target'
-        ).to.exist;
+        if (!this.config.allowUnlistedTargetRemoval) {
+          expect(
+            this.connection.activeTargets[targetId],
+            'Removing a non-active target'
+          ).to.exist;
+        }
         delete this.connection.activeTargets[targetId];
       });
     }
@@ -1403,6 +1405,9 @@ export interface SpecConfig {
 
   /** The number of active clients for this test run. */
   numClients: number;
+
+  /** A boolean to allow removal of non-active targets by the server. */
+  allowUnlistedTargetRemoval?: boolean;
 
   /**
    * The maximum number of concurrently-active listens for limbo resolutions.


### PR DESCRIPTION
To run this test:

`npx ts-node ./scripts/run-tests.ts --main=test/register.ts --emulator 'test/unit/specs/remote_store_spec.test.ts'`