### PR TITLE
Crashlytics Refactor for Tracing Logic

### DIFF
--- a/packages/crashlytics/src/api.test.ts
+++ b/packages/crashlytics/src/api.test.ts
@@ -34,7 +34,7 @@ import {
 import { Component, ComponentType } from '@firebase/component';
 import { FirebaseAppCheckInternal } from '@firebase/app-check-interop-types';
 import { recordError, flush, getCrashlytics } from './api';
-import { SIGNAL_ATTRIBUTE_KEYS, CRASHLYTICS_SESSION_ID_KEY } from './constants';
+import { CRASHLYTICS_ATTRIBUTE_KEYS, CRASHLYTICS_SESSION_ID_KEY } from './constants';
 import { CrashlyticsService } from './service';
 import { registerCrashlytics } from './register';
 import { _FirebaseInstallationsInternal } from '@firebase/installations';
@@ -194,8 +194,8 @@ describe('Top level API', () => {
       expect(log.attributes).to.deep.equal({
         'error.type': 'TestError',
         'error.stack': '...stack trace...',
-        [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
-        [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
+        [CRASHLYTICS_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
+        [CRASHLYTICS_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -212,8 +212,8 @@ describe('Top level API', () => {
       expect(log.attributes).to.deep.equal({
         'error.type': 'Error',
         'error.stack': 'No stack trace available',
-        [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
-        [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
+        [CRASHLYTICS_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
+        [CRASHLYTICS_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -225,8 +225,8 @@ describe('Top level API', () => {
       expect(log.severityNumber).to.equal(SeverityNumber.ERROR);
       expect(log.body).to.equal('a string error');
       expect(log.attributes).to.deep.equal({
-        [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
-        [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
+        [CRASHLYTICS_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
+        [CRASHLYTICS_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -238,8 +238,8 @@ describe('Top level API', () => {
       expect(log.severityNumber).to.equal(SeverityNumber.ERROR);
       expect(log.body).to.equal('Unknown error type: number');
       expect(log.attributes).to.deep.equal({
-        [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
-        [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
+        [CRASHLYTICS_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
+        [CRASHLYTICS_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -266,10 +266,10 @@ describe('Top level API', () => {
       expect(emittedLogs[0].attributes).to.deep.equal({
         'error.type': 'TestError',
         'error.stack': '...stack trace...',
-        [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
+        [CRASHLYTICS_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
         'logging.googleapis.com/trace': `projects/${PROJECT_ID}/traces/my-trace`,
         'logging.googleapis.com/spanId': `my-span`,
-        [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
+        [CRASHLYTICS_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -292,14 +292,14 @@ describe('Top level API', () => {
       expect(log.attributes).to.deep.equal({
         'error.type': 'TestError',
         'error.stack': '...stack trace...',
-        [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
+        [CRASHLYTICS_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
         strAttr: 'string attribute',
         mapAttr: {
           boolAttr: true,
           numAttr: 2
         },
         arrAttr: [1, 2, 3],
-        [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
+        [CRASHLYTICS_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -318,8 +318,8 @@ describe('Top level API', () => {
       expect(emittedLogs.length).to.equal(1);
       const log = emittedLogs[0];
       expect(log.attributes).to.deep.equal({
-        [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: '1.0.0',
-        [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
+        [CRASHLYTICS_ATTRIBUTE_KEYS.APP_VERSION]: '1.0.0',
+        [CRASHLYTICS_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -331,8 +331,8 @@ describe('Top level API', () => {
       expect(emittedLogs.length).to.equal(1);
       const log = emittedLogs[0];
       expect(log.attributes).to.deep.equal({
-        [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: '1.2.3',
-        [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
+        [CRASHLYTICS_ATTRIBUTE_KEYS.APP_VERSION]: '1.2.3',
+        [CRASHLYTICS_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -354,10 +354,10 @@ describe('Top level API', () => {
       expect(log.attributes).to.deep.equal({
         'error.type': 'TestError',
         'error.stack': '...stack trace...',
-        [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
+        [CRASHLYTICS_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
         'framework_attr1': 'framework attribute #1',
         'framework_attr2': 'framework attribute #2',
-        [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
+        [CRASHLYTICS_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -369,7 +369,7 @@ describe('Top level API', () => {
 
         expect(emittedLogs.length).to.equal(1);
         const log = emittedLogs[0];
-        expect(log.attributes![SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]).to.equal(
+        expect(log.attributes![CRASHLYTICS_ATTRIBUTE_KEYS.SESSION_ID]).to.equal(
           'existing-session-id'
         );
       });
@@ -391,7 +391,7 @@ describe('Top level API', () => {
 
         expect(emittedLogs.length).to.equal(1);
         const log = emittedLogs[0];
-        expect(log.attributes![SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]).to.be
+        expect(log.attributes![CRASHLYTICS_ATTRIBUTE_KEYS.SESSION_ID]).to.be
           .undefined;
       });
 
@@ -412,7 +412,7 @@ describe('Top level API', () => {
 
         expect(emittedLogs.length).to.equal(1);
         const log = emittedLogs[0];
-        expect(log.attributes![SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]).to.be
+        expect(log.attributes![CRASHLYTICS_ATTRIBUTE_KEYS.SESSION_ID]).to.be
           .undefined;
       });
     });

--- a/packages/crashlytics/src/api.test.ts
+++ b/packages/crashlytics/src/api.test.ts
@@ -34,10 +34,7 @@ import {
 import { Component, ComponentType } from '@firebase/component';
 import { FirebaseAppCheckInternal } from '@firebase/app-check-interop-types';
 import { recordError, flush, getCrashlytics } from './api';
-import {
-  SIGNAL_ATTRIBUTE_KEYS,
-  CRASHLYTICS_SESSION_ID_KEY
-} from './constants';
+import { SIGNAL_ATTRIBUTE_KEYS, CRASHLYTICS_SESSION_ID_KEY } from './constants';
 import { CrashlyticsService } from './service';
 import { registerCrashlytics } from './register';
 import { _FirebaseInstallationsInternal } from '@firebase/installations';

--- a/packages/crashlytics/src/api.test.ts
+++ b/packages/crashlytics/src/api.test.ts
@@ -34,7 +34,10 @@ import {
 import { Component, ComponentType } from '@firebase/component';
 import { FirebaseAppCheckInternal } from '@firebase/app-check-interop-types';
 import { recordError, flush, getCrashlytics } from './api';
-import { CRASHLYTICS_ATTRIBUTE_KEYS, CRASHLYTICS_SESSION_ID_KEY } from './constants';
+import {
+  CRASHLYTICS_ATTRIBUTE_KEYS,
+  CRASHLYTICS_SESSION_ID_KEY
+} from './constants';
 import { CrashlyticsService } from './service';
 import { registerCrashlytics } from './register';
 import { _FirebaseInstallationsInternal } from '@firebase/installations';

--- a/packages/crashlytics/src/api.test.ts
+++ b/packages/crashlytics/src/api.test.ts
@@ -35,7 +35,7 @@ import { Component, ComponentType } from '@firebase/component';
 import { FirebaseAppCheckInternal } from '@firebase/app-check-interop-types';
 import { recordError, flush, getCrashlytics } from './api';
 import {
-  LOG_ENTRY_ATTRIBUTE_KEYS,
+  SIGNAL_ATTRIBUTE_KEYS,
   CRASHLYTICS_SESSION_ID_KEY
 } from './constants';
 import { CrashlyticsService } from './service';
@@ -197,8 +197,8 @@ describe('Top level API', () => {
       expect(log.attributes).to.deep.equal({
         'error.type': 'TestError',
         'error.stack': '...stack trace...',
-        [LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
-        [LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
+        [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
+        [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -215,8 +215,8 @@ describe('Top level API', () => {
       expect(log.attributes).to.deep.equal({
         'error.type': 'Error',
         'error.stack': 'No stack trace available',
-        [LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
-        [LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
+        [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
+        [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -228,8 +228,8 @@ describe('Top level API', () => {
       expect(log.severityNumber).to.equal(SeverityNumber.ERROR);
       expect(log.body).to.equal('a string error');
       expect(log.attributes).to.deep.equal({
-        [LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
-        [LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
+        [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
+        [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -241,8 +241,8 @@ describe('Top level API', () => {
       expect(log.severityNumber).to.equal(SeverityNumber.ERROR);
       expect(log.body).to.equal('Unknown error type: number');
       expect(log.attributes).to.deep.equal({
-        [LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
-        [LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
+        [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
+        [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -269,10 +269,10 @@ describe('Top level API', () => {
       expect(emittedLogs[0].attributes).to.deep.equal({
         'error.type': 'TestError',
         'error.stack': '...stack trace...',
-        [LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
+        [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
         'logging.googleapis.com/trace': `projects/${PROJECT_ID}/traces/my-trace`,
         'logging.googleapis.com/spanId': `my-span`,
-        [LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
+        [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -295,14 +295,14 @@ describe('Top level API', () => {
       expect(log.attributes).to.deep.equal({
         'error.type': 'TestError',
         'error.stack': '...stack trace...',
-        [LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
+        [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
         strAttr: 'string attribute',
         mapAttr: {
           boolAttr: true,
           numAttr: 2
         },
         arrAttr: [1, 2, 3],
-        [LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
+        [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -321,8 +321,8 @@ describe('Top level API', () => {
       expect(emittedLogs.length).to.equal(1);
       const log = emittedLogs[0];
       expect(log.attributes).to.deep.equal({
-        [LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION]: '1.0.0',
-        [LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
+        [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: '1.0.0',
+        [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -334,8 +334,8 @@ describe('Top level API', () => {
       expect(emittedLogs.length).to.equal(1);
       const log = emittedLogs[0];
       expect(log.attributes).to.deep.equal({
-        [LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION]: '1.2.3',
-        [LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
+        [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: '1.2.3',
+        [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -357,10 +357,10 @@ describe('Top level API', () => {
       expect(log.attributes).to.deep.equal({
         'error.type': 'TestError',
         'error.stack': '...stack trace...',
-        [LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
+        [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: 'unset',
         'framework_attr1': 'framework attribute #1',
         'framework_attr2': 'framework attribute #2',
-        [LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
+        [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -372,7 +372,7 @@ describe('Top level API', () => {
 
         expect(emittedLogs.length).to.equal(1);
         const log = emittedLogs[0];
-        expect(log.attributes![LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID]).to.equal(
+        expect(log.attributes![SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]).to.equal(
           'existing-session-id'
         );
       });
@@ -394,7 +394,7 @@ describe('Top level API', () => {
 
         expect(emittedLogs.length).to.equal(1);
         const log = emittedLogs[0];
-        expect(log.attributes![LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID]).to.be
+        expect(log.attributes![SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]).to.be
           .undefined;
       });
 
@@ -415,7 +415,7 @@ describe('Top level API', () => {
 
         expect(emittedLogs.length).to.equal(1);
         const log = emittedLogs[0];
-        expect(log.attributes![LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID]).to.be
+        expect(log.attributes![SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]).to.be
           .undefined;
       });
     });

--- a/packages/crashlytics/src/api.ts
+++ b/packages/crashlytics/src/api.ts
@@ -16,7 +16,7 @@
  */
 
 import { _getProvider, FirebaseApp, getApp } from '@firebase/app';
-import { SIGNAL_ATTRIBUTE_KEYS, CRASHLYTICS_TYPE } from './constants';
+import { CRASHLYTICS_ATTRIBUTE_KEYS, CRASHLYTICS_TYPE } from './constants';
 import { Crashlytics, CrashlyticsOptions } from './public-types';
 import { Provider } from '@firebase/component';
 import { AnyValueMap, SeverityNumber } from '@opentelemetry/api-logs';
@@ -106,13 +106,13 @@ export function recordError(
   }
 
   // Add app version metadata
-  customAttributes[SIGNAL_ATTRIBUTE_KEYS.APP_VERSION] =
+  customAttributes[CRASHLYTICS_ATTRIBUTE_KEYS.APP_VERSION] =
     getAppVersion(crashlytics);
 
   // Add session ID metadata
   const sessionId = getSessionId();
   if (sessionId) {
-    customAttributes[SIGNAL_ATTRIBUTE_KEYS.SESSION_ID] = sessionId;
+    customAttributes[CRASHLYTICS_ATTRIBUTE_KEYS.SESSION_ID] = sessionId;
   }
 
   // Merge in any additional attributes. Explicitly provided attributes take precedence over

--- a/packages/crashlytics/src/api.ts
+++ b/packages/crashlytics/src/api.ts
@@ -16,7 +16,7 @@
  */
 
 import { _getProvider, FirebaseApp, getApp } from '@firebase/app';
-import { LOG_ENTRY_ATTRIBUTE_KEYS, CRASHLYTICS_TYPE } from './constants';
+import { SIGNAL_ATTRIBUTE_KEYS, CRASHLYTICS_TYPE } from './constants';
 import { Crashlytics, CrashlyticsOptions } from './public-types';
 import { Provider } from '@firebase/component';
 import { AnyValueMap, SeverityNumber } from '@opentelemetry/api-logs';
@@ -106,13 +106,13 @@ export function recordError(
   }
 
   // Add app version metadata
-  customAttributes[LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION] =
+  customAttributes[SIGNAL_ATTRIBUTE_KEYS.APP_VERSION] =
     getAppVersion(crashlytics);
 
   // Add session ID metadata
   const sessionId = getSessionId();
   if (sessionId) {
-    customAttributes[LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID] = sessionId;
+    customAttributes[SIGNAL_ATTRIBUTE_KEYS.SESSION_ID] = sessionId;
   }
 
   // Merge in any additional attributes. Explicitly provided attributes take precedence over

--- a/packages/crashlytics/src/constants.ts
+++ b/packages/crashlytics/src/constants.ts
@@ -22,7 +22,7 @@ export const CRASHLYTICS_TYPE = 'crashlytics';
 export const CRASHLYTICS_SESSION_ID_KEY = 'firebasecrashlytics.sessionid';
 
 /** Label keys that we write in all telemetry log entries. */
-export const LOG_ENTRY_ATTRIBUTE_KEYS = {
+export const SIGNAL_ATTRIBUTE_KEYS = {
   APP_VERSION: 'app_version',
   SESSION_ID: 'session_id',
   USER_ID: 'user_id'

--- a/packages/crashlytics/src/constants.ts
+++ b/packages/crashlytics/src/constants.ts
@@ -21,8 +21,8 @@ export const CRASHLYTICS_TYPE = 'crashlytics';
 /** Key for storing the session ID in sessionStorage. */
 export const CRASHLYTICS_SESSION_ID_KEY = 'firebasecrashlytics.sessionid';
 
-/** Label keys that we write in all telemetry log entries. */
-export const SIGNAL_ATTRIBUTE_KEYS = {
+/** Label keys that we write in all telemetry signal entries. */
+export const CRASHLYTICS_ATTRIBUTE_KEYS = {
   APP_VERSION: 'app_version',
   SESSION_ID: 'session_id',
   USER_ID: 'user_id'

--- a/packages/crashlytics/src/fetch-transport.test.ts
+++ b/packages/crashlytics/src/fetch-transport.test.ts
@@ -20,8 +20,8 @@
 
 import * as sinon from 'sinon';
 import * as assert from 'assert';
-import { DynamicHeaderProvider } from '../types';
-import { FetchTransport } from '../fetch-transport';
+import { DynamicHeaderProvider } from './types';
+import { FetchTransport } from './fetch-transport';
 import {
   ExportResponseRetryable,
   ExportResponseFailure,

--- a/packages/crashlytics/src/fetch-transport.ts
+++ b/packages/crashlytics/src/fetch-transport.ts
@@ -23,7 +23,7 @@ import {
   ExportResponse
 } from '@opentelemetry/otlp-exporter-base';
 import { diag } from '@opentelemetry/api';
-import { DynamicHeaderProvider } from '../types';
+import { DynamicHeaderProvider } from './types';
 
 function isExportRetryable(statusCode: number): boolean {
   const retryCodes = [429, 502, 503, 504];
@@ -63,7 +63,7 @@ export interface FetchTransportParameters {
  * @internal
  */
 export class FetchTransport implements IExporterTransport {
-  constructor(private parameters: FetchTransportParameters) {}
+  constructor(private parameters: FetchTransportParameters) { }
 
   async send(data: Uint8Array, timeoutMillis: number): Promise<ExportResponse> {
     const abortController = new AbortController();

--- a/packages/crashlytics/src/fetch-transport.ts
+++ b/packages/crashlytics/src/fetch-transport.ts
@@ -63,7 +63,7 @@ export interface FetchTransportParameters {
  * @internal
  */
 export class FetchTransport implements IExporterTransport {
-  constructor(private parameters: FetchTransportParameters) { }
+  constructor(private parameters: FetchTransportParameters) {}
 
   async send(data: Uint8Array, timeoutMillis: number): Promise<ExportResponse> {
     const abortController = new AbortController();

--- a/packages/crashlytics/src/helpers.test.ts
+++ b/packages/crashlytics/src/helpers.test.ts
@@ -21,7 +21,7 @@ import { Logger, LogRecord } from '@opentelemetry/api-logs';
 import { isNode } from '@firebase/util';
 import { registerListeners, startNewSession } from './helpers';
 import {
-  LOG_ENTRY_ATTRIBUTE_KEYS,
+  SIGNAL_ATTRIBUTE_KEYS,
   CRASHLYTICS_SESSION_ID_KEY
 } from './constants';
 import { AUTO_CONSTANTS } from './auto-constants';
@@ -118,8 +118,8 @@ describe('helpers', () => {
       expect(storage[CRASHLYTICS_SESSION_ID_KEY]).to.equal(MOCK_SESSION_ID);
       expect(emittedLogs.length).to.equal(1);
       expect(emittedLogs[0].attributes).to.deep.equal({
-        [LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID,
-        [LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION]: 'unset'
+        [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID,
+        [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: 'unset'
       });
     });
 
@@ -128,8 +128,8 @@ describe('helpers', () => {
       startNewSession(fakeCrashlytics);
 
       expect(emittedLogs[0].attributes).to.deep.equal({
-        [LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID,
-        [LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION]: '1.2.3'
+        [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID,
+        [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: '1.2.3'
       });
     });
 
@@ -143,8 +143,8 @@ describe('helpers', () => {
       startNewSession(telemetryWithVersion);
 
       expect(emittedLogs[0].attributes).to.deep.equal({
-        [LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID,
-        [LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION]: '9.9.9'
+        [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID,
+        [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: '9.9.9'
       });
     });
   });

--- a/packages/crashlytics/src/helpers.test.ts
+++ b/packages/crashlytics/src/helpers.test.ts
@@ -20,10 +20,7 @@ import { LoggerProvider } from '@opentelemetry/sdk-logs';
 import { Logger, LogRecord } from '@opentelemetry/api-logs';
 import { isNode } from '@firebase/util';
 import { registerListeners, startNewSession } from './helpers';
-import {
-  SIGNAL_ATTRIBUTE_KEYS,
-  CRASHLYTICS_SESSION_ID_KEY
-} from './constants';
+import { SIGNAL_ATTRIBUTE_KEYS, CRASHLYTICS_SESSION_ID_KEY } from './constants';
 import { AUTO_CONSTANTS } from './auto-constants';
 import { CrashlyticsService } from './service';
 import { CrashlyticsInternal } from './types';

--- a/packages/crashlytics/src/helpers.test.ts
+++ b/packages/crashlytics/src/helpers.test.ts
@@ -20,7 +20,7 @@ import { LoggerProvider } from '@opentelemetry/sdk-logs';
 import { Logger, LogRecord } from '@opentelemetry/api-logs';
 import { isNode } from '@firebase/util';
 import { registerListeners, startNewSession } from './helpers';
-import { SIGNAL_ATTRIBUTE_KEYS, CRASHLYTICS_SESSION_ID_KEY } from './constants';
+import { CRASHLYTICS_ATTRIBUTE_KEYS, CRASHLYTICS_SESSION_ID_KEY } from './constants';
 import { AUTO_CONSTANTS } from './auto-constants';
 import { CrashlyticsService } from './service';
 import { CrashlyticsInternal } from './types';
@@ -115,8 +115,8 @@ describe('helpers', () => {
       expect(storage[CRASHLYTICS_SESSION_ID_KEY]).to.equal(MOCK_SESSION_ID);
       expect(emittedLogs.length).to.equal(1);
       expect(emittedLogs[0].attributes).to.deep.equal({
-        [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID,
-        [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: 'unset'
+        [CRASHLYTICS_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID,
+        [CRASHLYTICS_ATTRIBUTE_KEYS.APP_VERSION]: 'unset'
       });
     });
 
@@ -125,8 +125,8 @@ describe('helpers', () => {
       startNewSession(fakeCrashlytics);
 
       expect(emittedLogs[0].attributes).to.deep.equal({
-        [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID,
-        [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: '1.2.3'
+        [CRASHLYTICS_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID,
+        [CRASHLYTICS_ATTRIBUTE_KEYS.APP_VERSION]: '1.2.3'
       });
     });
 
@@ -140,8 +140,8 @@ describe('helpers', () => {
       startNewSession(telemetryWithVersion);
 
       expect(emittedLogs[0].attributes).to.deep.equal({
-        [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID,
-        [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: '9.9.9'
+        [CRASHLYTICS_ATTRIBUTE_KEYS.SESSION_ID]: MOCK_SESSION_ID,
+        [CRASHLYTICS_ATTRIBUTE_KEYS.APP_VERSION]: '9.9.9'
       });
     });
   });

--- a/packages/crashlytics/src/helpers.test.ts
+++ b/packages/crashlytics/src/helpers.test.ts
@@ -20,7 +20,10 @@ import { LoggerProvider } from '@opentelemetry/sdk-logs';
 import { Logger, LogRecord } from '@opentelemetry/api-logs';
 import { isNode } from '@firebase/util';
 import { registerListeners, startNewSession } from './helpers';
-import { CRASHLYTICS_ATTRIBUTE_KEYS, CRASHLYTICS_SESSION_ID_KEY } from './constants';
+import {
+  CRASHLYTICS_ATTRIBUTE_KEYS,
+  CRASHLYTICS_SESSION_ID_KEY
+} from './constants';
 import { AUTO_CONSTANTS } from './auto-constants';
 import { CrashlyticsService } from './service';
 import { CrashlyticsInternal } from './types';

--- a/packages/crashlytics/src/helpers.ts
+++ b/packages/crashlytics/src/helpers.ts
@@ -17,10 +17,7 @@
 
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import * as constants from './auto-constants';
-import {
-  SIGNAL_ATTRIBUTE_KEYS,
-  CRASHLYTICS_SESSION_ID_KEY
-} from './constants';
+import { SIGNAL_ATTRIBUTE_KEYS, CRASHLYTICS_SESSION_ID_KEY } from './constants';
 import { Crashlytics } from './public-types';
 import { CrashlyticsService } from './service';
 import { CrashlyticsInternal } from './types';

--- a/packages/crashlytics/src/helpers.ts
+++ b/packages/crashlytics/src/helpers.ts
@@ -18,7 +18,7 @@
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import * as constants from './auto-constants';
 import {
-  LOG_ENTRY_ATTRIBUTE_KEYS,
+  SIGNAL_ATTRIBUTE_KEYS,
   CRASHLYTICS_SESSION_ID_KEY
 } from './constants';
 import { Crashlytics } from './public-types';
@@ -72,8 +72,8 @@ export function startNewSession(crashlytics: Crashlytics): void {
         severityNumber: SeverityNumber.DEBUG,
         body: 'Session created',
         attributes: {
-          [LOG_ENTRY_ATTRIBUTE_KEYS.SESSION_ID]: sessionId,
-          [LOG_ENTRY_ATTRIBUTE_KEYS.APP_VERSION]: getAppVersion(crashlytics)
+          [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: sessionId,
+          [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: getAppVersion(crashlytics)
         }
       });
     } catch (e) {

--- a/packages/crashlytics/src/helpers.ts
+++ b/packages/crashlytics/src/helpers.ts
@@ -17,7 +17,10 @@
 
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import * as constants from './auto-constants';
-import { CRASHLYTICS_ATTRIBUTE_KEYS, CRASHLYTICS_SESSION_ID_KEY } from './constants';
+import {
+  CRASHLYTICS_ATTRIBUTE_KEYS,
+  CRASHLYTICS_SESSION_ID_KEY
+} from './constants';
 import { Crashlytics } from './public-types';
 import { CrashlyticsService } from './service';
 import { CrashlyticsInternal } from './types';

--- a/packages/crashlytics/src/helpers.ts
+++ b/packages/crashlytics/src/helpers.ts
@@ -17,7 +17,7 @@
 
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import * as constants from './auto-constants';
-import { SIGNAL_ATTRIBUTE_KEYS, CRASHLYTICS_SESSION_ID_KEY } from './constants';
+import { CRASHLYTICS_ATTRIBUTE_KEYS, CRASHLYTICS_SESSION_ID_KEY } from './constants';
 import { Crashlytics } from './public-types';
 import { CrashlyticsService } from './service';
 import { CrashlyticsInternal } from './types';
@@ -69,8 +69,8 @@ export function startNewSession(crashlytics: Crashlytics): void {
         severityNumber: SeverityNumber.DEBUG,
         body: 'Session created',
         attributes: {
-          [SIGNAL_ATTRIBUTE_KEYS.SESSION_ID]: sessionId,
-          [SIGNAL_ATTRIBUTE_KEYS.APP_VERSION]: getAppVersion(crashlytics)
+          [CRASHLYTICS_ATTRIBUTE_KEYS.SESSION_ID]: sessionId,
+          [CRASHLYTICS_ATTRIBUTE_KEYS.APP_VERSION]: getAppVersion(crashlytics)
         }
       });
     } catch (e) {

--- a/packages/crashlytics/src/logging/fetch-transport.test.ts
+++ b/packages/crashlytics/src/logging/fetch-transport.test.ts
@@ -21,7 +21,7 @@
 import * as sinon from 'sinon';
 import * as assert from 'assert';
 import { DynamicHeaderProvider } from '../types';
-import { FetchTransport } from './fetch-transport';
+import { FetchTransport } from '../fetch-transport';
 import {
   ExportResponseRetryable,
   ExportResponseFailure,

--- a/packages/crashlytics/src/logging/installation-id-provider.test.ts
+++ b/packages/crashlytics/src/logging/installation-id-provider.test.ts
@@ -18,7 +18,7 @@
 import { InstallationIdProvider } from './installation-id-provider';
 import { _FirebaseInstallationsInternal } from '@firebase/installations';
 import { expect } from 'chai';
-import { SIGNAL_ATTRIBUTE_KEYS } from '../constants';
+import { CRASHLYTICS_ATTRIBUTE_KEYS } from '../constants';
 
 describe('InstallationIdProvider', () => {
   it('should cache the installation id after the first call', async () => {
@@ -38,11 +38,11 @@ describe('InstallationIdProvider', () => {
     const provider = new InstallationIdProvider(mockProvider);
 
     const attr1 = await provider.getAttribute();
-    expect(attr1).to.deep.equal([SIGNAL_ATTRIBUTE_KEYS.USER_ID, 'iid-123']);
+    expect(attr1).to.deep.equal([CRASHLYTICS_ATTRIBUTE_KEYS.USER_ID, 'iid-123']);
     expect(callCount).to.equal(1);
 
     const attr2 = await provider.getAttribute();
-    expect(attr2).to.deep.equal([SIGNAL_ATTRIBUTE_KEYS.USER_ID, 'iid-123']);
+    expect(attr2).to.deep.equal([CRASHLYTICS_ATTRIBUTE_KEYS.USER_ID, 'iid-123']);
     expect(callCount).to.equal(1); // Should still be 1
   });
 
@@ -69,12 +69,12 @@ describe('InstallationIdProvider', () => {
 
     returnValue = 'iid-456';
     const attr2 = await provider.getAttribute();
-    expect(attr2).to.deep.equal([SIGNAL_ATTRIBUTE_KEYS.USER_ID, 'iid-456']);
+    expect(attr2).to.deep.equal([CRASHLYTICS_ATTRIBUTE_KEYS.USER_ID, 'iid-456']);
     expect(callCount).to.equal(2);
 
     // Should cache now
     const attr3 = await provider.getAttribute();
-    expect(attr3).to.deep.equal([SIGNAL_ATTRIBUTE_KEYS.USER_ID, 'iid-456']);
+    expect(attr3).to.deep.equal([CRASHLYTICS_ATTRIBUTE_KEYS.USER_ID, 'iid-456']);
     expect(callCount).to.equal(2);
   });
 });

--- a/packages/crashlytics/src/logging/installation-id-provider.test.ts
+++ b/packages/crashlytics/src/logging/installation-id-provider.test.ts
@@ -38,11 +38,17 @@ describe('InstallationIdProvider', () => {
     const provider = new InstallationIdProvider(mockProvider);
 
     const attr1 = await provider.getAttribute();
-    expect(attr1).to.deep.equal([CRASHLYTICS_ATTRIBUTE_KEYS.USER_ID, 'iid-123']);
+    expect(attr1).to.deep.equal([
+      CRASHLYTICS_ATTRIBUTE_KEYS.USER_ID,
+      'iid-123'
+    ]);
     expect(callCount).to.equal(1);
 
     const attr2 = await provider.getAttribute();
-    expect(attr2).to.deep.equal([CRASHLYTICS_ATTRIBUTE_KEYS.USER_ID, 'iid-123']);
+    expect(attr2).to.deep.equal([
+      CRASHLYTICS_ATTRIBUTE_KEYS.USER_ID,
+      'iid-123'
+    ]);
     expect(callCount).to.equal(1); // Should still be 1
   });
 
@@ -69,12 +75,18 @@ describe('InstallationIdProvider', () => {
 
     returnValue = 'iid-456';
     const attr2 = await provider.getAttribute();
-    expect(attr2).to.deep.equal([CRASHLYTICS_ATTRIBUTE_KEYS.USER_ID, 'iid-456']);
+    expect(attr2).to.deep.equal([
+      CRASHLYTICS_ATTRIBUTE_KEYS.USER_ID,
+      'iid-456'
+    ]);
     expect(callCount).to.equal(2);
 
     // Should cache now
     const attr3 = await provider.getAttribute();
-    expect(attr3).to.deep.equal([CRASHLYTICS_ATTRIBUTE_KEYS.USER_ID, 'iid-456']);
+    expect(attr3).to.deep.equal([
+      CRASHLYTICS_ATTRIBUTE_KEYS.USER_ID,
+      'iid-456'
+    ]);
     expect(callCount).to.equal(2);
   });
 });

--- a/packages/crashlytics/src/logging/installation-id-provider.test.ts
+++ b/packages/crashlytics/src/logging/installation-id-provider.test.ts
@@ -18,7 +18,7 @@
 import { InstallationIdProvider } from './installation-id-provider';
 import { _FirebaseInstallationsInternal } from '@firebase/installations';
 import { expect } from 'chai';
-import { LOG_ENTRY_ATTRIBUTE_KEYS } from '../constants';
+import { SIGNAL_ATTRIBUTE_KEYS } from '../constants';
 
 describe('InstallationIdProvider', () => {
   it('should cache the installation id after the first call', async () => {
@@ -38,11 +38,11 @@ describe('InstallationIdProvider', () => {
     const provider = new InstallationIdProvider(mockProvider);
 
     const attr1 = await provider.getAttribute();
-    expect(attr1).to.deep.equal([LOG_ENTRY_ATTRIBUTE_KEYS.USER_ID, 'iid-123']);
+    expect(attr1).to.deep.equal([SIGNAL_ATTRIBUTE_KEYS.USER_ID, 'iid-123']);
     expect(callCount).to.equal(1);
 
     const attr2 = await provider.getAttribute();
-    expect(attr2).to.deep.equal([LOG_ENTRY_ATTRIBUTE_KEYS.USER_ID, 'iid-123']);
+    expect(attr2).to.deep.equal([SIGNAL_ATTRIBUTE_KEYS.USER_ID, 'iid-123']);
     expect(callCount).to.equal(1); // Should still be 1
   });
 
@@ -69,12 +69,12 @@ describe('InstallationIdProvider', () => {
 
     returnValue = 'iid-456';
     const attr2 = await provider.getAttribute();
-    expect(attr2).to.deep.equal([LOG_ENTRY_ATTRIBUTE_KEYS.USER_ID, 'iid-456']);
+    expect(attr2).to.deep.equal([SIGNAL_ATTRIBUTE_KEYS.USER_ID, 'iid-456']);
     expect(callCount).to.equal(2);
 
     // Should cache now
     const attr3 = await provider.getAttribute();
-    expect(attr3).to.deep.equal([LOG_ENTRY_ATTRIBUTE_KEYS.USER_ID, 'iid-456']);
+    expect(attr3).to.deep.equal([SIGNAL_ATTRIBUTE_KEYS.USER_ID, 'iid-456']);
     expect(callCount).to.equal(2);
   });
 });

--- a/packages/crashlytics/src/logging/installation-id-provider.ts
+++ b/packages/crashlytics/src/logging/installation-id-provider.ts
@@ -16,16 +16,16 @@
  */
 
 import { Provider } from '@firebase/component';
-import { DynamicLogAttributeProvider, LogEntryAttribute } from '../types';
+import { DynamicAttributeProvider, SignalAttribute } from '../types';
 import { _FirebaseInstallationsInternal } from '@firebase/installations';
-import { LOG_ENTRY_ATTRIBUTE_KEYS } from '../constants';
+import { SIGNAL_ATTRIBUTE_KEYS } from '../constants';
 
 /**
  * Allows logging to include the client's installation ID.
  *
  * @internal
  */
-export class InstallationIdProvider implements DynamicLogAttributeProvider {
+export class InstallationIdProvider implements DynamicAttributeProvider {
   private installations: _FirebaseInstallationsInternal | null;
   private _iid: string | undefined;
 
@@ -41,12 +41,12 @@ export class InstallationIdProvider implements DynamicLogAttributeProvider {
     }
   }
 
-  async getAttribute(): Promise<LogEntryAttribute | null> {
+  async getAttribute(): Promise<SignalAttribute | null> {
     if (!this.installations) {
       return null;
     }
     if (this._iid) {
-      return [LOG_ENTRY_ATTRIBUTE_KEYS.USER_ID, this._iid];
+      return [SIGNAL_ATTRIBUTE_KEYS.USER_ID, this._iid];
     }
 
     const iid = await this.installations.getId();
@@ -55,6 +55,6 @@ export class InstallationIdProvider implements DynamicLogAttributeProvider {
     }
 
     this._iid = iid;
-    return [LOG_ENTRY_ATTRIBUTE_KEYS.USER_ID, iid];
+    return [SIGNAL_ATTRIBUTE_KEYS.USER_ID, iid];
   }
 }

--- a/packages/crashlytics/src/logging/installation-id-provider.ts
+++ b/packages/crashlytics/src/logging/installation-id-provider.ts
@@ -18,7 +18,7 @@
 import { Provider } from '@firebase/component';
 import { DynamicAttributeProvider, SignalAttribute } from '../types';
 import { _FirebaseInstallationsInternal } from '@firebase/installations';
-import { SIGNAL_ATTRIBUTE_KEYS } from '../constants';
+import { CRASHLYTICS_ATTRIBUTE_KEYS } from '../constants';
 
 /**
  * Allows logging to include the client's installation ID.
@@ -46,7 +46,7 @@ export class InstallationIdProvider implements DynamicAttributeProvider {
       return null;
     }
     if (this._iid) {
-      return [SIGNAL_ATTRIBUTE_KEYS.USER_ID, this._iid];
+      return [CRASHLYTICS_ATTRIBUTE_KEYS.USER_ID, this._iid];
     }
 
     const iid = await this.installations.getId();
@@ -55,6 +55,6 @@ export class InstallationIdProvider implements DynamicAttributeProvider {
     }
 
     this._iid = iid;
-    return [SIGNAL_ATTRIBUTE_KEYS.USER_ID, iid];
+    return [CRASHLYTICS_ATTRIBUTE_KEYS.USER_ID, iid];
   }
 }

--- a/packages/crashlytics/src/logging/logger-provider.ts
+++ b/packages/crashlytics/src/logging/logger-provider.ts
@@ -29,7 +29,7 @@ import {
   OTLPExporterBase,
   createOtlpNetworkExportDelegate
 } from '@opentelemetry/otlp-exporter-base';
-import { FetchTransport } from './fetch-transport';
+import { FetchTransport } from '../fetch-transport';
 import { DynamicHeaderProvider, DynamicAttributeProvider } from '../types';
 import { FirebaseApp } from '@firebase/app';
 import { ExportResult } from '@opentelemetry/core';

--- a/packages/crashlytics/src/logging/logger-provider.ts
+++ b/packages/crashlytics/src/logging/logger-provider.ts
@@ -30,7 +30,7 @@ import {
   createOtlpNetworkExportDelegate
 } from '@opentelemetry/otlp-exporter-base';
 import { FetchTransport } from './fetch-transport';
-import { DynamicHeaderProvider, DynamicLogAttributeProvider } from '../types';
+import { DynamicHeaderProvider, DynamicAttributeProvider } from '../types';
 import { FirebaseApp } from '@firebase/app';
 import { ExportResult } from '@opentelemetry/core';
 
@@ -43,7 +43,7 @@ export function createLoggerProvider(
   app: FirebaseApp,
   endpointUrl: string,
   dynamicHeaderProviders: DynamicHeaderProvider[] = [],
-  dynamicLogAttributeProviders: DynamicLogAttributeProvider[] = []
+  dynamicAttributeProviders: DynamicAttributeProvider[] = []
 ): LoggerProvider {
   const resource = resourceFromAttributes({
     [ATTR_SERVICE_NAME]: 'firebase_telemetry_service'
@@ -63,7 +63,7 @@ export function createLoggerProvider(
       }
     },
     dynamicHeaderProviders,
-    dynamicLogAttributeProviders
+    dynamicAttributeProviders
   );
 
   return new LoggerProvider({
@@ -76,12 +76,11 @@ export function createLoggerProvider(
 /** OTLP exporter that uses custom FetchTransport and resolves async attributes. */
 class OTLPLogExporter
   extends OTLPExporterBase<ReadableLogRecord[]>
-  implements LogRecordExporter
-{
+  implements LogRecordExporter {
   constructor(
     config: OTLPExporterConfigBase = {},
     dynamicHeaderProviders: DynamicHeaderProvider[] = [],
-    private dynamicLogAttributeProviders: DynamicLogAttributeProvider[] = []
+    private dynamicAttributeProviders: DynamicAttributeProvider[] = []
   ) {
     super(
       createOtlpNetworkExportDelegate(
@@ -105,7 +104,7 @@ class OTLPLogExporter
     resultCallback: (result: ExportResult) => void
   ): Promise<void> {
     const attributes = await Promise.all(
-      this.dynamicLogAttributeProviders.map(provider => provider.getAttribute())
+      this.dynamicAttributeProviders.map(provider => provider.getAttribute())
     );
 
     const attributesToApply = Object.fromEntries(

--- a/packages/crashlytics/src/logging/logger-provider.ts
+++ b/packages/crashlytics/src/logging/logger-provider.ts
@@ -76,7 +76,8 @@ export function createLoggerProvider(
 /** OTLP exporter that uses custom FetchTransport and resolves async attributes. */
 class OTLPLogExporter
   extends OTLPExporterBase<ReadableLogRecord[]>
-  implements LogRecordExporter {
+  implements LogRecordExporter
+{
   constructor(
     config: OTLPExporterConfigBase = {},
     dynamicHeaderProviders: DynamicHeaderProvider[] = [],

--- a/packages/crashlytics/src/register.ts
+++ b/packages/crashlytics/src/register.ts
@@ -50,14 +50,14 @@ export function registerCrashlytics(): void {
           'installations-internal'
         );
         const dynamicHeaderProviders = [new AppCheckProvider(appCheckProvider)];
-        const dynamicLogAttributeProviders = [
+        const dynamicAttributeProviders = [
           new InstallationIdProvider(installationsProvider)
         ];
         const loggerProvider = createLoggerProvider(
           app,
           endpointUrl,
           dynamicHeaderProviders,
-          dynamicLogAttributeProviders
+          dynamicAttributeProviders
         );
 
         const crashlyticsService = new CrashlyticsService(app, loggerProvider);

--- a/packages/crashlytics/src/types.ts
+++ b/packages/crashlytics/src/types.ts
@@ -34,7 +34,7 @@ type KeyValuePair = [key: string, value: string];
  *
  * @internal
  */
-export type LogEntryAttribute = KeyValuePair;
+export type SignalAttribute = KeyValuePair;
 
 /**
  * An interface for classes that provide dynamic log entry attributes.
@@ -43,14 +43,14 @@ export type LogEntryAttribute = KeyValuePair;
  *
  * @internal
  */
-export interface DynamicLogAttributeProvider {
+export interface DynamicAttributeProvider {
   /**
    * Returns a record of attributes to be added to a log entry.
    *
-   * @returns A {@link Promise} that resolves to a {@link LogEntryAttribute} key-value pair,
+   * @returns A {@link Promise} that resolves to a {@link SignalAttribute} key-value pair,
    * or null if no attribute is to be added.
    */
-  getAttribute(): Promise<LogEntryAttribute | null>;
+  getAttribute(): Promise<SignalAttribute | null>;
 }
 
 /**

--- a/packages/crashlytics/src/types.ts
+++ b/packages/crashlytics/src/types.ts
@@ -30,14 +30,14 @@ export interface CrashlyticsInternal extends Crashlytics {
 type KeyValuePair = [key: string, value: string];
 
 /**
- * A type for Cloud Logging log entry attributes
+ * A type for Cloud Telemetry signal attributes
  *
  * @internal
  */
 export type SignalAttribute = KeyValuePair;
 
 /**
- * An interface for classes that provide dynamic log entry attributes.
+ * An interface for classes that provide dynamic signal attributes.
  *
  * Classes that implement this interface can be used to supply custom headers for logging.
  *


### PR DESCRIPTION
Refactoring for structural changes in the code to match future changes in the crashlytics tracing branch for tracing logic. The goal is to make this refactor to prevent future merge conflicts from mismatched naming conventions.

Changes:
1.  Renamed variables: DynamicLogAttributeProvider -> DynamicAttributeProvider, LogEntryAttribute -> SignalAttribute, LOG_ENTRY_ATTRIBUTE_KEYS -> CRASHLYTICS_ATTRIBUTE_KEYS
2. Moved fetch-transport.ts and fetch-transport.test.ts out of logging folder and under src directory as they will be used by both a logger and tracing provider.
