### PR TITLE
feat(data-connect): add query de-duplication to stream transport

### DIFF
--- a/packages/data-connect/src/network/stream/streamTransport.ts
+++ b/packages/data-connect/src/network/stream/streamTransport.ts
@@ -49,10 +49,9 @@ const IDLE_CONNECTION_TIMEOUT_MS = 60 * 1000; // 1 minute
  */
 interface InvokeOperationPromise<Data> {
   responsePromise: Promise<DataConnectResponse<Data>>;
+  resolveFn: (response: DataConnectResponse<Data>) => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  resolveFn: (data: any) => void;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  rejectFn: (err: any) => void;
+  rejectFn: (reason: any) => void;
 }
 
 /**
@@ -140,6 +139,15 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
   >();
 
   /**
+   * Map of query/variables to queued execute requests awaiting for active request to resolve.
+   */
+  private queuedInvokeQueryRequests = new Map<
+    string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    InvokeOperationPromise<any>
+  >();
+
+  /**
    * Map of mutation/variables to their active {@linkcode ExecuteStreamRequest} request bodies. Mutations
    * can have more than one active request at a time as they are not idempotent, and therefore should
    * not be de-duplicated.
@@ -164,7 +172,8 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
    */
   private invokeOperationPromises = new Map<
     string,
-    InvokeOperationPromise<unknown>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    InvokeOperationPromise<any>
   >();
 
   /**
@@ -182,41 +191,6 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
   private hasWaitedForInitialAuth = false;
 
   /**
-   * Tracks an {@linkcode invokeQuery} request, storing the request body and creating and storing a
-   * response promise that will be resolved when the response is received.
-   * @returns The tracked {@linkcode InvokeOperationPromise}.
-   *
-   * @remarks
-   * This method returns a promise, but is synchronous.
-   */
-  private trackInvokeQueryRequest<Data>(
-    requestId: string,
-    mapKey: string,
-    executeBody: ExecuteStreamRequest<unknown>
-  ): InvokeOperationPromise<Data> {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let resolveFn: (data: any) => void;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let rejectFn: (err: any) => void;
-    const responsePromise = new Promise<DataConnectResponse<Data>>(
-      (resolve, reject) => {
-        resolveFn = resolve;
-        rejectFn = reject;
-      }
-    );
-    const executeRequestPromise: InvokeOperationPromise<Data> = {
-      responsePromise,
-      resolveFn: resolveFn!,
-      rejectFn: rejectFn!
-    };
-
-    this.activeInvokeQueryRequests.set(mapKey, executeBody);
-    this.invokeOperationPromises.set(requestId, executeRequestPromise);
-
-    return executeRequestPromise;
-  }
-
-  /**
    * Tracks an {@linkcode invokeMutation} request, storing the request body and creating and storing a
    * response promise that will be resolved when the response is received.
    * @returns The tracked {@linkcode InvokeOperationPromise}.
@@ -229,10 +203,9 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     mapKey: string,
     executeBody: ExecuteStreamRequest<unknown>
   ): InvokeOperationPromise<Data> {
+    let resolveFn: (response: DataConnectResponse<Data>) => void;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let resolveFn: (data: any) => void;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let rejectFn: (err: any) => void;
+    let rejectFn: (reason: any) => void;
     const responsePromise = new Promise<DataConnectResponse<Data>>(
       (resolve, reject) => {
         resolveFn = resolve;
@@ -396,11 +369,14 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     this.activeInvokeSubscribeRequests.clear();
 
     const error = new DataConnectError(code, reason);
+    for (const [mapKey, { rejectFn }] of this.queuedInvokeQueryRequests) {
+      this.queuedInvokeQueryRequests.delete(mapKey);
+      rejectFn(error);
+    }
     for (const [requestId, { rejectFn }] of this.invokeOperationPromises) {
       this.invokeOperationPromises.delete(requestId);
       rejectFn(error);
     }
-
     for (const [requestId, observer] of this.subscribeObservers) {
       this.subscribeObservers.delete(requestId);
       observer.onDisconnect(code, reason);
@@ -513,21 +489,120 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     queryName: string,
     variables?: Variables
   ): Promise<DataConnectResponse<Data>> {
-    const requestId = this.nextRequestId();
-    const activeRequestKey = { operationName: queryName, variables };
     const mapKey = this.getMapKey(queryName, variables);
-    const executeBody: ExecuteStreamRequest<Variables> = {
-      requestId,
-      execute: activeRequestKey
-    };
 
-    let { responsePromise, rejectFn } = this.trackInvokeQueryRequest<Data>(
-      requestId,
-      mapKey,
-      executeBody
+    if (this.activeInvokeQueryRequests.has(mapKey)) {
+      return this.queueInvokeQueryRequest(mapKey);
+    }
+
+    return this.executeOrResumeQuery(queryName, variables, mapKey);
+  }
+
+  /**
+   * Queue a new query execute request to be executed after the currently active query execute
+   * request resolves, and track + return a promise associated with the queued request. If there is
+   * already a queued request for this mapKey, return the existing queued request's promise instead.
+   */
+  private queueInvokeQueryRequest<Data>(
+    mapKey: string
+  ): Promise<DataConnectResponse<Data>> {
+    const existingQueued = this.queuedInvokeQueryRequests.get(mapKey);
+    if (existingQueued) {
+      // only queue one request per mapKey - return existing queued request promise
+      return existingQueued.responsePromise as Promise<
+        DataConnectResponse<Data>
+      >;
+    }
+
+    let resolveFn: (response: DataConnectResponse<Data>) => void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let rejectFn: (reason: any) => void;
+    const responsePromise = new Promise<DataConnectResponse<Data>>(
+      (resolve, reject) => {
+        resolveFn = resolve;
+        rejectFn = reject;
+      }
     );
-    responsePromise = responsePromise.finally(() => {
-      this.cleanupInvokeQueryRequest(requestId, mapKey);
+
+    this.queuedInvokeQueryRequests.set(mapKey, {
+      responsePromise,
+      resolveFn: resolveFn!,
+      rejectFn: rejectFn!
+    });
+
+    return responsePromise;
+  }
+
+  /**
+   * Executes a query.
+   */
+  private executeOrResumeQuery<Data, Variables>(
+    queryName: string,
+    variables: Variables | undefined,
+    mapKey: string,
+    queuedInvokeOperationPromise?: InvokeOperationPromise<Data>
+  ): Promise<DataConnectResponse<Data>> {
+    let resolveFn: (response: DataConnectResponse<Data>) => void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let rejectFn: (reason: any) => void;
+    let responsePromise: Promise<DataConnectResponse<Data>>;
+
+    if (queuedInvokeOperationPromise) {
+      resolveFn = queuedInvokeOperationPromise.resolveFn;
+      rejectFn = queuedInvokeOperationPromise.rejectFn;
+      responsePromise = queuedInvokeOperationPromise.responsePromise;
+    } else {
+      responsePromise = new Promise<DataConnectResponse<Data>>(
+        (resolve, reject) => {
+          resolveFn = resolve;
+          rejectFn = reject;
+        }
+      );
+    }
+
+    const requestId = this.nextRequestId();
+    const requestBody = {
+      requestId,
+      execute: { operationName: queryName, variables }
+    } as ExecuteStreamRequest<Variables>;
+
+    this.invokeOperationPromises.set(requestId, {
+      responsePromise,
+      resolveFn: resolveFn!,
+      rejectFn: rejectFn!
+    });
+
+    this.activeInvokeQueryRequests.set(mapKey, requestBody);
+
+    void responsePromise.finally(() => {
+      this.onInvokeQueryRequestFulfilled(
+        queryName,
+        variables,
+        mapKey,
+        requestId
+      );
+    });
+
+    this.sendRequestMessage(requestBody).catch(err => {
+      rejectFn(err);
+    });
+    return responsePromise;
+  }
+
+  /**
+   * When a query invoke request is fulfilled, clean up and trigger the next queued
+   * request if one exists.
+   */
+  private onInvokeQueryRequestFulfilled(
+    queryName: string,
+    variables: unknown,
+    mapKey: string,
+    requestId: string
+  ): void {
+    this.cleanupInvokeQueryRequest(requestId, mapKey);
+
+    const queuedRequestPromise = this.queuedInvokeQueryRequests.get(mapKey);
+    if (!queuedRequestPromise) {
       if (
         !this.hasActiveSubscriptions &&
         !this.hasActiveExecuteRequests &&
@@ -535,13 +610,17 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       ) {
         void this.attemptClose();
       }
-    });
+      return;
+    }
 
-    // asynchronous, fire and forget
-    this.sendRequestMessage<Variables>(executeBody).catch(err => {
-      rejectFn(err);
-    });
-    return responsePromise;
+    this.queuedInvokeQueryRequests.delete(mapKey);
+
+    void this.executeOrResumeQuery(
+      queryName,
+      variables,
+      mapKey,
+      queuedRequestPromise
+    );
   }
 
   /**

--- a/packages/data-connect/src/network/stream/streamTransport.ts
+++ b/packages/data-connect/src/network/stream/streamTransport.ts
@@ -47,7 +47,7 @@ const IDLE_CONNECTION_TIMEOUT_MS = 60 * 1000; // 1 minute
 /**
  * A promise that is settled for a request is received, and the functions that resolve or reject it.
  */
-interface TrackedExecuteRequestPromise<Data> {
+interface InvokeQueryPromise<Data> {
   responsePromise: Promise<DataConnectResponse<Data>>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   resolveFn: (data: any) => void;
@@ -78,14 +78,14 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
 
   /** True if there are active subscriptions on the stream */
   get hasActiveSubscriptions(): boolean {
-    return this.activeSubscribeRequests.size > 0;
+    return this.activeInvokeSubscribeRequests.size > 0;
   }
 
   /** True if there are active execute or mutation requests on the stream */
   get hasActiveExecuteRequests(): boolean {
     return (
-      this.activeQueryExecuteRequests.size > 0 ||
-      this.activeMutationExecuteRequests.size > 0
+      this.activeInvokeQueryRequests.size > 0 ||
+      this.activeInvokeMutationRequests.size > 0
     );
   }
 
@@ -131,7 +131,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
   /**
    * Map of query/variables to their active execute/resume request bodies.
    */
-  private activeQueryExecuteRequests = new Map<
+  private activeInvokeQueryRequests = new Map<
     string,
     ExecuteStreamRequest<unknown> | ResumeStreamRequest
   >();
@@ -139,7 +139,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
   /**
    * Map of mutation/variables to their active execute request bodies.
    */
-  private activeMutationExecuteRequests = new Map<
+  private activeInvokeMutationRequests = new Map<
     string,
     Array<ExecuteStreamRequest<unknown>>
   >();
@@ -147,7 +147,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
   /**
    * Map of query/variables to their active subscribe request bodies.
    */
-  private activeSubscribeRequests = new Map<
+  private activeInvokeSubscribeRequests = new Map<
     string,
     SubscribeStreamRequest<unknown>
   >();
@@ -157,7 +157,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
    */
   private executeRequestPromises = new Map<
     string,
-    TrackedExecuteRequestPromise<unknown>
+    InvokeQueryPromise<unknown>
   >();
 
   /**
@@ -182,11 +182,11 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
    * @remarks
    * This method returns a promise, but is synchronous.
    */
-  private trackQueryExecuteRequest<Data>(
+  private trackInvokeQueryRequest<Data>(
     requestId: string,
     mapKey: string,
     executeBody: ExecuteStreamRequest<unknown>
-  ): TrackedExecuteRequestPromise<Data> {
+  ): InvokeQueryPromise<Data> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let resolveFn: (data: any) => void;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -197,13 +197,13 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
         rejectFn = reject;
       }
     );
-    const executeRequestPromise: TrackedExecuteRequestPromise<Data> = {
+    const executeRequestPromise: InvokeQueryPromise<Data> = {
       responsePromise,
       resolveFn: resolveFn!,
       rejectFn: rejectFn!
     };
 
-    this.activeQueryExecuteRequests.set(mapKey, executeBody);
+    this.activeInvokeQueryRequests.set(mapKey, executeBody);
     this.executeRequestPromises.set(requestId, executeRequestPromise);
 
     return executeRequestPromise;
@@ -217,11 +217,11 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
    * @remarks
    * This method returns a promise, but is synchronous.
    */
-  private trackMutationExecuteRequest<Data>(
+  private trackInvokeMutationRequest<Data>(
     requestId: string,
     mapKey: string,
     executeBody: ExecuteStreamRequest<unknown>
-  ): TrackedExecuteRequestPromise<Data> {
+  ): InvokeQueryPromise<Data> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let resolveFn: (data: any) => void;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -232,15 +232,15 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
         rejectFn = reject;
       }
     );
-    const executeRequestPromise: TrackedExecuteRequestPromise<Data> = {
+    const executeRequestPromise: InvokeQueryPromise<Data> = {
       responsePromise,
       resolveFn: resolveFn!,
       rejectFn: rejectFn!
     };
 
-    const activeRequests = this.activeMutationExecuteRequests.get(mapKey) || [];
+    const activeRequests = this.activeInvokeMutationRequests.get(mapKey) || [];
     activeRequests.push(executeBody);
-    this.activeMutationExecuteRequests.set(mapKey, activeRequests);
+    this.activeInvokeMutationRequests.set(mapKey, activeRequests);
     this.executeRequestPromises.set(requestId, executeRequestPromise);
 
     return executeRequestPromise;
@@ -251,13 +251,13 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
    * @remarks
    * This method is synchronous.
    */
-  private trackSubscribeRequest<Data>(
+  private trackInvokeSubscribeRequest<Data>(
     requestId: string,
     mapKey: string,
     subscribeBody: SubscribeStreamRequest<unknown>,
     observer: SubscribeObserver<Data>
   ): void {
-    this.activeSubscribeRequests.set(mapKey, subscribeBody);
+    this.activeInvokeSubscribeRequests.set(mapKey, subscribeBody);
     this.subscribeObservers.set(
       requestId,
       observer as SubscribeObserver<unknown>
@@ -268,8 +268,8 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
    * Cleans up the query execute request tracking data structures, deleting the tracked request and
    * it's associated promise.
    */
-  private cleanupQueryExecuteRequest(requestId: string, mapKey: string): void {
-    this.activeQueryExecuteRequests.delete(mapKey);
+  private cleanupInvokeQueryRequest(requestId: string, mapKey: string): void {
+    this.activeInvokeQueryRequests.delete(mapKey);
     this.executeRequestPromises.delete(requestId);
   }
 
@@ -277,19 +277,19 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
    * Cleans up the mutation execute request tracking data structures, deleting the tracked request and
    * it's associated promise.
    */
-  private cleanupMutationExecuteRequest(
+  private cleanupInvokeMutationRequest(
     requestId: string,
     mapKey: string
   ): void {
-    const executeRequests = this.activeMutationExecuteRequests.get(mapKey);
+    const executeRequests = this.activeInvokeMutationRequests.get(mapKey);
     if (executeRequests) {
       const updatedRequests = executeRequests.filter(
         req => req.requestId !== requestId
       );
       if (updatedRequests.length > 0) {
-        this.activeMutationExecuteRequests.set(mapKey, updatedRequests);
+        this.activeInvokeMutationRequests.set(mapKey, updatedRequests);
       } else {
-        this.activeMutationExecuteRequests.delete(mapKey);
+        this.activeInvokeMutationRequests.delete(mapKey);
       }
     }
     this.executeRequestPromises.delete(requestId);
@@ -299,8 +299,11 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
    * Cleans up the subscribe request tracking data structures, deleting the tracked request and
    * it's associated promise.
    */
-  private cleanupSubscribeRequest(requestId: string, mapKey: string): void {
-    this.activeSubscribeRequests.delete(mapKey);
+  private cleanupInvokeSubscribeRequest(
+    requestId: string,
+    mapKey: string
+  ): void {
+    this.activeInvokeSubscribeRequests.delete(mapKey);
     this.subscribeObservers.delete(requestId);
   }
 
@@ -348,11 +351,12 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
   }
 
   /**
-   * Begin closing the connection. Waits for and cleans up all active requests, and waits for
-   * {@link IDLE_CONNECTION_TIMEOUT_MS}. This is a graceful close - it will be called when there are
-   * no more active subscriptions, so there's no need to cleanup.
+   * Begin closing the connection. Waits for {@link IDLE_CONNECTION_TIMEOUT_MS} without cleaning up
+   * and requests (meaning it will not close after the timeout unless the requests are closed first).
+   * This is a graceful close - it will be called when there are no more active subscriptions, so
+   * there's no need to cleanup.
    */
-  private prepareToCloseGracefully(): void {
+  private closeAfterTimeout(): void {
     if (this.pendingClose) {
       return;
     }
@@ -379,10 +383,10 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
    * Reject all active execute promises and notify all subscribe observers with the given error.
    * Clear active request tracking maps without cancelling or re-invoking any requests.
    */
-  private rejectAllActiveRequests(code: Code, reason: string): void {
-    this.activeQueryExecuteRequests.clear();
-    this.activeMutationExecuteRequests.clear();
-    this.activeSubscribeRequests.clear();
+  private rejectAllRequests(code: Code, reason: string): void {
+    this.activeInvokeQueryRequests.clear();
+    this.activeInvokeMutationRequests.clear();
+    this.activeInvokeSubscribeRequests.clear();
 
     const error = new DataConnectError(code, reason);
     for (const [requestId, { rejectFn }] of this.executeRequestPromises) {
@@ -400,7 +404,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
    * Called by concrete implementations when the stream is successfully closed, gracefully or otherwise.
    */
   protected onStreamClose(code: number, reason: string): void {
-    this.rejectAllActiveRequests(
+    this.rejectAllRequests(
       Code.OTHER,
       `Stream disconnected with code ${code}: ${reason}`
     );
@@ -511,13 +515,13 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       execute: activeRequestKey
     };
 
-    let { responsePromise, rejectFn } = this.trackQueryExecuteRequest<Data>(
+    let { responsePromise, rejectFn } = this.trackInvokeQueryRequest<Data>(
       requestId,
       mapKey,
       executeBody
     );
     responsePromise = responsePromise.finally(() => {
-      this.cleanupQueryExecuteRequest(requestId, mapKey);
+      this.cleanupInvokeQueryRequest(requestId, mapKey);
       if (
         !this.hasActiveSubscriptions &&
         !this.hasActiveExecuteRequests &&
@@ -553,13 +557,13 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       execute: activeRequestKey
     };
 
-    let { responsePromise, rejectFn } = this.trackMutationExecuteRequest<Data>(
+    let { responsePromise, rejectFn } = this.trackInvokeMutationRequest<Data>(
       requestId,
       mapKey,
       executeBody
     );
     responsePromise = responsePromise.finally(() => {
-      this.cleanupMutationExecuteRequest(requestId, mapKey);
+      this.cleanupInvokeMutationRequest(requestId, mapKey);
       if (
         !this.hasActiveSubscriptions &&
         !this.hasActiveExecuteRequests &&
@@ -600,7 +604,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       subscribe: activeRequestKey
     };
 
-    this.trackSubscribeRequest<Data>(
+    this.trackInvokeSubscribeRequest<Data>(
       requestId,
       mapKey,
       subscribeBody,
@@ -610,9 +614,9 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     // asynchronous, fire and forget
     this.sendRequestMessage<Variables>(subscribeBody).catch(err => {
       observer.onError(err instanceof Error ? err : new Error(String(err)));
-      this.cleanupSubscribeRequest(requestId, mapKey);
+      this.cleanupInvokeSubscribeRequest(requestId, mapKey);
       if (!this.hasActiveSubscriptions) {
-        this.prepareToCloseGracefully();
+        this.closeAfterTimeout();
       }
     });
   }
@@ -626,7 +630,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
    */
   invokeUnsubscribe<Variables>(queryName: string, variables: Variables): void {
     const mapKey = this.getMapKey(queryName, variables);
-    const subscribeRequest = this.activeSubscribeRequests.get(mapKey);
+    const subscribeRequest = this.activeInvokeSubscribeRequests.get(mapKey);
     if (!subscribeRequest) {
       return;
     }
@@ -636,7 +640,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       cancel: {}
     };
 
-    this.cleanupSubscribeRequest(requestId, mapKey);
+    this.cleanupInvokeSubscribeRequest(requestId, mapKey);
 
     // asynchronous, fire and forget
     this.sendRequestMessage(cancelBody).catch(err => {
@@ -644,7 +648,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     });
 
     if (!this.hasActiveSubscriptions) {
-      this.prepareToCloseGracefully();
+      this.closeAfterTimeout();
     }
   }
 
@@ -668,7 +672,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       (!oldAuthUid && newAuthUid) || // user logged in
       (oldAuthUid && newAuthUid !== oldAuthUid) // logged in user changed
     ) {
-      this.rejectAllActiveRequests(
+      this.rejectAllRequests(
         Code.UNAUTHORIZED,
         'Stream disconnected due to auth change.'
       );

--- a/packages/data-connect/src/network/stream/streamTransport.ts
+++ b/packages/data-connect/src/network/stream/streamTransport.ts
@@ -678,12 +678,17 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     queryName: string,
     variables: Variables
   ): void {
+    const mapKey = this.getMapKey(queryName, variables);
+
+    if (this.activeInvokeSubscribeRequests.has(mapKey)) {
+      // de-duplicate subscribe requests
+      return;
+    }
+
     // if we are waiting to close the stream, cancel closing!
     this.cancelClose();
-
     const requestId = this.nextRequestId();
     const activeRequestKey = { operationName: queryName, variables };
-    const mapKey = this.getMapKey(queryName, variables);
     const subscribeBody: SubscribeStreamRequest<Variables> = {
       requestId,
       subscribe: activeRequestKey

--- a/packages/data-connect/src/network/stream/streamTransport.ts
+++ b/packages/data-connect/src/network/stream/streamTransport.ts
@@ -682,6 +682,8 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
 
     if (this.activeInvokeSubscribeRequests.has(mapKey)) {
       // de-duplicate subscribe requests
+      // the Query Layer also de-dupes subscribe requests, but this is here for good measure.
+      // note that we do not multiplex observers here, that is handled by the Query Layer.
       return;
     }
 

--- a/packages/data-connect/src/network/stream/streamTransport.ts
+++ b/packages/data-connect/src/network/stream/streamTransport.ts
@@ -45,7 +45,7 @@ const FIRST_REQUEST_ID = 1;
 const IDLE_CONNECTION_TIMEOUT_MS = 60 * 1000; // 1 minute
 
 /**
- * A promise returned to the user from when invoking an operation, and the functions that resolve/reject it.
+ * A promise returned to the user when invoking an operation, and the functions that resolve/reject it.
  */
 interface InvokeOperationPromise<Data> {
   responsePromise: Promise<DataConnectResponse<Data>>;

--- a/packages/data-connect/src/network/stream/streamTransport.ts
+++ b/packages/data-connect/src/network/stream/streamTransport.ts
@@ -38,16 +38,16 @@ import {
   SubscribeStreamRequest
 } from './wire';
 
-/** The request id of the first request over the stream */
+/** The Request ID of the first request over the stream */
 const FIRST_REQUEST_ID = 1;
 
-/** Time to wait before closing an idle connection (no active subscriptions) */
+/** Time to wait before closing an idle connection (no active subscriptions). */
 const IDLE_CONNECTION_TIMEOUT_MS = 60 * 1000; // 1 minute
 
 /**
- * A promise that is settled for a request is received, and the functions that resolve or reject it.
+ * A promise returned to the user from when invoking an operation, and the functions that resolve/reject it.
  */
-interface InvokeQueryPromise<Data> {
+interface InvokeOperationPromise<Data> {
   responsePromise: Promise<DataConnectResponse<Data>>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   resolveFn: (data: any) => void;
@@ -56,8 +56,9 @@ interface InvokeQueryPromise<Data> {
 }
 
 /**
- * The base class for all {@link DataConnectStreamTransport | Stream Transport} implementations.
- * Handles management of logical streams (requests), authentication, data routing to query layer, etc.
+ * The base class for all Stream Transport implementations.
+ * Handles management of logical streams (requests), authentication, data routing to query layer,
+ * request optimizations, etc.
  * @internal
  */
 export abstract class AbstractDataConnectStreamTransport extends AbstractDataConnectTransport {
@@ -97,14 +98,13 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
 
   /**
    * Close the physical connection with the server. Handles no cleanup - simply closes the
-   * implementation-specific connection.
+   * implementation-specific connection. On failure to close, the connection is still considered closed.
    * @returns a promise which resolves when the connection is closed, or rejects if it fails to close.
-   * On failure to close, the connection is still considered closed.
    */
   protected abstract closeConnection(): Promise<void>;
 
   /**
-   * Queue a message to be sent over the stream.
+   * Queue a {@linkcode DataConnectStreamRequest} to be sent over the stream.
    * @param requestBody The body of the message to be sent.
    * @throws DataConnectError if sending fails.
    */
@@ -119,17 +119,20 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
    */
   protected abstract ensureConnection(): Promise<void>;
 
-  /** The request ID of the next message to be sent. Monotonically increasing sequence number. */
+  /** The Request ID of the next message to be sent. Monotonically increasing sequence number starting at {@linkcode FIRST_REQUEST_ID}. */
   private requestNumber = FIRST_REQUEST_ID;
   /**
-   * Generates and returns the next request ID.
+   * Generates and returns the next Request ID. Starts at {@linkcode FIRST_REQUEST_ID} and increments
+   * for each request sent.
    */
   private nextRequestId(): string {
     return (this.requestNumber++).toString();
   }
 
   /**
-   * Map of query/variables to their active execute/resume request bodies.
+   * Map of query/variables to their active {@linkcode ExecuteStreamRequest} or {@linkcode ResumeStreamRequest}
+   * request bodies. These requests are de-duplicated by query/variables so that there is only one active
+   * request for each query/variables combination.
    */
   private activeInvokeQueryRequests = new Map<
     string,
@@ -137,7 +140,9 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
   >();
 
   /**
-   * Map of mutation/variables to their active execute request bodies.
+   * Map of mutation/variables to their active {@linkcode ExecuteStreamRequest} request bodies. Mutations
+   * can have more than one active request at a time as they are not idempotent, and therefore should
+   * not be de-duplicated.
    */
   private activeInvokeMutationRequests = new Map<
     string,
@@ -145,7 +150,8 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
   >();
 
   /**
-   * Map of query/variables to their active subscribe request bodies.
+   * Map of query/variables to their active {@linkcode SubscribeStreamRequest} request bodies. There
+   * may only be one active request for each query/variables combination.
    */
   private activeInvokeSubscribeRequests = new Map<
     string,
@@ -153,15 +159,16 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
   >();
 
   /**
-   * Map of active execution RequestIds and their corresponding Promises and resolvers.
+   * Map of active {@linkcode invokeQuery} and {@linkcode invokeMutation} RequestIds and their
+   * corresponding {@linkcode InvokeOperationPromise}.
    */
-  private executeRequestPromises = new Map<
+  private invokeOperationPromises = new Map<
     string,
-    InvokeQueryPromise<unknown>
+    InvokeOperationPromise<unknown>
   >();
 
   /**
-   * Map of active subscription RequestIds and their corresponding observers.
+   * Map of active {@linkcode invokeSubscribe} RequestIds and their corresponding {@linkcode SubscribeObserver}.
    */
   private subscribeObservers = new Map<string, SubscribeObserver<unknown>>();
 
@@ -175,9 +182,9 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
   private hasWaitedForInitialAuth = false;
 
   /**
-   * Tracks a query execution request, storing the request body and creating and storing a promise that
-   * will be resolved when the response is received.
-   * @returns The reject function and the response promise.
+   * Tracks an {@linkcode invokeQuery} request, storing the request body and creating and storing a
+   * response promise that will be resolved when the response is received.
+   * @returns The tracked {@linkcode InvokeOperationPromise}.
    *
    * @remarks
    * This method returns a promise, but is synchronous.
@@ -186,7 +193,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     requestId: string,
     mapKey: string,
     executeBody: ExecuteStreamRequest<unknown>
-  ): InvokeQueryPromise<Data> {
+  ): InvokeOperationPromise<Data> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let resolveFn: (data: any) => void;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -197,22 +204,22 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
         rejectFn = reject;
       }
     );
-    const executeRequestPromise: InvokeQueryPromise<Data> = {
+    const executeRequestPromise: InvokeOperationPromise<Data> = {
       responsePromise,
       resolveFn: resolveFn!,
       rejectFn: rejectFn!
     };
 
     this.activeInvokeQueryRequests.set(mapKey, executeBody);
-    this.executeRequestPromises.set(requestId, executeRequestPromise);
+    this.invokeOperationPromises.set(requestId, executeRequestPromise);
 
     return executeRequestPromise;
   }
 
   /**
-   * Tracks a mutation execution request, storing the request body and creating and storing a promise
-   * that will be resolved when the response is received.
-   * @returns The reject function and the response promise.
+   * Tracks an {@linkcode invokeMutation} request, storing the request body and creating and storing a
+   * response promise that will be resolved when the response is received.
+   * @returns The tracked {@linkcode InvokeOperationPromise}.
    *
    * @remarks
    * This method returns a promise, but is synchronous.
@@ -221,7 +228,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     requestId: string,
     mapKey: string,
     executeBody: ExecuteStreamRequest<unknown>
-  ): InvokeQueryPromise<Data> {
+  ): InvokeOperationPromise<Data> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let resolveFn: (data: any) => void;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -232,7 +239,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
         rejectFn = reject;
       }
     );
-    const executeRequestPromise: InvokeQueryPromise<Data> = {
+    const executeRequestPromise: InvokeOperationPromise<Data> = {
       responsePromise,
       resolveFn: resolveFn!,
       rejectFn: rejectFn!
@@ -241,13 +248,13 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     const activeRequests = this.activeInvokeMutationRequests.get(mapKey) || [];
     activeRequests.push(executeBody);
     this.activeInvokeMutationRequests.set(mapKey, activeRequests);
-    this.executeRequestPromises.set(requestId, executeRequestPromise);
+    this.invokeOperationPromises.set(requestId, executeRequestPromise);
 
     return executeRequestPromise;
   }
 
   /**
-   * Tracks a subscribe request, storing the request body and the notification observer.
+   * Tracks an {@linkcode invokeSubscribe} request, storing the request body and the {@linkcode SubscribeObserver}.
    * @remarks
    * This method is synchronous.
    */
@@ -270,7 +277,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
    */
   private cleanupInvokeQueryRequest(requestId: string, mapKey: string): void {
     this.activeInvokeQueryRequests.delete(mapKey);
-    this.executeRequestPromises.delete(requestId);
+    this.invokeOperationPromises.delete(requestId);
   }
 
   /**
@@ -292,7 +299,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
         this.activeInvokeMutationRequests.delete(mapKey);
       }
     }
-    this.executeRequestPromises.delete(requestId);
+    this.invokeOperationPromises.delete(requestId);
   }
 
   /**
@@ -339,7 +346,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
 
   /**
    * Attempt to close the connection. Will only close if there are no active requests preventing it
-   * from doing so.
+   * from doing so. Does not respect any {@linkcode closeTimeout}.
    */
   private async attemptClose(): Promise<void> {
     if (this.hasActiveSubscriptions || this.hasActiveExecuteRequests) {
@@ -351,8 +358,8 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
   }
 
   /**
-   * Begin closing the connection. Waits for {@link IDLE_CONNECTION_TIMEOUT_MS} without cleaning up
-   * and requests (meaning it will not close after the timeout unless the requests are closed first).
+   * Begin closing the connection. Waits for {@linkcode IDLE_CONNECTION_TIMEOUT_MS} without cleaning up
+   * any requests (meaning it will not close after the timeout unless the requests are closed first).
    * This is a graceful close - it will be called when there are no more active subscriptions, so
    * there's no need to cleanup.
    */
@@ -389,8 +396,8 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     this.activeInvokeSubscribeRequests.clear();
 
     const error = new DataConnectError(code, reason);
-    for (const [requestId, { rejectFn }] of this.executeRequestPromises) {
-      this.executeRequestPromises.delete(requestId);
+    for (const [requestId, { rejectFn }] of this.invokeOperationPromises) {
+      this.invokeOperationPromises.delete(requestId);
       rejectFn(error);
     }
 
@@ -447,7 +454,6 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     return preparedRequestBody;
   }
 
-  // TODO(stephenarosaj): just make this async
   /**
    * Sends a request message to the server via the concrete implementation.
    * Ensures the connection is ready and prepares the message before sending.
@@ -471,7 +477,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
   }
 
   /**
-   * Helper to generate a consistent string key for the tracking maps.
+   * Helper to generate a consistent string key for the request tracking maps.
    */
   private getMapKey(operationName: string, variables?: unknown): string {
     const sortedVariables = this.sortObjectKeys(variables);
@@ -682,18 +688,18 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
 
   /**
    * Handle a response message from the server. Called by the connection-specific implementation after
-   * it's transformed a message from the server into a {@link DataConnectResponse}.
-   * @param requestId the requestId associated with this response.
+   * it's transformed a message from the server into a {@linkcode DataConnectResponse}.
+   * @param requestId the Request ID associated with this response.
    * @param response the response from the server.
    */
   protected async handleResponse<Data>(
     requestId: string,
     response: DataConnectResponse<Data>
   ): Promise<void> {
-    if (this.executeRequestPromises.has(requestId)) {
+    if (this.invokeOperationPromises.has(requestId)) {
       // don't clean up the tracking maps here, they're handled automatically when the execute promise settles
       const { resolveFn, rejectFn } =
-        this.executeRequestPromises.get(requestId)!;
+        this.invokeOperationPromises.get(requestId)!;
       if (response.errors && response.errors.length) {
         const failureResponse: DataConnectOperationFailureResponse = {
           errors: response.errors as [],

--- a/packages/data-connect/test/unit/streamTransport.test.ts
+++ b/packages/data-connect/test/unit/streamTransport.test.ts
@@ -677,6 +677,98 @@ describe('AbstractDataConnectStreamTransport', () => {
           const requestId = sendMessageStub.firstCall.args[0].requestId;
           expect(transport.invokeOperationPromises.has(requestId)).to.be.false;
         });
+
+        describe('de-duplication', () => {
+          it('should NOT de-duplicate identical mutation requests', async () => {
+            const sendMessageSpy = sinon.spy(transport, 'sendMessage');
+
+            const promises = [];
+            for (let i = 1; i <= 5; i++) {
+              promises.push(
+                transport.invokeMutation(mutationName1, variables1)
+              );
+            }
+
+            expect(sendMessageSpy.callCount).to.equal(5);
+
+            const mapKey = transport.getMapKey(mutationName1, variables1);
+            const requests = transport.activeInvokeMutationRequests.get(mapKey);
+            expect(requests).to.have.lengthOf(5);
+
+            for (let i = 0; i < 5; i++) {
+              for (let j = i + 1; j < 5; j++) {
+                expect(promises[i]).to.not.equal(promises[j]);
+              }
+            }
+          });
+
+          it('mutation requests should resolve totally independent of one another', async () => {
+            const sendMessageSpy = sinon.spy(transport, 'sendMessage');
+
+            const promise1 = transport.invokeMutation(
+              mutationName1,
+              variables1
+            );
+            const promise2 = transport.invokeMutation(
+              mutationName1,
+              variables1
+            );
+            const promise3 = transport.invokeMutation(
+              mutationName1,
+              variables1
+            );
+
+            expect(sendMessageSpy.callCount).to.equal(3);
+
+            const mapKey = transport.getMapKey(mutationName1, variables1);
+            const requests = transport.activeInvokeMutationRequests.get(mapKey);
+            expect(requests).to.have.lengthOf(3);
+
+            const requestId1 = requests![0].requestId;
+            const requestId2 = requests![1].requestId;
+            const requestId3 = requests![2].requestId;
+
+            const response1 = {
+              data: { result: '1' },
+              errors: [],
+              extensions: {}
+            };
+            const response2 = {
+              data: { result: '2' },
+              errors: [],
+              extensions: {}
+            };
+            const response3 = {
+              data: { result: '3' },
+              errors: [],
+              extensions: {}
+            };
+
+            await transport.invokeHandleResponse(requestId1, response1);
+            await expect(promise1).to.eventually.deep.equal(response1);
+            await expectIsNotSettled(promise2, 100);
+            await expectIsNotSettled(promise3, 100);
+
+            await transport.invokeHandleResponse(requestId2, response2);
+            await expect(promise1).to.eventually.deep.equal(response1);
+            await expect(promise2).to.eventually.deep.equal(response2);
+            await expectIsNotSettled(promise3, 100);
+
+            await transport.invokeHandleResponse(requestId3, response3);
+            await expect(promise1).to.eventually.deep.equal(response1);
+            await expect(promise2).to.eventually.deep.equal(response2);
+            await expect(promise3).to.eventually.deep.equal(response3);
+
+            expect(transport.activeInvokeMutationRequests.has(mapKey)).to.be
+              .false;
+            expect(transport.invokeOperationPromises.has(requestId1)).to.be
+              .false;
+            expect(transport.invokeOperationPromises.has(requestId2)).to.be
+              .false;
+            expect(transport.invokeOperationPromises.has(requestId3)).to.be
+              .false;
+          });
+        });
       });
 
       describe('invokeSubscribe', () => {
@@ -708,6 +800,17 @@ describe('AbstractDataConnectStreamTransport', () => {
           expect(sentMessage.subscribe).to.not.be.undefined;
           expect(sentMessage.subscribe?.operationName).to.equal(queryName1);
           expect(sentMessage.subscribe?.variables).to.deep.equal(variables1);
+        });
+ 
+        it('should NOT de-duplicate identical subscribe requests', async () => {
+          const sendMessageSpy = sinon.spy(transport, 'sendMessage');
+          const observer1 = { onData: sinon.spy(), onDisconnect: sinon.spy(), onError: sinon.spy() };
+          const observer2 = { onData: sinon.spy(), onDisconnect: sinon.spy(), onError: sinon.spy() };
+ 
+          transport.invokeSubscribe(observer1, queryName1, variables1);
+          transport.invokeSubscribe(observer2, queryName1, variables1);
+ 
+          expect(sendMessageSpy.callCount).to.equal(2);
         });
 
         it('should asynchronously call observer with error and clean up if sendMessage fails', async () => {

--- a/packages/data-connect/test/unit/streamTransport.test.ts
+++ b/packages/data-connect/test/unit/streamTransport.test.ts
@@ -138,7 +138,7 @@ interface TransportWithInternals {
     Array<ExecuteStreamRequest<unknown>>
   >;
   activeInvokeSubscribeRequests: Map<string, SubscribeStreamRequest<unknown>>;
-  executeRequestPromises: Map<
+  invokeOperationPromises: Map<
     string,
     {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -469,7 +469,7 @@ describe('AbstractDataConnectStreamTransport', () => {
 
           const requestId = (request as ExecuteStreamRequest<unknown>)
             .requestId;
-          expect(transport.executeRequestPromises.has(requestId)).to.be.true;
+          expect(transport.invokeOperationPromises.has(requestId)).to.be.true;
 
           expect(sendMessageSpy).to.have.been.calledOnce;
           const sentMessage = sendMessageSpy.firstCall.args[0];
@@ -492,7 +492,7 @@ describe('AbstractDataConnectStreamTransport', () => {
           expect(transport.activeInvokeQueryRequests.has(mapKey)).to.be.false;
 
           const requestId = sendMessageStub.firstCall.args[0].requestId;
-          expect(transport.executeRequestPromises.has(requestId)).to.be.false;
+          expect(transport.invokeOperationPromises.has(requestId)).to.be.false;
         });
       });
 
@@ -511,7 +511,7 @@ describe('AbstractDataConnectStreamTransport', () => {
           expect(requests).to.have.lengthOf(1);
           expect(requests![0].execute?.operationName).to.equal(mutationName1);
           const requestId = requests![0].requestId;
-          expect(transport.executeRequestPromises.has(requestId)).to.be.true;
+          expect(transport.invokeOperationPromises.has(requestId)).to.be.true;
 
           expect(sendMessageSpy).to.have.been.calledOnce;
           const sentMessage = sendMessageSpy.firstCall.args[0];
@@ -538,7 +538,7 @@ describe('AbstractDataConnectStreamTransport', () => {
             .false;
 
           const requestId = sendMessageStub.firstCall.args[0].requestId;
-          expect(transport.executeRequestPromises.has(requestId)).to.be.false;
+          expect(transport.invokeOperationPromises.has(requestId)).to.be.false;
         });
       });
 
@@ -820,15 +820,15 @@ describe('AbstractDataConnectStreamTransport', () => {
           await transport.invokeHandleResponse(requestId1, errorResponse);
           expect(transport.activeInvokeQueryRequests.has(expectedKey1)).to.be
             .false;
-          expect(transport.executeRequestPromises.has(requestId1)).to.be.false;
+          expect(transport.invokeOperationPromises.has(requestId1)).to.be.false;
           expect(transport.activeInvokeQueryRequests.has(expectedKey2)).to.be
             .true;
-          expect(transport.executeRequestPromises.has(requestId2)).to.be.true;
+          expect(transport.invokeOperationPromises.has(requestId2)).to.be.true;
 
           await transport.invokeHandleResponse(requestId2, errorResponse);
           expect(transport.activeInvokeQueryRequests.has(expectedKey2)).to.be
             .false;
-          expect(transport.executeRequestPromises.has(requestId2)).to.be.false;
+          expect(transport.invokeOperationPromises.has(requestId2)).to.be.false;
         });
       });
 
@@ -883,16 +883,16 @@ describe('AbstractDataConnectStreamTransport', () => {
 
           await transport.invokeHandleResponse(requestId1, response1);
           await mutationPromise1;
-          expect(transport.executeRequestPromises.has(requestId1)).to.be.false;
+          expect(transport.invokeOperationPromises.has(requestId1)).to.be.false;
           expect(transport.activeInvokeMutationRequests.has(expectedKey1)).to.be
             .false;
-          expect(transport.executeRequestPromises.has(requestId2)).to.be.true;
+          expect(transport.invokeOperationPromises.has(requestId2)).to.be.true;
           expect(transport.activeInvokeMutationRequests.has(expectedKey2)).to.be
             .true;
 
           await transport.invokeHandleResponse(requestId2, response2);
           await mutationPromise2;
-          expect(transport.executeRequestPromises.has(requestId2)).to.be.false;
+          expect(transport.invokeOperationPromises.has(requestId2)).to.be.false;
           expect(transport.activeInvokeMutationRequests.has(expectedKey2)).to.be
             .false;
         });
@@ -946,15 +946,15 @@ describe('AbstractDataConnectStreamTransport', () => {
           await transport.invokeHandleResponse(requestId1, errorResponse);
           expect(transport.activeInvokeMutationRequests.has(expectedKey1)).to.be
             .false;
-          expect(transport.executeRequestPromises.has(requestId1)).to.be.false;
+          expect(transport.invokeOperationPromises.has(requestId1)).to.be.false;
           expect(transport.activeInvokeMutationRequests.has(expectedKey2)).to.be
             .true;
-          expect(transport.executeRequestPromises.has(requestId2)).to.be.true;
+          expect(transport.invokeOperationPromises.has(requestId2)).to.be.true;
 
           await transport.invokeHandleResponse(requestId2, errorResponse);
           expect(transport.activeInvokeMutationRequests.has(expectedKey2)).to.be
             .false;
-          expect(transport.executeRequestPromises.has(requestId2)).to.be.false;
+          expect(transport.invokeOperationPromises.has(requestId2)).to.be.false;
         });
       });
 

--- a/packages/data-connect/test/unit/streamTransport.test.ts
+++ b/packages/data-connect/test/unit/streamTransport.test.ts
@@ -129,23 +129,23 @@ interface TransportWithInternals {
   >(
     requestBody: StreamBody
   ): StreamBody;
-  activeQueryExecuteRequests: Map<
+  activeInvokeQueryRequests: Map<
     string,
     ExecuteStreamRequest<unknown> | ResumeStreamRequest
   >;
-  activeMutationExecuteRequests: Map<
+  activeInvokeMutationRequests: Map<
     string,
     Array<ExecuteStreamRequest<unknown>>
   >;
-  activeSubscribeRequests: Map<string, SubscribeStreamRequest<unknown>>;
+  activeInvokeSubscribeRequests: Map<string, SubscribeStreamRequest<unknown>>;
   executeRequestPromises: Map<
     string,
     {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      resolve: (data: any) => void;
+      resolveFn: (response: DataConnectResponse<any>) => void;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      reject: (err: any) => void;
-      promise: Promise<DataConnectResponse<unknown>>;
+      rejectFn: (reason: any) => void;
+      responsePromise: Promise<DataConnectResponse<unknown>>;
     }
   >;
   subscribeObservers: Map<string, unknown>;
@@ -461,9 +461,9 @@ describe('AbstractDataConnectStreamTransport', () => {
           const queryPromise = transport.invokeQuery(queryName1, variables1);
 
           const expectedKey = transport.getMapKey(queryName1, variables1);
-          expect(transport.activeQueryExecuteRequests.has(expectedKey)).to.be
+          expect(transport.activeInvokeQueryRequests.has(expectedKey)).to.be
             .true;
-          const request = transport.activeQueryExecuteRequests.get(expectedKey);
+          const request = transport.activeInvokeQueryRequests.get(expectedKey);
           expect(request?.execute?.operationName).to.equal(queryName1);
           expect(request?.execute?.variables).to.deep.equal(variables1);
 
@@ -489,7 +489,7 @@ describe('AbstractDataConnectStreamTransport', () => {
           await expect(queryPromise).to.be.rejectedWith(expectedError);
 
           const mapKey = transport.getMapKey(queryName1, variables1);
-          expect(transport.activeQueryExecuteRequests.has(mapKey)).to.be.false;
+          expect(transport.activeInvokeQueryRequests.has(mapKey)).to.be.false;
 
           const requestId = sendMessageStub.firstCall.args[0].requestId;
           expect(transport.executeRequestPromises.has(requestId)).to.be.false;
@@ -507,7 +507,7 @@ describe('AbstractDataConnectStreamTransport', () => {
 
           const expectedKey = transport.getMapKey(mutationName1, variables1);
           const requests =
-            transport.activeMutationExecuteRequests.get(expectedKey);
+            transport.activeInvokeMutationRequests.get(expectedKey);
           expect(requests).to.have.lengthOf(1);
           expect(requests![0].execute?.operationName).to.equal(mutationName1);
           const requestId = requests![0].requestId;
@@ -534,7 +534,7 @@ describe('AbstractDataConnectStreamTransport', () => {
           await expect(mutationPromise).to.be.rejectedWith(expectedError);
 
           const mapKey = transport.getMapKey(mutationName1, variables1);
-          expect(transport.activeMutationExecuteRequests.has(mapKey)).to.be
+          expect(transport.activeInvokeMutationRequests.has(mapKey)).to.be
             .false;
 
           const requestId = sendMessageStub.firstCall.args[0].requestId;
@@ -554,8 +554,10 @@ describe('AbstractDataConnectStreamTransport', () => {
           transport.invokeSubscribe(observer, queryName1, variables1);
 
           const expectedKey = transport.getMapKey(queryName1, variables1);
-          expect(transport.activeSubscribeRequests.has(expectedKey)).to.be.true;
-          const request = transport.activeSubscribeRequests.get(expectedKey);
+          expect(transport.activeInvokeSubscribeRequests.has(expectedKey)).to.be
+            .true;
+          const request =
+            transport.activeInvokeSubscribeRequests.get(expectedKey);
           expect(request?.subscribe?.operationName).to.equal(queryName1);
           expect(request?.subscribe?.variables).to.deep.equal(variables1);
 
@@ -590,7 +592,8 @@ describe('AbstractDataConnectStreamTransport', () => {
           expect(result).to.equal(expectedError);
 
           const mapKey = transport.getMapKey(queryName1, variables1);
-          expect(transport.activeSubscribeRequests.has(mapKey)).to.be.false;
+          expect(transport.activeInvokeSubscribeRequests.has(mapKey)).to.be
+            .false;
           const requestId = sendMessageStub.firstCall.args[0].requestId;
           expect(transport.subscribeObservers.has(requestId)).to.be.false;
         });
@@ -608,9 +611,10 @@ describe('AbstractDataConnectStreamTransport', () => {
           transport.invokeSubscribe(observer, queryName1, variables1);
 
           const expectedKey = transport.getMapKey(queryName1, variables1);
-          expect(transport.activeSubscribeRequests.has(expectedKey)).to.be.true;
+          expect(transport.activeInvokeSubscribeRequests.has(expectedKey)).to.be
+            .true;
           const subscribeRequest =
-            transport.activeSubscribeRequests.get(expectedKey);
+            transport.activeInvokeSubscribeRequests.get(expectedKey);
           const subscribeRequestId = (
             subscribeRequest as SubscribeStreamRequest<unknown>
           ).requestId;
@@ -622,7 +626,7 @@ describe('AbstractDataConnectStreamTransport', () => {
           expect(sendMessageSpy).to.have.been.calledTwice;
           const unsubscribeMessage = sendMessageSpy.secondCall.args[0];
 
-          expect(transport.activeSubscribeRequests.has(expectedKey)).to.be
+          expect(transport.activeInvokeSubscribeRequests.has(expectedKey)).to.be
             .false;
           expect(transport.subscribeObservers.has(subscribeRequestId)).to.be
             .false;
@@ -645,7 +649,7 @@ describe('AbstractDataConnectStreamTransport', () => {
 
           const expectedKey = transport.getMapKey(queryName1, variables1);
           const subscribeRequest =
-            transport.activeSubscribeRequests.get(expectedKey);
+            transport.activeInvokeSubscribeRequests.get(expectedKey);
           const subscribeRequestId = subscribeRequest?.requestId!;
 
           transport.invokeUnsubscribe(queryName1, variables1);
@@ -658,7 +662,7 @@ describe('AbstractDataConnectStreamTransport', () => {
             'Stream Transport failed to send unsubscribe message'
           );
 
-          expect(transport.activeSubscribeRequests.has(expectedKey)).to.be
+          expect(transport.activeInvokeSubscribeRequests.has(expectedKey)).to.be
             .false;
           expect(transport.subscribeObservers.has(subscribeRequestId)).to.be
             .false;
@@ -721,12 +725,12 @@ describe('AbstractDataConnectStreamTransport', () => {
 
           const expectedKey1 = transport.getMapKey(queryName1, variables1);
           const request1 =
-            transport.activeQueryExecuteRequests.get(expectedKey1);
+            transport.activeInvokeQueryRequests.get(expectedKey1);
           const requestId1 = (request1 as ExecuteStreamRequest<unknown>)
             .requestId;
           const expectedKey2 = transport.getMapKey(queryName2, variables2);
           const request2 =
-            transport.activeQueryExecuteRequests.get(expectedKey2);
+            transport.activeInvokeQueryRequests.get(expectedKey2);
           const requestId2 = (request2 as ExecuteStreamRequest<unknown>)
             .requestId;
 
@@ -745,28 +749,28 @@ describe('AbstractDataConnectStreamTransport', () => {
 
           const expectedKey1 = transport.getMapKey(queryName1, variables1);
           const request1 =
-            transport.activeQueryExecuteRequests.get(expectedKey1);
+            transport.activeInvokeQueryRequests.get(expectedKey1);
           const requestId1 = (request1 as ExecuteStreamRequest<unknown>)
             .requestId;
           const expectedKey2 = transport.getMapKey(queryName2, variables2);
           const request2 =
-            transport.activeQueryExecuteRequests.get(expectedKey2);
+            transport.activeInvokeQueryRequests.get(expectedKey2);
           const requestId2 = (request2 as ExecuteStreamRequest<unknown>)
             .requestId;
 
           await transport.invokeHandleResponse(requestId1, response1);
           await queryPromise1;
-          expect(transport.activeQueryExecuteRequests.has(expectedKey1)).to.be
+          expect(transport.activeInvokeQueryRequests.has(expectedKey1)).to.be
             .false;
-          expect(transport.activeQueryExecuteRequests.has(expectedKey2)).to.be
+          expect(transport.activeInvokeQueryRequests.has(expectedKey2)).to.be
             .true;
 
           await transport.invokeHandleResponse(requestId2, response2);
           await queryPromise2;
 
-          expect(transport.activeQueryExecuteRequests.has(expectedKey1)).to.be
+          expect(transport.activeInvokeQueryRequests.has(expectedKey1)).to.be
             .false;
-          expect(transport.activeQueryExecuteRequests.has(expectedKey2)).to.be
+          expect(transport.activeInvokeQueryRequests.has(expectedKey2)).to.be
             .false;
         });
 
@@ -776,11 +780,11 @@ describe('AbstractDataConnectStreamTransport', () => {
           const expectedKey1 = transport.getMapKey(queryName1, variables1);
           const expectedKey2 = transport.getMapKey(queryName2, variables2);
           const request1 =
-            transport.activeQueryExecuteRequests.get(expectedKey1);
+            transport.activeInvokeQueryRequests.get(expectedKey1);
           const requestId1 = (request1 as ExecuteStreamRequest<unknown>)
             .requestId;
           const request2 =
-            transport.activeQueryExecuteRequests.get(expectedKey2);
+            transport.activeInvokeQueryRequests.get(expectedKey2);
           const requestId2 = (request2 as ExecuteStreamRequest<unknown>)
             .requestId;
 
@@ -804,25 +808,25 @@ describe('AbstractDataConnectStreamTransport', () => {
 
           const expectedKey1 = transport.getMapKey(queryName1, variables1);
           const request1 =
-            transport.activeQueryExecuteRequests.get(expectedKey1);
+            transport.activeInvokeQueryRequests.get(expectedKey1);
           const requestId1 = (request1 as ExecuteStreamRequest<unknown>)
             .requestId;
           const expectedKey2 = transport.getMapKey(queryName2, variables2);
           const request2 =
-            transport.activeQueryExecuteRequests.get(expectedKey2);
+            transport.activeInvokeQueryRequests.get(expectedKey2);
           const requestId2 = (request2 as ExecuteStreamRequest<unknown>)
             .requestId;
 
           await transport.invokeHandleResponse(requestId1, errorResponse);
-          expect(transport.activeQueryExecuteRequests.has(expectedKey1)).to.be
+          expect(transport.activeInvokeQueryRequests.has(expectedKey1)).to.be
             .false;
           expect(transport.executeRequestPromises.has(requestId1)).to.be.false;
-          expect(transport.activeQueryExecuteRequests.has(expectedKey2)).to.be
+          expect(transport.activeInvokeQueryRequests.has(expectedKey2)).to.be
             .true;
           expect(transport.executeRequestPromises.has(requestId2)).to.be.true;
 
           await transport.invokeHandleResponse(requestId2, errorResponse);
-          expect(transport.activeQueryExecuteRequests.has(expectedKey2)).to.be
+          expect(transport.activeInvokeQueryRequests.has(expectedKey2)).to.be
             .false;
           expect(transport.executeRequestPromises.has(requestId2)).to.be.false;
         });
@@ -841,11 +845,11 @@ describe('AbstractDataConnectStreamTransport', () => {
 
           const expectedKey1 = transport.getMapKey(mutationName1, variables1);
           const activeRequests1 =
-            transport.activeMutationExecuteRequests.get(expectedKey1);
+            transport.activeInvokeMutationRequests.get(expectedKey1);
           const requestId1 = activeRequests1![0].requestId;
           const expectedKey2 = transport.getMapKey(mutationName2, variables2);
           const activeRequests2 =
-            transport.activeMutationExecuteRequests.get(expectedKey2);
+            transport.activeInvokeMutationRequests.get(expectedKey2);
           const requestId2 = activeRequests2![0].requestId;
 
           await transport.invokeHandleResponse(requestId1, response1);
@@ -870,27 +874,27 @@ describe('AbstractDataConnectStreamTransport', () => {
 
           const expectedKey1 = transport.getMapKey(mutationName1, variables1);
           const activeRequests1 =
-            transport.activeMutationExecuteRequests.get(expectedKey1);
+            transport.activeInvokeMutationRequests.get(expectedKey1);
           const requestId1 = activeRequests1![0].requestId;
           const expectedKey2 = transport.getMapKey(mutationName2, variables2);
           const activeRequests2 =
-            transport.activeMutationExecuteRequests.get(expectedKey2);
+            transport.activeInvokeMutationRequests.get(expectedKey2);
           const requestId2 = activeRequests2![0].requestId;
 
           await transport.invokeHandleResponse(requestId1, response1);
           await mutationPromise1;
           expect(transport.executeRequestPromises.has(requestId1)).to.be.false;
-          expect(transport.activeMutationExecuteRequests.has(expectedKey1)).to
-            .be.false;
+          expect(transport.activeInvokeMutationRequests.has(expectedKey1)).to.be
+            .false;
           expect(transport.executeRequestPromises.has(requestId2)).to.be.true;
-          expect(transport.activeMutationExecuteRequests.has(expectedKey2)).to
-            .be.true;
+          expect(transport.activeInvokeMutationRequests.has(expectedKey2)).to.be
+            .true;
 
           await transport.invokeHandleResponse(requestId2, response2);
           await mutationPromise2;
           expect(transport.executeRequestPromises.has(requestId2)).to.be.false;
-          expect(transport.activeMutationExecuteRequests.has(expectedKey2)).to
-            .be.false;
+          expect(transport.activeInvokeMutationRequests.has(expectedKey2)).to.be
+            .false;
         });
 
         it('should reject the correct mutation promise with DataConnectOperationError if response has errors', async () => {
@@ -904,11 +908,11 @@ describe('AbstractDataConnectStreamTransport', () => {
           );
           const expectedKey1 = transport.getMapKey(mutationName1, variables1);
           const activeRequests1 =
-            transport.activeMutationExecuteRequests.get(expectedKey1);
+            transport.activeInvokeMutationRequests.get(expectedKey1);
           const requestId1 = activeRequests1![0].requestId;
           const expectedKey2 = transport.getMapKey(mutationName2, variables2);
           const activeRequests2 =
-            transport.activeMutationExecuteRequests.get(expectedKey2);
+            transport.activeInvokeMutationRequests.get(expectedKey2);
           const requestId2 = activeRequests2![0].requestId;
 
           await transport.invokeHandleResponse(requestId1, errorResponse);
@@ -933,23 +937,23 @@ describe('AbstractDataConnectStreamTransport', () => {
           const expectedKey1 = transport.getMapKey(mutationName1, variables1);
           const expectedKey2 = transport.getMapKey(mutationName2, variables2);
           const activeRequests1 =
-            transport.activeMutationExecuteRequests.get(expectedKey1);
+            transport.activeInvokeMutationRequests.get(expectedKey1);
           const activeRequests2 =
-            transport.activeMutationExecuteRequests.get(expectedKey2);
+            transport.activeInvokeMutationRequests.get(expectedKey2);
           const requestId1 = activeRequests1![0].requestId;
           const requestId2 = activeRequests2![0].requestId;
 
           await transport.invokeHandleResponse(requestId1, errorResponse);
-          expect(transport.activeMutationExecuteRequests.has(expectedKey1)).to
-            .be.false;
+          expect(transport.activeInvokeMutationRequests.has(expectedKey1)).to.be
+            .false;
           expect(transport.executeRequestPromises.has(requestId1)).to.be.false;
-          expect(transport.activeMutationExecuteRequests.has(expectedKey2)).to
-            .be.true;
+          expect(transport.activeInvokeMutationRequests.has(expectedKey2)).to.be
+            .true;
           expect(transport.executeRequestPromises.has(requestId2)).to.be.true;
 
           await transport.invokeHandleResponse(requestId2, errorResponse);
-          expect(transport.activeMutationExecuteRequests.has(expectedKey2)).to
-            .be.false;
+          expect(transport.activeInvokeMutationRequests.has(expectedKey2)).to.be
+            .false;
           expect(transport.executeRequestPromises.has(requestId2)).to.be.false;
         });
       });
@@ -980,7 +984,8 @@ describe('AbstractDataConnectStreamTransport', () => {
           transport.invokeSubscribe(observer2, queryName2, variables2);
 
           const expectedKey1 = transport.getMapKey(queryName1, variables1);
-          const request1 = transport.activeSubscribeRequests.get(expectedKey1);
+          const request1 =
+            transport.activeInvokeSubscribeRequests.get(expectedKey1);
           const requestId1 = request1?.requestId!;
 
           await transport.invokeHandleResponse(requestId1, response1);
@@ -991,7 +996,8 @@ describe('AbstractDataConnectStreamTransport', () => {
           expect(observer1.onData).to.have.been.calledWithExactly(response2);
 
           const expectedKey2 = transport.getMapKey(queryName2, variables2);
-          const request2 = transport.activeSubscribeRequests.get(expectedKey2);
+          const request2 =
+            transport.activeInvokeSubscribeRequests.get(expectedKey2);
           const requestId2 = request2?.requestId!;
 
           await transport.invokeHandleResponse(requestId2, response3);
@@ -1007,10 +1013,12 @@ describe('AbstractDataConnectStreamTransport', () => {
           transport.invokeSubscribe(observer2, queryName2, variables2);
 
           const expectedKey1 = transport.getMapKey(queryName1, variables1);
-          const request1 = transport.activeSubscribeRequests.get(expectedKey1);
+          const request1 =
+            transport.activeInvokeSubscribeRequests.get(expectedKey1);
           const requestId1 = request1?.requestId!;
           const expectedKey2 = transport.getMapKey(queryName2, variables2);
-          const request2 = transport.activeSubscribeRequests.get(expectedKey2);
+          const request2 =
+            transport.activeInvokeSubscribeRequests.get(expectedKey2);
           const requestId2 = request2?.requestId!;
 
           await transport.invokeHandleResponse(requestId1, errorResponse);
@@ -1030,18 +1038,20 @@ describe('AbstractDataConnectStreamTransport', () => {
           transport.invokeSubscribe(observer2, queryName2, variables2);
           const expectedKey1 = transport.getMapKey(queryName1, variables1);
           const expectedKey2 = transport.getMapKey(queryName2, variables2);
-          const request1 = transport.activeSubscribeRequests.get(expectedKey1);
-          const request2 = transport.activeSubscribeRequests.get(expectedKey2);
+          const request1 =
+            transport.activeInvokeSubscribeRequests.get(expectedKey1);
+          const request2 =
+            transport.activeInvokeSubscribeRequests.get(expectedKey2);
           const requestId1 = request1?.requestId!;
           const requestId2 = request2?.requestId!;
 
           await transport.invokeHandleResponse(requestId1, errorResponse);
           await transport.invokeHandleResponse(requestId2, errorResponse);
-          expect(transport.activeSubscribeRequests.has(expectedKey1)).to.be
-            .true;
+          expect(transport.activeInvokeSubscribeRequests.has(expectedKey1)).to
+            .be.true;
           expect(transport.subscribeObservers.has(requestId1)).to.be.true;
-          expect(transport.activeSubscribeRequests.has(expectedKey2)).to.be
-            .true;
+          expect(transport.activeInvokeSubscribeRequests.has(expectedKey2)).to
+            .be.true;
           expect(transport.subscribeObservers.has(requestId2)).to.be.true;
         });
       });
@@ -1161,7 +1171,7 @@ describe('AbstractDataConnectStreamTransport', () => {
       expect(closeSpy).to.not.have.been.called;
 
       const expectedKey = transport.getMapKey(queryName2, variables2);
-      const request = transport.activeQueryExecuteRequests.get(expectedKey);
+      const request = transport.activeInvokeQueryRequests.get(expectedKey);
       const requestId = (request as ExecuteStreamRequest<unknown>).requestId;
 
       const dummyResponse = {

--- a/packages/data-connect/test/unit/streamTransport.test.ts
+++ b/packages/data-connect/test/unit/streamTransport.test.ts
@@ -133,6 +133,7 @@ interface TransportWithInternals {
     string,
     ExecuteStreamRequest<unknown> | ResumeStreamRequest
   >;
+  queuedInvokeQueryRequests: Map<string, ExecuteStreamRequest<unknown>>;
   activeInvokeMutationRequests: Map<
     string,
     Array<ExecuteStreamRequest<unknown>>
@@ -493,6 +494,142 @@ describe('AbstractDataConnectStreamTransport', () => {
 
           const requestId = sendMessageStub.firstCall.args[0].requestId;
           expect(transport.invokeOperationPromises.has(requestId)).to.be.false;
+        });
+
+        describe('de-duplication', () => {
+          it('should send the first request and queue subsequent requests when they are identical', async () => {
+            const sendMessageSpy = sinon.spy(transport, 'sendMessage');
+
+            const promises = [];
+            for (let i = 1; i <= 20; i++) {
+              promises.push(transport.invokeQuery(queryName1, variables1));
+            }
+            const mapKey = transport.getMapKey(queryName1, variables1);
+
+            expect(sendMessageSpy).to.have.been.calledOnce;
+            const sentMessage = sendMessageSpy.firstCall.args[0];
+            expect(sentMessage.execute?.operationName).to.equal(queryName1);
+
+            expect(transport.activeInvokeQueryRequests.has(mapKey)).to.be.true;
+            const activeRequest =
+              transport.activeInvokeQueryRequests.get(mapKey);
+            expect(activeRequest?.execute?.operationName).to.equal(queryName1);
+
+            const queuedMap = transport.queuedInvokeQueryRequests;
+            expect(queuedMap.has(mapKey)).to.be.true;
+
+            // promises 1 and 2 should be different, but 2-20 should be the same!
+            expect(promises[0]).to.not.equal(promises[1]);
+            for (let i = 1; i < 20; i++) {
+              expect(promises[i]).to.equal(promises[1]);
+            }
+          });
+
+          it('should resolve only the first request when it completes', async () => {
+            sinon.stub(transport, 'sendMessage').resolves();
+
+            const promises = [];
+            for (let i = 1; i <= 20; i++) {
+              promises.push(transport.invokeQuery(queryName1, variables1));
+            }
+
+            const mapKey = transport.getMapKey(queryName1, variables1);
+            const activeRequest =
+              transport.activeInvokeQueryRequests.get(mapKey);
+            const requestId1 = (activeRequest as ExecuteStreamRequest<unknown>)
+              .requestId;
+
+            const response1 = {
+              data: { result: '1' },
+              errors: [],
+              extensions: {}
+            };
+
+            await transport.invokeHandleResponse(requestId1, response1);
+
+            // verify promise 1 resolved, but other promises are not yet settled
+            const result1 = await promises[0];
+            expect(result1).to.deep.equal(response1);
+            for (let i = 1; i < 20; i++) {
+              await expectIsNotSettled(promises[i], 100);
+            }
+          });
+
+          it('should send the next request and clear queue when first request completes', async () => {
+            const sendMessageSpy = sinon.spy(transport, 'sendMessage');
+
+            const promises = [];
+            for (let i = 1; i <= 20; i++) {
+              promises.push(transport.invokeQuery(queryName1, variables1));
+            }
+
+            const mapKey = transport.getMapKey(queryName1, variables1);
+            const activeRequest =
+              transport.activeInvokeQueryRequests.get(mapKey);
+            const requestId1 = (activeRequest as ExecuteStreamRequest<unknown>)
+              .requestId;
+
+            const response1 = {
+              data: { result: '1' },
+              errors: [],
+              extensions: {}
+            };
+
+            await transport.invokeHandleResponse(requestId1, response1);
+
+            // verify queued request was popped + sent
+            expect(transport.queuedInvokeQueryRequests.has(mapKey)).to.be.false;
+            expect(transport.activeInvokeQueryRequests.has(mapKey)).to.be.true;
+            expect(sendMessageSpy).to.have.been.calledTwice;
+            const secondSentMessage = sendMessageSpy.secondCall.args[0];
+            expect(secondSentMessage.execute?.operationName).to.equal(
+              queryName1
+            );
+            expect(secondSentMessage.requestId).to.not.equal(requestId1);
+          });
+
+          it('should resolve all waiting promises when a queued request completes', async () => {
+            sinon.stub(transport, 'sendMessage').resolves();
+
+            const promises = [];
+            for (let i = 1; i <= 20; i++) {
+              promises.push(transport.invokeQuery(queryName1, variables1));
+            }
+
+            const mapKey = transport.getMapKey(queryName1, variables1);
+            const activeRequest1 =
+              transport.activeInvokeQueryRequests.get(mapKey);
+            const requestId1 = (activeRequest1 as ExecuteStreamRequest<unknown>)
+              .requestId;
+            const response1 = {
+              data: { result: '1' },
+              errors: [],
+              extensions: {}
+            };
+            await transport.invokeHandleResponse(requestId1, response1);
+
+            const activeRequest2 =
+              transport.activeInvokeQueryRequests.get(mapKey);
+            const requestId2 = (activeRequest2 as ExecuteStreamRequest<unknown>)
+              .requestId;
+            expect(requestId2).to.not.equal(requestId1);
+
+            const response2 = {
+              data: { result: '2' },
+              errors: [],
+              extensions: {}
+            };
+
+            await transport.invokeHandleResponse(requestId2, response2);
+
+            // verify all queued promises resolved to response2, and nothing active or in queue
+            for (let i = 1; i < 20; i++) {
+              const result = await promises[i];
+              expect(result).to.deep.equal(response2);
+            }
+            expect(transport.activeInvokeQueryRequests.has(mapKey)).to.be.false;
+            expect(transport.queuedInvokeQueryRequests.has(mapKey)).to.be.false;
+          });
         });
       });
 

--- a/packages/data-connect/test/unit/streamTransport.test.ts
+++ b/packages/data-connect/test/unit/streamTransport.test.ts
@@ -588,6 +588,83 @@ describe('AbstractDataConnectStreamTransport', () => {
             expect(secondSentMessage.requestId).to.not.equal(requestId1);
           });
 
+          it('should send the next request even if the first request fails with response errors', async () => {
+            const sendMessageSpy = sinon.spy(transport, 'sendMessage');
+
+            const promises = [];
+            for (let i = 1; i <= 20; i++) {
+              promises.push(transport.invokeQuery(queryName1, variables1));
+            }
+
+            const mapKey = transport.getMapKey(queryName1, variables1);
+            const activeRequest =
+              transport.activeInvokeQueryRequests.get(mapKey);
+            const requestId1 = activeRequest!.requestId;
+            const promise1 = promises[0];
+            expect(transport.activeInvokeQueryRequests.has(mapKey)).to.be.true;
+            expect(transport.queuedInvokeQueryRequests.has(mapKey)).to.be.true;
+
+            const errorResponse = {
+              data: null,
+              errors: [new Error('Query failed')],
+              extensions: {}
+            };
+            await transport.invokeHandleResponse(requestId1, errorResponse);
+
+            await expect(promise1).to.be.rejectedWith(
+              /DataConnect error while performing request/
+            );
+            expect(transport.queuedInvokeQueryRequests.has(mapKey)).to.be.false;
+            expect(transport.activeInvokeQueryRequests.has(mapKey)).to.be.true;
+            expect(sendMessageSpy).to.have.been.calledTwice;
+
+            // queued request should not be affected by the failure of request 1
+            const secondSentMessage = sendMessageSpy.secondCall.args[0];
+            expect(secondSentMessage.execute?.operationName).to.equal(
+              queryName1
+            );
+            expect(secondSentMessage.requestId).to.not.equal(requestId1);
+            await expectIsNotSettled(promises[1], 100);
+            const activeRequest2 =
+              transport.activeInvokeQueryRequests.get(mapKey);
+            const requestId2 = activeRequest2!.requestId;
+            const response2 = {
+              data: { result: '2' },
+              errors: [],
+              extensions: {}
+            };
+            await transport.invokeHandleResponse(requestId2, response2);
+            const result2 = await promises[1];
+            expect(result2).to.deep.equal(response2);
+          });
+
+          it('should send the next request even if the first request fails with errors', async () => {
+            const sendMessageStub = sinon.stub(transport, 'sendMessage');
+            sendMessageStub.onFirstCall().rejects(expectedError);
+            sendMessageStub.onSecondCall().resolves();
+
+            const promises = [];
+            for (let i = 1; i <= 20; i++) {
+              promises.push(transport.invokeQuery(queryName1, variables1));
+            }
+
+            const mapKey = transport.getMapKey(queryName1, variables1);
+            const activeRequest =
+              transport.activeInvokeQueryRequests.get(mapKey);
+            const requestId1 = activeRequest!.requestId;
+
+            await expect(promises[0]).to.be.rejectedWith(expectedError);
+            expect(transport.queuedInvokeQueryRequests.has(mapKey)).to.be.false;
+            expect(transport.activeInvokeQueryRequests.has(mapKey)).to.be.true;
+            expect(sendMessageStub).to.have.been.calledTwice;
+
+            const secondSentMessage = sendMessageStub.secondCall.args[0];
+            expect(secondSentMessage.execute?.operationName).to.equal(
+              queryName1
+            );
+            expect(secondSentMessage.requestId).to.not.equal(requestId1);
+          });
+
           it('should resolve all waiting promises when a queued request completes', async () => {
             sinon.stub(transport, 'sendMessage').resolves();
 

--- a/packages/data-connect/test/unit/streamTransport.test.ts
+++ b/packages/data-connect/test/unit/streamTransport.test.ts
@@ -801,16 +801,24 @@ describe('AbstractDataConnectStreamTransport', () => {
           expect(sentMessage.subscribe?.operationName).to.equal(queryName1);
           expect(sentMessage.subscribe?.variables).to.deep.equal(variables1);
         });
- 
-        it('should NOT de-duplicate identical subscribe requests', async () => {
+
+        it('should de-duplicate identical subscribe requests', async () => {
           const sendMessageSpy = sinon.spy(transport, 'sendMessage');
-          const observer1 = { onData: sinon.spy(), onDisconnect: sinon.spy(), onError: sinon.spy() };
-          const observer2 = { onData: sinon.spy(), onDisconnect: sinon.spy(), onError: sinon.spy() };
- 
+          const observer1 = {
+            onData: sinon.spy(),
+            onDisconnect: sinon.spy(),
+            onError: sinon.spy()
+          };
+          const observer2 = {
+            onData: sinon.spy(),
+            onDisconnect: sinon.spy(),
+            onError: sinon.spy()
+          };
+
           transport.invokeSubscribe(observer1, queryName1, variables1);
           transport.invokeSubscribe(observer2, queryName1, variables1);
- 
-          expect(sendMessageSpy.callCount).to.equal(2);
+
+          expect(sendMessageSpy.callCount).to.equal(1);
         });
 
         it('should asynchronously call observer with error and clean up if sendMessage fails', async () => {

--- a/packages/data-connect/test/unit/websocketTransport.test.ts
+++ b/packages/data-connect/test/unit/websocketTransport.test.ts
@@ -48,7 +48,7 @@ interface TransportWithInternals {
     requestId: string,
     response: DataConnectResponse<Data>
   ): Promise<void>;
-  rejectAllActiveRequests(code: Code, reason: string): void;
+  rejectAllRequests(code: Code, reason: string): void;
 }
 
 describe('WebSocketTransport', () => {
@@ -181,12 +181,12 @@ describe('WebSocketTransport', () => {
       expect(transport.connection).to.be.undefined;
     });
 
-    it('should call rejectAllActiveRequests and clean up when closed externally', async () => {
+    it('should call rejectAllRequests and clean up when closed externally', async () => {
       const openPromise = transport.openConnection();
       await transport.connection!.simulateOpen();
       await openPromise;
 
-      const rejectSpy = sinon.spy(transport, 'rejectAllActiveRequests');
+      const rejectSpy = sinon.spy(transport, 'rejectAllRequests');
 
       await transport.connection!.simulateClose();
 


### PR DESCRIPTION
## Description
✨ Implement streaming transport invokeQuery and invokeMutation request de-duplication. This PR introduces a delayed queue for duplicate queries to share results and ignores duplicate subscriptions while preserving independent execution for mutations, which are non-idempotent.

## Changes
- Renamed a few terms to use "Streaming" and "Invoke" consistently.
- Implemented query coalescing via a delayed queue of size `1`.
- Added subscribe de-duplication to ignore duplicate requests (this is just a failsafe - the Query Layer already de-dupes subscribe requests).

## Testing
- Added unit tests for query coalescing (success/failure) in `streamTransport.test.ts`.
- Added unit tests for subscribe de-duplication in `streamTransport.test.ts`.
- Fixed promise assertions in mutation tests in `streamTransport.test.ts`.