### PR TITLE
chore: Add combine PRs workflow

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -1,0 +1,23 @@
+name: Combine PRs
+
+on:
+  workflow_dispatch: # allows you to manually trigger the workflow
+
+# The minimum permissions required to run this Action
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+
+jobs:
+  combine-prs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: combine-prs
+        id: combine-prs
+        # This action defaults to combining branches that begin with
+        # "dependabot" but can be configured.
+        uses: github/combine-prs@v5.2.0
+        with:
+          labels: combined-pr # Optional: add a label to the combined PR

--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Combine PRs
 
 on:


### PR DESCRIPTION
Add a workflow that calls the Github "combine-prs" action to combine dependabot PRs into a single one: https://github.com/github/combine-prs