### PR TITLE
build(firestore): improve protobuf generation scripts

### DIFF
--- a/packages/firestore/src/protos/compile.sh
+++ b/packages/firestore/src/protos/compile.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2017 Google Inc.
+# Copyright 2026 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,19 +16,19 @@
 
 set -euo pipefail
 
-# Variables
-PROTOS_DIR="."
-PBJS="../../node_modules/.bin/pbjs"
-PBTS="../../node_modules/.bin/pbts"
+# Verify dependencies
+for cmd in npx find; do
+  if ! command -v "$cmd" &> /dev/null; then
+    echo "Error: $cmd is required but not installed." >&2
+    exit 1
+  fi
+done
 
-"${PBJS}" --path=. --target=json -o protos.json \
-  -r firestore/v1 "${PROTOS_DIR}/google/firestore/v1/*.proto" \
-  "${PROTOS_DIR}/google/protobuf/*.proto" "${PROTOS_DIR}/google/type/*.proto" \
-  "${PROTOS_DIR}/google/rpc/*.proto" "${PROTOS_DIR}/google/api/*.proto"
+PROTOS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROTO_FILES=$(find "${PROTOS_DIR}/google" -name "*.proto")
 
-"${PBJS}" --path="${PROTOS_DIR}" --target=static -o temp.js \
-  -r firestore/v1 "${PROTOS_DIR}/google/firestore/v1/*.proto" \
-  "${PROTOS_DIR}/google/protobuf/*.proto" "${PROTOS_DIR}/google/type/*.proto" \
-  "${PROTOS_DIR}/google/rpc/*.proto" "${PROTOS_DIR}/google/api/*.proto"
+# Generate JSON representation
+npx pbjs --path="${PROTOS_DIR}" --target=json -o "${PROTOS_DIR}/protos.json" \
+  -r firestore/v1 $PROTO_FILES
 
-"${PBTS}" -o temp.d.ts --no-comments temp.js
+rm -f "${PROTOS_DIR}/temp.d.ts"

--- a/packages/firestore/src/protos/google/api/annotations.proto
+++ b/packages/firestore/src/protos/google/api/annotations.proto
@@ -1,4 +1,4 @@
-// Copyright 2015 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/firestore/src/protos/google/api/client.proto
+++ b/packages/firestore/src/protos/google/api/client.proto
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@ syntax = "proto3";
 
 package google.api;
 
+import "google/api/launch_stage.proto";
 import "google/protobuf/descriptor.proto";
+import "google/protobuf/duration.proto";
 
 option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
 option java_multiple_files = true;
@@ -39,15 +41,15 @@ extend google.protobuf.MethodOptions {
   //
   // For example, the proto RPC and annotation:
   //
-  //   rpc CreateSubscription(CreateSubscriptionRequest)
-  //       returns (Subscription) {
-  //     option (google.api.method_signature) = "name,topic";
-  //   }
+  //     rpc CreateSubscription(CreateSubscriptionRequest)
+  //         returns (Subscription) {
+  //       option (google.api.method_signature) = "name,topic";
+  //     }
   //
   // Would add the following Java overload (in addition to the method accepting
   // the request object):
   //
-  //   public final Subscription createSubscription(String name, String topic)
+  //     public final Subscription createSubscription(String name, String topic)
   //
   // The following backwards-compatibility guidelines apply:
   //
@@ -69,31 +71,528 @@ extend google.protobuf.ServiceOptions {
   //
   // Example:
   //
-  //   service Foo {
-  //     option (google.api.default_host) = "foo.googleapi.com";
-  //     ...
-  //   }
+  //     service Foo {
+  //       option (google.api.default_host) = "foo.googleapi.com";
+  //       ...
+  //     }
   string default_host = 1049;
 
   // OAuth scopes needed for the client.
   //
   // Example:
   //
-  //   service Foo {
-  //     option (google.api.oauth_scopes) = \
-  //       "https://www.googleapis.com/auth/cloud-platform";
-  //     ...
-  //   }
+  //     service Foo {
+  //       option (google.api.oauth_scopes) = \
+  //         "https://www.googleapis.com/auth/cloud-platform";
+  //       ...
+  //     }
   //
   // If there is more than one scope, use a comma-separated string:
   //
   // Example:
   //
-  //   service Foo {
-  //     option (google.api.oauth_scopes) = \
-  //       "https://www.googleapis.com/auth/cloud-platform,"
-  //       "https://www.googleapis.com/auth/monitoring";
-  //     ...
-  //   }
+  //     service Foo {
+  //       option (google.api.oauth_scopes) = \
+  //         "https://www.googleapis.com/auth/cloud-platform,"
+  //         "https://www.googleapis.com/auth/monitoring";
+  //       ...
+  //     }
   string oauth_scopes = 1050;
+
+  // The API version of this service, which should be sent by version-aware
+  // clients to the service. This allows services to abide by the schema and
+  // behavior of the service at the time this API version was deployed.
+  // The format of the API version must be treated as opaque by clients.
+  // Services may use a format with an apparent structure, but clients must
+  // not rely on this to determine components within an API version, or attempt
+  // to construct other valid API versions. Note that this is for upcoming
+  // functionality and may not be implemented for all services.
+  //
+  // Example:
+  //
+  //     service Foo {
+  //       option (google.api.api_version) = "v1_20230821_preview";
+  //     }
+  string api_version = 525000001;
+}
+
+// Required information for every language.
+message CommonLanguageSettings {
+  // Link to automatically generated reference documentation.  Example:
+  // https://cloud.google.com/nodejs/docs/reference/asset/latest
+  string reference_docs_uri = 1 [deprecated = true];
+
+  // The destination where API teams want this client library to be published.
+  repeated ClientLibraryDestination destinations = 2;
+
+  // Configuration for which RPCs should be generated in the GAPIC client.
+  //
+  // Note: This field should not be used in most cases.
+  SelectiveGapicGeneration selective_gapic_generation = 3;
+}
+
+// Details about how and where to publish client libraries.
+message ClientLibrarySettings {
+  // Version of the API to apply these settings to. This is the full protobuf
+  // package for the API, ending in the version element.
+  // Examples: "google.cloud.speech.v1" and "google.spanner.admin.database.v1".
+  string version = 1;
+
+  // Launch stage of this version of the API.
+  LaunchStage launch_stage = 2;
+
+  // When using transport=rest, the client request will encode enums as
+  // numbers rather than strings.
+  bool rest_numeric_enums = 3;
+
+  // Settings for legacy Java features, supported in the Service YAML.
+  JavaSettings java_settings = 21;
+
+  // Settings for C++ client libraries.
+  CppSettings cpp_settings = 22;
+
+  // Settings for PHP client libraries.
+  PhpSettings php_settings = 23;
+
+  // Settings for Python client libraries.
+  PythonSettings python_settings = 24;
+
+  // Settings for Node client libraries.
+  NodeSettings node_settings = 25;
+
+  // Settings for .NET client libraries.
+  DotnetSettings dotnet_settings = 26;
+
+  // Settings for Ruby client libraries.
+  RubySettings ruby_settings = 27;
+
+  // Settings for Go client libraries.
+  GoSettings go_settings = 28;
+}
+
+// This message configures the settings for publishing [Google Cloud Client
+// libraries](https://cloud.google.com/apis/docs/cloud-client-libraries)
+// generated from the service config.
+message Publishing {
+  // A list of API method settings, e.g. the behavior for methods that use the
+  // long-running operation pattern.
+  repeated MethodSettings method_settings = 2;
+
+  // Link to a *public* URI where users can report issues.  Example:
+  // https://issuetracker.google.com/issues/new?component=190865&template=1161103
+  string new_issue_uri = 101;
+
+  // Link to product home page.  Example:
+  // https://cloud.google.com/asset-inventory/docs/overview
+  string documentation_uri = 102;
+
+  // Used as a tracking tag when collecting data about the APIs developer
+  // relations artifacts like docs, packages delivered to package managers,
+  // etc.  Example: "speech".
+  string api_short_name = 103;
+
+  // GitHub label to apply to issues and pull requests opened for this API.
+  string github_label = 104;
+
+  // GitHub teams to be added to CODEOWNERS in the directory in GitHub
+  // containing source code for the client libraries for this API.
+  repeated string codeowner_github_teams = 105;
+
+  // A prefix used in sample code when demarking regions to be included in
+  // documentation.
+  string doc_tag_prefix = 106;
+
+  // For whom the client library is being published.
+  ClientLibraryOrganization organization = 107;
+
+  // Client library settings.  If the same version string appears multiple
+  // times in this list, then the last one wins.  Settings from earlier
+  // settings with the same version string are discarded.
+  repeated ClientLibrarySettings library_settings = 109;
+
+  // Optional link to proto reference documentation.  Example:
+  // https://cloud.google.com/pubsub/lite/docs/reference/rpc
+  string proto_reference_documentation_uri = 110;
+
+  // Optional link to REST reference documentation.  Example:
+  // https://cloud.google.com/pubsub/lite/docs/reference/rest
+  string rest_reference_documentation_uri = 111;
+}
+
+// Settings for Java client libraries.
+message JavaSettings {
+  // The package name to use in Java. Clobbers the java_package option
+  // set in the protobuf. This should be used **only** by APIs
+  // who have already set the language_settings.java.package_name" field
+  // in gapic.yaml. API teams should use the protobuf java_package option
+  // where possible.
+  //
+  // Example of a YAML configuration::
+  //
+  //     publishing:
+  //       library_settings:
+  //         java_settings:
+  //           library_package: com.google.cloud.pubsub.v1
+  string library_package = 1;
+
+  // Configure the Java class name to use instead of the service's for its
+  // corresponding generated GAPIC client. Keys are fully-qualified
+  // service names as they appear in the protobuf (including the full
+  // the language_settings.java.interface_names" field in gapic.yaml. API
+  // teams should otherwise use the service name as it appears in the
+  // protobuf.
+  //
+  // Example of a YAML configuration::
+  //
+  //     publishing:
+  //       java_settings:
+  //         service_class_names:
+  //           - google.pubsub.v1.Publisher: TopicAdmin
+  //           - google.pubsub.v1.Subscriber: SubscriptionAdmin
+  map<string, string> service_class_names = 2;
+
+  // Some settings.
+  CommonLanguageSettings common = 3;
+}
+
+// Settings for C++ client libraries.
+message CppSettings {
+  // Some settings.
+  CommonLanguageSettings common = 1;
+}
+
+// Settings for Php client libraries.
+message PhpSettings {
+  // Some settings.
+  CommonLanguageSettings common = 1;
+
+  // The package name to use in Php. Clobbers the php_namespace option
+  // set in the protobuf. This should be used **only** by APIs
+  // who have already set the language_settings.php.package_name" field
+  // in gapic.yaml. API teams should use the protobuf php_namespace option
+  // where possible.
+  //
+  // Example of a YAML configuration::
+  //
+  //     publishing:
+  //       library_settings:
+  //         php_settings:
+  //           library_package: Google\Cloud\PubSub\V1
+  string library_package = 2;
+}
+
+// Settings for Python client libraries.
+message PythonSettings {
+  // Experimental features to be included during client library generation.
+  // These fields will be deprecated once the feature graduates and is enabled
+  // by default.
+  message ExperimentalFeatures {
+    // Enables generation of asynchronous REST clients if `rest` transport is
+    // enabled. By default, asynchronous REST clients will not be generated.
+    // This feature will be enabled by default 1 month after launching the
+    // feature in preview packages.
+    bool rest_async_io_enabled = 1;
+
+    // Enables generation of protobuf code using new types that are more
+    // Pythonic which are included in `protobuf>=5.29.x`. This feature will be
+    // enabled by default 1 month after launching the feature in preview
+    // packages.
+    bool protobuf_pythonic_types_enabled = 2;
+
+    // Disables generation of an unversioned Python package for this client
+    // library. This means that the module names will need to be versioned in
+    // import statements. For example `import google.cloud.library_v2` instead
+    // of `import google.cloud.library`.
+    bool unversioned_package_disabled = 3;
+  }
+
+  // Some settings.
+  CommonLanguageSettings common = 1;
+
+  // Experimental features to be included during client library generation.
+  ExperimentalFeatures experimental_features = 2;
+}
+
+// Settings for Node client libraries.
+message NodeSettings {
+  // Some settings.
+  CommonLanguageSettings common = 1;
+}
+
+// Settings for Dotnet client libraries.
+message DotnetSettings {
+  // Some settings.
+  CommonLanguageSettings common = 1;
+
+  // Map from original service names to renamed versions.
+  // This is used when the default generated types
+  // would cause a naming conflict. (Neither name is
+  // fully-qualified.)
+  // Example: Subscriber to SubscriberServiceApi.
+  map<string, string> renamed_services = 2;
+
+  // Map from full resource types to the effective short name
+  // for the resource. This is used when otherwise resource
+  // named from different services would cause naming collisions.
+  // Example entry:
+  // "datalabeling.googleapis.com/Dataset": "DataLabelingDataset"
+  map<string, string> renamed_resources = 3;
+
+  // List of full resource types to ignore during generation.
+  // This is typically used for API-specific Location resources,
+  // which should be handled by the generator as if they were actually
+  // the common Location resources.
+  // Example entry: "documentai.googleapis.com/Location"
+  repeated string ignored_resources = 4;
+
+  // Namespaces which must be aliased in snippets due to
+  // a known (but non-generator-predictable) naming collision
+  repeated string forced_namespace_aliases = 5;
+
+  // Method signatures (in the form "service.method(signature)")
+  // which are provided separately, so shouldn't be generated.
+  // Snippets *calling* these methods are still generated, however.
+  repeated string handwritten_signatures = 6;
+}
+
+// Settings for Ruby client libraries.
+message RubySettings {
+  // Some settings.
+  CommonLanguageSettings common = 1;
+}
+
+// Settings for Go client libraries.
+message GoSettings {
+  // Some settings.
+  CommonLanguageSettings common = 1;
+
+  // Map of service names to renamed services. Keys are the package relative
+  // service names and values are the name to be used for the service client
+  // and call options.
+  //
+  // Example:
+  //
+  //     publishing:
+  //       go_settings:
+  //         renamed_services:
+  //           Publisher: TopicAdmin
+  map<string, string> renamed_services = 2;
+}
+
+// Describes the generator configuration for a method.
+message MethodSettings {
+  // Describes settings to use when generating API methods that use the
+  // long-running operation pattern.
+  // All default values below are from those used in the client library
+  // generators (e.g.
+  // [Java](https://github.com/googleapis/gapic-generator-java/blob/04c2faa191a9b5a10b92392fe8482279c4404803/src/main/java/com/google/api/generator/gapic/composer/common/RetrySettingsComposer.java)).
+  message LongRunning {
+    // Initial delay after which the first poll request will be made.
+    // Default value: 5 seconds.
+    google.protobuf.Duration initial_poll_delay = 1;
+
+    // Multiplier to gradually increase delay between subsequent polls until it
+    // reaches max_poll_delay.
+    // Default value: 1.5.
+    float poll_delay_multiplier = 2;
+
+    // Maximum time between two subsequent poll requests.
+    // Default value: 45 seconds.
+    google.protobuf.Duration max_poll_delay = 3;
+
+    // Total polling timeout.
+    // Default value: 5 minutes.
+    google.protobuf.Duration total_poll_timeout = 4;
+  }
+
+  // The fully qualified name of the method, for which the options below apply.
+  // This is used to find the method to apply the options.
+  //
+  // Example:
+  //
+  //     publishing:
+  //       method_settings:
+  //       - selector: google.storage.control.v2.StorageControl.CreateFolder
+  //         # method settings for CreateFolder...
+  string selector = 1;
+
+  // Describes settings to use for long-running operations when generating
+  // API methods for RPCs. Complements RPCs that use the annotations in
+  // google/longrunning/operations.proto.
+  //
+  // Example of a YAML configuration::
+  //
+  //     publishing:
+  //       method_settings:
+  //       - selector: google.cloud.speech.v2.Speech.BatchRecognize
+  //         long_running:
+  //           initial_poll_delay: 60s # 1 minute
+  //           poll_delay_multiplier: 1.5
+  //           max_poll_delay: 360s # 6 minutes
+  //           total_poll_timeout: 54000s # 90 minutes
+  LongRunning long_running = 2;
+
+  // List of top-level fields of the request message, that should be
+  // automatically populated by the client libraries based on their
+  // (google.api.field_info).format. Currently supported format: UUID4.
+  //
+  // Example of a YAML configuration:
+  //
+  //     publishing:
+  //       method_settings:
+  //       - selector: google.example.v1.ExampleService.CreateExample
+  //         auto_populated_fields:
+  //         - request_id
+  repeated string auto_populated_fields = 3;
+
+  // Batching configuration for an API method in client libraries.
+  //
+  // Example of a YAML configuration:
+  //
+  //     publishing:
+  //       method_settings:
+  //       - selector: google.example.v1.ExampleService.BatchCreateExample
+  //         batching:
+  //           element_count_threshold: 1000
+  //           request_byte_threshold: 100000000
+  //           delay_threshold_millis: 10
+  BatchingConfigProto batching = 4;
+}
+
+// The organization for which the client libraries are being published.
+// Affects the url where generated docs are published, etc.
+enum ClientLibraryOrganization {
+  // Not useful.
+  CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED = 0;
+
+  // Google Cloud Platform Org.
+  CLOUD = 1;
+
+  // Ads (Advertising) Org.
+  ADS = 2;
+
+  // Photos Org.
+  PHOTOS = 3;
+
+  // Street View Org.
+  STREET_VIEW = 4;
+
+  // Shopping Org.
+  SHOPPING = 5;
+
+  // Geo Org.
+  GEO = 6;
+
+  // Generative AI - https://developers.generativeai.google
+  GENERATIVE_AI = 7;
+}
+
+// To where should client libraries be published?
+enum ClientLibraryDestination {
+  // Client libraries will neither be generated nor published to package
+  // managers.
+  CLIENT_LIBRARY_DESTINATION_UNSPECIFIED = 0;
+
+  // Generate the client library in a repo under github.com/googleapis,
+  // but don't publish it to package managers.
+  GITHUB = 10;
+
+  // Publish the library to package managers like nuget.org and npmjs.com.
+  PACKAGE_MANAGER = 20;
+}
+
+// This message is used to configure the generation of a subset of the RPCs in
+// a service for client libraries.
+//
+// Note: This feature should not be used in most cases.
+message SelectiveGapicGeneration {
+  // An allowlist of the fully qualified names of RPCs that should be included
+  // on public client surfaces.
+  repeated string methods = 1;
+
+  // Setting this to true indicates to the client generators that methods
+  // that would be excluded from the generation should instead be generated
+  // in a way that indicates these methods should not be consumed by
+  // end users. How this is expressed is up to individual language
+  // implementations to decide. Some examples may be: added annotations,
+  // obfuscated identifiers, or other language idiomatic patterns.
+  bool generate_omitted_as_internal = 2;
+}
+
+// `BatchingConfigProto` defines the batching configuration for an API method.
+message BatchingConfigProto {
+  // The thresholds which trigger a batched request to be sent.
+  BatchingSettingsProto thresholds = 1;
+
+  // The request and response fields used in batching.
+  BatchingDescriptorProto batch_descriptor = 2;
+}
+
+// `BatchingSettingsProto` specifies a set of batching thresholds, each of
+// which acts as a trigger to send a batch of messages as a request. At least
+// one threshold must be positive nonzero.
+message BatchingSettingsProto {
+  // The number of elements of a field collected into a batch which, if
+  // exceeded, causes the batch to be sent.
+  int32 element_count_threshold = 1;
+
+  // The aggregated size of the batched field which, if exceeded, causes the
+  // batch to be sent. This size is computed by aggregating the sizes of the
+  // request field to be batched, not of the entire request message.
+  int64 request_byte_threshold = 2;
+
+  // The duration after which a batch should be sent, starting from the addition
+  // of the first message to that batch.
+  google.protobuf.Duration delay_threshold = 3;
+
+  // The maximum number of elements collected in a batch that could be accepted
+  // by server.
+  int32 element_count_limit = 4;
+
+  // The maximum size of the request that could be accepted by server.
+  int32 request_byte_limit = 5;
+
+  // The maximum number of elements allowed by flow control.
+  int32 flow_control_element_limit = 6;
+
+  // The maximum size of data allowed by flow control.
+  int32 flow_control_byte_limit = 7;
+
+  // The behavior to take when the flow control limit is exceeded.
+  FlowControlLimitExceededBehaviorProto flow_control_limit_exceeded_behavior =
+      8;
+}
+
+// The behavior to take when the flow control limit is exceeded.
+enum FlowControlLimitExceededBehaviorProto {
+  // Default behavior, system-defined.
+  UNSET_BEHAVIOR = 0;
+
+  // Stop operation, raise error.
+  THROW_EXCEPTION = 1;
+
+  // Pause operation until limit clears.
+  BLOCK = 2;
+
+  // Continue operation, disregard limit.
+  IGNORE = 3;
+}
+
+// `BatchingDescriptorProto` specifies the fields of the request message to be
+// used for batching, and, optionally, the fields of the response message to be
+// used for demultiplexing.
+message BatchingDescriptorProto {
+  // The repeated field in the request message to be aggregated by batching.
+  string batched_field = 1;
+
+  // A list of the fields in the request message. Two requests will be batched
+  // together only if the values of every field specified in
+  // `request_discriminator_fields` is equal between the two requests.
+  repeated string discriminator_fields = 2;
+
+  // Optional. When present, indicates the field in the response message to be
+  // used to demultiplex the response into multiple response messages, in
+  // correspondence with the multiple request messages originally batched
+  // together.
+  string subresponse_field = 3;
 }

--- a/packages/firestore/src/protos/google/api/field_behavior.proto
+++ b/packages/firestore/src/protos/google/api/field_behavior.proto
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ extend google.protobuf.FieldOptions {
   //   google.protobuf.Timestamp expire_time = 1
   //     [(google.api.field_behavior) = OUTPUT_ONLY,
   //      (google.api.field_behavior) = IMMUTABLE];
-  repeated google.api.FieldBehavior field_behavior = 1052;
+  repeated google.api.FieldBehavior field_behavior = 1052 [packed = false];
 }
 
 // An indicator of the behavior of a given field (for example, that a field
@@ -87,4 +87,18 @@ enum FieldBehavior {
   // a non-empty value will be returned. The user will not be aware of what
   // non-empty value to expect.
   NON_EMPTY_DEFAULT = 7;
+
+  // Denotes that the field in a resource (a message annotated with
+  // google.api.resource) is used in the resource name to uniquely identify the
+  // resource. For AIP-compliant APIs, this should only be applied to the
+  // `name` field on the resource.
+  //
+  // This behavior should not be applied to references to other resources within
+  // the message.
+  //
+  // The identifier field of resources often have different field behavior
+  // depending on the request it is embedded in (e.g. for Create methods name
+  // is optional and unused, while for Update methods it is required). Instead
+  // of method-specific annotations, only `IDENTIFIER` is required.
+  IDENTIFIER = 8;
 }

--- a/packages/firestore/src/protos/google/api/http.proto
+++ b/packages/firestore/src/protos/google/api/http.proto
@@ -1,4 +1,4 @@
-// Copyright 2015 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@ syntax = "proto3";
 
 package google.api;
 
-option cc_enable_arenas = true;
 option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
 option java_multiple_files = true;
 option java_outer_classname = "HttpProto";
@@ -41,7 +40,7 @@ message Http {
   bool fully_decode_reserved_expansion = 2;
 }
 
-// # gRPC Transcoding
+// gRPC Transcoding
 //
 // gRPC Transcoding is a feature for mapping between a gRPC method and one or
 // more HTTP REST endpoints. It allows developers to build a single API service
@@ -82,9 +81,8 @@ message Http {
 //
 // This enables an HTTP REST to gRPC mapping as below:
 //
-// HTTP | gRPC
-// -----|-----
-// `GET /v1/messages/123456`  | `GetMessage(name: "messages/123456")`
+// - HTTP: `GET /v1/messages/123456`
+// - gRPC: `GetMessage(name: "messages/123456")`
 //
 // Any fields in the request message which are not bound by the path template
 // automatically become HTTP query parameters if there is no HTTP request body.
@@ -108,11 +106,9 @@ message Http {
 //
 // This enables a HTTP JSON to RPC mapping as below:
 //
-// HTTP | gRPC
-// -----|-----
-// `GET /v1/messages/123456?revision=2&sub.subfield=foo` |
-// `GetMessage(message_id: "123456" revision: 2 sub: SubMessage(subfield:
-// "foo"))`
+// - HTTP: `GET /v1/messages/123456?revision=2&sub.subfield=foo`
+// - gRPC: `GetMessage(message_id: "123456" revision: 2 sub:
+// SubMessage(subfield: "foo"))`
 //
 // Note that fields which are mapped to URL query parameters must have a
 // primitive type or a repeated primitive type or a non-repeated message type.
@@ -142,10 +138,8 @@ message Http {
 // representation of the JSON in the request body is determined by
 // protos JSON encoding:
 //
-// HTTP | gRPC
-// -----|-----
-// `PATCH /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id:
-// "123456" message { text: "Hi!" })`
+// - HTTP: `PATCH /v1/messages/123456 { "text": "Hi!" }`
+// - gRPC: `UpdateMessage(message_id: "123456" message { text: "Hi!" })`
 //
 // The special name `*` can be used in the body mapping to define that
 // every field not bound by the path template should be mapped to the
@@ -168,10 +162,8 @@ message Http {
 //
 // The following HTTP JSON to RPC mapping is enabled:
 //
-// HTTP | gRPC
-// -----|-----
-// `PATCH /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id:
-// "123456" text: "Hi!")`
+// - HTTP: `PATCH /v1/messages/123456 { "text": "Hi!" }`
+// - gRPC: `UpdateMessage(message_id: "123456" text: "Hi!")`
 //
 // Note that when using `*` in the body mapping, it is not possible to
 // have HTTP parameters, as all fields not bound by the path end in
@@ -199,29 +191,32 @@ message Http {
 //
 // This enables the following two alternative HTTP JSON to RPC mappings:
 //
-// HTTP | gRPC
-// -----|-----
-// `GET /v1/messages/123456` | `GetMessage(message_id: "123456")`
-// `GET /v1/users/me/messages/123456` | `GetMessage(user_id: "me" message_id:
-// "123456")`
+// - HTTP: `GET /v1/messages/123456`
+// - gRPC: `GetMessage(message_id: "123456")`
 //
-// ## Rules for HTTP mapping
+// - HTTP: `GET /v1/users/me/messages/123456`
+// - gRPC: `GetMessage(user_id: "me" message_id: "123456")`
+//
+// Rules for HTTP mapping
 //
 // 1. Leaf request fields (recursive expansion nested messages in the request
 //    message) are classified into three categories:
 //    - Fields referred by the path template. They are passed via the URL path.
-//    - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They are passed via the HTTP
+//    - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They
+//    are passed via the HTTP
 //      request body.
 //    - All other fields are passed via the URL query parameters, and the
 //      parameter name is the field path in the request message. A repeated
 //      field can be represented as multiple query parameters under the same
 //      name.
-//  2. If [HttpRule.body][google.api.HttpRule.body] is "*", there is no URL query parameter, all fields
+//  2. If [HttpRule.body][google.api.HttpRule.body] is "*", there is no URL
+//  query parameter, all fields
 //     are passed via URL path and HTTP request body.
-//  3. If [HttpRule.body][google.api.HttpRule.body] is omitted, there is no HTTP request body, all
+//  3. If [HttpRule.body][google.api.HttpRule.body] is omitted, there is no HTTP
+//  request body, all
 //     fields are passed via URL path and URL query parameters.
 //
-// ### Path template syntax
+// Path template syntax
 //
 //     Template = "/" Segments [ Verb ] ;
 //     Segments = Segment { "/" Segment } ;
@@ -260,7 +255,7 @@ message Http {
 // Document](https://developers.google.com/discovery/v1/reference/apis) as
 // `{+var}`.
 //
-// ## Using gRPC API Service Configuration
+// Using gRPC API Service Configuration
 //
 // gRPC API Service Configuration (service config) is a configuration language
 // for configuring a gRPC service to become a user-facing product. The
@@ -275,15 +270,14 @@ message Http {
 // specified in the service config will override any matching transcoding
 // configuration in the proto.
 //
-// Example:
+// The following example selects a gRPC method and applies an `HttpRule` to it:
 //
 //     http:
 //       rules:
-//         # Selects a gRPC method and applies HttpRule to it.
 //         - selector: example.v1.Messaging.GetMessage
 //           get: /v1/messages/{message_id}/{sub.subfield}
 //
-// ## Special notes
+// Special notes
 //
 // When gRPC Transcoding is used to map a gRPC to JSON REST endpoints, the
 // proto to JSON conversion must follow the [proto3
@@ -313,7 +307,8 @@ message Http {
 message HttpRule {
   // Selects a method to which this rule applies.
   //
-  // Refer to [selector][google.api.DocumentationRule.selector] for syntax details.
+  // Refer to [selector][google.api.DocumentationRule.selector] for syntax
+  // details.
   string selector = 1;
 
   // Determines the URL pattern is matched by this rules. This pattern can be

--- a/packages/firestore/src/protos/google/api/launch_stage.proto
+++ b/packages/firestore/src/protos/google/api/launch_stage.proto
@@ -1,0 +1,72 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+option go_package = "google.golang.org/genproto/googleapis/api;api";
+option java_multiple_files = true;
+option java_outer_classname = "LaunchStageProto";
+option java_package = "com.google.api";
+option objc_class_prefix = "GAPI";
+
+// The launch stage as defined by [Google Cloud Platform
+// Launch Stages](https://cloud.google.com/terms/launch-stages).
+enum LaunchStage {
+  // Do not use this default value.
+  LAUNCH_STAGE_UNSPECIFIED = 0;
+
+  // The feature is not yet implemented. Users can not use it.
+  UNIMPLEMENTED = 6;
+
+  // Prelaunch features are hidden from users and are only visible internally.
+  PRELAUNCH = 7;
+
+  // Early Access features are limited to a closed group of testers. To use
+  // these features, you must sign up in advance and sign a Trusted Tester
+  // agreement (which includes confidentiality provisions). These features may
+  // be unstable, changed in backward-incompatible ways, and are not
+  // guaranteed to be released.
+  EARLY_ACCESS = 1;
+
+  // Alpha is a limited availability test for releases before they are cleared
+  // for widespread use. By Alpha, all significant design issues are resolved
+  // and we are in the process of verifying functionality. Alpha customers
+  // need to apply for access, agree to applicable terms, and have their
+  // projects allowlisted. Alpha releases don't have to be feature complete,
+  // no SLAs are provided, and there are no technical support obligations, but
+  // they will be far enough along that customers can actually use them in
+  // test environments or for limited-use tests -- just like they would in
+  // normal production cases.
+  ALPHA = 2;
+
+  // Beta is the point at which we are ready to open a release for any
+  // customer to use. There are no SLA or technical support obligations in a
+  // Beta release. Products will be complete from a feature perspective, but
+  // may have some open outstanding issues. Beta releases are suitable for
+  // limited production use cases.
+  BETA = 3;
+
+  // GA features are open to all developers and are considered stable and
+  // fully qualified for production use.
+  GA = 4;
+
+  // Deprecated features are scheduled to be shut down and removed. For more
+  // information, see the "Deprecation Policy" section of our [Terms of
+  // Service](https://cloud.google.com/terms/)
+  // and the [Google Cloud Platform Subject to the Deprecation
+  // Policy](https://cloud.google.com/terms/deprecation) documentation.
+  DEPRECATED = 5;
+}

--- a/packages/firestore/src/protos/google/api/resource.proto
+++ b/packages/firestore/src/protos/google/api/resource.proto
@@ -1,0 +1,242 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+import "google/protobuf/descriptor.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
+option java_multiple_files = true;
+option java_outer_classname = "ResourceProto";
+option java_package = "com.google.api";
+option objc_class_prefix = "GAPI";
+
+extend google.protobuf.FieldOptions {
+  // An annotation that describes a resource reference, see
+  // [ResourceReference][].
+  google.api.ResourceReference resource_reference = 1055;
+}
+
+extend google.protobuf.FileOptions {
+  // An annotation that describes a resource definition without a corresponding
+  // message; see [ResourceDescriptor][].
+  repeated google.api.ResourceDescriptor resource_definition = 1053;
+}
+
+extend google.protobuf.MessageOptions {
+  // An annotation that describes a resource definition, see
+  // [ResourceDescriptor][].
+  google.api.ResourceDescriptor resource = 1053;
+}
+
+// A simple descriptor of a resource type.
+//
+// ResourceDescriptor annotates a resource message (either by means of a
+// protobuf annotation or use in the service config), and associates the
+// resource's schema, the resource type, and the pattern of the resource name.
+//
+// Example:
+//
+//     message Topic {
+//       // Indicates this message defines a resource schema.
+//       // Declares the resource type in the format of {service}/{kind}.
+//       // For Kubernetes resources, the format is {api group}/{kind}.
+//       option (google.api.resource) = {
+//         type: "pubsub.googleapis.com/Topic"
+//         pattern: "projects/{project}/topics/{topic}"
+//       };
+//     }
+//
+// The ResourceDescriptor Yaml config will look like:
+//
+//     resources:
+//     - type: "pubsub.googleapis.com/Topic"
+//       pattern: "projects/{project}/topics/{topic}"
+//
+// Sometimes, resources have multiple patterns, typically because they can
+// live under multiple parents.
+//
+// Example:
+//
+//     message LogEntry {
+//       option (google.api.resource) = {
+//         type: "logging.googleapis.com/LogEntry"
+//         pattern: "projects/{project}/logs/{log}"
+//         pattern: "folders/{folder}/logs/{log}"
+//         pattern: "organizations/{organization}/logs/{log}"
+//         pattern: "billingAccounts/{billing_account}/logs/{log}"
+//       };
+//     }
+//
+// The ResourceDescriptor Yaml config will look like:
+//
+//     resources:
+//     - type: 'logging.googleapis.com/LogEntry'
+//       pattern: "projects/{project}/logs/{log}"
+//       pattern: "folders/{folder}/logs/{log}"
+//       pattern: "organizations/{organization}/logs/{log}"
+//       pattern: "billingAccounts/{billing_account}/logs/{log}"
+message ResourceDescriptor {
+  // A description of the historical or future-looking state of the
+  // resource pattern.
+  enum History {
+    // The "unset" value.
+    HISTORY_UNSPECIFIED = 0;
+
+    // The resource originally had one pattern and launched as such, and
+    // additional patterns were added later.
+    ORIGINALLY_SINGLE_PATTERN = 1;
+
+    // The resource has one pattern, but the API owner expects to add more
+    // later. (This is the inverse of ORIGINALLY_SINGLE_PATTERN, and prevents
+    // that from being necessary once there are multiple patterns.)
+    FUTURE_MULTI_PATTERN = 2;
+  }
+
+  // A flag representing a specific style that a resource claims to conform to.
+  enum Style {
+    // The unspecified value. Do not use.
+    STYLE_UNSPECIFIED = 0;
+
+    // This resource is intended to be "declarative-friendly".
+    //
+    // Declarative-friendly resources must be more strictly consistent, and
+    // setting this to true communicates to tools that this resource should
+    // adhere to declarative-friendly expectations.
+    //
+    // Note: This is used by the API linter (linter.aip.dev) to enable
+    // additional checks.
+    DECLARATIVE_FRIENDLY = 1;
+  }
+
+  // The resource type. It must be in the format of
+  // {service_name}/{resource_type_kind}. The `resource_type_kind` must be
+  // singular and must not include version numbers.
+  //
+  // Example: `storage.googleapis.com/Bucket`
+  //
+  // The value of the resource_type_kind must follow the regular expression
+  // /[A-Za-z][a-zA-Z0-9]+/. It should start with an upper case character and
+  // should use PascalCase (UpperCamelCase). The maximum number of
+  // characters allowed for the `resource_type_kind` is 100.
+  string type = 1;
+
+  // Optional. The relative resource name pattern associated with this resource
+  // type. The DNS prefix of the full resource name shouldn't be specified here.
+  //
+  // The path pattern must follow the syntax, which aligns with HTTP binding
+  // syntax:
+  //
+  //     Template = Segment { "/" Segment } ;
+  //     Segment = LITERAL | Variable ;
+  //     Variable = "{" LITERAL "}" ;
+  //
+  // Examples:
+  //
+  //     - "projects/{project}/topics/{topic}"
+  //     - "projects/{project}/knowledgeBases/{knowledge_base}"
+  //
+  // The components in braces correspond to the IDs for each resource in the
+  // hierarchy. It is expected that, if multiple patterns are provided,
+  // the same component name (e.g. "project") refers to IDs of the same
+  // type of resource.
+  repeated string pattern = 2;
+
+  // Optional. The field on the resource that designates the resource name
+  // field. If omitted, this is assumed to be "name".
+  string name_field = 3;
+
+  // Optional. The historical or future-looking state of the resource pattern.
+  //
+  // Example:
+  //
+  //     // The InspectTemplate message originally only supported resource
+  //     // names with organization, and project was added later.
+  //     message InspectTemplate {
+  //       option (google.api.resource) = {
+  //         type: "dlp.googleapis.com/InspectTemplate"
+  //         pattern:
+  //         "organizations/{organization}/inspectTemplates/{inspect_template}"
+  //         pattern: "projects/{project}/inspectTemplates/{inspect_template}"
+  //         history: ORIGINALLY_SINGLE_PATTERN
+  //       };
+  //     }
+  History history = 4;
+
+  // The plural name used in the resource name and permission names, such as
+  // 'projects' for the resource name of 'projects/{project}' and the permission
+  // name of 'cloudresourcemanager.googleapis.com/projects.get'. One exception
+  // to this is for Nested Collections that have stuttering names, as defined
+  // in [AIP-122](https://google.aip.dev/122#nested-collections), where the
+  // collection ID in the resource name pattern does not necessarily directly
+  // match the `plural` value.
+  //
+  // It is the same concept of the `plural` field in k8s CRD spec
+  // https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/
+  //
+  // Note: The plural form is required even for singleton resources. See
+  // https://aip.dev/156
+  string plural = 5;
+
+  // The same concept of the `singular` field in k8s CRD spec
+  // https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/
+  // Such as "project" for the `resourcemanager.googleapis.com/Project` type.
+  string singular = 6;
+
+  // Style flag(s) for this resource.
+  // These indicate that a resource is expected to conform to a given
+  // style. See the specific style flags for additional information.
+  repeated Style style = 10;
+}
+
+// Defines a proto annotation that describes a string field that refers to
+// an API resource.
+message ResourceReference {
+  // The resource type that the annotated field references.
+  //
+  // Example:
+  //
+  //     message Subscription {
+  //       string topic = 2 [(google.api.resource_reference) = {
+  //         type: "pubsub.googleapis.com/Topic"
+  //       }];
+  //     }
+  //
+  // Occasionally, a field may reference an arbitrary resource. In this case,
+  // APIs use the special value * in their resource reference.
+  //
+  // Example:
+  //
+  //     message GetIamPolicyRequest {
+  //       string resource = 2 [(google.api.resource_reference) = {
+  //         type: "*"
+  //       }];
+  //     }
+  string type = 1;
+
+  // The resource type of a child collection that the annotated field
+  // references. This is useful for annotating the `parent` field that
+  // doesn't have a fixed resource type.
+  //
+  // Example:
+  //
+  //     message ListLogEntriesRequest {
+  //       string parent = 1 [(google.api.resource_reference) = {
+  //         child_type: "logging.googleapis.com/LogEntry"
+  //       };
+  //     }
+  string child_type = 2;
+}

--- a/packages/firestore/src/protos/google/api/routing.proto
+++ b/packages/firestore/src/protos/google/api/routing.proto
@@ -1,0 +1,465 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+import "google/protobuf/descriptor.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
+option java_multiple_files = true;
+option java_outer_classname = "RoutingProto";
+option java_package = "com.google.api";
+option objc_class_prefix = "GAPI";
+
+extend google.protobuf.MethodOptions {
+  // See RoutingRule.
+  google.api.RoutingRule routing = 72295729;
+}
+
+// Specifies the routing information that should be sent along with the request
+// in the form of routing header.
+// **NOTE:** All service configuration rules follow the "last one wins" order.
+//
+// The examples below will apply to an RPC which has the following request type:
+//
+// Message Definition:
+//
+//     message Request {
+//       // The name of the Table
+//       // Values can be of the following formats:
+//       // - `projects/<project>/tables/<table>`
+//       // - `projects/<project>/instances/<instance>/tables/<table>`
+//       // - `region/<region>/zones/<zone>/tables/<table>`
+//       string table_name = 1;
+//
+//       // This value specifies routing for replication.
+//       // It can be in the following formats:
+//       // - `profiles/<profile_id>`
+//       // - a legacy `profile_id` that can be any string
+//       string app_profile_id = 2;
+//     }
+//
+// Example message:
+//
+//     {
+//       table_name: projects/proj_foo/instances/instance_bar/table/table_baz,
+//       app_profile_id: profiles/prof_qux
+//     }
+//
+// The routing header consists of one or multiple key-value pairs. The order of
+// the key-value pairs is undefined, the order of the `routing_parameters` in
+// the `RoutingRule` only matters for the evaluation order of the path
+// templates when `field` is the same. See the examples below for more details.
+//
+// Every key and value in the routing header must be percent-encoded,
+// and joined together in the following format: `key1=value1&key2=value2`.
+// The examples below skip the percent-encoding for readability.
+//
+// Example 1
+//
+// Extracting a field from the request to put into the routing header
+// unchanged, with the key equal to the field name.
+//
+// annotation:
+//
+//     option (google.api.routing) = {
+//       // Take the `app_profile_id`.
+//       routing_parameters {
+//         field: "app_profile_id"
+//       }
+//     };
+//
+// result:
+//
+//     x-goog-request-params: app_profile_id=profiles/prof_qux
+//
+// Example 2
+//
+// Extracting a field from the request to put into the routing header
+// unchanged, with the key different from the field name.
+//
+// annotation:
+//
+//     option (google.api.routing) = {
+//       // Take the `app_profile_id`, but name it `routing_id` in the header.
+//       routing_parameters {
+//         field: "app_profile_id"
+//         path_template: "{routing_id=**}"
+//       }
+//     };
+//
+// result:
+//
+//     x-goog-request-params: routing_id=profiles/prof_qux
+//
+// Example 3
+//
+// Extracting a field from the request to put into the routing
+// header, while matching a path template syntax on the field's value.
+//
+// NB: it is more useful to send nothing than to send garbage for the purpose
+// of dynamic routing, since garbage pollutes cache. Thus the matching.
+//
+// Sub-example 3a
+//
+// The field matches the template.
+//
+// annotation:
+//
+//     option (google.api.routing) = {
+//       // Take the `table_name`, if it's well-formed (with project-based
+//       // syntax).
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{table_name=projects/*/instances/*/**}"
+//       }
+//     };
+//
+// result:
+//
+//     x-goog-request-params:
+//     table_name=projects/proj_foo/instances/instance_bar/table/table_baz
+//
+// Sub-example 3b
+//
+// The field does not match the template.
+//
+// annotation:
+//
+//     option (google.api.routing) = {
+//       // Take the `table_name`, if it's well-formed (with region-based
+//       // syntax).
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{table_name=regions/*/zones/*/**}"
+//       }
+//     };
+//
+// result:
+//
+//     <no routing header will be sent>
+//
+// Sub-example 3c
+//
+// Multiple alternative conflictingly named path templates are
+// specified. The one that matches is used to construct the header.
+//
+// annotation:
+//
+//     option (google.api.routing) = {
+//       // Take the `table_name`, if it's well-formed, whether
+//       // using the region- or projects-based syntax.
+//
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{table_name=regions/*/zones/*/**}"
+//       }
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{table_name=projects/*/instances/*/**}"
+//       }
+//     };
+//
+// result:
+//
+//     x-goog-request-params:
+//     table_name=projects/proj_foo/instances/instance_bar/table/table_baz
+//
+// Example 4
+//
+// Extracting a single routing header key-value pair by matching a
+// template syntax on (a part of) a single request field.
+//
+// annotation:
+//
+//     option (google.api.routing) = {
+//       // Take just the project id from the `table_name` field.
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{routing_id=projects/*}/**"
+//       }
+//     };
+//
+// result:
+//
+//     x-goog-request-params: routing_id=projects/proj_foo
+//
+// Example 5
+//
+// Extracting a single routing header key-value pair by matching
+// several conflictingly named path templates on (parts of) a single request
+// field. The last template to match "wins" the conflict.
+//
+// annotation:
+//
+//     option (google.api.routing) = {
+//       // If the `table_name` does not have instances information,
+//       // take just the project id for routing.
+//       // Otherwise take project + instance.
+//
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{routing_id=projects/*}/**"
+//       }
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{routing_id=projects/*/instances/*}/**"
+//       }
+//     };
+//
+// result:
+//
+//     x-goog-request-params:
+//     routing_id=projects/proj_foo/instances/instance_bar
+//
+// Example 6
+//
+// Extracting multiple routing header key-value pairs by matching
+// several non-conflicting path templates on (parts of) a single request field.
+//
+// Sub-example 6a
+//
+// Make the templates strict, so that if the `table_name` does not
+// have an instance information, nothing is sent.
+//
+// annotation:
+//
+//     option (google.api.routing) = {
+//       // The routing code needs two keys instead of one composite
+//       // but works only for the tables with the "project-instance" name
+//       // syntax.
+//
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{project_id=projects/*}/instances/*/**"
+//       }
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "projects/*/{instance_id=instances/*}/**"
+//       }
+//     };
+//
+// result:
+//
+//     x-goog-request-params:
+//     project_id=projects/proj_foo&instance_id=instances/instance_bar
+//
+// Sub-example 6b
+//
+// Make the templates loose, so that if the `table_name` does not
+// have an instance information, just the project id part is sent.
+//
+// annotation:
+//
+//     option (google.api.routing) = {
+//       // The routing code wants two keys instead of one composite
+//       // but will work with just the `project_id` for tables without
+//       // an instance in the `table_name`.
+//
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{project_id=projects/*}/**"
+//       }
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "projects/*/{instance_id=instances/*}/**"
+//       }
+//     };
+//
+// result (is the same as 6a for our example message because it has the instance
+// information):
+//
+//     x-goog-request-params:
+//     project_id=projects/proj_foo&instance_id=instances/instance_bar
+//
+// Example 7
+//
+// Extracting multiple routing header key-value pairs by matching
+// several path templates on multiple request fields.
+//
+// NB: note that here there is no way to specify sending nothing if one of the
+// fields does not match its template. E.g. if the `table_name` is in the wrong
+// format, the `project_id` will not be sent, but the `routing_id` will be.
+// The backend routing code has to be aware of that and be prepared to not
+// receive a full complement of keys if it expects multiple.
+//
+// annotation:
+//
+//     option (google.api.routing) = {
+//       // The routing needs both `project_id` and `routing_id`
+//       // (from the `app_profile_id` field) for routing.
+//
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{project_id=projects/*}/**"
+//       }
+//       routing_parameters {
+//         field: "app_profile_id"
+//         path_template: "{routing_id=**}"
+//       }
+//     };
+//
+// result:
+//
+//     x-goog-request-params:
+//     project_id=projects/proj_foo&routing_id=profiles/prof_qux
+//
+// Example 8
+//
+// Extracting a single routing header key-value pair by matching
+// several conflictingly named path templates on several request fields. The
+// last template to match "wins" the conflict.
+//
+// annotation:
+//
+//     option (google.api.routing) = {
+//       // The `routing_id` can be a project id or a region id depending on
+//       // the table name format, but only if the `app_profile_id` is not set.
+//       // If `app_profile_id` is set it should be used instead.
+//
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{routing_id=projects/*}/**"
+//       }
+//       routing_parameters {
+//          field: "table_name"
+//          path_template: "{routing_id=regions/*}/**"
+//       }
+//       routing_parameters {
+//         field: "app_profile_id"
+//         path_template: "{routing_id=**}"
+//       }
+//     };
+//
+// result:
+//
+//     x-goog-request-params: routing_id=profiles/prof_qux
+//
+// Example 9
+//
+// Bringing it all together.
+//
+// annotation:
+//
+//     option (google.api.routing) = {
+//       // For routing both `table_location` and a `routing_id` are needed.
+//       //
+//       // table_location can be either an instance id or a region+zone id.
+//       //
+//       // For `routing_id`, take the value of `app_profile_id`
+//       // - If it's in the format `profiles/<profile_id>`, send
+//       // just the `<profile_id>` part.
+//       // - If it's any other literal, send it as is.
+//       // If the `app_profile_id` is empty, and the `table_name` starts with
+//       // the project_id, send that instead.
+//
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "projects/*/{table_location=instances/*}/tables/*"
+//       }
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{table_location=regions/*/zones/*}/tables/*"
+//       }
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{routing_id=projects/*}/**"
+//       }
+//       routing_parameters {
+//         field: "app_profile_id"
+//         path_template: "{routing_id=**}"
+//       }
+//       routing_parameters {
+//         field: "app_profile_id"
+//         path_template: "profiles/{routing_id=*}"
+//       }
+//     };
+//
+// result:
+//
+//     x-goog-request-params:
+//     table_location=instances/instance_bar&routing_id=prof_qux
+message RoutingRule {
+  // A collection of Routing Parameter specifications.
+  // **NOTE:** If multiple Routing Parameters describe the same key
+  // (via the `path_template` field or via the `field` field when
+  // `path_template` is not provided), "last one wins" rule
+  // determines which Parameter gets used.
+  // See the examples for more details.
+  repeated RoutingParameter routing_parameters = 2;
+}
+
+// A projection from an input message to the GRPC or REST header.
+message RoutingParameter {
+  // A request field to extract the header key-value pair from.
+  string field = 1;
+
+  // A pattern matching the key-value field. Optional.
+  // If not specified, the whole field specified in the `field` field will be
+  // taken as value, and its name used as key. If specified, it MUST contain
+  // exactly one named segment (along with any number of unnamed segments) The
+  // pattern will be matched over the field specified in the `field` field, then
+  // if the match is successful:
+  // - the name of the single named segment will be used as a header name,
+  // - the match value of the segment will be used as a header value;
+  // if the match is NOT successful, nothing will be sent.
+  //
+  // Example:
+  //
+  //               -- This is a field in the request message
+  //              |   that the header value will be extracted from.
+  //              |
+  //              |                     -- This is the key name in the
+  //              |                    |   routing header.
+  //              V                    |
+  //     field: "table_name"           v
+  //     path_template: "projects/*/{table_location=instances/*}/tables/*"
+  //                                                ^            ^
+  //                                                |            |
+  //       In the {} brackets is the pattern that --             |
+  //       specifies what to extract from the                    |
+  //       field as a value to be sent.                          |
+  //                                                             |
+  //      The string in the field must match the whole pattern --
+  //      before brackets, inside brackets, after brackets.
+  //
+  // When looking at this specific example, we can see that:
+  // - A key-value pair with the key `table_location`
+  //   and the value matching `instances/*` should be added
+  //   to the x-goog-request-params routing header.
+  // - The value is extracted from the request message's `table_name` field
+  //   if it matches the full pattern specified:
+  //   `projects/*/instances/*/tables/*`.
+  //
+  // **NB:** If the `path_template` field is not provided, the key name is
+  // equal to the field name, and the whole field should be sent as a value.
+  // This makes the pattern for the field and the value functionally equivalent
+  // to `**`, and the configuration
+  //
+  //     {
+  //       field: "table_name"
+  //     }
+  //
+  // is a functionally equivalent shorthand to:
+  //
+  //     {
+  //       field: "table_name"
+  //       path_template: "{table_name=**}"
+  //     }
+  //
+  // See Example 1 for more details.
+  string path_template = 2;
+}

--- a/packages/firestore/src/protos/google/firestore/v1/bloom_filter.proto
+++ b/packages/firestore/src/protos/google/firestore/v1/bloom_filter.proto
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ syntax = "proto3";
 package google.firestore.v1;
 
 option csharp_namespace = "Google.Cloud.Firestore.V1";
-option go_package = "google.golang.org/genproto/googleapis/firestore/v1;firestore";
+option go_package = "cloud.google.com/go/firestore/apiv1/firestorepb;firestorepb";
 option java_multiple_files = true;
 option java_outer_classname = "BloomFilterProto";
 option java_package = "com.google.firestore.v1";
@@ -32,21 +32,21 @@ option ruby_package = "Google::Cloud::Firestore::V1";
 // defines the number of bits of the last byte to be ignored as "padding". The
 // values of these "padding" bits are unspecified and must be ignored.
 //
-// To retrieve the first bit, bit 0, calculate: (bitmap[0] & 0x01) != 0.
-// To retrieve the second bit, bit 1, calculate: (bitmap[0] & 0x02) != 0.
-// To retrieve the third bit, bit 2, calculate: (bitmap[0] & 0x04) != 0.
-// To retrieve the fourth bit, bit 3, calculate: (bitmap[0] & 0x08) != 0.
-// To retrieve bit n, calculate: (bitmap[n / 8] & (0x01 << (n % 8))) != 0.
+// To retrieve the first bit, bit 0, calculate: `(bitmap[0] & 0x01) != 0`.
+// To retrieve the second bit, bit 1, calculate: `(bitmap[0] & 0x02) != 0`.
+// To retrieve the third bit, bit 2, calculate: `(bitmap[0] & 0x04) != 0`.
+// To retrieve the fourth bit, bit 3, calculate: `(bitmap[0] & 0x08) != 0`.
+// To retrieve bit n, calculate: `(bitmap[n / 8] & (0x01 << (n % 8))) != 0`.
 //
 // The "size" of a `BitSequence` (the number of bits it contains) is calculated
-// by this formula: (bitmap.length * 8) - padding.
+// by this formula: `(bitmap.length * 8) - padding`.
 message BitSequence {
   // The bytes that encode the bit sequence.
   // May have a length of zero.
   bytes bitmap = 1;
 
   // The number of bits of the last byte in `bitmap` to ignore as "padding".
-  // If the length of `bitmap` is zero, then this value must be 0.
+  // If the length of `bitmap` is zero, then this value must be `0`.
   // Otherwise, this value must be between 0 and 7, inclusive.
   int32 padding = 2;
 }
@@ -57,10 +57,10 @@ message BitSequence {
 // hash as 2 distinct 64-bit hash values, interpreted as unsigned integers
 // using 2's complement encoding.
 //
-// These two hash values, named h1 and h2, are then used to compute the
-// `hash_count` hash values using the formula, starting at i=0:
+// These two hash values, named `h1` and `h2`, are then used to compute the
+// `hash_count` hash values using the formula, starting at `i=0`:
 //
-//   h(i) = h1 + (i * h2)
+//     h(i) = h1 + (i * h2)
 //
 // These resulting values are then taken modulo the number of bits in the bloom
 // filter to get the bits of the bloom filter to test for the given entry.

--- a/packages/firestore/src/protos/google/firestore/v1/common.proto
+++ b/packages/firestore/src/protos/google/firestore/v1/common.proto
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,10 +17,9 @@ syntax = "proto3";
 package google.firestore.v1;
 
 import "google/protobuf/timestamp.proto";
-import "google/api/annotations.proto";
 
 option csharp_namespace = "Google.Cloud.Firestore.V1";
-option go_package = "google.golang.org/genproto/googleapis/firestore/v1;firestore";
+option go_package = "cloud.google.com/go/firestore/apiv1/firestorepb;firestorepb";
 option java_multiple_files = true;
 option java_outer_classname = "CommonProto";
 option java_package = "com.google.firestore.v1";
@@ -32,10 +31,12 @@ option ruby_package = "Google::Cloud::Firestore::V1";
 // Used to restrict a get or update operation on a document to a subset of its
 // fields.
 // This is different from standard field masks, as this is always scoped to a
-// [Document][google.firestore.v1.Document], and takes in account the dynamic nature of [Value][google.firestore.v1.Value].
+// [Document][google.firestore.v1.Document], and takes in account the dynamic
+// nature of [Value][google.firestore.v1.Value].
 message DocumentMask {
-  // The list of field paths in the mask. See [Document.fields][google.firestore.v1.Document.fields] for a field
-  // path syntax reference.
+  // The list of field paths in the mask. See
+  // [Document.fields][google.firestore.v1.Document.fields] for a field path
+  // syntax reference.
   repeated string field_paths = 1;
 }
 
@@ -48,7 +49,7 @@ message Precondition {
     bool exists = 1;
 
     // When set, the target document must exist and have been last updated at
-    // that time.
+    // that time. Timestamp must be microsecond aligned.
     google.protobuf.Timestamp update_time = 2;
   }
 }
@@ -56,6 +57,9 @@ message Precondition {
 // Options for creating a new transaction.
 message TransactionOptions {
   // Options for a transaction that can be used to read and write documents.
+  //
+  // Firestore does not allow 3rd party auth requests to create read-write.
+  // transactions.
   message ReadWrite {
     // An optional transaction to retry.
     bytes retry_transaction = 1;
@@ -67,7 +71,10 @@ message TransactionOptions {
     // consistency.
     oneof consistency_selector {
       // Reads documents at the given time.
-      // This may not be older than 60 seconds.
+      //
+      // This must be a microsecond precision timestamp within the past one
+      // hour, or if Point-in-Time Recovery is enabled, can additionally be a
+      // whole minute timestamp within the past 7 days.
       google.protobuf.Timestamp read_time = 2;
     }
   }

--- a/packages/firestore/src/protos/google/firestore/v1/document.proto
+++ b/packages/firestore/src/protos/google/firestore/v1/document.proto
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@ syntax = "proto3";
 
 package google.firestore.v1;
 
+import "google/api/field_behavior.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "google/type/latlng.proto";
-import "google/api/annotations.proto";
 
 option csharp_namespace = "Google.Cloud.Firestore.V1";
-option go_package = "google.golang.org/genproto/googleapis/firestore/v1;firestore";
+option go_package = "cloud.google.com/go/firestore/apiv1/firestorepb;firestorepb";
 option java_multiple_files = true;
 option java_outer_classname = "DocumentProto";
 option java_package = "com.google.firestore.v1";
@@ -42,23 +42,23 @@ message Document {
   //
   // The map keys represent field names.
   //
+  // Field names matching the regular expression `__.*__` are reserved. Reserved
+  // field names are forbidden except in certain documented contexts. The field
+  // names, represented as UTF-8, must not exceed 1,500 bytes and cannot be
+  // empty.
+  //
+  // Field paths may be used in other contexts to refer to structured fields
+  // defined here. For `map_value`, the field path is represented by a
+  // dot-delimited (`.`) string of segments. Each segment is either a simple
+  // field name (defined below) or a quoted field name. For example, the
+  // structured field `"foo" : { map_value: { "x&y" : { string_value: "hello"
+  // }}}` would be represented by the field path `` foo.`x&y` ``.
+  //
   // A simple field name contains only characters `a` to `z`, `A` to `Z`,
   // `0` to `9`, or `_`, and must not start with `0` to `9`. For example,
   // `foo_bar_17`.
   //
-  // Field names matching the regular expression `__.*__` are reserved. Reserved
-  // field names are forbidden except in certain documented contexts. The map
-  // keys, represented as UTF-8, must not exceed 1,500 bytes and cannot be
-  // empty.
-  //
-  // Field paths may be used in other contexts to refer to structured fields
-  // defined here. For `map_value`, the field path is represented by the simple
-  // or quoted field names of the containing fields, delimited by `.`. For
-  // example, the structured field
-  // `"foo" : { map_value: { "x&y" : { string_value: "hello" }}}` would be
-  // represented by the field path `foo.x&y`.
-  //
-  // Within a field path, a quoted field name starts and ends with `` ` `` and
+  // A quoted field name starts and ends with `` ` `` and
   // may contain any character. Some characters, including `` ` ``, must be
   // escaped using a `\`. For example, `` `x&y` `` represents `x&y` and
   // `` `bak\`tik` `` represents `` bak`tik ``.
@@ -123,12 +123,13 @@ message Value {
 
     // An array value.
     //
-    // Cannot directly contain another array value, though can contain an
+    // Cannot directly contain another array value, though can contain a
     // map which contains another array.
     ArrayValue array_value = 9;
 
     // A map value.
     MapValue map_value = 6;
+
     // Value which references a field.
     //
     // This is considered relative (vs absolute) since it only refers to a field
@@ -139,9 +140,6 @@ message Value {
     // * Must follow [field reference][FieldReference.field_path] limitations.
     //
     // * Not allowed to be used when writing documents.
-    //
-    // (-- NOTE(batchik): long term, there is no reason this type should not be
-    //     allowed to be used on the write path. --)
     string field_reference_value = 19;
 
     // Pointer to a variable defined elsewhere in a pipeline.
@@ -156,13 +154,6 @@ message Value {
     // **Requires:**
     //
     // * Not allowed to be used when writing documents.
-    //
-    // (-- NOTE(batchik): similar to above, there is no reason to not allow
-    //     storing expressions into the database, just no plan to support in
-    //     the near term.
-    //
-    //     This would actually be an interesting way to represent user-defined
-    //     functions or more expressive rules-based systems. --)
     Function function_value = 20;
 
     // A value that represents an unevaluated pipeline.
@@ -170,13 +161,6 @@ message Value {
     // **Requires:**
     //
     // * Not allowed to be used when writing documents.
-    //
-    // (-- NOTE(batchik): similar to above, there is no reason to not allow
-    //     storing expressions into the database, just no plan to support in
-    //     the near term.
-    //
-    //     This would actually be an interesting way to represent user-defined
-    //     functions or more expressive rules-based systems. --)
     Pipeline pipeline_value = 21;
   }
 }
@@ -198,7 +182,6 @@ message MapValue {
   map<string, Value> fields = 1;
 }
 
-
 // Represents an unevaluated scalar expression.
 //
 // For example, the expression `like(user_name, "%alice%")` is represented as:
@@ -208,23 +191,19 @@ message MapValue {
 // args { field_reference: "user_name" }
 // args { string_value: "%alice%" }
 // ```
-//
-// (-- api-linter: core::0123::resource-annotation=disabled
-//     aip.dev/not-precedent: this is not a One Platform API resource. --)
 message Function {
-  // The name of the function to evaluate.
+  // Required. The name of the function to evaluate.
   //
   // **Requires:**
   //
   // * must be in snake case (lower case with underscore separator).
-  //
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
 
-  // Ordered list of arguments the given function expects.
-  repeated Value args = 2;
+  // Optional. Ordered list of arguments the given function expects.
+  repeated Value args = 2 [(google.api.field_behavior) = OPTIONAL];
 
-  // Optional named arguments that certain functions may support.
-  map<string, Value> options = 3;
+  // Optional. Optional named arguments that certain functions may support.
+  map<string, Value> options = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // A Firestore query represented as an ordered list of operations / stages.
@@ -249,21 +228,20 @@ message Pipeline {
   //
   // See public documentation for the full list.
   message Stage {
-    // The name of the stage to evaluate.
+    // Required. The name of the stage to evaluate.
     //
     // **Requires:**
     //
     // * must be in snake case (lower case with underscore separator).
-    //
-    string name = 1;
+    string name = 1 [(google.api.field_behavior) = REQUIRED];
 
-    // Ordered list of arguments the given stage expects.
-    repeated Value args = 2;
+    // Optional. Ordered list of arguments the given stage expects.
+    repeated Value args = 2 [(google.api.field_behavior) = OPTIONAL];
 
-    // Optional named arguments that certain functions may support.
-    map<string, Value> options = 3;
+    // Optional. Optional named arguments that certain functions may support.
+    map<string, Value> options = 3 [(google.api.field_behavior) = OPTIONAL];
   }
 
-  // Ordered list of stages to evaluate.
-  repeated Stage stages = 1;
+  // Required. Ordered list of stages to evaluate.
+  repeated Stage stages = 1 [(google.api.field_behavior) = REQUIRED];
 }

--- a/packages/firestore/src/protos/google/firestore/v1/explain_stats.proto
+++ b/packages/firestore/src/protos/google/firestore/v1/explain_stats.proto
@@ -16,28 +16,26 @@ syntax = "proto3";
 
 package google.firestore.v1;
 
-import "google/firestore/v1/document.proto";
+import "google/protobuf/any.proto";
 
 option csharp_namespace = "Google.Cloud.Firestore.V1";
 option go_package = "cloud.google.com/go/firestore/apiv1/firestorepb;firestorepb";
 option java_multiple_files = true;
-option java_outer_classname = "AggregationResultProto";
+option java_outer_classname = "ExplainStatsProto";
 option java_package = "com.google.firestore.v1";
-option objc_class_prefix = "GCFS";
 option php_namespace = "Google\\Cloud\\Firestore\\V1";
 option ruby_package = "Google::Cloud::Firestore::V1";
 
-// The result of a single bucket from a Firestore aggregation query.
+// Specification of Firestore Explain Stats fields.
+
+// Pipeline explain stats.
 //
-// The keys of `aggregate_fields` are the same for all results in an aggregation
-// query, unlike document queries which can have different fields present for
-// each result.
-message AggregationResult {
-  // The result of the aggregation functions, ex: `COUNT(*) AS total_docs`.
+// Depending on the explain options in the original request, this can contain
+// the optimized plan and / or execution stats.
+message ExplainStats {
+  // The format depends on the `output_format` options in the request.
   //
-  // The key is the
-  // [alias][google.firestore.v1.StructuredAggregationQuery.Aggregation.alias]
-  // assigned to the aggregation function on input and the size of this map
-  // equals the number of aggregation functions in the query.
-  map<string, Value> aggregate_fields = 2;
+  // Currently there are two supported options: `TEXT` and `JSON`.
+  // Both supply a `google.protobuf.StringValue`.
+  google.protobuf.Any data = 1;
 }

--- a/packages/firestore/src/protos/google/firestore/v1/firestore.proto
+++ b/packages/firestore/src/protos/google/firestore/v1/firestore.proto
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,11 +19,14 @@ package google.firestore.v1;
 import "google/api/annotations.proto";
 import "google/api/client.proto";
 import "google/api/field_behavior.proto";
+import "google/api/routing.proto";
 import "google/firestore/v1/aggregation_result.proto";
 import "google/firestore/v1/common.proto";
 import "google/firestore/v1/document.proto";
+import "google/firestore/v1/explain_stats.proto";
 import "google/firestore/v1/pipeline.proto";
 import "google/firestore/v1/query.proto";
+import "google/firestore/v1/query_profile.proto";
 import "google/firestore/v1/write.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
@@ -31,11 +34,10 @@ import "google/protobuf/wrappers.proto";
 import "google/rpc/status.proto";
 
 option csharp_namespace = "Google.Cloud.Firestore.V1";
-option go_package = "google.golang.org/genproto/googleapis/firestore/v1;firestore";
+option go_package = "cloud.google.com/go/firestore/apiv1/firestorepb;firestorepb";
 option java_multiple_files = true;
 option java_outer_classname = "FirestoreProto";
 option java_package = "com.google.firestore.v1";
-option objc_class_prefix = "GCFS";
 option php_namespace = "Google\\Cloud\\Firestore\\V1";
 option ruby_package = "Google::Cloud::Firestore::V1";
 
@@ -47,8 +49,8 @@ option ruby_package = "Google::Cloud::Firestore::V1";
 // document database that simplifies storing, syncing, and querying data for
 // your mobile, web, and IoT apps at global scale. Its client libraries provide
 // live synchronization and offline support, while its security features and
-// integrations with Firebase and Google Cloud Platform (GCP) accelerate
-// building truly serverless apps.
+// integrations with Firebase and Google Cloud Platform accelerate building
+// truly serverless apps.
 service Firestore {
   option (google.api.default_host) = "firestore.googleapis.com";
   option (google.api.oauth_scopes) =
@@ -66,6 +68,9 @@ service Firestore {
   rpc ListDocuments(ListDocumentsRequest) returns (ListDocumentsResponse) {
     option (google.api.http) = {
       get: "/v1/{parent=projects/*/databases/*/documents/*/**}/{collection_id}"
+      additional_bindings {
+        get: "/v1/{parent=projects/*/databases/*/documents}/{collection_id}"
+      }
     };
   }
 
@@ -90,7 +95,8 @@ service Firestore {
   //
   // Documents returned by this method are not guaranteed to be returned in the
   // same order that they were requested.
-  rpc BatchGetDocuments(BatchGetDocumentsRequest) returns (stream BatchGetDocumentsResponse) {
+  rpc BatchGetDocuments(BatchGetDocumentsRequest)
+      returns (stream BatchGetDocumentsResponse) {
     option (google.api.http) = {
       post: "/v1/{database=projects/*/databases/*}/documents:batchGet"
       body: "*"
@@ -98,7 +104,8 @@ service Firestore {
   }
 
   // Starts a new transaction.
-  rpc BeginTransaction(BeginTransactionRequest) returns (BeginTransactionResponse) {
+  rpc BeginTransaction(BeginTransactionRequest)
+      returns (BeginTransactionResponse) {
     option (google.api.http) = {
       post: "/v1/{database=projects/*/databases/*}/documents:beginTransaction"
       body: "*"
@@ -143,12 +150,23 @@ service Firestore {
       post: "/v1/{database=projects/*/databases/*}/documents:executePipeline"
       body: "*"
     };
+    option (google.api.routing) = {
+      routing_parameters {
+        field: "database"
+        path_template: "projects/{project_id=*}/**"
+      }
+      routing_parameters {
+        field: "database"
+        path_template: "projects/*/databases/{database_id=*}/**"
+      }
+    };
   }
 
   // Runs an aggregation query.
   //
-  // Rather than producing [Document][google.firestore.v1.Document] results like [Firestore.RunQuery][google.firestore.v1.Firestore.RunQuery],
-  // this API allows running an aggregation to produce a series of
+  // Rather than producing [Document][google.firestore.v1.Document] results like
+  // [Firestore.RunQuery][google.firestore.v1.Firestore.RunQuery], this API
+  // allows running an aggregation to produce a series of
   // [AggregationResult][google.firestore.v1.AggregationResult] server-side.
   //
   // High-Level Example:
@@ -157,7 +175,8 @@ service Firestore {
   // -- Return the number of documents in table given a filter.
   // SELECT COUNT(*) FROM ( SELECT * FROM k where a = true );
   // ```
-  rpc RunAggregationQuery(RunAggregationQueryRequest) returns (stream RunAggregationQueryResponse) {
+  rpc RunAggregationQuery(RunAggregationQueryRequest)
+      returns (stream RunAggregationQueryResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*/databases/*/documents}:runAggregationQuery"
       body: "*"
@@ -182,7 +201,8 @@ service Firestore {
     };
   }
 
-  // Streams batches of document updates and deletes, in order.
+  // Streams batches of document updates and deletes, in order. This method is
+  // only available via gRPC or WebChannel (not REST).
   rpc Write(stream WriteRequest) returns (stream WriteResponse) {
     option (google.api.http) = {
       post: "/v1/{database=projects/*/databases/*}/documents:write"
@@ -190,7 +210,8 @@ service Firestore {
     };
   }
 
-  // Listens to changes.
+  // Listens to changes. This method is only available via gRPC or WebChannel
+  // (not REST).
   rpc Listen(stream ListenRequest) returns (stream ListenResponse) {
     option (google.api.http) = {
       post: "/v1/{database=projects/*/databases/*}/documents:listen"
@@ -199,7 +220,8 @@ service Firestore {
   }
 
   // Lists all the collection IDs underneath a document.
-  rpc ListCollectionIds(ListCollectionIdsRequest) returns (ListCollectionIdsResponse) {
+  rpc ListCollectionIds(ListCollectionIdsRequest)
+      returns (ListCollectionIdsResponse) {
     option (google.api.http) = {
       post: "/v1/{parent=projects/*/databases/*/documents}:listCollectionIds"
       body: "*"
@@ -216,7 +238,8 @@ service Firestore {
   // The BatchWrite method does not apply the write operations atomically
   // and can apply them out of order. Method does not allow more than one write
   // per document. Each write succeeds or fails independently. See the
-  // [BatchWriteResponse][google.firestore.v1.BatchWriteResponse] for the success status of each write.
+  // [BatchWriteResponse][google.firestore.v1.BatchWriteResponse] for the
+  // success status of each write.
   //
   // If you require an atomically applied set of writes, use
   // [Commit][google.firestore.v1.Firestore.Commit] instead.
@@ -236,7 +259,8 @@ service Firestore {
   }
 }
 
-// The request for [Firestore.GetDocument][google.firestore.v1.Firestore.GetDocument].
+// The request for
+// [Firestore.GetDocument][google.firestore.v1.Firestore.GetDocument].
 message GetDocumentRequest {
   // Required. The resource name of the Document to get. In the format:
   // `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
@@ -255,78 +279,109 @@ message GetDocumentRequest {
     bytes transaction = 3;
 
     // Reads the version of the document at the given time.
-    // This may not be older than 270 seconds.
+    //
+    // This must be a microsecond precision timestamp within the past one hour,
+    // or if Point-in-Time Recovery is enabled, can additionally be a whole
+    // minute timestamp within the past 7 days.
     google.protobuf.Timestamp read_time = 5;
   }
 }
 
-// The request for [Firestore.ListDocuments][google.firestore.v1.Firestore.ListDocuments].
+// The request for
+// [Firestore.ListDocuments][google.firestore.v1.Firestore.ListDocuments].
 message ListDocumentsRequest {
   // Required. The parent resource name. In the format:
   // `projects/{project_id}/databases/{database_id}/documents` or
   // `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+  //
   // For example:
   // `projects/my-project/databases/my-database/documents` or
   // `projects/my-project/databases/my-database/documents/chatrooms/my-chatroom`
   string parent = 1 [(google.api.field_behavior) = REQUIRED];
 
-  // Required. The collection ID, relative to `parent`, to list. For example: `chatrooms`
-  // or `messages`.
-  string collection_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // Optional. The collection ID, relative to `parent`, to list.
+  //
+  // For example: `chatrooms` or `messages`.
+  //
+  // This is optional, and when not provided, Firestore will list documents
+  // from all collections under the provided `parent`.
+  string collection_id = 2 [(google.api.field_behavior) = OPTIONAL];
 
-  // The maximum number of documents to return.
-  int32 page_size = 3;
+  // Optional. The maximum number of documents to return in a single response.
+  //
+  // Firestore may return fewer than this value.
+  int32 page_size = 3 [(google.api.field_behavior) = OPTIONAL];
 
-  // The `next_page_token` value returned from a previous List request, if any.
-  string page_token = 4;
+  // Optional. A page token, received from a previous `ListDocuments` response.
+  //
+  // Provide this to retrieve the subsequent page. When paginating, all other
+  // parameters (with the exception of `page_size`) must match the values set
+  // in the request that generated the page token.
+  string page_token = 4 [(google.api.field_behavior) = OPTIONAL];
 
-  // The order to sort results by. For example: `priority desc, name`.
-  string order_by = 6;
+  // Optional. The optional ordering of the documents to return.
+  //
+  // For example: `priority desc, __name__ desc`.
+  //
+  // This mirrors the [`ORDER BY`][google.firestore.v1.StructuredQuery.order_by]
+  // used in Firestore queries but in a string representation. When absent,
+  // documents are ordered based on `__name__ ASC`.
+  string order_by = 6 [(google.api.field_behavior) = OPTIONAL];
 
-  // The fields to return. If not set, returns all fields.
+  // Optional. The fields to return. If not set, returns all fields.
   //
   // If a document has a field that is not present in this mask, that field
   // will not be returned in the response.
-  DocumentMask mask = 7;
+  DocumentMask mask = 7 [(google.api.field_behavior) = OPTIONAL];
 
   // The consistency mode for this transaction.
   // If not set, defaults to strong consistency.
   oneof consistency_selector {
-    // Reads documents in a transaction.
+    // Perform the read as part of an already active transaction.
     bytes transaction = 8;
 
-    // Reads documents as they were at the given time.
-    // This may not be older than 270 seconds.
+    // Perform the read at the provided time.
+    //
+    // This must be a microsecond precision timestamp within the past one hour,
+    // or if Point-in-Time Recovery is enabled, can additionally be a whole
+    // minute timestamp within the past 7 days.
     google.protobuf.Timestamp read_time = 10;
   }
 
-  // If the list should show missing documents. A missing document is a
-  // document that does not exist but has sub-documents. These documents will
-  // be returned with a key but will not have fields, [Document.create_time][google.firestore.v1.Document.create_time],
-  // or [Document.update_time][google.firestore.v1.Document.update_time] set.
+  // If the list should show missing documents.
   //
-  // Requests with `show_missing` may not specify `where` or
-  // `order_by`.
+  // A document is missing if it does not exist, but there are sub-documents
+  // nested underneath it. When true, such missing documents will be returned
+  // with a key but will not have fields,
+  // [`create_time`][google.firestore.v1.Document.create_time], or
+  // [`update_time`][google.firestore.v1.Document.update_time] set.
+  //
+  // Requests with `show_missing` may not specify `where` or `order_by`.
   bool show_missing = 12;
 }
 
-// The response for [Firestore.ListDocuments][google.firestore.v1.Firestore.ListDocuments].
+// The response for
+// [Firestore.ListDocuments][google.firestore.v1.Firestore.ListDocuments].
 message ListDocumentsResponse {
   // The Documents found.
   repeated Document documents = 1;
 
-  // The next page token.
+  // A token to retrieve the next page of documents.
+  //
+  // If this field is omitted, there are no subsequent pages.
   string next_page_token = 2;
 }
 
-// The request for [Firestore.CreateDocument][google.firestore.v1.Firestore.CreateDocument].
+// The request for
+// [Firestore.CreateDocument][google.firestore.v1.Firestore.CreateDocument].
 message CreateDocumentRequest {
   // Required. The parent resource. For example:
   // `projects/{project_id}/databases/{database_id}/documents` or
   // `projects/{project_id}/databases/{database_id}/documents/chatrooms/{chatroom_id}`
   string parent = 1 [(google.api.field_behavior) = REQUIRED];
 
-  // Required. The collection ID, relative to `parent`, to list. For example: `chatrooms`.
+  // Required. The collection ID, relative to `parent`, to list. For example:
+  // `chatrooms`.
   string collection_id = 2 [(google.api.field_behavior) = REQUIRED];
 
   // The client-assigned document ID to use for this document.
@@ -344,7 +399,8 @@ message CreateDocumentRequest {
   DocumentMask mask = 5;
 }
 
-// The request for [Firestore.UpdateDocument][google.firestore.v1.Firestore.UpdateDocument].
+// The request for
+// [Firestore.UpdateDocument][google.firestore.v1.Firestore.UpdateDocument].
 message UpdateDocumentRequest {
   // Required. The updated document.
   // Creates the document if it does not already exist.
@@ -370,7 +426,8 @@ message UpdateDocumentRequest {
   Precondition current_document = 4;
 }
 
-// The request for [Firestore.DeleteDocument][google.firestore.v1.Firestore.DeleteDocument].
+// The request for
+// [Firestore.DeleteDocument][google.firestore.v1.Firestore.DeleteDocument].
 message DeleteDocumentRequest {
   // Required. The resource name of the Document to delete. In the format:
   // `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
@@ -381,7 +438,8 @@ message DeleteDocumentRequest {
   Precondition current_document = 2;
 }
 
-// The request for [Firestore.BatchGetDocuments][google.firestore.v1.Firestore.BatchGetDocuments].
+// The request for
+// [Firestore.BatchGetDocuments][google.firestore.v1.Firestore.BatchGetDocuments].
 message BatchGetDocumentsRequest {
   // Required. The database name. In the format:
   // `projects/{project_id}/databases/{database_id}`.
@@ -412,12 +470,16 @@ message BatchGetDocumentsRequest {
     TransactionOptions new_transaction = 5;
 
     // Reads documents as they were at the given time.
-    // This may not be older than 270 seconds.
+    //
+    // This must be a microsecond precision timestamp within the past one hour,
+    // or if Point-in-Time Recovery is enabled, can additionally be a whole
+    // minute timestamp within the past 7 days.
     google.protobuf.Timestamp read_time = 7;
   }
 }
 
-// The streamed response for [Firestore.BatchGetDocuments][google.firestore.v1.Firestore.BatchGetDocuments].
+// The streamed response for
+// [Firestore.BatchGetDocuments][google.firestore.v1.Firestore.BatchGetDocuments].
 message BatchGetDocumentsResponse {
   // A single result.
   // This can be empty if the server is just returning a transaction.
@@ -432,17 +494,19 @@ message BatchGetDocumentsResponse {
 
   // The transaction that was started as part of this request.
   // Will only be set in the first response, and only if
-  // [BatchGetDocumentsRequest.new_transaction][google.firestore.v1.BatchGetDocumentsRequest.new_transaction] was set in the request.
+  // [BatchGetDocumentsRequest.new_transaction][google.firestore.v1.BatchGetDocumentsRequest.new_transaction]
+  // was set in the request.
   bytes transaction = 3;
 
   // The time at which the document was read.
-  // This may be monotonically increasing, in this case the previous documents in
+  // This may be monotically increasing, in this case the previous documents in
   // the result stream are guaranteed not to have changed between their
   // read_time and this one.
   google.protobuf.Timestamp read_time = 4;
 }
 
-// The request for [Firestore.BeginTransaction][google.firestore.v1.Firestore.BeginTransaction].
+// The request for
+// [Firestore.BeginTransaction][google.firestore.v1.Firestore.BeginTransaction].
 message BeginTransactionRequest {
   // Required. The database name. In the format:
   // `projects/{project_id}/databases/{database_id}`.
@@ -453,7 +517,8 @@ message BeginTransactionRequest {
   TransactionOptions options = 2;
 }
 
-// The response for [Firestore.BeginTransaction][google.firestore.v1.Firestore.BeginTransaction].
+// The response for
+// [Firestore.BeginTransaction][google.firestore.v1.Firestore.BeginTransaction].
 message BeginTransactionResponse {
   // The transaction that was started.
   bytes transaction = 1;
@@ -516,7 +581,9 @@ message RunQueryRequest {
   // The consistency mode for this transaction.
   // If not set, defaults to strong consistency.
   oneof consistency_selector {
-    // Reads documents in a transaction.
+    // Run the query within an already active transaction.
+    //
+    // The value here is the opaque transaction ID to execute the query in.
     bytes transaction = 5;
 
     // Starts a new transaction and reads the documents.
@@ -526,21 +593,29 @@ message RunQueryRequest {
     TransactionOptions new_transaction = 6;
 
     // Reads documents as they were at the given time.
-    // This may not be older than 270 seconds.
+    //
+    // This must be a microsecond precision timestamp within the past one hour,
+    // or if Point-in-Time Recovery is enabled, can additionally be a whole
+    // minute timestamp within the past 7 days.
     google.protobuf.Timestamp read_time = 7;
   }
+
+  // Optional. Explain options for the query. If set, additional query
+  // statistics will be returned. If not, only query results will be returned.
+  ExplainOptions explain_options = 10 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// The response for [Firestore.RunQuery][google.firestore.v1.Firestore.RunQuery].
+// The response for
+// [Firestore.RunQuery][google.firestore.v1.Firestore.RunQuery].
 message RunQueryResponse {
   // The transaction that was started as part of this request.
   // Can only be set in the first response, and only if
-  // [RunQueryRequest.new_transaction][google.firestore.v1.RunQueryRequest.new_transaction] was set in the request.
-  // If set, no other fields will be set in this response.
+  // [RunQueryRequest.new_transaction][google.firestore.v1.RunQueryRequest.new_transaction]
+  // was set in the request. If set, no other fields will be set in this
+  // response.
   bytes transaction = 2;
 
-  // A query result.
-  // Not set when reporting partial progress.
+  // A query result, not set when reporting partial progress.
   Document document = 1;
 
   // The time at which the document was read. This may be monotonically
@@ -555,14 +630,28 @@ message RunQueryResponse {
   // The number of results that have been skipped due to an offset between
   // the last response and the current response.
   int32 skipped_results = 4;
+
+  // The continuation mode for the query. If present, it indicates the current
+  // query response stream has finished. This can be set with or without a
+  // `document` present, but when set, no more results are returned.
+  oneof continuation_selector {
+    // If present, Firestore has completely finished the request and no more
+    // documents will be returned.
+    bool done = 6;
+  }
+
+  // Query explain metrics. This is only present when the
+  // [RunQueryRequest.explain_options][google.firestore.v1.RunQueryRequest.explain_options]
+  // is provided, and it is sent only once with the last response in the stream.
+  ExplainMetrics explain_metrics = 11;
 }
 
-// The request for [Firestore.ExecutePipeline][].
+// The request for
+// [Firestore.ExecutePipeline][google.firestore.v1.Firestore.ExecutePipeline].
 message ExecutePipelineRequest {
-  // Database identifier, in the form `projects/{project}/databases/{database}`.
-  string database = 1 [
-    (google.api.field_behavior) = REQUIRED
-  ];
+  // Required. Database identifier, in the form
+  // `projects/{project}/databases/{database}`.
+  string database = 1 [(google.api.field_behavior) = REQUIRED];
 
   oneof pipeline_type {
     // A pipelined operation.
@@ -589,17 +678,15 @@ message ExecutePipelineRequest {
     // minute timestamp within the past 7 days.
     google.protobuf.Timestamp read_time = 7;
   }
-
-  // Explain / analyze options for the pipeline.
-  // ExplainOptions explain_options = 8 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // The response for [Firestore.Execute][].
 message ExecutePipelineResponse {
   // Newly created transaction identifier.
   //
-  // This field is only specified on the first response from the server when
-  // the request specified [ExecuteRequest.new_transaction][].
+  // This field is only specified as part of the first response from the server,
+  // alongside the `results` field when the original request specified
+  // [ExecuteRequest.new_transaction][].
   bytes transaction = 1;
 
   // An ordered batch of results returned executing a pipeline.
@@ -608,32 +695,38 @@ message ExecutePipelineResponse {
   // progress message is returned.
   //
   // The fields present in the returned documents are only those that were
-  // explicitly requested in the pipeline, this include those like
-  // [`__name__`][Document.name] & [`__update_time__`][Document.update_time].
-  // This is explicitly a divergence from `Firestore.RunQuery` /
-  // `Firestore.GetDocument` RPCs which always return such fields even when they
-  // are not specified in the [`mask`][DocumentMask].
+  // explicitly requested in the pipeline, this includes those like
+  // [`__name__`][google.firestore.v1.Document.name] and
+  // [`__update_time__`][google.firestore.v1.Document.update_time]. This is
+  // explicitly a divergence from `Firestore.RunQuery` / `Firestore.GetDocument`
+  // RPCs which always return such fields even when they are not specified in
+  // the [`mask`][google.firestore.v1.DocumentMask].
   repeated Document results = 2;
 
-  // The time at which the document(s) were read.
+  // The time at which the results are valid.
   //
-  // This may be monotonically increasing; in this case, the previous documents
-  // in the result stream are guaranteed not to have changed between their
-  // `execution_time` and this one.
+  // This is a (not strictly) monotonically increasing value across multiple
+  // responses in the same stream. The API guarantees that all previously
+  // returned results are still valid at the latest `execution_time`. This
+  // allows the API consumer to treat the query if it ran at the latest
+  // `execution_time` returned.
   //
   // If the query returns no results, a response with `execution_time` and no
   // `results` will be sent, and this represents the time at which the operation
   // was run.
   google.protobuf.Timestamp execution_time = 3;
 
-  // Query explain metrics.
+  // Query explain stats.
   //
-  // Set on the last response when [ExecutePipelineRequest.explain_options][]
-  // was specified on the request.
-  // ExplainMetrics explain_metrics = 4;
+  // This is present on the **last** response if the request configured explain
+  // to run in 'analyze' or 'explain' mode in the pipeline options. If the query
+  // does not return any results, a response with `explain_stats` and no
+  // `results` will still be sent.
+  ExplainStats explain_stats = 4;
 }
 
-// The request for [Firestore.RunAggregationQuery][google.firestore.v1.Firestore.RunAggregationQuery].
+// The request for
+// [Firestore.RunAggregationQuery][google.firestore.v1.Firestore.RunAggregationQuery].
 message RunAggregationQueryRequest {
   // Required. The parent resource name. In the format:
   // `projects/{project_id}/databases/{database_id}/documents` or
@@ -664,19 +757,23 @@ message RunAggregationQueryRequest {
 
     // Executes the query at the given timestamp.
     //
-    // Requires:
-    //
-    // * Cannot be more than 270 seconds in the past.
+    // This must be a microsecond precision timestamp within the past one hour,
+    // or if Point-in-Time Recovery is enabled, can additionally be a whole
+    // minute timestamp within the past 7 days.
     google.protobuf.Timestamp read_time = 6;
   }
+
+  // Optional. Explain options for the query. If set, additional query
+  // statistics will be returned. If not, only query results will be returned.
+  ExplainOptions explain_options = 8 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// The response for [Firestore.RunAggregationQuery][google.firestore.v1.Firestore.RunAggregationQuery].
+// The response for
+// [Firestore.RunAggregationQuery][google.firestore.v1.Firestore.RunAggregationQuery].
 message RunAggregationQueryResponse {
   // A single aggregation result.
   //
-  // Not present when reporting partial progress or when the query produced
-  // zero results.
+  // Not present when reporting partial progress.
   AggregationResult result = 1;
 
   // The transaction that was started as part of this request.
@@ -685,11 +782,24 @@ message RunAggregationQueryResponse {
   // a new transaction.
   bytes transaction = 2;
 
-  // The time at which the aggregate value is valid for.
+  // The time at which the aggregate result was computed. This is always
+  // monotonically increasing; in this case, the previous AggregationResult in
+  // the result stream are guaranteed not to have changed between their
+  // `read_time` and this one.
+  //
+  // If the query returns no results, a response with `read_time` and no
+  // `result` will be sent, and this represents the time at which the query
+  // was run.
   google.protobuf.Timestamp read_time = 3;
+
+  // Query explain metrics. This is only present when the
+  // [RunAggregationQueryRequest.explain_options][google.firestore.v1.RunAggregationQueryRequest.explain_options]
+  // is provided, and it is sent only once with the last response in the stream.
+  ExplainMetrics explain_metrics = 10;
 }
 
-// The request for [Firestore.PartitionQuery][google.firestore.v1.Firestore.PartitionQuery].
+// The request for
+// [Firestore.PartitionQuery][google.firestore.v1.Firestore.PartitionQuery].
 message PartitionQueryRequest {
   // Required. The parent resource name. In the format:
   // `projects/{project_id}/databases/{database_id}/documents`.
@@ -739,9 +849,21 @@ message PartitionQueryRequest {
   // if more results exist. A second call to PartitionQuery will return up to
   // 2 partitions, to complete the total of 10 specified in `partition_count`.
   int32 page_size = 5;
+
+  // The consistency mode for this request.
+  // If not set, defaults to strong consistency.
+  oneof consistency_selector {
+    // Reads documents as they were at the given time.
+    //
+    // This must be a microsecond precision timestamp within the past one hour,
+    // or if Point-in-Time Recovery is enabled, can additionally be a whole
+    // minute timestamp within the past 7 days.
+    google.protobuf.Timestamp read_time = 6;
+  }
 }
 
-// The response for [Firestore.PartitionQuery][google.firestore.v1.Firestore.PartitionQuery].
+// The response for
+// [Firestore.PartitionQuery][google.firestore.v1.Firestore.PartitionQuery].
 message PartitionQueryResponse {
   // Partition results.
   // Each partition is a split point that can be used by RunQuery as a starting
@@ -759,7 +881,7 @@ message PartitionQueryResponse {
   //  * query, start_at B
   //
   // An empty result may indicate that the query has too few results to be
-  // partitioned.
+  // partitioned, or that the query is not yet supported for partitioning.
   repeated Cursor partitions = 1;
 
   // A page token that may be used to request an additional set of results, up
@@ -800,9 +922,9 @@ message WriteRequest {
   // A stream token that was previously sent by the server.
   //
   // The client should set this field to the token from the most recent
-  // [WriteResponse][google.firestore.v1.WriteResponse] it has received. This acknowledges that the client has
-  // received responses up to this token. After sending this token, earlier
-  // tokens may not be used anymore.
+  // [WriteResponse][google.firestore.v1.WriteResponse] it has received. This
+  // acknowledges that the client has received responses up to this token. After
+  // sending this token, earlier tokens may not be used anymore.
   //
   // The server may close the stream if there are too many unacknowledged
   // responses.
@@ -872,8 +994,8 @@ message ListenResponse {
     // A [Document][google.firestore.v1.Document] has been deleted.
     DocumentDelete document_delete = 4;
 
-    // A [Document][google.firestore.v1.Document] has been removed from a target (because it is no longer
-    // relevant to that target).
+    // A [Document][google.firestore.v1.Document] has been removed from a target
+    // (because it is no longer relevant to that target).
     DocumentRemove document_remove = 6;
 
     // A filter to apply to the set of documents previously returned for the
@@ -924,10 +1046,12 @@ message Target {
 
   // When to start listening.
   //
-  // If not specified, all matching Documents are returned before any
-  // subsequent changes.
+  // If specified, only the matching Documents that have been updated AFTER the
+  // `resume_token` or `read_time` will be returned. Otherwise, all matching
+  // Documents are returned before any subsequent changes.
   oneof resume_type {
-    // A resume token from a prior [TargetChange][google.firestore.v1.TargetChange] for an identical target.
+    // A resume token from a prior
+    // [TargetChange][google.firestore.v1.TargetChange] for an identical target.
     //
     // Using a resume token with a different target is unsupported and may fail.
     bytes resume_token = 4;
@@ -940,6 +1064,21 @@ message Target {
 
   // The target ID that identifies the target on the stream. Must be a positive
   // number and non-zero.
+  //
+  // If `target_id` is 0 (or unspecified), the server will assign an ID for this
+  // target and return that in a `TargetChange::ADD` event. Once a target with
+  // `target_id=0` is added, all subsequent targets must also have
+  // `target_id=0`. If an `AddTarget` request with `target_id != 0` is
+  // sent to the server after a target with `target_id=0` is added, the server
+  // will immediately send a response with a `TargetChange::Remove` event.
+  //
+  // Note that if the client sends multiple `AddTarget` requests
+  // without an ID, the order of IDs returned in `TargetChange.target_ids` are
+  // undefined. Therefore, clients should provide a target ID instead of relying
+  // on the server to assign one.
+  //
+  // If `target_id` is non-zero, there must not be an existing active target on
+  // this stream with the same ID.
   int32 target_id = 5;
 
   // If the target should be removed once it is current and consistent.
@@ -951,7 +1090,6 @@ message Target {
   // This value is only relevant when a `resume_type` is provided. This value
   // being present and greater than zero signals that the client wants
   // `ExistenceFilter.unchanged_names` to be included in the response.
-  //
   google.protobuf.Int32Value expected_count = 12;
 }
 
@@ -1018,7 +1156,8 @@ message TargetChange {
   google.protobuf.Timestamp read_time = 6;
 }
 
-// The request for [Firestore.ListCollectionIds][google.firestore.v1.Firestore.ListCollectionIds].
+// The request for
+// [Firestore.ListCollectionIds][google.firestore.v1.Firestore.ListCollectionIds].
 message ListCollectionIdsRequest {
   // Required. The parent document. In the format:
   // `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
@@ -1032,9 +1171,21 @@ message ListCollectionIdsRequest {
   // A page token. Must be a value from
   // [ListCollectionIdsResponse][google.firestore.v1.ListCollectionIdsResponse].
   string page_token = 3;
+
+  // The consistency mode for this request.
+  // If not set, defaults to strong consistency.
+  oneof consistency_selector {
+    // Reads documents as they were at the given time.
+    //
+    // This must be a microsecond precision timestamp within the past one hour,
+    // or if Point-in-Time Recovery is enabled, can additionally be a whole
+    // minute timestamp within the past 7 days.
+    google.protobuf.Timestamp read_time = 4;
+  }
 }
 
-// The response from [Firestore.ListCollectionIds][google.firestore.v1.Firestore.ListCollectionIds].
+// The response from
+// [Firestore.ListCollectionIds][google.firestore.v1.Firestore.ListCollectionIds].
 message ListCollectionIdsResponse {
   // The collection ids.
   repeated string collection_ids = 1;
@@ -1043,7 +1194,8 @@ message ListCollectionIdsResponse {
   string next_page_token = 2;
 }
 
-// The request for [Firestore.BatchWrite][google.firestore.v1.Firestore.BatchWrite].
+// The request for
+// [Firestore.BatchWrite][google.firestore.v1.Firestore.BatchWrite].
 message BatchWriteRequest {
   // Required. The database name. In the format:
   // `projects/{project_id}/databases/{database_id}`.
@@ -1060,7 +1212,8 @@ message BatchWriteRequest {
   map<string, string> labels = 3;
 }
 
-// The response from [Firestore.BatchWrite][google.firestore.v1.Firestore.BatchWrite].
+// The response from
+// [Firestore.BatchWrite][google.firestore.v1.Firestore.BatchWrite].
 message BatchWriteResponse {
   // The result of applying the writes.
   //

--- a/packages/firestore/src/protos/google/firestore/v1/pipeline.proto
+++ b/packages/firestore/src/protos/google/firestore/v1/pipeline.proto
@@ -1,41 +1,43 @@
-/*!
- * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 syntax = "proto3";
+
 package google.firestore.v1;
+
+import "google/api/field_behavior.proto";
 import "google/firestore/v1/document.proto";
+
 option csharp_namespace = "Google.Cloud.Firestore.V1";
+option go_package = "cloud.google.com/go/firestore/apiv1/firestorepb;firestorepb";
+option java_multiple_files = true;
+option java_outer_classname = "PipelineProto";
+option java_package = "com.google.firestore.v1";
+option objc_class_prefix = "GCFS";
 option php_namespace = "Google\\Cloud\\Firestore\\V1";
 option ruby_package = "Google::Cloud::Firestore::V1";
-option java_multiple_files = true;
-option java_package = "com.google.firestore.v1";
-option java_outer_classname = "PipelineProto";
-option objc_class_prefix = "GCFS";
+
 // A Firestore query represented as an ordered list of operations / stages.
 //
-// This is considered the top-level function which plans & executes a query.
+// This is considered the top-level function which plans and executes a query.
 // It is logically equivalent to `query(stages, options)`, but prevents the
 // client from having to build a function wrapper.
 message StructuredPipeline {
-  // The pipeline query to execute.
-  Pipeline pipeline = 1;
-  // Optional query-level arguments.
+  // Required. The pipeline query to execute.
+  Pipeline pipeline = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Optional. Optional query-level arguments.
   //
-  // (-- Think query statement hints. --)
-  //
-  // (-- TODO(batchik): define the api contract of using an unsupported hint --)
-  map<string, Value> options = 2;
+  map<string, Value> options = 2 [(google.api.field_behavior) = OPTIONAL];
 }

--- a/packages/firestore/src/protos/google/firestore/v1/query.proto
+++ b/packages/firestore/src/protos/google/firestore/v1/query.proto
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@ syntax = "proto3";
 
 package google.firestore.v1;
 
+import "google/api/field_behavior.proto";
 import "google/firestore/v1/document.proto";
 import "google/protobuf/wrappers.proto";
-import "google/api/annotations.proto";
 
 option csharp_namespace = "Google.Cloud.Firestore.V1";
-option go_package = "google.golang.org/genproto/googleapis/firestore/v1;firestore";
+option go_package = "cloud.google.com/go/firestore/apiv1/firestorepb;firestorepb";
 option java_multiple_files = true;
 option java_outer_classname = "QueryProto";
 option java_package = "com.google.firestore.v1";
@@ -30,6 +30,15 @@ option php_namespace = "Google\\Cloud\\Firestore\\V1";
 option ruby_package = "Google::Cloud::Firestore::V1";
 
 // A Firestore query.
+//
+// The query stages are executed in the following order:
+// 1. from
+// 2. where
+// 3. select
+// 4. order_by + start_at + end_at
+// 5. offset
+// 6. limit
+// 7. find_nearest
 message StructuredQuery {
   // A selection of a collection, such as `messages as m1`.
   message CollectionSelector {
@@ -76,7 +85,10 @@ message StructuredQuery {
     Operator op = 1;
 
     // The list of filters to combine.
-    // Must contain at least one filter.
+    //
+    // Requires:
+    //
+    // * At least one filter is present.
     repeated Filter filters = 2;
   }
 
@@ -133,8 +145,9 @@ message StructuredQuery {
       //
       // Requires:
       //
-      // * That `value` is a non-empty `ArrayValue` with at most 10 values.
-      // * No other `IN` or `ARRAY_CONTAINS_ANY` or `NOT_IN`.
+      // * That `value` is a non-empty `ArrayValue`, subject to disjunction
+      //   limits.
+      // * No `NOT_IN` filters in the same query.
       IN = 8;
 
       // The given `field` is an array that contains any of the values in the
@@ -142,8 +155,10 @@ message StructuredQuery {
       //
       // Requires:
       //
-      // * That `value` is a non-empty `ArrayValue` with at most 10 values.
-      // * No other `IN` or `ARRAY_CONTAINS_ANY` or `NOT_IN`.
+      // * That `value` is a non-empty `ArrayValue`, subject to disjunction
+      //   limits.
+      // * No other `ARRAY_CONTAINS_ANY` filters within the same disjunction.
+      // * No `NOT_IN` filters in the same query.
       ARRAY_CONTAINS_ANY = 9;
 
       // The value of the `field` is not in the given array.
@@ -151,7 +166,7 @@ message StructuredQuery {
       // Requires:
       //
       // * That `value` is a non-empty `ArrayValue` with at most 10 values.
-      // * No other `IN`, `ARRAY_CONTAINS_ANY`, `NOT_IN`, `NOT_EQUAL`,
+      // * No other `OR`, `IN`, `ARRAY_CONTAINS_ANY`, `NOT_IN`, `NOT_EQUAL`,
       //   `IS_NOT_NULL`, or `IS_NOT_NAN`.
       // * That `field` comes first in the `order_by`.
       NOT_IN = 10;
@@ -216,20 +231,6 @@ message StructuredQuery {
     Direction direction = 2;
   }
 
-  // A reference to a field, such as `max(messages.time) as max_time`.
-  message FieldReference {
-    string field_path = 2;
-  }
-
-  // The projection of document's fields to return.
-  message Projection {
-    // The fields to return.
-    //
-    // If empty, all fields are returned. To only return the name
-    // of the document, use `['__name__']`.
-    repeated FieldReference fields = 2;
-  }
-
   // A sort direction.
   enum Direction {
     // Unspecified.
@@ -242,7 +243,99 @@ message StructuredQuery {
     DESCENDING = 2;
   }
 
-  // The projection to return.
+  // A reference to a field in a document, ex: `stats.operations`.
+  message FieldReference {
+    // A reference to a field in a document.
+    //
+    // Requires:
+    //
+    // * MUST be a dot-delimited (`.`) string of segments, where each segment
+    // conforms to [document field name][google.firestore.v1.Document.fields]
+    // limitations.
+    string field_path = 2;
+  }
+
+  // The projection of document's fields to return.
+  message Projection {
+    // The fields to return.
+    //
+    // If empty, all fields are returned. To only return the name
+    // of the document, use `['__name__']`.
+    repeated FieldReference fields = 2;
+  }
+
+  // Nearest Neighbors search config. The ordering provided by FindNearest
+  // supersedes the order_by stage. If multiple documents have the same vector
+  // distance, the returned document order is not guaranteed to be stable
+  // between queries.
+  message FindNearest {
+    // The distance measure to use when comparing vectors.
+    enum DistanceMeasure {
+      // Should not be set.
+      DISTANCE_MEASURE_UNSPECIFIED = 0;
+
+      // Measures the EUCLIDEAN distance between the vectors. See
+      // [Euclidean](https://en.wikipedia.org/wiki/Euclidean_distance) to learn
+      // more. The resulting distance decreases the more similar two vectors
+      // are.
+      EUCLIDEAN = 1;
+
+      // COSINE distance compares vectors based on the angle between them, which
+      // allows you to measure similarity that isn't based on the vectors
+      // magnitude. We recommend using DOT_PRODUCT with unit normalized vectors
+      // instead of COSINE distance, which is mathematically equivalent with
+      // better performance. See [Cosine
+      // Similarity](https://en.wikipedia.org/wiki/Cosine_similarity) to learn
+      // more about COSINE similarity and COSINE distance. The resulting
+      // COSINE distance decreases the more similar two vectors are.
+      COSINE = 2;
+
+      // Similar to cosine but is affected by the magnitude of the vectors. See
+      // [Dot Product](https://en.wikipedia.org/wiki/Dot_product) to learn more.
+      // The resulting distance increases the more similar two vectors are.
+      DOT_PRODUCT = 3;
+    }
+
+    // Required. An indexed vector field to search upon. Only documents which
+    // contain vectors whose dimensionality match the query_vector can be
+    // returned.
+    FieldReference vector_field = 1 [(google.api.field_behavior) = REQUIRED];
+
+    // Required. The query vector that we are searching on. Must be a vector of
+    // no more than 2048 dimensions.
+    Value query_vector = 2 [(google.api.field_behavior) = REQUIRED];
+
+    // Required. The distance measure to use, required.
+    DistanceMeasure distance_measure = 3
+        [(google.api.field_behavior) = REQUIRED];
+
+    // Required. The number of nearest neighbors to return. Must be a positive
+    // integer of no more than 1000.
+    google.protobuf.Int32Value limit = 4
+        [(google.api.field_behavior) = REQUIRED];
+
+    // Optional. Optional name of the field to output the result of the vector
+    // distance calculation. Must conform to [document field
+    // name][google.firestore.v1.Document.fields] limitations.
+    string distance_result_field = 5 [(google.api.field_behavior) = OPTIONAL];
+
+    // Optional. Option to specify a threshold for which no less similar
+    // documents will be returned. The behavior of the specified
+    // `distance_measure` will affect the meaning of the distance threshold.
+    // Since DOT_PRODUCT distances increase when the vectors are more similar,
+    // the comparison is inverted.
+    //
+    // * For EUCLIDEAN, COSINE: `WHERE distance <= distance_threshold`
+    // * For DOT_PRODUCT:       `WHERE distance >= distance_threshold`
+    google.protobuf.DoubleValue distance_threshold = 6
+        [(google.api.field_behavior) = OPTIONAL];
+  }
+
+  // Optional sub-set of the fields to return.
+  //
+  // This acts as a [DocumentMask][google.firestore.v1.DocumentMask] over the
+  // documents returned from a query. When not set, assumes that the caller
+  // wants all fields returned.
   Projection select = 1;
 
   // The collections to query.
@@ -253,66 +346,126 @@ message StructuredQuery {
 
   // The order to apply to the query results.
   //
-  // Firestore guarantees a stable ordering through the following rules:
+  // Firestore allows callers to provide a full ordering, a partial ordering, or
+  // no ordering at all. In all cases, Firestore guarantees a stable ordering
+  // through the following rules:
   //
-  //  * Any field required to appear in `order_by`, that is not already
-  //    specified in `order_by`, is appended to the order in field name order
-  //    by default.
+  //  * The `order_by` is required to reference all fields used with an
+  //    inequality filter.
+  //  * All fields that are required to be in the `order_by` but are not already
+  //    present are appended in lexicographical ordering of the field name.
   //  * If an order on `__name__` is not specified, it is appended by default.
   //
   // Fields are appended with the same sort direction as the last order
   // specified, or 'ASCENDING' if no order was specified. For example:
   //
-  //  * `SELECT * FROM Foo ORDER BY A` becomes
-  //    `SELECT * FROM Foo ORDER BY A, __name__`
-  //  * `SELECT * FROM Foo ORDER BY A DESC` becomes
-  //    `SELECT * FROM Foo ORDER BY A DESC, __name__ DESC`
-  //  * `SELECT * FROM Foo WHERE A > 1` becomes
-  //    `SELECT * FROM Foo WHERE A > 1 ORDER BY A, __name__`
+  //  * `ORDER BY a` becomes `ORDER BY a ASC, __name__ ASC`
+  //  * `ORDER BY a DESC` becomes `ORDER BY a DESC, __name__ DESC`
+  //  * `WHERE a > 1` becomes `WHERE a > 1 ORDER BY a ASC, __name__ ASC`
+  //  * `WHERE __name__ > ... AND a > 1` becomes
+  //     `WHERE __name__ > ... AND a > 1 ORDER BY a ASC, __name__ ASC`
   repeated Order order_by = 4;
 
-  // A starting point for the query results.
+  // A potential prefix of a position in the result set to start the query at.
+  //
+  // The ordering of the result set is based on the `ORDER BY` clause of the
+  // original query.
+  //
+  // ```
+  // SELECT * FROM k WHERE a = 1 AND b > 2 ORDER BY b ASC, __name__ ASC;
+  // ```
+  //
+  // This query's results are ordered by `(b ASC, __name__ ASC)`.
+  //
+  // Cursors can reference either the full ordering or a prefix of the location,
+  // though it cannot reference more fields than what are in the provided
+  // `ORDER BY`.
+  //
+  // Continuing off the example above, attaching the following start cursors
+  // will have varying impact:
+  //
+  // - `START BEFORE (2, /k/123)`: start the query right before `a = 1 AND
+  //    b > 2 AND __name__ > /k/123`.
+  // - `START AFTER (10)`: start the query right after `a = 1 AND b > 10`.
+  //
+  // Unlike `OFFSET` which requires scanning over the first N results to skip,
+  // a start cursor allows the query to begin at a logical position. This
+  // position is not required to match an actual result, it will scan forward
+  // from this position to find the next document.
+  //
+  // Requires:
+  //
+  // * The number of values cannot be greater than the number of fields
+  //   specified in the `ORDER BY` clause.
   Cursor start_at = 7;
 
-  // A end point for the query results.
+  // A potential prefix of a position in the result set to end the query at.
+  //
+  // This is similar to `START_AT` but with it controlling the end position
+  // rather than the start position.
+  //
+  // Requires:
+  //
+  // * The number of values cannot be greater than the number of fields
+  //   specified in the `ORDER BY` clause.
   Cursor end_at = 8;
 
-  // The number of results to skip.
+  // The number of documents to skip before returning the first result.
   //
-  // Applies before limit, but after all other constraints. Must be >= 0 if
-  // specified.
+  // This applies after the constraints specified by the `WHERE`, `START AT`, &
+  // `END AT` but before the `LIMIT` clause.
+  //
+  // Requires:
+  //
+  // * The value must be greater than or equal to zero if specified.
   int32 offset = 6;
 
   // The maximum number of results to return.
   //
   // Applies after all other constraints.
-  // Must be >= 0 if specified.
+  //
+  // Requires:
+  //
+  // * The value must be greater than or equal to zero if specified.
   google.protobuf.Int32Value limit = 5;
+
+  // Optional. A potential nearest neighbors search.
+  //
+  // Applies after all other filters and ordering.
+  //
+  // Finds the closest vector embeddings to the given query vector.
+  FindNearest find_nearest = 9 [(google.api.field_behavior) = OPTIONAL];
 }
 
+// Firestore query for running an aggregation over a
+// [StructuredQuery][google.firestore.v1.StructuredQuery].
 message StructuredAggregationQuery {
-  // Defines a aggregation that produces a single result.
+  // Defines an aggregation that produces a single result.
   message Aggregation {
     // Count of documents that match the query.
     //
     // The `COUNT(*)` aggregation function operates on the entire document
     // so it does not require a field reference.
     message Count {
-      // Optional. Optional constraint on the maximum number of documents to count.
+      // Optional. Optional constraint on the maximum number of documents to
+      // count.
       //
       // This provides a way to set an upper bound on the number of documents
-      // to scan, limiting latency and cost.
+      // to scan, limiting latency, and cost.
+      //
+      // Unspecified is interpreted as no bound.
       //
       // High-Level Example:
       //
       // ```
-      // SELECT COUNT_UP_TO(1000) FROM ( SELECT * FROM k );
+      // AGGREGATE COUNT_UP_TO(1000) OVER ( SELECT * FROM k );
       // ```
       //
       // Requires:
       //
       // * Must be greater than zero when present.
-      google.protobuf.Int64Value up_to = 1;
+      google.protobuf.Int64Value up_to = 1
+          [(google.api.field_behavior) = OPTIONAL];
     }
 
     // Sum of the values of the requested field.
@@ -320,12 +473,22 @@ message StructuredAggregationQuery {
     // * Only numeric values will be aggregated. All non-numeric values
     // including `NULL` are skipped.
     //
-    // * If the aggregated values contain `NaN`, returns `NaN`.
+    // * If the aggregated values contain `NaN`, returns `NaN`. Infinity math
+    // follows IEEE-754 standards.
     //
     // * If the aggregated value set is empty, returns 0.
     //
-    // * Returns a 64-bit integer if the sum result is an integer value and does
-    // not overflow or underflow. Otherwise, the result is returned as a double.
+    // * Returns a 64-bit integer if all aggregated numbers are integers and the
+    // sum result does not overflow. Otherwise, the result is returned as a
+    // double. Note that even if all the aggregated values are integers, the
+    // result is returned as a double if it cannot fit within a 64-bit signed
+    // integer. When this occurs, the returned value will lose precision.
+    //
+    // * When underflow occurs, floating-point aggregation is non-deterministic.
+    // This means that running the same query repeatedly without any changes to
+    // the underlying values could produce slightly different results each
+    // time. In those cases, values should be stored as integers over
+    // floating-point numbers.
     message Sum {
       // The field to aggregate on.
       StructuredQuery.FieldReference field = 1;
@@ -336,7 +499,8 @@ message StructuredAggregationQuery {
     // * Only numeric values will be aggregated. All non-numeric values
     // including `NULL` are skipped.
     //
-    // * If the aggregated values contain `NaN`, returns `NaN`.
+    // * If the aggregated values contain `NaN`, returns `NaN`. Infinity math
+    // follows IEEE-754 standards.
     //
     // * If the aggregated value set is empty, returns `NULL`.
     //
@@ -358,14 +522,42 @@ message StructuredAggregationQuery {
       Avg avg = 3;
     }
 
-    // Required. The name of the field to store the result of the aggregation into.
+    // Optional. Optional name of the field to store the result of the
+    // aggregation into.
+    //
+    // If not provided, Firestore will pick a default name following the format
+    // `field_<incremental_id++>`. For example:
+    //
+    // ```
+    // AGGREGATE
+    //   COUNT_UP_TO(1) AS count_up_to_1,
+    //   COUNT_UP_TO(2),
+    //   COUNT_UP_TO(3) AS count_up_to_3,
+    //   COUNT(*)
+    // OVER (
+    //   ...
+    // );
+    // ```
+    //
+    // becomes:
+    //
+    // ```
+    // AGGREGATE
+    //   COUNT_UP_TO(1) AS count_up_to_1,
+    //   COUNT_UP_TO(2) AS field_1,
+    //   COUNT_UP_TO(3) AS count_up_to_3,
+    //   COUNT(*) AS field_2
+    // OVER (
+    //   ...
+    // );
+    // ```
     //
     // Requires:
     //
-    // * Must be present.
     // * Must be unique across all aggregation aliases.
-    // * Conform to existing [document field name][google.firestore.v1.Document.fields] limitations.
-    string alias = 7;
+    // * Conform to [document field name][google.firestore.v1.Document.fields]
+    // limitations.
+    string alias = 7 [(google.api.field_behavior) = OPTIONAL];
   }
 
   // The base query to aggregate over.
@@ -374,8 +566,14 @@ message StructuredAggregationQuery {
     StructuredQuery structured_query = 1;
   }
 
-  // Optional. Series of aggregations to apply on top of the `structured_query`.
-  repeated Aggregation aggregations = 3;
+  // Optional. Series of aggregations to apply over the results of the
+  // `structured_query`.
+  //
+  // Requires:
+  //
+  // * A minimum of one and maximum of five aggregations per query.
+  repeated Aggregation aggregations = 3
+      [(google.api.field_behavior) = OPTIONAL];
 }
 
 // A position in a query result set.

--- a/packages/firestore/src/protos/google/firestore/v1/query_profile.proto
+++ b/packages/firestore/src/protos/google/firestore/v1/query_profile.proto
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/firestore/src/protos/google/firestore/v1/write.proto
+++ b/packages/firestore/src/protos/google/firestore/v1/write.proto
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,10 +20,9 @@ import "google/firestore/v1/bloom_filter.proto";
 import "google/firestore/v1/common.proto";
 import "google/firestore/v1/document.proto";
 import "google/protobuf/timestamp.proto";
-import "google/api/annotations.proto";
 
 option csharp_namespace = "Google.Cloud.Firestore.V1";
-option go_package = "google.golang.org/genproto/googleapis/firestore/v1;firestore";
+option go_package = "cloud.google.com/go/firestore/apiv1/firestorepb;firestorepb";
 option java_multiple_files = true;
 option java_outer_classname = "WriteProto";
 option java_package = "com.google.firestore.v1";
@@ -91,8 +90,9 @@ message DocumentTransform {
       REQUEST_TIME = 1;
     }
 
-    // The path of the field. See [Document.fields][google.firestore.v1.Document.fields] for the field path syntax
-    // reference.
+    // The path of the field. See
+    // [Document.fields][google.firestore.v1.Document.fields] for the field path
+    // syntax reference.
     string field_path = 1;
 
     // The transformation to apply on the field.
@@ -186,18 +186,20 @@ message WriteResult {
   // previous update_time.
   google.protobuf.Timestamp update_time = 1;
 
-  // The results of applying each [DocumentTransform.FieldTransform][google.firestore.v1.DocumentTransform.FieldTransform], in the
-  // same order.
+  // The results of applying each
+  // [DocumentTransform.FieldTransform][google.firestore.v1.DocumentTransform.FieldTransform],
+  // in the same order.
   repeated Value transform_results = 2;
 }
 
 // A [Document][google.firestore.v1.Document] has changed.
 //
-// May be the result of multiple [writes][google.firestore.v1.Write], including deletes, that
-// ultimately resulted in a new value for the [Document][google.firestore.v1.Document].
+// May be the result of multiple [writes][google.firestore.v1.Write], including
+// deletes, that ultimately resulted in a new value for the
+// [Document][google.firestore.v1.Document].
 //
-// Multiple [DocumentChange][google.firestore.v1.DocumentChange] messages may be returned for the same logical
-// change, if multiple targets are affected.
+// Multiple [DocumentChange][google.firestore.v1.DocumentChange] messages may be
+// returned for the same logical change, if multiple targets are affected.
 message DocumentChange {
   // The new state of the [Document][google.firestore.v1.Document].
   //
@@ -213,13 +215,15 @@ message DocumentChange {
 
 // A [Document][google.firestore.v1.Document] has been deleted.
 //
-// May be the result of multiple [writes][google.firestore.v1.Write], including updates, the
-// last of which deleted the [Document][google.firestore.v1.Document].
+// May be the result of multiple [writes][google.firestore.v1.Write], including
+// updates, the last of which deleted the
+// [Document][google.firestore.v1.Document].
 //
-// Multiple [DocumentDelete][google.firestore.v1.DocumentDelete] messages may be returned for the same logical
-// delete, if multiple targets are affected.
+// Multiple [DocumentDelete][google.firestore.v1.DocumentDelete] messages may be
+// returned for the same logical delete, if multiple targets are affected.
 message DocumentDelete {
-  // The resource name of the [Document][google.firestore.v1.Document] that was deleted.
+  // The resource name of the [Document][google.firestore.v1.Document] that was
+  // deleted.
   string document = 1;
 
   // A set of target IDs for targets that previously matched this entity.
@@ -231,16 +235,19 @@ message DocumentDelete {
   google.protobuf.Timestamp read_time = 4;
 }
 
-// A [Document][google.firestore.v1.Document] has been removed from the view of the targets.
+// A [Document][google.firestore.v1.Document] has been removed from the view of
+// the targets.
 //
 // Sent if the document is no longer relevant to a target and is out of view.
 // Can be sent instead of a DocumentDelete or a DocumentChange if the server
-// cannot send the new value of the document.
+// can not send the new value of the document.
 //
-// Multiple [DocumentRemove][google.firestore.v1.DocumentRemove] messages may be returned for the same logical
-// write or delete, if multiple targets are affected.
+// Multiple [DocumentRemove][google.firestore.v1.DocumentRemove] messages may be
+// returned for the same logical write or delete, if multiple targets are
+// affected.
 message DocumentRemove {
-  // The resource name of the [Document][google.firestore.v1.Document] that has gone out of view.
+  // The resource name of the [Document][google.firestore.v1.Document] that has
+  // gone out of view.
   string document = 1;
 
   // A set of target IDs for targets that previously matched this document.
@@ -257,17 +264,22 @@ message ExistenceFilter {
   // The target ID to which this filter applies.
   int32 target_id = 1;
 
-  // The total count of documents that match [target_id][google.firestore.v1.ExistenceFilter.target_id].
+  // The total count of documents that match
+  // [target_id][google.firestore.v1.ExistenceFilter.target_id].
   //
   // If different from the count of documents in the client that match, the
   // client must manually determine which documents no longer match the target.
+  //
+  // The client can use the `unchanged_names` bloom filter to assist with
+  // this determination by testing ALL the document names against the filter;
+  // if the document name is NOT in the filter, it means the document no
+  // longer matches the target.
   int32 count = 2;
 
-  // A bloom filter that contains the UTF-8 byte encodings of the resource names
-  // of the documents that match [target_id][google.firestore.v1.ExistenceFilter.target_id], in the
-  // form `projects/{project_id}/databases/{database_id}/documents/{document_path}`
-  // that have NOT changed since the query results indicated by the resume token
-  // or timestamp given in `Target.resume_type`.
+  // A bloom filter that, despite its name, contains the UTF-8 byte encodings of
+  // the resource names of ALL the documents that match
+  // [target_id][google.firestore.v1.ExistenceFilter.target_id], in the form
+  // `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
   //
   // This bloom filter may be omitted at the server's discretion, such as if it
   // is deemed that the client will not make use of it or if it is too

--- a/packages/firestore/src/protos/google/protobuf/any.proto
+++ b/packages/firestore/src/protos/google/protobuf/any.proto
@@ -32,124 +32,75 @@ syntax = "proto3";
 
 package google.protobuf;
 
-option csharp_namespace = "Google.Protobuf.WellKnownTypes";
-option go_package = "github.com/golang/protobuf/ptypes/any";
+option go_package = "google.golang.org/protobuf/types/known/anypb";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "AnyProto";
 option java_multiple_files = true;
 option objc_class_prefix = "GPB";
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
 
 // `Any` contains an arbitrary serialized protocol buffer message along with a
 // URL that describes the type of the serialized message.
 //
-// Protobuf library provides support to pack/unpack Any values in the form
-// of utility functions or additional generated methods of the Any type.
+// In its binary encoding, an `Any` is an ordinary message; but in other wire
+// forms like JSON, it has a special encoding. The format of the type URL is
+// described on the `type_url` field.
 //
-// Example 1: Pack and unpack a message in C++.
+// Protobuf APIs provide utilities to interact with `Any` values:
 //
-//     Foo foo = ...;
-//     Any any;
-//     any.PackFrom(foo);
-//     ...
-//     if (any.UnpackTo(&foo)) {
-//       ...
-//     }
+// - A 'pack' operation accepts a message and constructs a generic `Any` wrapper
+//   around it.
+// - An 'unpack' operation reads the content of an `Any` message, either into an
+//   existing message or a new one. Unpack operations must check the type of the
+//   value they unpack against the declared `type_url`.
+// - An 'is' operation decides whether an `Any` contains a message of the given
+//   type, i.e. whether it can 'unpack' that type.
 //
-// Example 2: Pack and unpack a message in Java.
+// The JSON format representation of an `Any` follows one of these cases:
 //
-//     Foo foo = ...;
-//     Any any = Any.pack(foo);
-//     ...
-//     if (any.is(Foo.class)) {
-//       foo = any.unpack(Foo.class);
-//     }
+// - For types without special-cased JSON encodings, the JSON format
+//   representation of the `Any` is the same as that of the message, with an
+//   additional `@type` field which contains the type URL.
+// - For types with special-cased JSON encodings (typically called 'well-known'
+//   types, listed in https://protobuf.dev/programming-guides/json/#any), the
+//   JSON format representation has a key `@type` which contains the type URL
+//   and a key `value` which contains the JSON-serialized value.
 //
-//  Example 3: Pack and unpack a message in Python.
-//
-//     foo = Foo(...)
-//     any = Any()
-//     any.Pack(foo)
-//     ...
-//     if any.Is(Foo.DESCRIPTOR):
-//       any.Unpack(foo)
-//       ...
-//
-//  Example 4: Pack and unpack a message in Go
-//
-//      foo := &pb.Foo{...}
-//      any, err := ptypes.MarshalAny(foo)
-//      ...
-//      foo := &pb.Foo{}
-//      if err := ptypes.UnmarshalAny(any, foo); err != nil {
-//        ...
-//      }
-//
-// The pack methods provided by protobuf library will by default use
-// 'type.googleapis.com/full.type.name' as the type URL and the unpack
-// methods only use the fully qualified type name after the last '/'
-// in the type URL, for example "foo.bar.com/x/y.z" will yield type
-// name "y.z".
-//
-//
-// JSON
-// ====
-// The JSON representation of an `Any` value uses the regular
-// representation of the deserialized, embedded message, with an
-// additional field `@type` which contains the type URL. Example:
-//
-//     package google.profile;
-//     message Person {
-//       string first_name = 1;
-//       string last_name = 2;
-//     }
-//
-//     {
-//       "@type": "type.googleapis.com/google.profile.Person",
-//       "firstName": <string>,
-//       "lastName": <string>
-//     }
-//
-// If the embedded message type is well-known and has a custom JSON
-// representation, that representation will be embedded adding a field
-// `value` which holds the custom JSON in addition to the `@type`
-// field. Example (for message [google.protobuf.Duration][]):
-//
-//     {
-//       "@type": "type.googleapis.com/google.protobuf.Duration",
-//       "value": "1.212s"
-//     }
-//
+// The text format representation of an `Any` is like a message with one field
+// whose name is the type URL in brackets. For example, an `Any` containing a
+// `foo.Bar` message may be written `[type.googleapis.com/foo.Bar] { a: 2 }`.
 message Any {
-  // A URL/resource name that uniquely identifies the type of the serialized
-  // protocol buffer message. This string must contain at least
-  // one "/" character. The last segment of the URL's path must represent
-  // the fully qualified name of the type (as in
-  // `path/google.protobuf.Duration`). The name should be in a canonical form
-  // (e.g., leading "." is not accepted).
+  // Identifies the type of the serialized Protobuf message with a URI reference
+  // consisting of a prefix ending in a slash and the fully-qualified type name.
   //
-  // In practice, teams usually precompile into the binary all types that they
-  // expect it to use in the context of Any. However, for URLs which use the
-  // scheme `http`, `https`, or no scheme, one can optionally set up a type
-  // server that maps type URLs to message definitions as follows:
+  // Example: type.googleapis.com/google.protobuf.StringValue
   //
-  // * If no scheme is provided, `https` is assumed.
-  // * An HTTP GET on the URL must yield a [google.protobuf.Type][]
-  //   value in binary format, or produce an error.
-  // * Applications are allowed to cache lookup results based on the
-  //   URL, or have them precompiled into a binary to avoid any
-  //   lookup. Therefore, binary compatibility needs to be preserved
-  //   on changes to types. (Use versioned type names to manage
-  //   breaking changes.)
+  // This string must contain at least one `/` character, and the content after
+  // the last `/` must be the fully-qualified name of the type in canonical
+  // form, without a leading dot. Do not write a scheme on these URI references
+  // so that clients do not attempt to contact them.
   //
-  // Note: this functionality is not currently available in the official
-  // protobuf release, and it is not used for type URLs beginning with
-  // type.googleapis.com.
+  // The prefix is arbitrary and Protobuf implementations are expected to
+  // simply strip off everything up to and including the last `/` to identify
+  // the type. `type.googleapis.com/` is a common default prefix that some
+  // legacy implementations require. This prefix does not indicate the origin of
+  // the type, and URIs containing it are not expected to respond to any
+  // requests.
   //
-  // Schemes other than `http`, `https` (or the empty scheme) might be
-  // used with implementation specific semantics.
+  // All type URL strings must be legal URI references with the additional
+  // restriction (for the text format) that the content of the reference
+  // must consist only of alphanumeric characters, percent-encoded escapes, and
+  // characters in the following set (not including the outer backticks):
+  // `/-.~_!$&()*+,;=`. Despite our allowing percent encodings, implementations
+  // should not unescape them to prevent confusion with existing parsers. For
+  // example, `type.googleapis.com%2FFoo` should be rejected.
   //
+  // In the original design of `Any`, the possibility of launching a type
+  // resolution service at these type URLs was considered but Protobuf never
+  // implemented one and considers contacting these URLs to be problematic and
+  // a potential security issue. Do not attempt to contact type URLs.
   string type_url = 1;
 
-  // Must be a valid serialized protocol buffer of the above specified type.
+  // Holds a Protobuf serialization of the type described by type_url.
   bytes value = 2;
 }

--- a/packages/firestore/src/protos/google/protobuf/descriptor.proto
+++ b/packages/firestore/src/protos/google/protobuf/descriptor.proto
@@ -1,32 +1,9 @@
 // Protocol Buffers - Google's data interchange format
-// Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// Copyright 2008 Google LLC.  All rights reserved.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//     * Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//     * Redistributions in binary form must reproduce the above
-// copyright notice, this list of conditions and the following disclaimer
-// in the documentation and/or other materials provided with the
-// distribution.
-//     * Neither the name of Google Inc. nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
 
 // Author: kenton@google.com (Kenton Varda)
 //  Based on original Protocol Buffers design by
@@ -36,12 +13,11 @@
 // A valid .proto file can be translated directly to a FileDescriptorProto
 // without any other information (e.g. without reading its imports).
 
-
 syntax = "proto2";
 
 package google.protobuf;
 
-option go_package = "github.com/golang/protobuf/protoc-gen-go/descriptor;descriptor";
+option go_package = "google.golang.org/protobuf/types/descriptorpb";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "DescriptorProtos";
 option csharp_namespace = "Google.Protobuf.Reflection";
@@ -56,6 +32,53 @@ option optimize_for = SPEED;
 // files it parses.
 message FileDescriptorSet {
   repeated FileDescriptorProto file = 1;
+
+  // Extensions for tooling.
+  extensions 536000000 [declaration = {
+    number: 536000000
+    type: ".buf.descriptor.v1.FileDescriptorSetExtension"
+    full_name: ".buf.descriptor.v1.buf_file_descriptor_set_extension"
+  }];
+}
+
+// The full set of known editions.
+enum Edition {
+  // A placeholder for an unknown edition value.
+  EDITION_UNKNOWN = 0;
+
+  // A placeholder edition for specifying default behaviors *before* a feature
+  // was first introduced.  This is effectively an "infinite past".
+  EDITION_LEGACY = 900;
+
+  // Legacy syntax "editions".  These pre-date editions, but behave much like
+  // distinct editions.  These can't be used to specify the edition of proto
+  // files, but feature definitions must supply proto2/proto3 defaults for
+  // backwards compatibility.
+  EDITION_PROTO2 = 998;
+  EDITION_PROTO3 = 999;
+
+  // Editions that have been released.  The specific values are arbitrary and
+  // should not be depended on, but they will always be time-ordered for easy
+  // comparison.
+  EDITION_2023 = 1000;
+  EDITION_2024 = 1001;
+  EDITION_2026 = 1002;
+
+  // A placeholder edition for developing and testing unscheduled features.
+  EDITION_UNSTABLE = 9999;
+
+  // Placeholder editions for testing feature resolution.  These should not be
+  // used or relied on outside of tests.
+  EDITION_1_TEST_ONLY = 1;
+  EDITION_2_TEST_ONLY = 2;
+  EDITION_99997_TEST_ONLY = 99997;
+  EDITION_99998_TEST_ONLY = 99998;
+  EDITION_99999_TEST_ONLY = 99999;
+
+  // Placeholder for specifying unbounded edition support.  This should only
+  // ever be used by plugins that can expect to never require any changes to
+  // support a new edition.
+  EDITION_MAX = 0x7FFFFFFF;
 }
 
 // Describes a complete .proto file.
@@ -70,6 +93,10 @@ message FileDescriptorProto {
   // Indexes of the weak imported files in the dependency list.
   // For Google-internal migration only. Do not use.
   repeated int32 weak_dependency = 11;
+
+  // Names of files imported by this file purely for the purpose of providing
+  // option extensions. These are excluded from the dependency list above.
+  repeated string option_dependency = 15;
 
   // All top-level definitions in this file.
   repeated DescriptorProto message_type = 4;
@@ -86,8 +113,19 @@ message FileDescriptorProto {
   optional SourceCodeInfo source_code_info = 9;
 
   // The syntax of the proto file.
-  // The supported values are "proto2" and "proto3".
+  // The supported values are "proto2", "proto3", and "editions".
+  //
+  // If `edition` is present, this value must be "editions".
+  // WARNING: This field should only be used by protobuf plugins or special
+  // cases like the proto compiler. Other uses are discouraged and
+  // developers should rely on the protoreflect APIs for their client language.
   optional string syntax = 12;
+
+  // The edition of the proto file.
+  // WARNING: This field should only be used by protobuf plugins or special
+  // cases like the proto compiler. Other uses are discouraged and
+  // developers should rely on the protoreflect APIs for their client language.
+  optional Edition edition = 14;
 }
 
 // Describes a message type.
@@ -101,8 +139,8 @@ message DescriptorProto {
   repeated EnumDescriptorProto enum_type = 4;
 
   message ExtensionRange {
-    optional int32 start = 1;
-    optional int32 end = 2;
+    optional int32 start = 1;  // Inclusive.
+    optional int32 end = 2;    // Exclusive.
 
     optional ExtensionRangeOptions options = 3;
   }
@@ -123,11 +161,63 @@ message DescriptorProto {
   // Reserved field names, which may not be used by fields in the same message.
   // A given name may only be reserved once.
   repeated string reserved_name = 10;
+
+  // Support for `export` and `local` keywords on enums.
+  optional SymbolVisibility visibility = 11;
 }
 
 message ExtensionRangeOptions {
+  // Range reserved for first-class custom options defined by the Protobuf
+  // team. User custom options must use the 1000+ range instead.
+  extensions 990 to 998;
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
+
+  message Declaration {
+    // The extension number declared within the extension range.
+    optional int32 number = 1;
+
+    // The fully-qualified name of the extension field. There must be a leading
+    // dot in front of the full name.
+    optional string full_name = 2;
+
+    // The fully-qualified type name of the extension field. Unlike
+    // Metadata.type, Declaration.type must have a leading dot for messages
+    // and enums.
+    optional string type = 3;
+
+    // If true, indicates that the number is reserved in the extension range,
+    // and any extension field with the number will fail to compile. Set this
+    // when a declared extension field is deleted.
+    optional bool reserved = 5;
+
+    // If true, indicates that the extension must be defined as repeated.
+    // Otherwise the extension must be defined as optional.
+    optional bool repeated = 6;
+
+    reserved 4;  // removed is_repeated
+  }
+
+  // For external users: DO NOT USE. We are in the process of open sourcing
+  // extension declaration and executing internal cleanups before it can be
+  // used externally.
+  repeated Declaration declaration = 2 [retention = RETENTION_SOURCE];
+
+  // Any features defined in the specific edition.
+  optional FeatureSet features = 50;
+
+  // The verification state of the extension range.
+  enum VerificationState {
+    // All the extensions of the range must be declared.
+    DECLARATION = 0;
+    UNVERIFIED = 1;
+  }
+
+  // The verification state of the range.
+  // TODO: flip the default to DECLARATION once all empty ranges
+  // are marked as UNVERIFIED.
+  optional VerificationState verification = 3
+      [default = UNVERIFIED, retention = RETENTION_SOURCE];
 
   // Clients can define custom options in extensions of this message. See above.
   extensions 1000 to max;
@@ -152,9 +242,10 @@ message FieldDescriptorProto {
     TYPE_BOOL = 8;
     TYPE_STRING = 9;
     // Tag-delimited aggregate.
-    // Group type is deprecated and not supported in proto3. However, Proto3
+    // Group type is deprecated and not supported after google.protobuf. However, Proto3
     // implementations should still be able to parse the group wire format and
-    // treat group fields as unknown fields.
+    // treat group fields as unknown fields.  In Editions, the group wire format
+    // can be enabled via the `message_encoding` feature.
     TYPE_GROUP = 10;
     TYPE_MESSAGE = 11;  // Length-delimited aggregate.
 
@@ -171,8 +262,11 @@ message FieldDescriptorProto {
   enum Label {
     // 0 is reserved for errors
     LABEL_OPTIONAL = 1;
-    LABEL_REQUIRED = 2;
     LABEL_REPEATED = 3;
+    // The required label is only allowed in google.protobuf.  In proto3 and Editions
+    // it's explicitly prohibited.  In Editions, the `field_presence` feature
+    // can be used to get this behavior.
+    LABEL_REQUIRED = 2;
   }
 
   optional string name = 1;
@@ -198,7 +292,6 @@ message FieldDescriptorProto {
   // For booleans, "true" or "false".
   // For strings, contains the default text contents (not escaped in any way).
   // For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
-  // TODO(kenton):  Base-64 encode?
   optional string default_value = 7;
 
   // If set, gives the index of a oneof in the containing type's oneof_decl
@@ -212,6 +305,29 @@ message FieldDescriptorProto {
   optional string json_name = 10;
 
   optional FieldOptions options = 8;
+
+  // If true, this is a proto3 "optional". When a proto3 field is optional, it
+  // tracks presence regardless of field type.
+  //
+  // When proto3_optional is true, this field must belong to a oneof to signal
+  // to old proto3 clients that presence is tracked for this field. This oneof
+  // is known as a "synthetic" oneof, and this field must be its sole member
+  // (each proto3 optional field gets its own synthetic oneof). Synthetic oneofs
+  // exist in the descriptor only, and do not generate any API. Synthetic oneofs
+  // must be ordered after all "real" oneofs.
+  //
+  // For message fields, proto3_optional doesn't create any semantic change,
+  // since non-repeated message fields always track presence. However it still
+  // indicates the semantic detail of whether the user wrote "optional" or not.
+  // This can be useful for round-tripping the .proto file. For consistency we
+  // give message fields a synthetic oneof also, even though it is not required
+  // to track presence. This is especially important because the parser can't
+  // tell if a field is a message or an enum, so it must always create a
+  // synthetic oneof.
+  //
+  // Proto2 optional fields do not set this flag, because they already indicate
+  // optional with `LABEL_OPTIONAL`.
+  optional bool proto3_optional = 17;
 }
 
 // Describes a oneof.
@@ -247,6 +363,9 @@ message EnumDescriptorProto {
   // Reserved enum value names, which may not be reused. A given name may only
   // be reserved once.
   repeated string reserved_name = 5;
+
+  // Support for `export` and `local` keywords on enums.
+  optional SymbolVisibility visibility = 6;
 }
 
 // Describes a value within an enum.
@@ -263,6 +382,9 @@ message ServiceDescriptorProto {
   repeated MethodDescriptorProto method = 2;
 
   optional ServiceOptions options = 3;
+
+  reserved 4;
+  reserved "stream";
 }
 
 // Describes a method of a service.
@@ -281,7 +403,6 @@ message MethodDescriptorProto {
   // Identifies if server streams multiple server messages
   optional bool server_streaming = 6 [default = false];
 }
-
 
 // ===================================================================
 // Options
@@ -323,33 +444,45 @@ message FileOptions {
   // domain names.
   optional string java_package = 1;
 
-
-  // If set, all the classes from the .proto file are wrapped in a single
-  // outer class with the given name.  This applies to both Proto1
-  // (equivalent to the old "--one_java_file" option) and Proto2 (where
-  // a .proto always translates to a single class, but you may want to
-  // explicitly choose the class name).
+  // Controls the name of the wrapper Java class generated for the .proto file.
+  // That class will always contain the .proto file's getDescriptor() method as
+  // well as any top-level extensions defined in the .proto file.
+  // If java_multiple_files is disabled, then all the other classes from the
+  // .proto file will be nested inside the single wrapper outer class.
   optional string java_outer_classname = 8;
 
-  // If set true, then the Java code generator will generate a separate .java
+  // If enabled, then the Java code generator will generate a separate .java
   // file for each top-level message, enum, and service defined in the .proto
-  // file.  Thus, these types will *not* be nested inside the outer class
-  // named by java_outer_classname.  However, the outer class will still be
+  // file.  Thus, these types will *not* be nested inside the wrapper class
+  // named by java_outer_classname.  However, the wrapper class will still be
   // generated to contain the file's getDescriptor() method as well as any
   // top-level extensions defined in the file.
-  optional bool java_multiple_files = 10 [default = false];
+  optional bool java_multiple_files = 10 [
+    default = false,
+    feature_support = {
+      edition_introduced: EDITION_PROTO2
+      edition_removed: EDITION_2024
+      removal_error: "This behavior is enabled by default in editions 2024 and above. "
+                     "To disable it, you can set `features.(pb.java).nest_in_file_class = YES` "
+                     "on individual messages, enums, or services."
+
+    }
+  ];
 
   // This option does nothing.
   optional bool java_generate_equals_and_hash = 20 [deprecated=true];
 
-  // If set true, then the Java2 code generator will generate code that
-  // throws an exception whenever an attempt is made to assign a non-UTF-8
-  // byte sequence to a string field.
-  // Message reflection will do the same.
-  // However, an extension field still accepts non-UTF-8 byte sequences.
-  // This option has no effect on when used with the lite runtime.
+  // A proto2 file can set this to true to opt in to UTF-8 checking for Java,
+  // which will throw an exception if invalid UTF-8 is parsed from the wire or
+  // assigned to a string field.
+  //
+  // TODO: clarify exactly what kinds of field types this option
+  // applies to, and update these docs accordingly.
+  //
+  // Proto3 files already perform these checks. Setting the option explicitly to
+  // false has no effect: it cannot be used to opt proto3 files out of UTF-8
+  // checks.
   optional bool java_string_check_utf8 = 27 [default = false];
-
 
   // Generated classes can be optimized for speed or code size.
   enum OptimizeMode {
@@ -367,8 +500,6 @@ message FileOptions {
   //   - Otherwise, the basename of the .proto file, without extension.
   optional string go_package = 11;
 
-
-
   // Should generic services be generated in each language?  "Generic" services
   // are not specific to any particular RPC system.  They are generated by the
   // main code generators in each language (without additional plugins).
@@ -382,7 +513,8 @@ message FileOptions {
   optional bool cc_generic_services = 16 [default = false];
   optional bool java_generic_services = 17 [default = false];
   optional bool py_generic_services = 18 [default = false];
-  optional bool php_generic_services = 42 [default = false];
+  reserved 42;  // removed php_generic_services
+  reserved "php_generic_services";
 
   // Is this file deprecated?
   // Depending on the target platform, this can emit Deprecated annotations
@@ -392,8 +524,7 @@ message FileOptions {
 
   // Enables the use of arenas for the proto messages in this file. This applies
   // only to generated classes for C++.
-  optional bool cc_enable_arenas = 31 [default = false];
-
+  optional bool cc_enable_arenas = 31 [default = true];
 
   // Sets the objective c class prefix which is prepended to all objective c
   // generated classes from this .proto. There is no default.
@@ -426,6 +557,20 @@ message FileOptions {
   // is empty. When this option is not set, the package name will be used for
   // determining the ruby package.
   optional string ruby_package = 45;
+
+  // Any features defined in the specific edition.
+  // WARNING: This field should only be used by protobuf plugins or special
+  // cases like the proto compiler. Other uses are discouraged and
+  // developers should rely on the protoreflect APIs for their client language.
+  optional FeatureSet features = 50;
+
+  // Range reserved for first-class custom options defined by the Protobuf
+  // team. User custom options must use the 1000+ range instead.
+  extensions 990 to 998 [declaration = {
+    number: 990,
+    full_name: ".pb.file.cpp",
+    type: ".pb.file.CppFileOptions"
+  }];
 
   // The parser stores options it doesn't recognize here.
   // See the documentation for the "Options" section above.
@@ -470,6 +615,8 @@ message MessageOptions {
   // this is a formalization for deprecating messages.
   optional bool deprecated = 3 [default = false];
 
+  reserved 4, 5, 6;
+
   // Whether the message is an automatically generated map entry type for the
   // maps field.
   //
@@ -496,6 +643,28 @@ message MessageOptions {
   reserved 8;  // javalite_serializable
   reserved 9;  // javanano_as_lite
 
+  // Enable the legacy handling of JSON field name conflicts.  This lowercases
+  // and strips underscored from the fields before comparison in proto3 only.
+  // The new behavior takes `json_name` into account and applies to proto2 as
+  // well.
+  //
+  // This should only be used as a temporary measure against broken builds due
+  // to the change in behavior for JSON field name conflicts.
+  //
+  // TODO This is legacy behavior we plan to remove once downstream
+  // teams have had time to migrate.
+  optional bool deprecated_legacy_json_field_conflicts = 11 [deprecated = true];
+
+  // Any features defined in the specific edition.
+  // WARNING: This field should only be used by protobuf plugins or special
+  // cases like the proto compiler. Other uses are discouraged and
+  // developers should rely on the protoreflect APIs for their client language.
+  optional FeatureSet features = 12;
+
+  // Range reserved for first-class custom options defined by the Protobuf
+  // team. User custom options must use the 1000+ range instead.
+  extensions 990 to 998;
+
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
 
@@ -504,15 +673,24 @@ message MessageOptions {
 }
 
 message FieldOptions {
+  // NOTE: ctype is deprecated. Use `features.(pb.cpp).string_type` instead.
   // The ctype option instructs the C++ code generator to use a different
   // representation of the field than it normally would.  See the specific
-  // options below.  This option is not yet implemented in the open source
-  // release -- sorry, we'll try to include it in a future version!
-  optional CType ctype = 1 [default = STRING];
+  // options below.  This option is only implemented to support use of
+  // [ctype=CORD] and [ctype=STRING] (the default) on non-repeated fields of
+  // type "bytes" in the open source release.
+  // TODO: make ctype actually deprecated.
+  optional CType ctype = 1 [/*deprecated = true,*/ default = STRING];
   enum CType {
     // Default mode.
     STRING = 0;
 
+    // The option [ctype=CORD] may be applied to a non-repeated field of type
+    // "bytes". It indicates that in C++, the data should be stored in a Cord
+    // instead of a string.  For very large strings, this may reduce memory
+    // fragmentation. It may also allow better performance when parsing from a
+    // Cord, or when parsing with aliasing enabled, as the parsed Cord may then
+    // alias the original buffer.
     CORD = 1;
 
     STRING_PIECE = 2;
@@ -521,7 +699,9 @@ message FieldOptions {
   // a more efficient representation on the wire. Rather than repeatedly
   // writing the tag and type for each element, the entire array is encoded as
   // a single length-delimited blob. In proto3, only explicit setting it to
-  // false will avoid using packed encoding.
+  // false will avoid using packed encoding.  This option is prohibited in
+  // Editions, but the `repeated_field_encoding` feature can be used to control
+  // the behavior.
   optional bool packed = 2;
 
   // The jstype option determines the JavaScript type used for values of the
@@ -564,18 +744,17 @@ message FieldOptions {
   // call from multiple threads concurrently, while non-const methods continue
   // to require exclusive access.
   //
-  //
-  // Note that implementations may choose not to check required fields within
-  // a lazy sub-message.  That is, calling IsInitialized() on the outer message
-  // may return true even if the inner message has missing required fields.
-  // This is necessary because otherwise the inner message would have to be
-  // parsed in order to perform the check, defeating the purpose of lazy
-  // parsing.  An implementation which chooses not to check required fields
-  // must be consistent about it.  That is, for any particular sub-message, the
-  // implementation must either *always* check its required fields, or *never*
-  // check its required fields, regardless of whether or not the message has
-  // been parsed.
+  // Note that lazy message fields are still eagerly verified to check
+  // ill-formed wireformat or missing required fields. Calling IsInitialized()
+  // on the outer message would fail if the inner message has missing required
+  // fields. Failed verification would result in parsing failure (except when
+  // uninitialized messages are acceptable).
   optional bool lazy = 5 [default = false];
+
+  // unverified_lazy does no correctness checks on the byte stream. This should
+  // only be used where lazy with verification is prohibitive for performance
+  // reasons.
+  optional bool unverified_lazy = 15 [default = false];
 
   // Is this field deprecated?
   // Depending on the target platform, this can emit Deprecated annotations
@@ -583,9 +762,82 @@ message FieldOptions {
   // is a formalization for deprecating fields.
   optional bool deprecated = 3 [default = false];
 
+  // DEPRECATED. DO NOT USE!
   // For Google-internal migration only. Do not use.
-  optional bool weak = 10 [default = false];
+  optional bool weak = 10 [default = false, deprecated = true];
 
+  // Indicate that the field value should not be printed out when using debug
+  // formats, e.g. when the field contains sensitive credentials.
+  optional bool debug_redact = 16 [default = false];
+
+  // If set to RETENTION_SOURCE, the option will be omitted from the binary.
+  enum OptionRetention {
+    RETENTION_UNKNOWN = 0;
+    RETENTION_RUNTIME = 1;
+    RETENTION_SOURCE = 2;
+  }
+
+  optional OptionRetention retention = 17;
+
+  // This indicates the types of entities that the field may apply to when used
+  // as an option. If it is unset, then the field may be freely used as an
+  // option on any kind of entity.
+  enum OptionTargetType {
+    TARGET_TYPE_UNKNOWN = 0;
+    TARGET_TYPE_FILE = 1;
+    TARGET_TYPE_EXTENSION_RANGE = 2;
+    TARGET_TYPE_MESSAGE = 3;
+    TARGET_TYPE_FIELD = 4;
+    TARGET_TYPE_ONEOF = 5;
+    TARGET_TYPE_ENUM = 6;
+    TARGET_TYPE_ENUM_ENTRY = 7;
+    TARGET_TYPE_SERVICE = 8;
+    TARGET_TYPE_METHOD = 9;
+  }
+
+  repeated OptionTargetType targets = 19;
+
+  message EditionDefault {
+    optional Edition edition = 3;
+    optional string value = 2;  // Textproto value.
+  }
+  repeated EditionDefault edition_defaults = 20;
+
+  // Any features defined in the specific edition.
+  // WARNING: This field should only be used by protobuf plugins or special
+  // cases like the proto compiler. Other uses are discouraged and
+  // developers should rely on the protoreflect APIs for their client language.
+  optional FeatureSet features = 21;
+
+  // Information about the support window of a feature.
+  message FeatureSupport {
+    // The edition that this feature was first available in.  In editions
+    // earlier than this one, the default assigned to EDITION_LEGACY will be
+    // used, and proto files will not be able to override it.
+    optional Edition edition_introduced = 1;
+
+    // The edition this feature becomes deprecated in.  Using this after this
+    // edition may trigger warnings.
+    optional Edition edition_deprecated = 2;
+
+    // The deprecation warning text if this feature is used after the edition it
+    // was marked deprecated in.
+    optional string deprecation_warning = 3;
+
+    // The edition this feature is no longer available in.  In editions after
+    // this one, the last default assigned will be used, and proto files will
+    // not be able to override it.
+    optional Edition edition_removed = 4;
+
+    // The removal error text if this feature is used after the edition it was
+    // removed in.
+    optional string removal_error = 5;
+  }
+  optional FeatureSupport feature_support = 22;
+
+  // Range reserved for first-class custom options defined by the Protobuf
+  // team. User custom options must use the 1000+ range instead.
+  extensions 990 to 998;
 
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
@@ -593,10 +845,21 @@ message FieldOptions {
   // Clients can define custom options in extensions of this message. See above.
   extensions 1000 to max;
 
-  reserved 4;  // removed jtype
+  reserved 4;   // removed jtype
+  reserved 18;  // reserve target, target_obsolete_do_not_use
 }
 
 message OneofOptions {
+  // Any features defined in the specific edition.
+  // WARNING: This field should only be used by protobuf plugins or special
+  // cases like the proto compiler. Other uses are discouraged and
+  // developers should rely on the protoreflect APIs for their client language.
+  optional FeatureSet features = 1;
+
+  // Range reserved for first-class custom options defined by the Protobuf
+  // team. User custom options must use the 1000+ range instead.
+  extensions 990 to 998;
+
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
 
@@ -618,6 +881,24 @@ message EnumOptions {
 
   reserved 5;  // javanano_as_lite
 
+  // Enable the legacy handling of JSON field name conflicts.  This lowercases
+  // and strips underscored from the fields before comparison in proto3 only.
+  // The new behavior takes `json_name` into account and applies to proto2 as
+  // well.
+  // TODO Remove this legacy behavior once downstream teams have
+  // had time to migrate.
+  optional bool deprecated_legacy_json_field_conflicts = 6 [deprecated = true];
+
+  // Any features defined in the specific edition.
+  // WARNING: This field should only be used by protobuf plugins or special
+  // cases like the proto compiler. Other uses are discouraged and
+  // developers should rely on the protoreflect APIs for their client language.
+  optional FeatureSet features = 7;
+
+  // Range reserved for first-class custom options defined by the Protobuf
+  // team. User custom options must use the 1000+ range instead.
+  extensions 990 to 998;
+
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
 
@@ -632,6 +913,24 @@ message EnumValueOptions {
   // this is a formalization for deprecating enum values.
   optional bool deprecated = 1 [default = false];
 
+  // Any features defined in the specific edition.
+  // WARNING: This field should only be used by protobuf plugins or special
+  // cases like the proto compiler. Other uses are discouraged and
+  // developers should rely on the protoreflect APIs for their client language.
+  optional FeatureSet features = 2;
+
+  // Indicate that fields annotated with this enum value should not be printed
+  // out when using debug formats, e.g. when the field contains sensitive
+  // credentials.
+  optional bool debug_redact = 3 [default = false];
+
+  // Information about the support window of a feature value.
+  optional FieldOptions.FeatureSupport feature_support = 4;
+
+  // Range reserved for first-class extension options defined by the Protobuf
+  // team. Custom options must use the 1000+ range instead.
+  extensions 990 to 998;
+
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
 
@@ -640,6 +939,12 @@ message EnumValueOptions {
 }
 
 message ServiceOptions {
+
+  // Any features defined in the specific edition.
+  // WARNING: This field should only be used by protobuf plugins or special
+  // cases like the proto compiler. Other uses are discouraged and
+  // developers should rely on the protoreflect APIs for their client language.
+  optional FeatureSet features = 34;
 
   // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
   //   framework.  We apologize for hoarding these numbers to ourselves, but
@@ -651,6 +956,10 @@ message ServiceOptions {
   // for the service, or it will be completely ignored; in the very least,
   // this is a formalization for deprecating services.
   optional bool deprecated = 33 [default = false];
+
+  // Range reserved for first-class custom options defined by the Protobuf
+  // team. User custom options must use the 1000+ range instead.
+  extensions 990 to 998;
 
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
@@ -683,13 +992,22 @@ message MethodOptions {
   optional IdempotencyLevel idempotency_level = 34
       [default = IDEMPOTENCY_UNKNOWN];
 
+  // Any features defined in the specific edition.
+  // WARNING: This field should only be used by protobuf plugins or special
+  // cases like the proto compiler. Other uses are discouraged and
+  // developers should rely on the protoreflect APIs for their client language.
+  optional FeatureSet features = 35;
+
+  // Range reserved for first-class custom options defined by the Protobuf
+  // team. User custom options must use the 1000+ range instead.
+  extensions 990 to 998;
+
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
 
   // Clients can define custom options in extensions of this message. See above.
   extensions 1000 to max;
 }
-
 
 // A message representing a option the parser does not recognize. This only
 // appears in options protos created by the compiler::Parser class.
@@ -701,8 +1019,8 @@ message UninterpretedOption {
   // The name of the uninterpreted option.  Each string represents a segment in
   // a dot-separated name.  is_extension is true iff a segment represents an
   // extension (denoted with parentheses in options specs in .proto files).
-  // E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
-  // "foo.(bar.baz).qux".
+  // E.g.,{ ["foo", false], ["bar.baz", true], ["moo", false] } represents
+  // "foo.(bar.baz).moo".
   message NamePart {
     required string name_part = 1;
     required bool is_extension = 2;
@@ -717,6 +1035,248 @@ message UninterpretedOption {
   optional double double_value = 6;
   optional bytes string_value = 7;
   optional string aggregate_value = 8;
+}
+
+// ===================================================================
+// Features
+
+// TODO Enums in C++ gencode (and potentially other languages) are
+// not well scoped.  This means that each of the feature enums below can clash
+// with each other.  The short names we've chosen maximize call-site
+// readability, but leave us very open to this scenario.  A future feature will
+// be designed and implemented to handle this, hopefully before we ever hit a
+// conflict here.
+message FeatureSet {
+  enum FieldPresence {
+    FIELD_PRESENCE_UNKNOWN = 0;
+    EXPLICIT = 1;
+    IMPLICIT = 2;
+    LEGACY_REQUIRED = 3;
+  }
+  optional FieldPresence field_presence = 1 [
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE,
+    feature_support = {
+      edition_introduced: EDITION_2023,
+    },
+    edition_defaults = { edition: EDITION_LEGACY, value: "EXPLICIT" },
+    edition_defaults = { edition: EDITION_PROTO3, value: "IMPLICIT" },
+    edition_defaults = { edition: EDITION_2023, value: "EXPLICIT" }
+  ];
+
+  enum EnumType {
+    ENUM_TYPE_UNKNOWN = 0;
+    OPEN = 1;
+    CLOSED = 2;
+  }
+  optional EnumType enum_type = 2 [
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_ENUM,
+    targets = TARGET_TYPE_FILE,
+    feature_support = {
+      edition_introduced: EDITION_2023,
+    },
+    edition_defaults = { edition: EDITION_LEGACY, value: "CLOSED" },
+    edition_defaults = { edition: EDITION_PROTO3, value: "OPEN" }
+  ];
+
+  enum RepeatedFieldEncoding {
+    REPEATED_FIELD_ENCODING_UNKNOWN = 0;
+    PACKED = 1;
+    EXPANDED = 2;
+  }
+  optional RepeatedFieldEncoding repeated_field_encoding = 3 [
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE,
+    feature_support = {
+      edition_introduced: EDITION_2023,
+    },
+    edition_defaults = { edition: EDITION_LEGACY, value: "EXPANDED" },
+    edition_defaults = { edition: EDITION_PROTO3, value: "PACKED" }
+  ];
+
+  enum Utf8Validation {
+    UTF8_VALIDATION_UNKNOWN = 0;
+    VERIFY = 2;
+    NONE = 3;
+    reserved 1;
+  }
+  optional Utf8Validation utf8_validation = 4 [
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE,
+    feature_support = {
+      edition_introduced: EDITION_2023,
+    },
+    edition_defaults = { edition: EDITION_LEGACY, value: "NONE" },
+    edition_defaults = { edition: EDITION_PROTO3, value: "VERIFY" }
+  ];
+
+  enum MessageEncoding {
+    MESSAGE_ENCODING_UNKNOWN = 0;
+    LENGTH_PREFIXED = 1;
+    DELIMITED = 2;
+  }
+  optional MessageEncoding message_encoding = 5 [
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE,
+    feature_support = {
+      edition_introduced: EDITION_2023,
+    },
+    edition_defaults = { edition: EDITION_LEGACY, value: "LENGTH_PREFIXED" }
+  ];
+
+  enum JsonFormat {
+    JSON_FORMAT_UNKNOWN = 0;
+    ALLOW = 1;
+    LEGACY_BEST_EFFORT = 2;
+  }
+  optional JsonFormat json_format = 6 [
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_MESSAGE,
+    targets = TARGET_TYPE_ENUM,
+    targets = TARGET_TYPE_FILE,
+    feature_support = {
+      edition_introduced: EDITION_2023,
+    },
+    edition_defaults = { edition: EDITION_LEGACY, value: "LEGACY_BEST_EFFORT" },
+    edition_defaults = { edition: EDITION_PROTO3, value: "ALLOW" }
+  ];
+
+  enum EnforceNamingStyle {
+    ENFORCE_NAMING_STYLE_UNKNOWN = 0;
+    STYLE2024 = 1;
+    STYLE_LEGACY = 2;
+    STYLE2026 = 3;
+  }
+  optional EnforceNamingStyle enforce_naming_style = 7 [
+    retention = RETENTION_SOURCE,
+    targets = TARGET_TYPE_FILE,
+    targets = TARGET_TYPE_EXTENSION_RANGE,
+    targets = TARGET_TYPE_MESSAGE,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_ONEOF,
+    targets = TARGET_TYPE_ENUM,
+    targets = TARGET_TYPE_ENUM_ENTRY,
+    targets = TARGET_TYPE_SERVICE,
+    targets = TARGET_TYPE_METHOD,
+    feature_support = {
+      edition_introduced: EDITION_2024,
+    },
+    edition_defaults = { edition: EDITION_LEGACY, value: "STYLE_LEGACY" },
+    edition_defaults = { edition: EDITION_2024, value: "STYLE2024" },
+    edition_defaults = { edition: EDITION_UNSTABLE, value: "STYLE2026" }
+  ];
+
+  message VisibilityFeature {
+    enum DefaultSymbolVisibility {
+      DEFAULT_SYMBOL_VISIBILITY_UNKNOWN = 0;
+
+      // Default pre-EDITION_2024, all UNSET visibility are export.
+      EXPORT_ALL = 1;
+
+      // All top-level symbols default to export, nested default to local.
+      EXPORT_TOP_LEVEL = 2;
+
+      // All symbols default to local.
+      LOCAL_ALL = 3;
+
+      // All symbols local by default. Nested types cannot be exported.
+      // With special case caveat for message { enum {} reserved 1 to max; }
+      // This is the recommended setting for new protos.
+      STRICT = 4;
+    }
+    reserved 1 to max;
+  }
+  optional VisibilityFeature.DefaultSymbolVisibility default_symbol_visibility =
+      8 [
+        retention = RETENTION_SOURCE,
+        targets = TARGET_TYPE_FILE,
+        feature_support = {
+          edition_introduced: EDITION_2024,
+        },
+        edition_defaults = { edition: EDITION_LEGACY, value: "EXPORT_ALL" },
+        edition_defaults = { edition: EDITION_2024, value: "EXPORT_TOP_LEVEL" }
+      ];
+
+  reserved 999;
+
+  extensions 1000 to 9994 [
+    declaration = {
+      number: 1000,
+      full_name: ".pb.cpp",
+      type: ".pb.CppFeatures"
+    },
+    declaration = {
+      number: 1001,
+      full_name: ".pb.java",
+      type: ".pb.JavaFeatures"
+    },
+    declaration = { number: 1002, full_name: ".pb.go", type: ".pb.GoFeatures" },
+    declaration = {
+      number: 1003,
+      full_name: ".pb.python",
+      type: ".pb.PythonFeatures"
+    },
+    declaration = {
+      number: 1004,
+      full_name: ".pb.csharp",
+      type: ".pb.CSharpFeatures"
+    },
+    declaration = {
+      number: 1100,
+      full_name: ".imp.impress_feature_set",
+      type: ".imp.ImpressFeatureSet"
+    },
+    declaration = {
+      number: 9989,
+      full_name: ".pb.java_mutable",
+      type: ".pb.JavaMutableFeatures"
+    },
+    declaration = {
+      number: 9990,
+      full_name: ".pb.proto1",
+      type: ".pb.Proto1Features"
+    }
+  ];
+
+  extensions 9995 to 9999;  // For internal testing
+  extensions 10000;         // for https://github.com/bufbuild/protobuf-es
+}
+
+// A compiled specification for the defaults of a set of features.  These
+// messages are generated from FeatureSet extensions and can be used to seed
+// feature resolution. The resolution with this object becomes a simple search
+// for the closest matching edition, followed by proto merges.
+message FeatureSetDefaults {
+  // A map from every known edition with a unique set of defaults to its
+  // defaults. Not all editions may be contained here.  For a given edition,
+  // the defaults at the closest matching edition ordered at or before it should
+  // be used.  This field must be in strict ascending order by edition.
+  message FeatureSetEditionDefault {
+    optional Edition edition = 3;
+
+    // Defaults of features that can be overridden in this edition.
+    optional FeatureSet overridable_features = 4;
+
+    // Defaults of features that can't be overridden in this edition.
+    optional FeatureSet fixed_features = 5;
+
+    reserved 1, 2;
+    reserved "features";
+  }
+  repeated FeatureSetEditionDefault defaults = 1;
+
+  // The minimum supported edition (inclusive) when this was constructed.
+  // Editions before this will not have defaults.
+  optional Edition minimum_edition = 4;
+
+  // The maximum known edition (inclusive) when this was constructed. Editions
+  // after this will not have reliable defaults.
+  optional Edition maximum_edition = 5;
 }
 
 // ===================================================================
@@ -774,8 +1334,8 @@ message SourceCodeInfo {
     // location.
     //
     // Each element is a field number or an index.  They form a path from
-    // the root FileDescriptorProto to the place where the definition.  For
-    // example, this path:
+    // the root FileDescriptorProto to the place where the definition appears.
+    // For example, this path:
     //   [ 4, 3, 2, 7, 1 ]
     // refers to:
     //   file.message_type(3)  // 4, 3
@@ -829,13 +1389,13 @@ message SourceCodeInfo {
     //   // Comment attached to baz.
     //   // Another line attached to baz.
     //
-    //   // Comment attached to qux.
+    //   // Comment attached to moo.
     //   //
-    //   // Another line attached to qux.
-    //   optional double qux = 4;
+    //   // Another line attached to moo.
+    //   optional double moo = 4;
     //
     //   // Detached comment for corge. This is not leading or trailing comments
-    //   // to qux or corge because there are blank lines separating it from
+    //   // to moo or corge because there are blank lines separating it from
     //   // both.
     //
     //   // Detached comment for corge paragraph 2.
@@ -853,6 +1413,13 @@ message SourceCodeInfo {
     optional string trailing_comments = 4;
     repeated string leading_detached_comments = 6;
   }
+
+  // Extensions for tooling.
+  extensions 536000000 [declaration = {
+    number: 536000000
+    type: ".buf.descriptor.v1.SourceCodeInfoExtension"
+    full_name: ".buf.descriptor.v1.buf_source_code_info_extension"
+  }];
 }
 
 // Describes the relationship between generated code and its original source
@@ -875,8 +1442,31 @@ message GeneratedCodeInfo {
     optional int32 begin = 3;
 
     // Identifies the ending offset in bytes in the generated code that
-    // relates to the identified offset. The end offset should be one past
+    // relates to the identified object. The end offset should be one past
     // the last relevant byte (so the length of the text = end - begin).
     optional int32 end = 4;
+
+    // Represents the identified object's effect on the element in the original
+    // .proto file.
+    enum Semantic {
+      // There is no effect or the effect is indescribable.
+      NONE = 0;
+      // The element is set or otherwise mutated.
+      SET = 1;
+      // An alias to the element is returned.
+      ALIAS = 2;
+    }
+    optional Semantic semantic = 5;
   }
+}
+
+// Describes the 'visibility' of a symbol with respect to the proto import
+// system. Symbols can only be imported when the visibility rules do not prevent
+// it (ex: local symbols cannot be imported).  Visibility modifiers can only set
+// on `message` and `enum` as they are the only types available to be referenced
+// from other files.
+enum SymbolVisibility {
+  VISIBILITY_UNSET = 0;
+  VISIBILITY_LOCAL = 1;
+  VISIBILITY_EXPORT = 2;
 }

--- a/packages/firestore/src/protos/google/protobuf/empty.proto
+++ b/packages/firestore/src/protos/google/protobuf/empty.proto
@@ -32,12 +32,12 @@ syntax = "proto3";
 
 package google.protobuf;
 
-option csharp_namespace = "Google.Protobuf.WellKnownTypes";
-option go_package = "github.com/golang/protobuf/ptypes/empty";
+option go_package = "google.golang.org/protobuf/types/known/emptypb";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "EmptyProto";
 option java_multiple_files = true;
 option objc_class_prefix = "GPB";
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
 option cc_enable_arenas = true;
 
 // A generic empty message that you can re-use to avoid defining duplicated
@@ -48,5 +48,4 @@ option cc_enable_arenas = true;
 //       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
 //     }
 //
-// The JSON representation for `Empty` is empty JSON object `{}`.
 message Empty {}

--- a/packages/firestore/src/protos/google/protobuf/struct.proto
+++ b/packages/firestore/src/protos/google/protobuf/struct.proto
@@ -32,64 +32,79 @@ syntax = "proto3";
 
 package google.protobuf;
 
-option csharp_namespace = "Google.Protobuf.WellKnownTypes";
 option cc_enable_arenas = true;
-option go_package = "github.com/golang/protobuf/ptypes/struct;structpb";
+option go_package = "google.golang.org/protobuf/types/known/structpb";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "StructProto";
 option java_multiple_files = true;
 option objc_class_prefix = "GPB";
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
 
-
-// `Struct` represents a structured data value, consisting of fields
-// which map to dynamically typed values. In some languages, `Struct`
-// might be supported by a native representation. For example, in
-// scripting languages like JS a struct is represented as an
-// object. The details of that representation are described together
-// with the proto support for the language.
+// Represents a JSON object.
 //
-// The JSON representation for `Struct` is JSON object.
+// An unordered key-value map, intending to perfectly capture the semantics of a
+// JSON object. This enables parsing any arbitrary JSON payload as a message
+// field in ProtoJSON format.
+//
+// This follows RFC 8259 guidelines for interoperable JSON: notably this type
+// cannot represent large Int64 values or `NaN`/`Infinity` numbers,
+// since the JSON format generally does not support those values in its number
+// type.
+//
+// If you do not intend to parse arbitrary JSON into your message, a custom
+// typed message should be preferred instead of using this type.
 message Struct {
   // Unordered map of dynamically typed values.
   map<string, Value> fields = 1;
 }
 
+// Represents a JSON value.
+//
 // `Value` represents a dynamically typed value which can be either
 // null, a number, a string, a boolean, a recursive struct value, or a
-// list of values. A producer of value is expected to set one of that
-// variants, absence of any variant indicates an error.
-//
-// The JSON representation for `Value` is JSON value.
+// list of values. A producer of value is expected to set one of these
+// variants. Absence of any variant is an invalid state.
 message Value {
   // The kind of value.
   oneof kind {
-    // Represents a null value.
+    // Represents a JSON `null`.
     NullValue null_value = 1;
-    // Represents a double value.
+
+    // Represents a JSON number. Must not be `NaN`, `Infinity` or
+    // `-Infinity`, since those are not supported in JSON. This also cannot
+    // represent large Int64 values, since JSON format generally does not
+    // support them in its number type.
     double number_value = 2;
-    // Represents a string value.
+
+    // Represents a JSON string.
     string string_value = 3;
-    // Represents a boolean value.
+
+    // Represents a JSON boolean (`true` or `false` literal in JSON).
     bool bool_value = 4;
-    // Represents a structured value.
+
+    // Represents a JSON object.
     Struct struct_value = 5;
-    // Represents a repeated `Value`.
+
+    // Represents a JSON array.
     ListValue list_value = 6;
   }
 }
 
-// `NullValue` is a singleton enumeration to represent the null value for the
-// `Value` type union.
+// Represents a JSON `null`.
 //
-//  The JSON representation for `NullValue` is JSON `null`.
+// `NullValue` is a sentinel, using an enum with only one value to represent
+// the null value for the `Value` type union.
+//
+// A field of type `NullValue` with any value other than `0` is considered
+// invalid. Most ProtoJSON serializers will emit a Value with a `null_value` set
+// as a JSON `null` regardless of the integer value, and so will round trip to
+// a `0` value.
 enum NullValue {
   // Null value.
   NULL_VALUE = 0;
 }
 
-// `ListValue` is a wrapper around a repeated field of values.
-//
-// The JSON representation for `ListValue` is JSON array.
+// Represents a JSON array.
 message ListValue {
   // Repeated field of dynamically typed values.
   repeated Value values = 1;

--- a/packages/firestore/src/protos/google/protobuf/timestamp.proto
+++ b/packages/firestore/src/protos/google/protobuf/timestamp.proto
@@ -32,13 +32,13 @@ syntax = "proto3";
 
 package google.protobuf;
 
-option csharp_namespace = "Google.Protobuf.WellKnownTypes";
 option cc_enable_arenas = true;
-option go_package = "github.com/golang/protobuf/ptypes/timestamp";
+option go_package = "google.golang.org/protobuf/types/known/timestamppb";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "TimestampProto";
 option java_multiple_files = true;
 option objc_class_prefix = "GPB";
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
 
 // A Timestamp represents a point in time independent of any time zone or local
 // calendar, encoded as a count of seconds and fractions of seconds at
@@ -90,8 +90,15 @@ option objc_class_prefix = "GPB";
 //     Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
 //         .setNanos((int) ((millis % 1000) * 1000000)).build();
 //
+// Example 5: Compute Timestamp from Java `Instant.now()`.
 //
-// Example 5: Compute Timestamp from current time in Python.
+//     Instant now = Instant.now();
+//
+//     Timestamp timestamp =
+//         Timestamp.newBuilder().setSeconds(now.getEpochSecond())
+//             .setNanos(now.getNano()).build();
+//
+// Example 6: Compute Timestamp from current time in Python.
 //
 //     timestamp = Timestamp()
 //     timestamp.GetCurrentTime()
@@ -105,33 +112,34 @@ option objc_class_prefix = "GPB";
 // {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
 // seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
 // are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
-// is required. A proto3 JSON serializer should always use UTC (as indicated by
-// "Z") when printing the Timestamp type and a proto3 JSON parser should be
+// is required. A ProtoJSON serializer should always use UTC (as indicated by
+// "Z") when printing the Timestamp type and a ProtoJSON parser should be
 // able to accept both UTC and other timezones (as indicated by an offset).
 //
 // For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
 // 01:30 UTC on January 15, 2017.
 //
 // In JavaScript, one can convert a Date object to this format using the
-// standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)
+// standard
+// [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)
 // method. In Python, a standard `datetime.datetime` object can be converted
-// to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
-// with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
-// can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
-// http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime%2D%2D
+// to this format using
+// [`strftime`](https://docs.python.org/2/library/time.html#time.strftime) with
+// the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one can use
+// the Joda Time's [`ISODateTimeFormat.dateTime()`](
+// http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime()
 // ) to obtain a formatter capable of generating timestamps in this format.
 //
-//
 message Timestamp {
-
-  // Represents seconds of UTC time since Unix epoch
-  // 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
-  // 9999-12-31T23:59:59Z inclusive.
+  // Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must
+  // be between -62135596800 and 253402300799 inclusive (which corresponds to
+  // 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z).
   int64 seconds = 1;
 
-  // Non-negative fractions of a second at nanosecond resolution. Negative
-  // second values with fractions must still have non-negative nanos values
-  // that count forward in time. Must be from 0 to 999,999,999
+  // Non-negative fractions of a second at nanosecond resolution. This field is
+  // the nanosecond portion of the duration, not an alternative to seconds.
+  // Negative second values with fractions must still have non-negative nanos
+  // values that count forward in time. Must be between 0 and 999,999,999
   // inclusive.
   int32 nanos = 2;
 }

--- a/packages/firestore/src/protos/google/protobuf/wrappers.proto
+++ b/packages/firestore/src/protos/google/protobuf/wrappers.proto
@@ -27,11 +27,18 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-// Wrappers for primitive (non-message) types. These types are useful
-// for embedding primitives in the `google.protobuf.Any` type and for places
-// where we need to distinguish between the absence of a primitive
-// typed field and its default value.
+//
+// Wrappers for primitive (non-message) types. These types were needed
+// for legacy reasons and are not recommended for use in new APIs.
+//
+// Historically these wrappers were useful to have presence on proto3 primitive
+// fields, but proto3 syntax has been updated to support the `optional` keyword.
+// Using that keyword is now the strongly preferred way to add presence to
+// proto3 primitive fields.
+//
+// A secondary usecase was to embed primitives in the `google.protobuf.Any`
+// type: it is now recommended that you embed your value in your own wrapper
+// message which can be specifically documented.
 //
 // These wrappers have no meaningful use within repeated fields as they lack
 // the ability to detect presence on individual elements.
@@ -42,17 +49,20 @@ syntax = "proto3";
 
 package google.protobuf;
 
-option csharp_namespace = "Google.Protobuf.WellKnownTypes";
 option cc_enable_arenas = true;
-option go_package = "github.com/golang/protobuf/ptypes/wrappers";
+option go_package = "google.golang.org/protobuf/types/known/wrapperspb";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "WrappersProto";
 option java_multiple_files = true;
 option objc_class_prefix = "GPB";
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
 
 // Wrapper message for `double`.
 //
 // The JSON representation for `DoubleValue` is JSON number.
+//
+// Not recommended for use in new APIs, but still useful for legacy APIs and
+// has no plan to be removed.
 message DoubleValue {
   // The double value.
   double value = 1;
@@ -61,6 +71,9 @@ message DoubleValue {
 // Wrapper message for `float`.
 //
 // The JSON representation for `FloatValue` is JSON number.
+//
+// Not recommended for use in new APIs, but still useful for legacy APIs and
+// has no plan to be removed.
 message FloatValue {
   // The float value.
   float value = 1;
@@ -69,6 +82,9 @@ message FloatValue {
 // Wrapper message for `int64`.
 //
 // The JSON representation for `Int64Value` is JSON string.
+//
+// Not recommended for use in new APIs, but still useful for legacy APIs and
+// has no plan to be removed.
 message Int64Value {
   // The int64 value.
   int64 value = 1;
@@ -77,6 +93,9 @@ message Int64Value {
 // Wrapper message for `uint64`.
 //
 // The JSON representation for `UInt64Value` is JSON string.
+//
+// Not recommended for use in new APIs, but still useful for legacy APIs and
+// has no plan to be removed.
 message UInt64Value {
   // The uint64 value.
   uint64 value = 1;
@@ -85,6 +104,9 @@ message UInt64Value {
 // Wrapper message for `int32`.
 //
 // The JSON representation for `Int32Value` is JSON number.
+//
+// Not recommended for use in new APIs, but still useful for legacy APIs and
+// has no plan to be removed.
 message Int32Value {
   // The int32 value.
   int32 value = 1;
@@ -93,6 +115,9 @@ message Int32Value {
 // Wrapper message for `uint32`.
 //
 // The JSON representation for `UInt32Value` is JSON number.
+//
+// Not recommended for use in new APIs, but still useful for legacy APIs and
+// has no plan to be removed.
 message UInt32Value {
   // The uint32 value.
   uint32 value = 1;
@@ -101,6 +126,9 @@ message UInt32Value {
 // Wrapper message for `bool`.
 //
 // The JSON representation for `BoolValue` is JSON `true` and `false`.
+//
+// Not recommended for use in new APIs, but still useful for legacy APIs and
+// has no plan to be removed.
 message BoolValue {
   // The bool value.
   bool value = 1;
@@ -109,6 +137,9 @@ message BoolValue {
 // Wrapper message for `string`.
 //
 // The JSON representation for `StringValue` is JSON string.
+//
+// Not recommended for use in new APIs, but still useful for legacy APIs and
+// has no plan to be removed.
 message StringValue {
   // The string value.
   string value = 1;
@@ -117,6 +148,9 @@ message StringValue {
 // Wrapper message for `bytes`.
 //
 // The JSON representation for `BytesValue` is JSON string.
+//
+// Not recommended for use in new APIs, but still useful for legacy APIs and
+// has no plan to be removed.
 message BytesValue {
   // The bytes value.
   bytes value = 1;

--- a/packages/firestore/src/protos/google/rpc/status.proto
+++ b/packages/firestore/src/protos/google/rpc/status.proto
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package google.rpc;
 
 import "google/protobuf/any.proto";
 
-option cc_enable_arenas = true;
 option go_package = "google.golang.org/genproto/googleapis/rpc/status;status";
 option java_multiple_files = true;
 option java_outer_classname = "StatusProto";
@@ -33,12 +32,14 @@ option objc_class_prefix = "RPC";
 // You can find out more about this error model and how to work with it in the
 // [API Design Guide](https://cloud.google.com/apis/design/errors).
 message Status {
-  // The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+  // The status code, which should be an enum value of
+  // [google.rpc.Code][google.rpc.Code].
   int32 code = 1;
 
   // A developer-facing error message, which should be in English. Any
   // user-facing error message should be localized and sent in the
-  // [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+  // [google.rpc.Status.details][google.rpc.Status.details] field, or localized
+  // by the client.
   string message = 2;
 
   // A list of messages that carry the error details.  There is a common set of

--- a/packages/firestore/src/protos/google/type/latlng.proto
+++ b/packages/firestore/src/protos/google/type/latlng.proto
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@ syntax = "proto3";
 
 package google.type;
 
-option cc_enable_arenas = true;
 option go_package = "google.golang.org/genproto/googleapis/type/latlng;latlng";
 option java_multiple_files = true;
 option java_outer_classname = "LatLngProto";
@@ -25,9 +24,9 @@ option objc_class_prefix = "GTP";
 
 // An object that represents a latitude/longitude pair. This is expressed as a
 // pair of doubles to represent degrees latitude and degrees longitude. Unless
-// specified otherwise, this must conform to the
-// <a href="http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf">WGS84
-// standard</a>. Values must be within normalized ranges.
+// specified otherwise, this object must conform to the
+// <a href="https://en.wikipedia.org/wiki/World_Geodetic_System#1984_version">
+// WGS84 standard</a>. Values must be within normalized ranges.
 message LatLng {
   // The latitude in degrees. It must be in the range [-90.0, +90.0].
   double latitude = 1;

--- a/packages/firestore/src/protos/protos.json
+++ b/packages/firestore/src/protos/protos.json
@@ -1,1098 +1,10 @@
 {
+  "options": {
+    "syntax": "proto3"
+  },
   "nested": {
     "google": {
       "nested": {
-        "protobuf": {
-          "options": {
-            "go_package": "github.com/golang/protobuf/protoc-gen-go/descriptor;descriptor",
-            "java_package": "com.google.protobuf",
-            "java_outer_classname": "DescriptorProtos",
-            "csharp_namespace": "Google.Protobuf.Reflection",
-            "objc_class_prefix": "GPB",
-            "cc_enable_arenas": true,
-            "optimize_for": "SPEED"
-          },
-          "nested": {
-            "Struct": {
-              "fields": {
-                "fields": {
-                  "keyType": "string",
-                  "type": "Value",
-                  "id": 1
-                }
-              }
-            },
-            "Value": {
-              "oneofs": {
-                "kind": {
-                  "oneof": [
-                    "nullValue",
-                    "numberValue",
-                    "stringValue",
-                    "boolValue",
-                    "structValue",
-                    "listValue"
-                  ]
-                }
-              },
-              "fields": {
-                "nullValue": {
-                  "type": "NullValue",
-                  "id": 1
-                },
-                "numberValue": {
-                  "type": "double",
-                  "id": 2
-                },
-                "stringValue": {
-                  "type": "string",
-                  "id": 3
-                },
-                "boolValue": {
-                  "type": "bool",
-                  "id": 4
-                },
-                "structValue": {
-                  "type": "Struct",
-                  "id": 5
-                },
-                "listValue": {
-                  "type": "ListValue",
-                  "id": 6
-                }
-              }
-            },
-            "NullValue": {
-              "values": {
-                "NULL_VALUE": 0
-              }
-            },
-            "ListValue": {
-              "fields": {
-                "values": {
-                  "rule": "repeated",
-                  "type": "Value",
-                  "id": 1
-                }
-              }
-            },
-            "Timestamp": {
-              "fields": {
-                "seconds": {
-                  "type": "int64",
-                  "id": 1
-                },
-                "nanos": {
-                  "type": "int32",
-                  "id": 2
-                }
-              }
-            },
-            "FileDescriptorSet": {
-              "edition": "proto2",
-              "fields": {
-                "file": {
-                  "rule": "repeated",
-                  "type": "FileDescriptorProto",
-                  "id": 1
-                }
-              }
-            },
-            "FileDescriptorProto": {
-              "edition": "proto2",
-              "fields": {
-                "name": {
-                  "type": "string",
-                  "id": 1
-                },
-                "package": {
-                  "type": "string",
-                  "id": 2
-                },
-                "dependency": {
-                  "rule": "repeated",
-                  "type": "string",
-                  "id": 3
-                },
-                "publicDependency": {
-                  "rule": "repeated",
-                  "type": "int32",
-                  "id": 10
-                },
-                "weakDependency": {
-                  "rule": "repeated",
-                  "type": "int32",
-                  "id": 11
-                },
-                "messageType": {
-                  "rule": "repeated",
-                  "type": "DescriptorProto",
-                  "id": 4
-                },
-                "enumType": {
-                  "rule": "repeated",
-                  "type": "EnumDescriptorProto",
-                  "id": 5
-                },
-                "service": {
-                  "rule": "repeated",
-                  "type": "ServiceDescriptorProto",
-                  "id": 6
-                },
-                "extension": {
-                  "rule": "repeated",
-                  "type": "FieldDescriptorProto",
-                  "id": 7
-                },
-                "options": {
-                  "type": "FileOptions",
-                  "id": 8
-                },
-                "sourceCodeInfo": {
-                  "type": "SourceCodeInfo",
-                  "id": 9
-                },
-                "syntax": {
-                  "type": "string",
-                  "id": 12
-                }
-              }
-            },
-            "DescriptorProto": {
-              "edition": "proto2",
-              "fields": {
-                "name": {
-                  "type": "string",
-                  "id": 1
-                },
-                "field": {
-                  "rule": "repeated",
-                  "type": "FieldDescriptorProto",
-                  "id": 2
-                },
-                "extension": {
-                  "rule": "repeated",
-                  "type": "FieldDescriptorProto",
-                  "id": 6
-                },
-                "nestedType": {
-                  "rule": "repeated",
-                  "type": "DescriptorProto",
-                  "id": 3
-                },
-                "enumType": {
-                  "rule": "repeated",
-                  "type": "EnumDescriptorProto",
-                  "id": 4
-                },
-                "extensionRange": {
-                  "rule": "repeated",
-                  "type": "ExtensionRange",
-                  "id": 5
-                },
-                "oneofDecl": {
-                  "rule": "repeated",
-                  "type": "OneofDescriptorProto",
-                  "id": 8
-                },
-                "options": {
-                  "type": "MessageOptions",
-                  "id": 7
-                },
-                "reservedRange": {
-                  "rule": "repeated",
-                  "type": "ReservedRange",
-                  "id": 9
-                },
-                "reservedName": {
-                  "rule": "repeated",
-                  "type": "string",
-                  "id": 10
-                }
-              },
-              "nested": {
-                "ExtensionRange": {
-                  "fields": {
-                    "start": {
-                      "type": "int32",
-                      "id": 1
-                    },
-                    "end": {
-                      "type": "int32",
-                      "id": 2
-                    },
-                    "options": {
-                      "type": "ExtensionRangeOptions",
-                      "id": 3
-                    }
-                  }
-                },
-                "ReservedRange": {
-                  "fields": {
-                    "start": {
-                      "type": "int32",
-                      "id": 1
-                    },
-                    "end": {
-                      "type": "int32",
-                      "id": 2
-                    }
-                  }
-                }
-              }
-            },
-            "ExtensionRangeOptions": {
-              "edition": "proto2",
-              "fields": {
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ]
-            },
-            "FieldDescriptorProto": {
-              "edition": "proto2",
-              "fields": {
-                "name": {
-                  "type": "string",
-                  "id": 1
-                },
-                "number": {
-                  "type": "int32",
-                  "id": 3
-                },
-                "label": {
-                  "type": "Label",
-                  "id": 4
-                },
-                "type": {
-                  "type": "Type",
-                  "id": 5
-                },
-                "typeName": {
-                  "type": "string",
-                  "id": 6
-                },
-                "extendee": {
-                  "type": "string",
-                  "id": 2
-                },
-                "defaultValue": {
-                  "type": "string",
-                  "id": 7
-                },
-                "oneofIndex": {
-                  "type": "int32",
-                  "id": 9
-                },
-                "jsonName": {
-                  "type": "string",
-                  "id": 10
-                },
-                "options": {
-                  "type": "FieldOptions",
-                  "id": 8
-                }
-              },
-              "nested": {
-                "Type": {
-                  "values": {
-                    "TYPE_DOUBLE": 1,
-                    "TYPE_FLOAT": 2,
-                    "TYPE_INT64": 3,
-                    "TYPE_UINT64": 4,
-                    "TYPE_INT32": 5,
-                    "TYPE_FIXED64": 6,
-                    "TYPE_FIXED32": 7,
-                    "TYPE_BOOL": 8,
-                    "TYPE_STRING": 9,
-                    "TYPE_GROUP": 10,
-                    "TYPE_MESSAGE": 11,
-                    "TYPE_BYTES": 12,
-                    "TYPE_UINT32": 13,
-                    "TYPE_ENUM": 14,
-                    "TYPE_SFIXED32": 15,
-                    "TYPE_SFIXED64": 16,
-                    "TYPE_SINT32": 17,
-                    "TYPE_SINT64": 18
-                  }
-                },
-                "Label": {
-                  "values": {
-                    "LABEL_OPTIONAL": 1,
-                    "LABEL_REQUIRED": 2,
-                    "LABEL_REPEATED": 3
-                  }
-                }
-              }
-            },
-            "OneofDescriptorProto": {
-              "edition": "proto2",
-              "fields": {
-                "name": {
-                  "type": "string",
-                  "id": 1
-                },
-                "options": {
-                  "type": "OneofOptions",
-                  "id": 2
-                }
-              }
-            },
-            "EnumDescriptorProto": {
-              "edition": "proto2",
-              "fields": {
-                "name": {
-                  "type": "string",
-                  "id": 1
-                },
-                "value": {
-                  "rule": "repeated",
-                  "type": "EnumValueDescriptorProto",
-                  "id": 2
-                },
-                "options": {
-                  "type": "EnumOptions",
-                  "id": 3
-                },
-                "reservedRange": {
-                  "rule": "repeated",
-                  "type": "EnumReservedRange",
-                  "id": 4
-                },
-                "reservedName": {
-                  "rule": "repeated",
-                  "type": "string",
-                  "id": 5
-                }
-              },
-              "nested": {
-                "EnumReservedRange": {
-                  "fields": {
-                    "start": {
-                      "type": "int32",
-                      "id": 1
-                    },
-                    "end": {
-                      "type": "int32",
-                      "id": 2
-                    }
-                  }
-                }
-              }
-            },
-            "EnumValueDescriptorProto": {
-              "edition": "proto2",
-              "fields": {
-                "name": {
-                  "type": "string",
-                  "id": 1
-                },
-                "number": {
-                  "type": "int32",
-                  "id": 2
-                },
-                "options": {
-                  "type": "EnumValueOptions",
-                  "id": 3
-                }
-              }
-            },
-            "ServiceDescriptorProto": {
-              "edition": "proto2",
-              "fields": {
-                "name": {
-                  "type": "string",
-                  "id": 1
-                },
-                "method": {
-                  "rule": "repeated",
-                  "type": "MethodDescriptorProto",
-                  "id": 2
-                },
-                "options": {
-                  "type": "ServiceOptions",
-                  "id": 3
-                }
-              }
-            },
-            "MethodDescriptorProto": {
-              "edition": "proto2",
-              "fields": {
-                "name": {
-                  "type": "string",
-                  "id": 1
-                },
-                "inputType": {
-                  "type": "string",
-                  "id": 2
-                },
-                "outputType": {
-                  "type": "string",
-                  "id": 3
-                },
-                "options": {
-                  "type": "MethodOptions",
-                  "id": 4
-                },
-                "clientStreaming": {
-                  "type": "bool",
-                  "id": 5,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "serverStreaming": {
-                  "type": "bool",
-                  "id": 6,
-                  "options": {
-                    "default": false
-                  }
-                }
-              }
-            },
-            "FileOptions": {
-              "edition": "proto2",
-              "fields": {
-                "javaPackage": {
-                  "type": "string",
-                  "id": 1
-                },
-                "javaOuterClassname": {
-                  "type": "string",
-                  "id": 8
-                },
-                "javaMultipleFiles": {
-                  "type": "bool",
-                  "id": 10,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "javaGenerateEqualsAndHash": {
-                  "type": "bool",
-                  "id": 20,
-                  "options": {
-                    "deprecated": true
-                  }
-                },
-                "javaStringCheckUtf8": {
-                  "type": "bool",
-                  "id": 27,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "optimizeFor": {
-                  "type": "OptimizeMode",
-                  "id": 9,
-                  "options": {
-                    "default": "SPEED"
-                  }
-                },
-                "goPackage": {
-                  "type": "string",
-                  "id": 11
-                },
-                "ccGenericServices": {
-                  "type": "bool",
-                  "id": 16,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "javaGenericServices": {
-                  "type": "bool",
-                  "id": 17,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "pyGenericServices": {
-                  "type": "bool",
-                  "id": 18,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "phpGenericServices": {
-                  "type": "bool",
-                  "id": 42,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "deprecated": {
-                  "type": "bool",
-                  "id": 23,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "ccEnableArenas": {
-                  "type": "bool",
-                  "id": 31,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "objcClassPrefix": {
-                  "type": "string",
-                  "id": 36
-                },
-                "csharpNamespace": {
-                  "type": "string",
-                  "id": 37
-                },
-                "swiftPrefix": {
-                  "type": "string",
-                  "id": 39
-                },
-                "phpClassPrefix": {
-                  "type": "string",
-                  "id": 40
-                },
-                "phpNamespace": {
-                  "type": "string",
-                  "id": 41
-                },
-                "phpMetadataNamespace": {
-                  "type": "string",
-                  "id": 44
-                },
-                "rubyPackage": {
-                  "type": "string",
-                  "id": 45
-                },
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ],
-              "reserved": [
-                [
-                  38,
-                  38
-                ]
-              ],
-              "nested": {
-                "OptimizeMode": {
-                  "values": {
-                    "SPEED": 1,
-                    "CODE_SIZE": 2,
-                    "LITE_RUNTIME": 3
-                  }
-                }
-              }
-            },
-            "MessageOptions": {
-              "edition": "proto2",
-              "fields": {
-                "messageSetWireFormat": {
-                  "type": "bool",
-                  "id": 1,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "noStandardDescriptorAccessor": {
-                  "type": "bool",
-                  "id": 2,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "deprecated": {
-                  "type": "bool",
-                  "id": 3,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "mapEntry": {
-                  "type": "bool",
-                  "id": 7
-                },
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ],
-              "reserved": [
-                [
-                  8,
-                  8
-                ],
-                [
-                  9,
-                  9
-                ]
-              ]
-            },
-            "FieldOptions": {
-              "edition": "proto2",
-              "fields": {
-                "ctype": {
-                  "type": "CType",
-                  "id": 1,
-                  "options": {
-                    "default": "STRING"
-                  }
-                },
-                "packed": {
-                  "type": "bool",
-                  "id": 2
-                },
-                "jstype": {
-                  "type": "JSType",
-                  "id": 6,
-                  "options": {
-                    "default": "JS_NORMAL"
-                  }
-                },
-                "lazy": {
-                  "type": "bool",
-                  "id": 5,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "deprecated": {
-                  "type": "bool",
-                  "id": 3,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "weak": {
-                  "type": "bool",
-                  "id": 10,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ],
-              "reserved": [
-                [
-                  4,
-                  4
-                ]
-              ],
-              "nested": {
-                "CType": {
-                  "values": {
-                    "STRING": 0,
-                    "CORD": 1,
-                    "STRING_PIECE": 2
-                  }
-                },
-                "JSType": {
-                  "values": {
-                    "JS_NORMAL": 0,
-                    "JS_STRING": 1,
-                    "JS_NUMBER": 2
-                  }
-                }
-              }
-            },
-            "OneofOptions": {
-              "edition": "proto2",
-              "fields": {
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ]
-            },
-            "EnumOptions": {
-              "edition": "proto2",
-              "fields": {
-                "allowAlias": {
-                  "type": "bool",
-                  "id": 2
-                },
-                "deprecated": {
-                  "type": "bool",
-                  "id": 3,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ],
-              "reserved": [
-                [
-                  5,
-                  5
-                ]
-              ]
-            },
-            "EnumValueOptions": {
-              "edition": "proto2",
-              "fields": {
-                "deprecated": {
-                  "type": "bool",
-                  "id": 1,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ]
-            },
-            "ServiceOptions": {
-              "edition": "proto2",
-              "fields": {
-                "deprecated": {
-                  "type": "bool",
-                  "id": 33,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ]
-            },
-            "MethodOptions": {
-              "edition": "proto2",
-              "fields": {
-                "deprecated": {
-                  "type": "bool",
-                  "id": 33,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "idempotencyLevel": {
-                  "type": "IdempotencyLevel",
-                  "id": 34,
-                  "options": {
-                    "default": "IDEMPOTENCY_UNKNOWN"
-                  }
-                },
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ],
-              "nested": {
-                "IdempotencyLevel": {
-                  "values": {
-                    "IDEMPOTENCY_UNKNOWN": 0,
-                    "NO_SIDE_EFFECTS": 1,
-                    "IDEMPOTENT": 2
-                  }
-                }
-              }
-            },
-            "UninterpretedOption": {
-              "edition": "proto2",
-              "fields": {
-                "name": {
-                  "rule": "repeated",
-                  "type": "NamePart",
-                  "id": 2
-                },
-                "identifierValue": {
-                  "type": "string",
-                  "id": 3
-                },
-                "positiveIntValue": {
-                  "type": "uint64",
-                  "id": 4
-                },
-                "negativeIntValue": {
-                  "type": "int64",
-                  "id": 5
-                },
-                "doubleValue": {
-                  "type": "double",
-                  "id": 6
-                },
-                "stringValue": {
-                  "type": "bytes",
-                  "id": 7
-                },
-                "aggregateValue": {
-                  "type": "string",
-                  "id": 8
-                }
-              },
-              "nested": {
-                "NamePart": {
-                  "fields": {
-                    "namePart": {
-                      "rule": "required",
-                      "type": "string",
-                      "id": 1
-                    },
-                    "isExtension": {
-                      "rule": "required",
-                      "type": "bool",
-                      "id": 2
-                    }
-                  }
-                }
-              }
-            },
-            "SourceCodeInfo": {
-              "edition": "proto2",
-              "fields": {
-                "location": {
-                  "rule": "repeated",
-                  "type": "Location",
-                  "id": 1
-                }
-              },
-              "nested": {
-                "Location": {
-                  "fields": {
-                    "path": {
-                      "rule": "repeated",
-                      "type": "int32",
-                      "id": 1,
-                      "options": {
-                        "packed": true
-                      }
-                    },
-                    "span": {
-                      "rule": "repeated",
-                      "type": "int32",
-                      "id": 2,
-                      "options": {
-                        "packed": true
-                      }
-                    },
-                    "leadingComments": {
-                      "type": "string",
-                      "id": 3
-                    },
-                    "trailingComments": {
-                      "type": "string",
-                      "id": 4
-                    },
-                    "leadingDetachedComments": {
-                      "rule": "repeated",
-                      "type": "string",
-                      "id": 6
-                    }
-                  }
-                }
-              }
-            },
-            "GeneratedCodeInfo": {
-              "edition": "proto2",
-              "fields": {
-                "annotation": {
-                  "rule": "repeated",
-                  "type": "Annotation",
-                  "id": 1
-                }
-              },
-              "nested": {
-                "Annotation": {
-                  "fields": {
-                    "path": {
-                      "rule": "repeated",
-                      "type": "int32",
-                      "id": 1,
-                      "options": {
-                        "packed": true
-                      }
-                    },
-                    "sourceFile": {
-                      "type": "string",
-                      "id": 2
-                    },
-                    "begin": {
-                      "type": "int32",
-                      "id": 3
-                    },
-                    "end": {
-                      "type": "int32",
-                      "id": 4
-                    }
-                  }
-                }
-              }
-            },
-            "DoubleValue": {
-              "fields": {
-                "value": {
-                  "type": "double",
-                  "id": 1
-                }
-              }
-            },
-            "FloatValue": {
-              "fields": {
-                "value": {
-                  "type": "float",
-                  "id": 1
-                }
-              }
-            },
-            "Int64Value": {
-              "fields": {
-                "value": {
-                  "type": "int64",
-                  "id": 1
-                }
-              }
-            },
-            "UInt64Value": {
-              "fields": {
-                "value": {
-                  "type": "uint64",
-                  "id": 1
-                }
-              }
-            },
-            "Int32Value": {
-              "fields": {
-                "value": {
-                  "type": "int32",
-                  "id": 1
-                }
-              }
-            },
-            "UInt32Value": {
-              "fields": {
-                "value": {
-                  "type": "uint32",
-                  "id": 1
-                }
-              }
-            },
-            "BoolValue": {
-              "fields": {
-                "value": {
-                  "type": "bool",
-                  "id": 1
-                }
-              }
-            },
-            "StringValue": {
-              "fields": {
-                "value": {
-                  "type": "string",
-                  "id": 1
-                }
-              }
-            },
-            "BytesValue": {
-              "fields": {
-                "value": {
-                  "type": "bytes",
-                  "id": 1
-                }
-              }
-            },
-            "Empty": {
-              "fields": {}
-            },
-            "Any": {
-              "fields": {
-                "type_url": {
-                  "type": "string",
-                  "id": 1
-                },
-                "value": {
-                  "type": "bytes",
-                  "id": 2
-                }
-              }
-            },
-            "Duration": {
-              "fields": {
-                "seconds": {
-                  "type": "int64",
-                  "id": 1
-                },
-                "nanos": {
-                  "type": "int32",
-                  "id": 2
-                }
-              }
-            }
-          }
-        },
         "firestore": {
           "nested": {
             "v1": {
@@ -1100,7 +12,7 @@
                 "csharp_namespace": "Google.Cloud.Firestore.V1",
                 "go_package": "cloud.google.com/go/firestore/apiv1/firestorepb;firestorepb",
                 "java_multiple_files": true,
-                "java_outer_classname": "QueryProfileProto",
+                "java_outer_classname": "QueryProto",
                 "java_package": "com.google.firestore.v1",
                 "objc_class_prefix": "GCFS",
                 "php_namespace": "Google\\Cloud\\Firestore\\V1",
@@ -1244,17 +156,26 @@
                   "fields": {
                     "name": {
                       "type": "string",
-                      "id": 1
+                      "id": 1,
+                      "options": {
+                        "(google.api.field_behavior)": "REQUIRED"
+                      }
                     },
                     "args": {
                       "rule": "repeated",
                       "type": "Value",
-                      "id": 2
+                      "id": 2,
+                      "options": {
+                        "(google.api.field_behavior)": "OPTIONAL"
+                      }
                     },
                     "options": {
                       "keyType": "string",
                       "type": "Value",
-                      "id": 3
+                      "id": 3,
+                      "options": {
+                        "(google.api.field_behavior)": "OPTIONAL"
+                      }
                     }
                   }
                 },
@@ -1263,7 +184,10 @@
                     "stages": {
                       "rule": "repeated",
                       "type": "Stage",
-                      "id": 1
+                      "id": 1,
+                      "options": {
+                        "(google.api.field_behavior)": "REQUIRED"
+                      }
                     }
                   },
                   "nested": {
@@ -1271,19 +195,219 @@
                       "fields": {
                         "name": {
                           "type": "string",
-                          "id": 1
+                          "id": 1,
+                          "options": {
+                            "(google.api.field_behavior)": "REQUIRED"
+                          }
                         },
                         "args": {
                           "rule": "repeated",
                           "type": "Value",
-                          "id": 2
+                          "id": 2,
+                          "options": {
+                            "(google.api.field_behavior)": "OPTIONAL"
+                          }
                         },
                         "options": {
                           "keyType": "string",
                           "type": "Value",
-                          "id": 3
+                          "id": 3,
+                          "options": {
+                            "(google.api.field_behavior)": "OPTIONAL"
+                          }
                         }
                       }
+                    }
+                  }
+                },
+                "Write": {
+                  "oneofs": {
+                    "operation": {
+                      "oneof": [
+                        "update",
+                        "delete",
+                        "verify",
+                        "transform"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "update": {
+                      "type": "Document",
+                      "id": 1
+                    },
+                    "delete": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "verify": {
+                      "type": "string",
+                      "id": 5
+                    },
+                    "transform": {
+                      "type": "DocumentTransform",
+                      "id": 6
+                    },
+                    "updateMask": {
+                      "type": "DocumentMask",
+                      "id": 3
+                    },
+                    "updateTransforms": {
+                      "rule": "repeated",
+                      "type": "DocumentTransform.FieldTransform",
+                      "id": 7
+                    },
+                    "currentDocument": {
+                      "type": "Precondition",
+                      "id": 4
+                    }
+                  }
+                },
+                "DocumentTransform": {
+                  "fields": {
+                    "document": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "fieldTransforms": {
+                      "rule": "repeated",
+                      "type": "FieldTransform",
+                      "id": 2
+                    }
+                  },
+                  "nested": {
+                    "FieldTransform": {
+                      "oneofs": {
+                        "transformType": {
+                          "oneof": [
+                            "setToServerValue",
+                            "increment",
+                            "maximum",
+                            "minimum",
+                            "appendMissingElements",
+                            "removeAllFromArray"
+                          ]
+                        }
+                      },
+                      "fields": {
+                        "fieldPath": {
+                          "type": "string",
+                          "id": 1
+                        },
+                        "setToServerValue": {
+                          "type": "ServerValue",
+                          "id": 2
+                        },
+                        "increment": {
+                          "type": "Value",
+                          "id": 3
+                        },
+                        "maximum": {
+                          "type": "Value",
+                          "id": 4
+                        },
+                        "minimum": {
+                          "type": "Value",
+                          "id": 5
+                        },
+                        "appendMissingElements": {
+                          "type": "ArrayValue",
+                          "id": 6
+                        },
+                        "removeAllFromArray": {
+                          "type": "ArrayValue",
+                          "id": 7
+                        }
+                      },
+                      "nested": {
+                        "ServerValue": {
+                          "values": {
+                            "SERVER_VALUE_UNSPECIFIED": 0,
+                            "REQUEST_TIME": 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "WriteResult": {
+                  "fields": {
+                    "updateTime": {
+                      "type": "google.protobuf.Timestamp",
+                      "id": 1
+                    },
+                    "transformResults": {
+                      "rule": "repeated",
+                      "type": "Value",
+                      "id": 2
+                    }
+                  }
+                },
+                "DocumentChange": {
+                  "fields": {
+                    "document": {
+                      "type": "Document",
+                      "id": 1
+                    },
+                    "targetIds": {
+                      "rule": "repeated",
+                      "type": "int32",
+                      "id": 5
+                    },
+                    "removedTargetIds": {
+                      "rule": "repeated",
+                      "type": "int32",
+                      "id": 6
+                    }
+                  }
+                },
+                "DocumentDelete": {
+                  "fields": {
+                    "document": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "removedTargetIds": {
+                      "rule": "repeated",
+                      "type": "int32",
+                      "id": 6
+                    },
+                    "readTime": {
+                      "type": "google.protobuf.Timestamp",
+                      "id": 4
+                    }
+                  }
+                },
+                "DocumentRemove": {
+                  "fields": {
+                    "document": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "removedTargetIds": {
+                      "rule": "repeated",
+                      "type": "int32",
+                      "id": 2
+                    },
+                    "readTime": {
+                      "type": "google.protobuf.Timestamp",
+                      "id": 4
+                    }
+                  }
+                },
+                "ExistenceFilter": {
+                  "fields": {
+                    "targetId": {
+                      "type": "int32",
+                      "id": 1
+                    },
+                    "count": {
+                      "type": "int32",
+                      "id": 2
+                    },
+                    "unchangedNames": {
+                      "type": "BloomFilter",
+                      "id": 3
                     }
                   }
                 },
@@ -1385,6 +509,66 @@
                     }
                   }
                 },
+                "ExplainStats": {
+                  "fields": {
+                    "data": {
+                      "type": "google.protobuf.Any",
+                      "id": 1
+                    }
+                  }
+                },
+                "ExplainOptions": {
+                  "fields": {
+                    "analyze": {
+                      "type": "bool",
+                      "id": 1,
+                      "options": {
+                        "(google.api.field_behavior)": "OPTIONAL"
+                      }
+                    }
+                  }
+                },
+                "ExplainMetrics": {
+                  "fields": {
+                    "planSummary": {
+                      "type": "PlanSummary",
+                      "id": 1
+                    },
+                    "executionStats": {
+                      "type": "ExecutionStats",
+                      "id": 2
+                    }
+                  }
+                },
+                "PlanSummary": {
+                  "fields": {
+                    "indexesUsed": {
+                      "rule": "repeated",
+                      "type": "google.protobuf.Struct",
+                      "id": 1
+                    }
+                  }
+                },
+                "ExecutionStats": {
+                  "fields": {
+                    "resultsReturned": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "executionDuration": {
+                      "type": "google.protobuf.Duration",
+                      "id": 3
+                    },
+                    "readOperations": {
+                      "type": "int64",
+                      "id": 4
+                    },
+                    "debugStats": {
+                      "type": "google.protobuf.Struct",
+                      "id": 5
+                    }
+                  }
+                },
                 "Firestore": {
                   "options": {
                     "(google.api.default_host)": "firestore.googleapis.com",
@@ -1409,12 +593,16 @@
                       "requestType": "ListDocumentsRequest",
                       "responseType": "ListDocumentsResponse",
                       "options": {
-                        "(google.api.http).get": "/v1/{parent=projects/*/databases/*/documents/*/**}/{collection_id}"
+                        "(google.api.http).get": "/v1/{parent=projects/*/databases/*/documents/*/**}/{collection_id}",
+                        "(google.api.http).additional_bindings.get": "/v1/{parent=projects/*/databases/*/documents}/{collection_id}"
                       },
                       "parsedOptions": [
                         {
                           "(google.api.http)": {
-                            "get": "/v1/{parent=projects/*/databases/*/documents/*/**}/{collection_id}"
+                            "get": "/v1/{parent=projects/*/databases/*/documents/*/**}/{collection_id}",
+                            "additional_bindings": {
+                              "get": "/v1/{parent=projects/*/databases/*/documents}/{collection_id}"
+                            }
                           }
                         }
                       ]
@@ -1563,13 +751,29 @@
                       "responseStream": true,
                       "options": {
                         "(google.api.http).post": "/v1/{database=projects/*/databases/*}/documents:executePipeline",
-                        "(google.api.http).body": "*"
+                        "(google.api.http).body": "*",
+                        "(google.api.routing).routing_parameters.field": "database",
+                        "(google.api.routing).routing_parameters.path_template": "projects/*/databases/{database_id=*}/**"
                       },
                       "parsedOptions": [
                         {
                           "(google.api.http)": {
                             "post": "/v1/{database=projects/*/databases/*}/documents:executePipeline",
                             "body": "*"
+                          }
+                        },
+                        {
+                          "(google.api.routing)": {
+                            "routing_parameters": [
+                              {
+                                "field": "database",
+                                "path_template": "projects/{project_id=*}/**"
+                              },
+                              {
+                                "field": "database",
+                                "path_template": "projects/*/databases/{database_id=*}/**"
+                              }
+                            ]
                           }
                         }
                       ]
@@ -1767,24 +971,36 @@
                       "type": "string",
                       "id": 2,
                       "options": {
-                        "(google.api.field_behavior)": "REQUIRED"
+                        "(google.api.field_behavior)": "OPTIONAL"
                       }
                     },
                     "pageSize": {
                       "type": "int32",
-                      "id": 3
+                      "id": 3,
+                      "options": {
+                        "(google.api.field_behavior)": "OPTIONAL"
+                      }
                     },
                     "pageToken": {
                       "type": "string",
-                      "id": 4
+                      "id": 4,
+                      "options": {
+                        "(google.api.field_behavior)": "OPTIONAL"
+                      }
                     },
                     "orderBy": {
                       "type": "string",
-                      "id": 6
+                      "id": 6,
+                      "options": {
+                        "(google.api.field_behavior)": "OPTIONAL"
+                      }
                     },
                     "mask": {
                       "type": "DocumentMask",
-                      "id": 7
+                      "id": 7,
+                      "options": {
+                        "(google.api.field_behavior)": "OPTIONAL"
+                      }
                     },
                     "transaction": {
                       "type": "bytes",
@@ -2065,10 +1281,24 @@
                     "readTime": {
                       "type": "google.protobuf.Timestamp",
                       "id": 7
+                    },
+                    "explainOptions": {
+                      "type": "ExplainOptions",
+                      "id": 10,
+                      "options": {
+                        "(google.api.field_behavior)": "OPTIONAL"
+                      }
                     }
                   }
                 },
                 "RunQueryResponse": {
+                  "oneofs": {
+                    "continuationSelector": {
+                      "oneof": [
+                        "done"
+                      ]
+                    }
+                  },
                   "fields": {
                     "transaction": {
                       "type": "bytes",
@@ -2085,6 +1315,14 @@
                     "skippedResults": {
                       "type": "int32",
                       "id": 4
+                    },
+                    "done": {
+                      "type": "bool",
+                      "id": 6
+                    },
+                    "explainMetrics": {
+                      "type": "ExplainMetrics",
+                      "id": 11
                     }
                   }
                 },
@@ -2143,6 +1381,10 @@
                     "executionTime": {
                       "type": "google.protobuf.Timestamp",
                       "id": 3
+                    },
+                    "explainStats": {
+                      "type": "ExplainStats",
+                      "id": 4
                     }
                   }
                 },
@@ -2184,6 +1426,13 @@
                     "readTime": {
                       "type": "google.protobuf.Timestamp",
                       "id": 6
+                    },
+                    "explainOptions": {
+                      "type": "ExplainOptions",
+                      "id": 8,
+                      "options": {
+                        "(google.api.field_behavior)": "OPTIONAL"
+                      }
                     }
                   }
                 },
@@ -2200,6 +1449,10 @@
                     "readTime": {
                       "type": "google.protobuf.Timestamp",
                       "id": 3
+                    },
+                    "explainMetrics": {
+                      "type": "ExplainMetrics",
+                      "id": 10
                     }
                   }
                 },
@@ -2208,6 +1461,11 @@
                     "queryType": {
                       "oneof": [
                         "structuredQuery"
+                      ]
+                    },
+                    "consistencySelector": {
+                      "oneof": [
+                        "readTime"
                       ]
                     }
                   },
@@ -2234,6 +1492,10 @@
                     "pageSize": {
                       "type": "int32",
                       "id": 5
+                    },
+                    "readTime": {
+                      "type": "google.protobuf.Timestamp",
+                      "id": 6
                     }
                   }
                 },
@@ -2480,6 +1742,13 @@
                   }
                 },
                 "ListCollectionIdsRequest": {
+                  "oneofs": {
+                    "consistencySelector": {
+                      "oneof": [
+                        "readTime"
+                      ]
+                    }
+                  },
                   "fields": {
                     "parent": {
                       "type": "string",
@@ -2495,6 +1764,10 @@
                     "pageToken": {
                       "type": "string",
                       "id": 3
+                    },
+                    "readTime": {
+                      "type": "google.protobuf.Timestamp",
+                      "id": 4
                     }
                   }
                 },
@@ -2550,12 +1823,18 @@
                   "fields": {
                     "pipeline": {
                       "type": "Pipeline",
-                      "id": 1
+                      "id": 1,
+                      "options": {
+                        "(google.api.field_behavior)": "REQUIRED"
+                      }
                     },
                     "options": {
                       "keyType": "string",
                       "type": "Value",
-                      "id": 2
+                      "id": 2,
+                      "options": {
+                        "(google.api.field_behavior)": "OPTIONAL"
+                      }
                     }
                   }
                 },
@@ -2594,6 +1873,13 @@
                     "limit": {
                       "type": "google.protobuf.Int32Value",
                       "id": 5
+                    },
+                    "findNearest": {
+                      "type": "FindNearest",
+                      "id": 9,
+                      "options": {
+                        "(google.api.field_behavior)": "OPTIONAL"
+                      }
                     }
                   },
                   "nested": {
@@ -2731,6 +2017,13 @@
                         }
                       }
                     },
+                    "Direction": {
+                      "values": {
+                        "DIRECTION_UNSPECIFIED": 0,
+                        "ASCENDING": 1,
+                        "DESCENDING": 2
+                      }
+                    },
                     "FieldReference": {
                       "fields": {
                         "fieldPath": {
@@ -2748,11 +2041,60 @@
                         }
                       }
                     },
-                    "Direction": {
-                      "values": {
-                        "DIRECTION_UNSPECIFIED": 0,
-                        "ASCENDING": 1,
-                        "DESCENDING": 2
+                    "FindNearest": {
+                      "fields": {
+                        "vectorField": {
+                          "type": "FieldReference",
+                          "id": 1,
+                          "options": {
+                            "(google.api.field_behavior)": "REQUIRED"
+                          }
+                        },
+                        "queryVector": {
+                          "type": "Value",
+                          "id": 2,
+                          "options": {
+                            "(google.api.field_behavior)": "REQUIRED"
+                          }
+                        },
+                        "distanceMeasure": {
+                          "type": "DistanceMeasure",
+                          "id": 3,
+                          "options": {
+                            "(google.api.field_behavior)": "REQUIRED"
+                          }
+                        },
+                        "limit": {
+                          "type": "google.protobuf.Int32Value",
+                          "id": 4,
+                          "options": {
+                            "(google.api.field_behavior)": "REQUIRED"
+                          }
+                        },
+                        "distanceResultField": {
+                          "type": "string",
+                          "id": 5,
+                          "options": {
+                            "(google.api.field_behavior)": "OPTIONAL"
+                          }
+                        },
+                        "distanceThreshold": {
+                          "type": "google.protobuf.DoubleValue",
+                          "id": 6,
+                          "options": {
+                            "(google.api.field_behavior)": "OPTIONAL"
+                          }
+                        }
+                      },
+                      "nested": {
+                        "DistanceMeasure": {
+                          "values": {
+                            "DISTANCE_MEASURE_UNSPECIFIED": 0,
+                            "EUCLIDEAN": 1,
+                            "COSINE": 2,
+                            "DOT_PRODUCT": 3
+                          }
+                        }
                       }
                     }
                   }
@@ -2773,7 +2115,10 @@
                     "aggregations": {
                       "rule": "repeated",
                       "type": "Aggregation",
-                      "id": 3
+                      "id": 3,
+                      "options": {
+                        "(google.api.field_behavior)": "OPTIONAL"
+                      }
                     }
                   },
                   "nested": {
@@ -2802,7 +2147,10 @@
                         },
                         "alias": {
                           "type": "string",
-                          "id": 7
+                          "id": 7,
+                          "options": {
+                            "(google.api.field_behavior)": "OPTIONAL"
+                          }
                         }
                       },
                       "nested": {
@@ -2810,7 +2158,10 @@
                           "fields": {
                             "upTo": {
                               "type": "google.protobuf.Int64Value",
-                              "id": 1
+                              "id": 1,
+                              "options": {
+                                "(google.api.field_behavior)": "OPTIONAL"
+                              }
                             }
                           }
                         },
@@ -2846,273 +2197,6 @@
                       "id": 2
                     }
                   }
-                },
-                "Write": {
-                  "oneofs": {
-                    "operation": {
-                      "oneof": [
-                        "update",
-                        "delete",
-                        "verify",
-                        "transform"
-                      ]
-                    }
-                  },
-                  "fields": {
-                    "update": {
-                      "type": "Document",
-                      "id": 1
-                    },
-                    "delete": {
-                      "type": "string",
-                      "id": 2
-                    },
-                    "verify": {
-                      "type": "string",
-                      "id": 5
-                    },
-                    "transform": {
-                      "type": "DocumentTransform",
-                      "id": 6
-                    },
-                    "updateMask": {
-                      "type": "DocumentMask",
-                      "id": 3
-                    },
-                    "updateTransforms": {
-                      "rule": "repeated",
-                      "type": "DocumentTransform.FieldTransform",
-                      "id": 7
-                    },
-                    "currentDocument": {
-                      "type": "Precondition",
-                      "id": 4
-                    }
-                  }
-                },
-                "DocumentTransform": {
-                  "fields": {
-                    "document": {
-                      "type": "string",
-                      "id": 1
-                    },
-                    "fieldTransforms": {
-                      "rule": "repeated",
-                      "type": "FieldTransform",
-                      "id": 2
-                    }
-                  },
-                  "nested": {
-                    "FieldTransform": {
-                      "oneofs": {
-                        "transformType": {
-                          "oneof": [
-                            "setToServerValue",
-                            "increment",
-                            "maximum",
-                            "minimum",
-                            "appendMissingElements",
-                            "removeAllFromArray"
-                          ]
-                        }
-                      },
-                      "fields": {
-                        "fieldPath": {
-                          "type": "string",
-                          "id": 1
-                        },
-                        "setToServerValue": {
-                          "type": "ServerValue",
-                          "id": 2
-                        },
-                        "increment": {
-                          "type": "Value",
-                          "id": 3
-                        },
-                        "maximum": {
-                          "type": "Value",
-                          "id": 4
-                        },
-                        "minimum": {
-                          "type": "Value",
-                          "id": 5
-                        },
-                        "appendMissingElements": {
-                          "type": "ArrayValue",
-                          "id": 6
-                        },
-                        "removeAllFromArray": {
-                          "type": "ArrayValue",
-                          "id": 7
-                        }
-                      },
-                      "nested": {
-                        "ServerValue": {
-                          "values": {
-                            "SERVER_VALUE_UNSPECIFIED": 0,
-                            "REQUEST_TIME": 1
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "WriteResult": {
-                  "fields": {
-                    "updateTime": {
-                      "type": "google.protobuf.Timestamp",
-                      "id": 1
-                    },
-                    "transformResults": {
-                      "rule": "repeated",
-                      "type": "Value",
-                      "id": 2
-                    }
-                  }
-                },
-                "DocumentChange": {
-                  "fields": {
-                    "document": {
-                      "type": "Document",
-                      "id": 1
-                    },
-                    "targetIds": {
-                      "rule": "repeated",
-                      "type": "int32",
-                      "id": 5
-                    },
-                    "removedTargetIds": {
-                      "rule": "repeated",
-                      "type": "int32",
-                      "id": 6
-                    }
-                  }
-                },
-                "DocumentDelete": {
-                  "fields": {
-                    "document": {
-                      "type": "string",
-                      "id": 1
-                    },
-                    "removedTargetIds": {
-                      "rule": "repeated",
-                      "type": "int32",
-                      "id": 6
-                    },
-                    "readTime": {
-                      "type": "google.protobuf.Timestamp",
-                      "id": 4
-                    }
-                  }
-                },
-                "DocumentRemove": {
-                  "fields": {
-                    "document": {
-                      "type": "string",
-                      "id": 1
-                    },
-                    "removedTargetIds": {
-                      "rule": "repeated",
-                      "type": "int32",
-                      "id": 2
-                    },
-                    "readTime": {
-                      "type": "google.protobuf.Timestamp",
-                      "id": 4
-                    }
-                  }
-                },
-                "ExistenceFilter": {
-                  "fields": {
-                    "targetId": {
-                      "type": "int32",
-                      "id": 1
-                    },
-                    "count": {
-                      "type": "int32",
-                      "id": 2
-                    },
-                    "unchangedNames": {
-                      "type": "BloomFilter",
-                      "id": 3
-                    }
-                  }
-                },
-                "ExplainOptions": {
-                  "fields": {
-                    "analyze": {
-                      "type": "bool",
-                      "id": 1,
-                      "options": {
-                        "(google.api.field_behavior)": "OPTIONAL"
-                      }
-                    }
-                  }
-                },
-                "ExplainMetrics": {
-                  "fields": {
-                    "planSummary": {
-                      "type": "PlanSummary",
-                      "id": 1
-                    },
-                    "executionStats": {
-                      "type": "ExecutionStats",
-                      "id": 2
-                    }
-                  }
-                },
-                "PlanSummary": {
-                  "fields": {
-                    "indexesUsed": {
-                      "rule": "repeated",
-                      "type": "google.protobuf.Struct",
-                      "id": 1
-                    }
-                  }
-                },
-                "ExecutionStats": {
-                  "fields": {
-                    "resultsReturned": {
-                      "type": "int64",
-                      "id": 1
-                    },
-                    "executionDuration": {
-                      "type": "google.protobuf.Duration",
-                      "id": 3
-                    },
-                    "readOperations": {
-                      "type": "int64",
-                      "id": 4
-                    },
-                    "debugStats": {
-                      "type": "google.protobuf.Struct",
-                      "id": 5
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "type": {
-          "options": {
-            "cc_enable_arenas": true,
-            "go_package": "google.golang.org/genproto/googleapis/type/latlng;latlng",
-            "java_multiple_files": true,
-            "java_outer_classname": "LatLngProto",
-            "java_package": "com.google.type",
-            "objc_class_prefix": "GTP"
-          },
-          "nested": {
-            "LatLng": {
-              "fields": {
-                "latitude": {
-                  "type": "double",
-                  "id": 1
-                },
-                "longitude": {
-                  "type": "double",
-                  "id": 2
                 }
               }
             }
@@ -3122,12 +2206,33 @@
           "options": {
             "go_package": "google.golang.org/genproto/googleapis/api/annotations;annotations",
             "java_multiple_files": true,
-            "java_outer_classname": "FieldBehaviorProto",
+            "java_outer_classname": "ResourceProto",
             "java_package": "com.google.api",
-            "objc_class_prefix": "GAPI",
-            "cc_enable_arenas": true
+            "objc_class_prefix": "GAPI"
           },
           "nested": {
+            "fieldBehavior": {
+              "rule": "repeated",
+              "type": "google.api.FieldBehavior",
+              "id": 1052,
+              "extend": "google.protobuf.FieldOptions",
+              "options": {
+                "packed": false
+              }
+            },
+            "FieldBehavior": {
+              "values": {
+                "FIELD_BEHAVIOR_UNSPECIFIED": 0,
+                "OPTIONAL": 1,
+                "REQUIRED": 2,
+                "OUTPUT_ONLY": 3,
+                "INPUT_ONLY": 4,
+                "IMMUTABLE": 5,
+                "UNORDERED_LIST": 6,
+                "NON_EMPTY_DEFAULT": 7,
+                "IDENTIFIER": 8
+              }
+            },
             "http": {
               "type": "HttpRule",
               "id": 72295728,
@@ -3231,29 +2336,2192 @@
               "id": 1050,
               "extend": "google.protobuf.ServiceOptions"
             },
-            "fieldBehavior": {
-              "rule": "repeated",
-              "type": "google.api.FieldBehavior",
-              "id": 1052,
+            "apiVersion": {
+              "type": "string",
+              "id": 525000001,
+              "extend": "google.protobuf.ServiceOptions"
+            },
+            "CommonLanguageSettings": {
+              "fields": {
+                "referenceDocsUri": {
+                  "type": "string",
+                  "id": 1,
+                  "options": {
+                    "deprecated": true
+                  }
+                },
+                "destinations": {
+                  "rule": "repeated",
+                  "type": "ClientLibraryDestination",
+                  "id": 2
+                },
+                "selectiveGapicGeneration": {
+                  "type": "SelectiveGapicGeneration",
+                  "id": 3
+                }
+              }
+            },
+            "ClientLibrarySettings": {
+              "fields": {
+                "version": {
+                  "type": "string",
+                  "id": 1
+                },
+                "launchStage": {
+                  "type": "LaunchStage",
+                  "id": 2
+                },
+                "restNumericEnums": {
+                  "type": "bool",
+                  "id": 3
+                },
+                "javaSettings": {
+                  "type": "JavaSettings",
+                  "id": 21
+                },
+                "cppSettings": {
+                  "type": "CppSettings",
+                  "id": 22
+                },
+                "phpSettings": {
+                  "type": "PhpSettings",
+                  "id": 23
+                },
+                "pythonSettings": {
+                  "type": "PythonSettings",
+                  "id": 24
+                },
+                "nodeSettings": {
+                  "type": "NodeSettings",
+                  "id": 25
+                },
+                "dotnetSettings": {
+                  "type": "DotnetSettings",
+                  "id": 26
+                },
+                "rubySettings": {
+                  "type": "RubySettings",
+                  "id": 27
+                },
+                "goSettings": {
+                  "type": "GoSettings",
+                  "id": 28
+                }
+              }
+            },
+            "Publishing": {
+              "fields": {
+                "methodSettings": {
+                  "rule": "repeated",
+                  "type": "MethodSettings",
+                  "id": 2
+                },
+                "newIssueUri": {
+                  "type": "string",
+                  "id": 101
+                },
+                "documentationUri": {
+                  "type": "string",
+                  "id": 102
+                },
+                "apiShortName": {
+                  "type": "string",
+                  "id": 103
+                },
+                "githubLabel": {
+                  "type": "string",
+                  "id": 104
+                },
+                "codeownerGithubTeams": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 105
+                },
+                "docTagPrefix": {
+                  "type": "string",
+                  "id": 106
+                },
+                "organization": {
+                  "type": "ClientLibraryOrganization",
+                  "id": 107
+                },
+                "librarySettings": {
+                  "rule": "repeated",
+                  "type": "ClientLibrarySettings",
+                  "id": 109
+                },
+                "protoReferenceDocumentationUri": {
+                  "type": "string",
+                  "id": 110
+                },
+                "restReferenceDocumentationUri": {
+                  "type": "string",
+                  "id": 111
+                }
+              }
+            },
+            "JavaSettings": {
+              "fields": {
+                "libraryPackage": {
+                  "type": "string",
+                  "id": 1
+                },
+                "serviceClassNames": {
+                  "keyType": "string",
+                  "type": "string",
+                  "id": 2
+                },
+                "common": {
+                  "type": "CommonLanguageSettings",
+                  "id": 3
+                }
+              }
+            },
+            "CppSettings": {
+              "fields": {
+                "common": {
+                  "type": "CommonLanguageSettings",
+                  "id": 1
+                }
+              }
+            },
+            "PhpSettings": {
+              "fields": {
+                "common": {
+                  "type": "CommonLanguageSettings",
+                  "id": 1
+                },
+                "libraryPackage": {
+                  "type": "string",
+                  "id": 2
+                }
+              }
+            },
+            "PythonSettings": {
+              "fields": {
+                "common": {
+                  "type": "CommonLanguageSettings",
+                  "id": 1
+                },
+                "experimentalFeatures": {
+                  "type": "ExperimentalFeatures",
+                  "id": 2
+                }
+              },
+              "nested": {
+                "ExperimentalFeatures": {
+                  "fields": {
+                    "restAsyncIoEnabled": {
+                      "type": "bool",
+                      "id": 1
+                    },
+                    "protobufPythonicTypesEnabled": {
+                      "type": "bool",
+                      "id": 2
+                    },
+                    "unversionedPackageDisabled": {
+                      "type": "bool",
+                      "id": 3
+                    }
+                  }
+                }
+              }
+            },
+            "NodeSettings": {
+              "fields": {
+                "common": {
+                  "type": "CommonLanguageSettings",
+                  "id": 1
+                }
+              }
+            },
+            "DotnetSettings": {
+              "fields": {
+                "common": {
+                  "type": "CommonLanguageSettings",
+                  "id": 1
+                },
+                "renamedServices": {
+                  "keyType": "string",
+                  "type": "string",
+                  "id": 2
+                },
+                "renamedResources": {
+                  "keyType": "string",
+                  "type": "string",
+                  "id": 3
+                },
+                "ignoredResources": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 4
+                },
+                "forcedNamespaceAliases": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 5
+                },
+                "handwrittenSignatures": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 6
+                }
+              }
+            },
+            "RubySettings": {
+              "fields": {
+                "common": {
+                  "type": "CommonLanguageSettings",
+                  "id": 1
+                }
+              }
+            },
+            "GoSettings": {
+              "fields": {
+                "common": {
+                  "type": "CommonLanguageSettings",
+                  "id": 1
+                },
+                "renamedServices": {
+                  "keyType": "string",
+                  "type": "string",
+                  "id": 2
+                }
+              }
+            },
+            "MethodSettings": {
+              "fields": {
+                "selector": {
+                  "type": "string",
+                  "id": 1
+                },
+                "longRunning": {
+                  "type": "LongRunning",
+                  "id": 2
+                },
+                "autoPopulatedFields": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 3
+                },
+                "batching": {
+                  "type": "BatchingConfigProto",
+                  "id": 4
+                }
+              },
+              "nested": {
+                "LongRunning": {
+                  "fields": {
+                    "initialPollDelay": {
+                      "type": "google.protobuf.Duration",
+                      "id": 1
+                    },
+                    "pollDelayMultiplier": {
+                      "type": "float",
+                      "id": 2
+                    },
+                    "maxPollDelay": {
+                      "type": "google.protobuf.Duration",
+                      "id": 3
+                    },
+                    "totalPollTimeout": {
+                      "type": "google.protobuf.Duration",
+                      "id": 4
+                    }
+                  }
+                }
+              }
+            },
+            "ClientLibraryOrganization": {
+              "values": {
+                "CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED": 0,
+                "CLOUD": 1,
+                "ADS": 2,
+                "PHOTOS": 3,
+                "STREET_VIEW": 4,
+                "SHOPPING": 5,
+                "GEO": 6,
+                "GENERATIVE_AI": 7
+              }
+            },
+            "ClientLibraryDestination": {
+              "values": {
+                "CLIENT_LIBRARY_DESTINATION_UNSPECIFIED": 0,
+                "GITHUB": 10,
+                "PACKAGE_MANAGER": 20
+              }
+            },
+            "SelectiveGapicGeneration": {
+              "fields": {
+                "methods": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 1
+                },
+                "generateOmittedAsInternal": {
+                  "type": "bool",
+                  "id": 2
+                }
+              }
+            },
+            "BatchingConfigProto": {
+              "fields": {
+                "thresholds": {
+                  "type": "BatchingSettingsProto",
+                  "id": 1
+                },
+                "batchDescriptor": {
+                  "type": "BatchingDescriptorProto",
+                  "id": 2
+                }
+              }
+            },
+            "BatchingSettingsProto": {
+              "fields": {
+                "elementCountThreshold": {
+                  "type": "int32",
+                  "id": 1
+                },
+                "requestByteThreshold": {
+                  "type": "int64",
+                  "id": 2
+                },
+                "delayThreshold": {
+                  "type": "google.protobuf.Duration",
+                  "id": 3
+                },
+                "elementCountLimit": {
+                  "type": "int32",
+                  "id": 4
+                },
+                "requestByteLimit": {
+                  "type": "int32",
+                  "id": 5
+                },
+                "flowControlElementLimit": {
+                  "type": "int32",
+                  "id": 6
+                },
+                "flowControlByteLimit": {
+                  "type": "int32",
+                  "id": 7
+                },
+                "flowControlLimitExceededBehavior": {
+                  "type": "FlowControlLimitExceededBehaviorProto",
+                  "id": 8
+                }
+              }
+            },
+            "FlowControlLimitExceededBehaviorProto": {
+              "values": {
+                "UNSET_BEHAVIOR": 0,
+                "THROW_EXCEPTION": 1,
+                "BLOCK": 2,
+                "IGNORE": 3
+              }
+            },
+            "BatchingDescriptorProto": {
+              "fields": {
+                "batchedField": {
+                  "type": "string",
+                  "id": 1
+                },
+                "discriminatorFields": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 2
+                },
+                "subresponseField": {
+                  "type": "string",
+                  "id": 3
+                }
+              }
+            },
+            "LaunchStage": {
+              "values": {
+                "LAUNCH_STAGE_UNSPECIFIED": 0,
+                "UNIMPLEMENTED": 6,
+                "PRELAUNCH": 7,
+                "EARLY_ACCESS": 1,
+                "ALPHA": 2,
+                "BETA": 3,
+                "GA": 4,
+                "DEPRECATED": 5
+              }
+            },
+            "routing": {
+              "type": "google.api.RoutingRule",
+              "id": 72295729,
+              "extend": "google.protobuf.MethodOptions"
+            },
+            "RoutingRule": {
+              "fields": {
+                "routingParameters": {
+                  "rule": "repeated",
+                  "type": "RoutingParameter",
+                  "id": 2
+                }
+              }
+            },
+            "RoutingParameter": {
+              "fields": {
+                "field": {
+                  "type": "string",
+                  "id": 1
+                },
+                "pathTemplate": {
+                  "type": "string",
+                  "id": 2
+                }
+              }
+            },
+            "resourceReference": {
+              "type": "google.api.ResourceReference",
+              "id": 1055,
               "extend": "google.protobuf.FieldOptions"
             },
-            "FieldBehavior": {
+            "resourceDefinition": {
+              "rule": "repeated",
+              "type": "google.api.ResourceDescriptor",
+              "id": 1053,
+              "extend": "google.protobuf.FileOptions"
+            },
+            "resource": {
+              "type": "google.api.ResourceDescriptor",
+              "id": 1053,
+              "extend": "google.protobuf.MessageOptions"
+            },
+            "ResourceDescriptor": {
+              "fields": {
+                "type": {
+                  "type": "string",
+                  "id": 1
+                },
+                "pattern": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 2
+                },
+                "nameField": {
+                  "type": "string",
+                  "id": 3
+                },
+                "history": {
+                  "type": "History",
+                  "id": 4
+                },
+                "plural": {
+                  "type": "string",
+                  "id": 5
+                },
+                "singular": {
+                  "type": "string",
+                  "id": 6
+                },
+                "style": {
+                  "rule": "repeated",
+                  "type": "Style",
+                  "id": 10
+                }
+              },
+              "nested": {
+                "History": {
+                  "values": {
+                    "HISTORY_UNSPECIFIED": 0,
+                    "ORIGINALLY_SINGLE_PATTERN": 1,
+                    "FUTURE_MULTI_PATTERN": 2
+                  }
+                },
+                "Style": {
+                  "values": {
+                    "STYLE_UNSPECIFIED": 0,
+                    "DECLARATIVE_FRIENDLY": 1
+                  }
+                }
+              }
+            },
+            "ResourceReference": {
+              "fields": {
+                "type": {
+                  "type": "string",
+                  "id": 1
+                },
+                "childType": {
+                  "type": "string",
+                  "id": 2
+                }
+              }
+            }
+          }
+        },
+        "protobuf": {
+          "options": {
+            "go_package": "google.golang.org/protobuf/types/descriptorpb",
+            "java_package": "com.google.protobuf",
+            "java_outer_classname": "DescriptorProtos",
+            "csharp_namespace": "Google.Protobuf.Reflection",
+            "objc_class_prefix": "GPB",
+            "cc_enable_arenas": true,
+            "optimize_for": "SPEED"
+          },
+          "nested": {
+            "FileDescriptorSet": {
+              "fields": {
+                "file": {
+                  "rule": "repeated",
+                  "type": "FileDescriptorProto",
+                  "id": 1
+                }
+              },
+              "extensions": [
+                [
+                  536000000,
+                  536000000
+                ]
+              ]
+            },
+            "Edition": {
               "values": {
-                "FIELD_BEHAVIOR_UNSPECIFIED": 0,
-                "OPTIONAL": 1,
-                "REQUIRED": 2,
-                "OUTPUT_ONLY": 3,
-                "INPUT_ONLY": 4,
-                "IMMUTABLE": 5,
-                "UNORDERED_LIST": 6,
-                "NON_EMPTY_DEFAULT": 7
+                "EDITION_UNKNOWN": 0,
+                "EDITION_LEGACY": 900,
+                "EDITION_PROTO2": 998,
+                "EDITION_PROTO3": 999,
+                "EDITION_2023": 1000,
+                "EDITION_2024": 1001,
+                "EDITION_2026": 1002,
+                "EDITION_UNSTABLE": 9999,
+                "EDITION_1_TEST_ONLY": 1,
+                "EDITION_2_TEST_ONLY": 2,
+                "EDITION_99997_TEST_ONLY": 99997,
+                "EDITION_99998_TEST_ONLY": 99998,
+                "EDITION_99999_TEST_ONLY": 99999,
+                "EDITION_MAX": 2147483647
+              }
+            },
+            "FileDescriptorProto": {
+              "fields": {
+                "name": {
+                  "type": "string",
+                  "id": 1
+                },
+                "package": {
+                  "type": "string",
+                  "id": 2
+                },
+                "dependency": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 3
+                },
+                "publicDependency": {
+                  "rule": "repeated",
+                  "type": "int32",
+                  "id": 10,
+                  "options": {
+                    "packed": false
+                  }
+                },
+                "weakDependency": {
+                  "rule": "repeated",
+                  "type": "int32",
+                  "id": 11,
+                  "options": {
+                    "packed": false
+                  }
+                },
+                "optionDependency": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 15
+                },
+                "messageType": {
+                  "rule": "repeated",
+                  "type": "DescriptorProto",
+                  "id": 4
+                },
+                "enumType": {
+                  "rule": "repeated",
+                  "type": "EnumDescriptorProto",
+                  "id": 5
+                },
+                "service": {
+                  "rule": "repeated",
+                  "type": "ServiceDescriptorProto",
+                  "id": 6
+                },
+                "extension": {
+                  "rule": "repeated",
+                  "type": "FieldDescriptorProto",
+                  "id": 7
+                },
+                "options": {
+                  "type": "FileOptions",
+                  "id": 8
+                },
+                "sourceCodeInfo": {
+                  "type": "SourceCodeInfo",
+                  "id": 9
+                },
+                "syntax": {
+                  "type": "string",
+                  "id": 12
+                },
+                "edition": {
+                  "type": "Edition",
+                  "id": 14
+                }
+              }
+            },
+            "DescriptorProto": {
+              "fields": {
+                "name": {
+                  "type": "string",
+                  "id": 1
+                },
+                "field": {
+                  "rule": "repeated",
+                  "type": "FieldDescriptorProto",
+                  "id": 2
+                },
+                "extension": {
+                  "rule": "repeated",
+                  "type": "FieldDescriptorProto",
+                  "id": 6
+                },
+                "nestedType": {
+                  "rule": "repeated",
+                  "type": "DescriptorProto",
+                  "id": 3
+                },
+                "enumType": {
+                  "rule": "repeated",
+                  "type": "EnumDescriptorProto",
+                  "id": 4
+                },
+                "extensionRange": {
+                  "rule": "repeated",
+                  "type": "ExtensionRange",
+                  "id": 5
+                },
+                "oneofDecl": {
+                  "rule": "repeated",
+                  "type": "OneofDescriptorProto",
+                  "id": 8
+                },
+                "options": {
+                  "type": "MessageOptions",
+                  "id": 7
+                },
+                "reservedRange": {
+                  "rule": "repeated",
+                  "type": "ReservedRange",
+                  "id": 9
+                },
+                "reservedName": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 10
+                },
+                "visibility": {
+                  "type": "SymbolVisibility",
+                  "id": 11
+                }
+              },
+              "nested": {
+                "ExtensionRange": {
+                  "fields": {
+                    "start": {
+                      "type": "int32",
+                      "id": 1
+                    },
+                    "end": {
+                      "type": "int32",
+                      "id": 2
+                    },
+                    "options": {
+                      "type": "ExtensionRangeOptions",
+                      "id": 3
+                    }
+                  }
+                },
+                "ReservedRange": {
+                  "fields": {
+                    "start": {
+                      "type": "int32",
+                      "id": 1
+                    },
+                    "end": {
+                      "type": "int32",
+                      "id": 2
+                    }
+                  }
+                }
+              }
+            },
+            "ExtensionRangeOptions": {
+              "fields": {
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                },
+                "declaration": {
+                  "rule": "repeated",
+                  "type": "Declaration",
+                  "id": 2,
+                  "options": {
+                    "retention": "RETENTION_SOURCE"
+                  }
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 50
+                },
+                "verification": {
+                  "type": "VerificationState",
+                  "id": 3,
+                  "options": {
+                    "default": "UNVERIFIED",
+                    "retention": "RETENTION_SOURCE"
+                  }
+                }
+              },
+              "extensions": [
+                [
+                  990,
+                  998
+                ],
+                [
+                  1000,
+                  536870911
+                ]
+              ],
+              "nested": {
+                "Declaration": {
+                  "fields": {
+                    "number": {
+                      "type": "int32",
+                      "id": 1
+                    },
+                    "fullName": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "type": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "reserved": {
+                      "type": "bool",
+                      "id": 5
+                    },
+                    "repeated": {
+                      "type": "bool",
+                      "id": 6
+                    }
+                  },
+                  "reserved": [
+                    [
+                      4,
+                      4
+                    ]
+                  ]
+                },
+                "VerificationState": {
+                  "values": {
+                    "DECLARATION": 0,
+                    "UNVERIFIED": 1
+                  }
+                }
+              }
+            },
+            "FieldDescriptorProto": {
+              "fields": {
+                "name": {
+                  "type": "string",
+                  "id": 1
+                },
+                "number": {
+                  "type": "int32",
+                  "id": 3
+                },
+                "label": {
+                  "type": "Label",
+                  "id": 4
+                },
+                "type": {
+                  "type": "Type",
+                  "id": 5
+                },
+                "typeName": {
+                  "type": "string",
+                  "id": 6
+                },
+                "extendee": {
+                  "type": "string",
+                  "id": 2
+                },
+                "defaultValue": {
+                  "type": "string",
+                  "id": 7
+                },
+                "oneofIndex": {
+                  "type": "int32",
+                  "id": 9
+                },
+                "jsonName": {
+                  "type": "string",
+                  "id": 10
+                },
+                "options": {
+                  "type": "FieldOptions",
+                  "id": 8
+                },
+                "proto3Optional": {
+                  "type": "bool",
+                  "id": 17
+                }
+              },
+              "nested": {
+                "Type": {
+                  "values": {
+                    "TYPE_DOUBLE": 1,
+                    "TYPE_FLOAT": 2,
+                    "TYPE_INT64": 3,
+                    "TYPE_UINT64": 4,
+                    "TYPE_INT32": 5,
+                    "TYPE_FIXED64": 6,
+                    "TYPE_FIXED32": 7,
+                    "TYPE_BOOL": 8,
+                    "TYPE_STRING": 9,
+                    "TYPE_GROUP": 10,
+                    "TYPE_MESSAGE": 11,
+                    "TYPE_BYTES": 12,
+                    "TYPE_UINT32": 13,
+                    "TYPE_ENUM": 14,
+                    "TYPE_SFIXED32": 15,
+                    "TYPE_SFIXED64": 16,
+                    "TYPE_SINT32": 17,
+                    "TYPE_SINT64": 18
+                  }
+                },
+                "Label": {
+                  "values": {
+                    "LABEL_OPTIONAL": 1,
+                    "LABEL_REPEATED": 3,
+                    "LABEL_REQUIRED": 2
+                  }
+                }
+              }
+            },
+            "OneofDescriptorProto": {
+              "fields": {
+                "name": {
+                  "type": "string",
+                  "id": 1
+                },
+                "options": {
+                  "type": "OneofOptions",
+                  "id": 2
+                }
+              }
+            },
+            "EnumDescriptorProto": {
+              "fields": {
+                "name": {
+                  "type": "string",
+                  "id": 1
+                },
+                "value": {
+                  "rule": "repeated",
+                  "type": "EnumValueDescriptorProto",
+                  "id": 2
+                },
+                "options": {
+                  "type": "EnumOptions",
+                  "id": 3
+                },
+                "reservedRange": {
+                  "rule": "repeated",
+                  "type": "EnumReservedRange",
+                  "id": 4
+                },
+                "reservedName": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 5
+                },
+                "visibility": {
+                  "type": "SymbolVisibility",
+                  "id": 6
+                }
+              },
+              "nested": {
+                "EnumReservedRange": {
+                  "fields": {
+                    "start": {
+                      "type": "int32",
+                      "id": 1
+                    },
+                    "end": {
+                      "type": "int32",
+                      "id": 2
+                    }
+                  }
+                }
+              }
+            },
+            "EnumValueDescriptorProto": {
+              "fields": {
+                "name": {
+                  "type": "string",
+                  "id": 1
+                },
+                "number": {
+                  "type": "int32",
+                  "id": 2
+                },
+                "options": {
+                  "type": "EnumValueOptions",
+                  "id": 3
+                }
+              }
+            },
+            "ServiceDescriptorProto": {
+              "fields": {
+                "name": {
+                  "type": "string",
+                  "id": 1
+                },
+                "method": {
+                  "rule": "repeated",
+                  "type": "MethodDescriptorProto",
+                  "id": 2
+                },
+                "options": {
+                  "type": "ServiceOptions",
+                  "id": 3
+                }
+              },
+              "reserved": [
+                [
+                  4,
+                  4
+                ],
+                "stream"
+              ]
+            },
+            "MethodDescriptorProto": {
+              "fields": {
+                "name": {
+                  "type": "string",
+                  "id": 1
+                },
+                "inputType": {
+                  "type": "string",
+                  "id": 2
+                },
+                "outputType": {
+                  "type": "string",
+                  "id": 3
+                },
+                "options": {
+                  "type": "MethodOptions",
+                  "id": 4
+                },
+                "clientStreaming": {
+                  "type": "bool",
+                  "id": 5,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "serverStreaming": {
+                  "type": "bool",
+                  "id": 6,
+                  "options": {
+                    "default": false
+                  }
+                }
+              }
+            },
+            "FileOptions": {
+              "fields": {
+                "javaPackage": {
+                  "type": "string",
+                  "id": 1
+                },
+                "javaOuterClassname": {
+                  "type": "string",
+                  "id": 8
+                },
+                "javaMultipleFiles": {
+                  "type": "bool",
+                  "id": 10,
+                  "options": {
+                    "default": false,
+                    "feature_support.edition_introduced": "EDITION_PROTO2",
+                    "feature_support.edition_removed": "EDITION_2024",
+                    "feature_support.removal_error": "This behavior is enabled by default in editions 2024 and above. To disable it, you can set `features.(pb.java).nest_in_file_class = YES` on individual messages, enums, or services."
+                  }
+                },
+                "javaGenerateEqualsAndHash": {
+                  "type": "bool",
+                  "id": 20,
+                  "options": {
+                    "deprecated": true
+                  }
+                },
+                "javaStringCheckUtf8": {
+                  "type": "bool",
+                  "id": 27,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "optimizeFor": {
+                  "type": "OptimizeMode",
+                  "id": 9,
+                  "options": {
+                    "default": "SPEED"
+                  }
+                },
+                "goPackage": {
+                  "type": "string",
+                  "id": 11
+                },
+                "ccGenericServices": {
+                  "type": "bool",
+                  "id": 16,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "javaGenericServices": {
+                  "type": "bool",
+                  "id": 17,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "pyGenericServices": {
+                  "type": "bool",
+                  "id": 18,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "deprecated": {
+                  "type": "bool",
+                  "id": 23,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "ccEnableArenas": {
+                  "type": "bool",
+                  "id": 31,
+                  "options": {
+                    "default": true
+                  }
+                },
+                "objcClassPrefix": {
+                  "type": "string",
+                  "id": 36
+                },
+                "csharpNamespace": {
+                  "type": "string",
+                  "id": 37
+                },
+                "swiftPrefix": {
+                  "type": "string",
+                  "id": 39
+                },
+                "phpClassPrefix": {
+                  "type": "string",
+                  "id": 40
+                },
+                "phpNamespace": {
+                  "type": "string",
+                  "id": 41
+                },
+                "phpMetadataNamespace": {
+                  "type": "string",
+                  "id": 44
+                },
+                "rubyPackage": {
+                  "type": "string",
+                  "id": 45
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 50
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  990,
+                  998
+                ],
+                [
+                  1000,
+                  536870911
+                ]
+              ],
+              "reserved": [
+                [
+                  42,
+                  42
+                ],
+                "php_generic_services",
+                [
+                  38,
+                  38
+                ]
+              ],
+              "nested": {
+                "OptimizeMode": {
+                  "values": {
+                    "SPEED": 1,
+                    "CODE_SIZE": 2,
+                    "LITE_RUNTIME": 3
+                  }
+                }
+              }
+            },
+            "MessageOptions": {
+              "fields": {
+                "messageSetWireFormat": {
+                  "type": "bool",
+                  "id": 1,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "noStandardDescriptorAccessor": {
+                  "type": "bool",
+                  "id": 2,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "deprecated": {
+                  "type": "bool",
+                  "id": 3,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "mapEntry": {
+                  "type": "bool",
+                  "id": 7
+                },
+                "deprecatedLegacyJsonFieldConflicts": {
+                  "type": "bool",
+                  "id": 11,
+                  "options": {
+                    "deprecated": true
+                  }
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 12
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  990,
+                  998
+                ],
+                [
+                  1000,
+                  536870911
+                ]
+              ],
+              "reserved": [
+                [
+                  4,
+                  4
+                ],
+                [
+                  5,
+                  5
+                ],
+                [
+                  6,
+                  6
+                ],
+                [
+                  8,
+                  8
+                ],
+                [
+                  9,
+                  9
+                ]
+              ]
+            },
+            "FieldOptions": {
+              "fields": {
+                "ctype": {
+                  "type": "CType",
+                  "id": 1,
+                  "options": {
+                    "default": "STRING"
+                  }
+                },
+                "packed": {
+                  "type": "bool",
+                  "id": 2
+                },
+                "jstype": {
+                  "type": "JSType",
+                  "id": 6,
+                  "options": {
+                    "default": "JS_NORMAL"
+                  }
+                },
+                "lazy": {
+                  "type": "bool",
+                  "id": 5,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "unverifiedLazy": {
+                  "type": "bool",
+                  "id": 15,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "deprecated": {
+                  "type": "bool",
+                  "id": 3,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "weak": {
+                  "type": "bool",
+                  "id": 10,
+                  "options": {
+                    "default": false,
+                    "deprecated": true
+                  }
+                },
+                "debugRedact": {
+                  "type": "bool",
+                  "id": 16,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "retention": {
+                  "type": "OptionRetention",
+                  "id": 17
+                },
+                "targets": {
+                  "rule": "repeated",
+                  "type": "OptionTargetType",
+                  "id": 19,
+                  "options": {
+                    "packed": false
+                  }
+                },
+                "editionDefaults": {
+                  "rule": "repeated",
+                  "type": "EditionDefault",
+                  "id": 20
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 21
+                },
+                "featureSupport": {
+                  "type": "FeatureSupport",
+                  "id": 22
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  990,
+                  998
+                ],
+                [
+                  1000,
+                  536870911
+                ]
+              ],
+              "reserved": [
+                [
+                  4,
+                  4
+                ],
+                [
+                  18,
+                  18
+                ]
+              ],
+              "nested": {
+                "CType": {
+                  "values": {
+                    "STRING": 0,
+                    "CORD": 1,
+                    "STRING_PIECE": 2
+                  }
+                },
+                "JSType": {
+                  "values": {
+                    "JS_NORMAL": 0,
+                    "JS_STRING": 1,
+                    "JS_NUMBER": 2
+                  }
+                },
+                "OptionRetention": {
+                  "values": {
+                    "RETENTION_UNKNOWN": 0,
+                    "RETENTION_RUNTIME": 1,
+                    "RETENTION_SOURCE": 2
+                  }
+                },
+                "OptionTargetType": {
+                  "values": {
+                    "TARGET_TYPE_UNKNOWN": 0,
+                    "TARGET_TYPE_FILE": 1,
+                    "TARGET_TYPE_EXTENSION_RANGE": 2,
+                    "TARGET_TYPE_MESSAGE": 3,
+                    "TARGET_TYPE_FIELD": 4,
+                    "TARGET_TYPE_ONEOF": 5,
+                    "TARGET_TYPE_ENUM": 6,
+                    "TARGET_TYPE_ENUM_ENTRY": 7,
+                    "TARGET_TYPE_SERVICE": 8,
+                    "TARGET_TYPE_METHOD": 9
+                  }
+                },
+                "EditionDefault": {
+                  "fields": {
+                    "edition": {
+                      "type": "Edition",
+                      "id": 3
+                    },
+                    "value": {
+                      "type": "string",
+                      "id": 2
+                    }
+                  }
+                },
+                "FeatureSupport": {
+                  "fields": {
+                    "editionIntroduced": {
+                      "type": "Edition",
+                      "id": 1
+                    },
+                    "editionDeprecated": {
+                      "type": "Edition",
+                      "id": 2
+                    },
+                    "deprecationWarning": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "editionRemoved": {
+                      "type": "Edition",
+                      "id": 4
+                    },
+                    "removalError": {
+                      "type": "string",
+                      "id": 5
+                    }
+                  }
+                }
+              }
+            },
+            "OneofOptions": {
+              "fields": {
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 1
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  990,
+                  998
+                ],
+                [
+                  1000,
+                  536870911
+                ]
+              ]
+            },
+            "EnumOptions": {
+              "fields": {
+                "allowAlias": {
+                  "type": "bool",
+                  "id": 2
+                },
+                "deprecated": {
+                  "type": "bool",
+                  "id": 3,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "deprecatedLegacyJsonFieldConflicts": {
+                  "type": "bool",
+                  "id": 6,
+                  "options": {
+                    "deprecated": true
+                  }
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 7
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  990,
+                  998
+                ],
+                [
+                  1000,
+                  536870911
+                ]
+              ],
+              "reserved": [
+                [
+                  5,
+                  5
+                ]
+              ]
+            },
+            "EnumValueOptions": {
+              "fields": {
+                "deprecated": {
+                  "type": "bool",
+                  "id": 1,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 2
+                },
+                "debugRedact": {
+                  "type": "bool",
+                  "id": 3,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "featureSupport": {
+                  "type": "FieldOptions.FeatureSupport",
+                  "id": 4
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  990,
+                  998
+                ],
+                [
+                  1000,
+                  536870911
+                ]
+              ]
+            },
+            "ServiceOptions": {
+              "fields": {
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 34
+                },
+                "deprecated": {
+                  "type": "bool",
+                  "id": 33,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  990,
+                  998
+                ],
+                [
+                  1000,
+                  536870911
+                ]
+              ]
+            },
+            "MethodOptions": {
+              "fields": {
+                "deprecated": {
+                  "type": "bool",
+                  "id": 33,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "idempotencyLevel": {
+                  "type": "IdempotencyLevel",
+                  "id": 34,
+                  "options": {
+                    "default": "IDEMPOTENCY_UNKNOWN"
+                  }
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 35
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  990,
+                  998
+                ],
+                [
+                  1000,
+                  536870911
+                ]
+              ],
+              "nested": {
+                "IdempotencyLevel": {
+                  "values": {
+                    "IDEMPOTENCY_UNKNOWN": 0,
+                    "NO_SIDE_EFFECTS": 1,
+                    "IDEMPOTENT": 2
+                  }
+                }
+              }
+            },
+            "UninterpretedOption": {
+              "fields": {
+                "name": {
+                  "rule": "repeated",
+                  "type": "NamePart",
+                  "id": 2
+                },
+                "identifierValue": {
+                  "type": "string",
+                  "id": 3
+                },
+                "positiveIntValue": {
+                  "type": "uint64",
+                  "id": 4
+                },
+                "negativeIntValue": {
+                  "type": "int64",
+                  "id": 5
+                },
+                "doubleValue": {
+                  "type": "double",
+                  "id": 6
+                },
+                "stringValue": {
+                  "type": "bytes",
+                  "id": 7
+                },
+                "aggregateValue": {
+                  "type": "string",
+                  "id": 8
+                }
+              },
+              "nested": {
+                "NamePart": {
+                  "fields": {
+                    "namePart": {
+                      "rule": "required",
+                      "type": "string",
+                      "id": 1
+                    },
+                    "isExtension": {
+                      "rule": "required",
+                      "type": "bool",
+                      "id": 2
+                    }
+                  }
+                }
+              }
+            },
+            "FeatureSet": {
+              "fields": {
+                "fieldPresence": {
+                  "type": "FieldPresence",
+                  "id": 1,
+                  "options": {
+                    "retention": "RETENTION_RUNTIME",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2023",
+                    "edition_defaults.edition": "EDITION_2023",
+                    "edition_defaults.value": "EXPLICIT"
+                  }
+                },
+                "enumType": {
+                  "type": "EnumType",
+                  "id": 2,
+                  "options": {
+                    "retention": "RETENTION_RUNTIME",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2023",
+                    "edition_defaults.edition": "EDITION_PROTO3",
+                    "edition_defaults.value": "OPEN"
+                  }
+                },
+                "repeatedFieldEncoding": {
+                  "type": "RepeatedFieldEncoding",
+                  "id": 3,
+                  "options": {
+                    "retention": "RETENTION_RUNTIME",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2023",
+                    "edition_defaults.edition": "EDITION_PROTO3",
+                    "edition_defaults.value": "PACKED"
+                  }
+                },
+                "utf8Validation": {
+                  "type": "Utf8Validation",
+                  "id": 4,
+                  "options": {
+                    "retention": "RETENTION_RUNTIME",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2023",
+                    "edition_defaults.edition": "EDITION_PROTO3",
+                    "edition_defaults.value": "VERIFY"
+                  }
+                },
+                "messageEncoding": {
+                  "type": "MessageEncoding",
+                  "id": 5,
+                  "options": {
+                    "retention": "RETENTION_RUNTIME",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2023",
+                    "edition_defaults.edition": "EDITION_LEGACY",
+                    "edition_defaults.value": "LENGTH_PREFIXED"
+                  }
+                },
+                "jsonFormat": {
+                  "type": "JsonFormat",
+                  "id": 6,
+                  "options": {
+                    "retention": "RETENTION_RUNTIME",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2023",
+                    "edition_defaults.edition": "EDITION_PROTO3",
+                    "edition_defaults.value": "ALLOW"
+                  }
+                },
+                "enforceNamingStyle": {
+                  "type": "EnforceNamingStyle",
+                  "id": 7,
+                  "options": {
+                    "retention": "RETENTION_SOURCE",
+                    "targets": "TARGET_TYPE_METHOD",
+                    "feature_support.edition_introduced": "EDITION_2024",
+                    "edition_defaults.edition": "EDITION_UNSTABLE",
+                    "edition_defaults.value": "STYLE2026"
+                  }
+                },
+                "defaultSymbolVisibility": {
+                  "type": "VisibilityFeature.DefaultSymbolVisibility",
+                  "id": 8,
+                  "options": {
+                    "retention": "RETENTION_SOURCE",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2024",
+                    "edition_defaults.edition": "EDITION_2024",
+                    "edition_defaults.value": "EXPORT_TOP_LEVEL"
+                  }
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  9994
+                ],
+                [
+                  9995,
+                  9999
+                ],
+                [
+                  10000,
+                  10000
+                ]
+              ],
+              "reserved": [
+                [
+                  999,
+                  999
+                ]
+              ],
+              "nested": {
+                "FieldPresence": {
+                  "values": {
+                    "FIELD_PRESENCE_UNKNOWN": 0,
+                    "EXPLICIT": 1,
+                    "IMPLICIT": 2,
+                    "LEGACY_REQUIRED": 3
+                  }
+                },
+                "EnumType": {
+                  "values": {
+                    "ENUM_TYPE_UNKNOWN": 0,
+                    "OPEN": 1,
+                    "CLOSED": 2
+                  }
+                },
+                "RepeatedFieldEncoding": {
+                  "values": {
+                    "REPEATED_FIELD_ENCODING_UNKNOWN": 0,
+                    "PACKED": 1,
+                    "EXPANDED": 2
+                  }
+                },
+                "Utf8Validation": {
+                  "values": {
+                    "UTF8_VALIDATION_UNKNOWN": 0,
+                    "VERIFY": 2,
+                    "NONE": 3
+                  },
+                  "reserved": [
+                    [
+                      1,
+                      1
+                    ]
+                  ]
+                },
+                "MessageEncoding": {
+                  "values": {
+                    "MESSAGE_ENCODING_UNKNOWN": 0,
+                    "LENGTH_PREFIXED": 1,
+                    "DELIMITED": 2
+                  }
+                },
+                "JsonFormat": {
+                  "values": {
+                    "JSON_FORMAT_UNKNOWN": 0,
+                    "ALLOW": 1,
+                    "LEGACY_BEST_EFFORT": 2
+                  }
+                },
+                "EnforceNamingStyle": {
+                  "values": {
+                    "ENFORCE_NAMING_STYLE_UNKNOWN": 0,
+                    "STYLE2024": 1,
+                    "STYLE_LEGACY": 2,
+                    "STYLE2026": 3
+                  }
+                },
+                "VisibilityFeature": {
+                  "fields": {},
+                  "reserved": [
+                    [
+                      1,
+                      536870911
+                    ]
+                  ],
+                  "nested": {
+                    "DefaultSymbolVisibility": {
+                      "values": {
+                        "DEFAULT_SYMBOL_VISIBILITY_UNKNOWN": 0,
+                        "EXPORT_ALL": 1,
+                        "EXPORT_TOP_LEVEL": 2,
+                        "LOCAL_ALL": 3,
+                        "STRICT": 4
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "FeatureSetDefaults": {
+              "fields": {
+                "defaults": {
+                  "rule": "repeated",
+                  "type": "FeatureSetEditionDefault",
+                  "id": 1
+                },
+                "minimumEdition": {
+                  "type": "Edition",
+                  "id": 4
+                },
+                "maximumEdition": {
+                  "type": "Edition",
+                  "id": 5
+                }
+              },
+              "nested": {
+                "FeatureSetEditionDefault": {
+                  "fields": {
+                    "edition": {
+                      "type": "Edition",
+                      "id": 3
+                    },
+                    "overridableFeatures": {
+                      "type": "FeatureSet",
+                      "id": 4
+                    },
+                    "fixedFeatures": {
+                      "type": "FeatureSet",
+                      "id": 5
+                    }
+                  },
+                  "reserved": [
+                    [
+                      1,
+                      1
+                    ],
+                    [
+                      2,
+                      2
+                    ],
+                    "features"
+                  ]
+                }
+              }
+            },
+            "SourceCodeInfo": {
+              "fields": {
+                "location": {
+                  "rule": "repeated",
+                  "type": "Location",
+                  "id": 1
+                }
+              },
+              "extensions": [
+                [
+                  536000000,
+                  536000000
+                ]
+              ],
+              "nested": {
+                "Location": {
+                  "fields": {
+                    "path": {
+                      "rule": "repeated",
+                      "type": "int32",
+                      "id": 1
+                    },
+                    "span": {
+                      "rule": "repeated",
+                      "type": "int32",
+                      "id": 2
+                    },
+                    "leadingComments": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "trailingComments": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "leadingDetachedComments": {
+                      "rule": "repeated",
+                      "type": "string",
+                      "id": 6
+                    }
+                  }
+                }
+              }
+            },
+            "GeneratedCodeInfo": {
+              "fields": {
+                "annotation": {
+                  "rule": "repeated",
+                  "type": "Annotation",
+                  "id": 1
+                }
+              },
+              "nested": {
+                "Annotation": {
+                  "fields": {
+                    "path": {
+                      "rule": "repeated",
+                      "type": "int32",
+                      "id": 1
+                    },
+                    "sourceFile": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "begin": {
+                      "type": "int32",
+                      "id": 3
+                    },
+                    "end": {
+                      "type": "int32",
+                      "id": 4
+                    },
+                    "semantic": {
+                      "type": "Semantic",
+                      "id": 5
+                    }
+                  },
+                  "nested": {
+                    "Semantic": {
+                      "values": {
+                        "NONE": 0,
+                        "SET": 1,
+                        "ALIAS": 2
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "SymbolVisibility": {
+              "values": {
+                "VISIBILITY_UNSET": 0,
+                "VISIBILITY_LOCAL": 1,
+                "VISIBILITY_EXPORT": 2
+              }
+            },
+            "Struct": {
+              "fields": {
+                "fields": {
+                  "keyType": "string",
+                  "type": "Value",
+                  "id": 1
+                }
+              }
+            },
+            "Value": {
+              "oneofs": {
+                "kind": {
+                  "oneof": [
+                    "nullValue",
+                    "numberValue",
+                    "stringValue",
+                    "boolValue",
+                    "structValue",
+                    "listValue"
+                  ]
+                }
+              },
+              "fields": {
+                "nullValue": {
+                  "type": "NullValue",
+                  "id": 1
+                },
+                "numberValue": {
+                  "type": "double",
+                  "id": 2
+                },
+                "stringValue": {
+                  "type": "string",
+                  "id": 3
+                },
+                "boolValue": {
+                  "type": "bool",
+                  "id": 4
+                },
+                "structValue": {
+                  "type": "Struct",
+                  "id": 5
+                },
+                "listValue": {
+                  "type": "ListValue",
+                  "id": 6
+                }
+              }
+            },
+            "NullValue": {
+              "values": {
+                "NULL_VALUE": 0
+              }
+            },
+            "ListValue": {
+              "fields": {
+                "values": {
+                  "rule": "repeated",
+                  "type": "Value",
+                  "id": 1
+                }
+              }
+            },
+            "Timestamp": {
+              "fields": {
+                "seconds": {
+                  "type": "int64",
+                  "id": 1
+                },
+                "nanos": {
+                  "type": "int32",
+                  "id": 2
+                }
+              }
+            },
+            "Any": {
+              "fields": {
+                "type_url": {
+                  "type": "string",
+                  "id": 1
+                },
+                "value": {
+                  "type": "bytes",
+                  "id": 2
+                }
+              }
+            },
+            "Duration": {
+              "fields": {
+                "seconds": {
+                  "type": "int64",
+                  "id": 1
+                },
+                "nanos": {
+                  "type": "int32",
+                  "id": 2
+                }
+              }
+            },
+            "DoubleValue": {
+              "fields": {
+                "value": {
+                  "type": "double",
+                  "id": 1
+                }
+              }
+            },
+            "FloatValue": {
+              "fields": {
+                "value": {
+                  "type": "float",
+                  "id": 1
+                }
+              }
+            },
+            "Int64Value": {
+              "fields": {
+                "value": {
+                  "type": "int64",
+                  "id": 1
+                }
+              }
+            },
+            "UInt64Value": {
+              "fields": {
+                "value": {
+                  "type": "uint64",
+                  "id": 1
+                }
+              }
+            },
+            "Int32Value": {
+              "fields": {
+                "value": {
+                  "type": "int32",
+                  "id": 1
+                }
+              }
+            },
+            "UInt32Value": {
+              "fields": {
+                "value": {
+                  "type": "uint32",
+                  "id": 1
+                }
+              }
+            },
+            "BoolValue": {
+              "fields": {
+                "value": {
+                  "type": "bool",
+                  "id": 1
+                }
+              }
+            },
+            "StringValue": {
+              "fields": {
+                "value": {
+                  "type": "string",
+                  "id": 1
+                }
+              }
+            },
+            "BytesValue": {
+              "fields": {
+                "value": {
+                  "type": "bytes",
+                  "id": 1
+                }
+              }
+            },
+            "Empty": {
+              "fields": {}
+            }
+          }
+        },
+        "type": {
+          "options": {
+            "go_package": "google.golang.org/genproto/googleapis/type/latlng;latlng",
+            "java_multiple_files": true,
+            "java_outer_classname": "LatLngProto",
+            "java_package": "com.google.type",
+            "objc_class_prefix": "GTP"
+          },
+          "nested": {
+            "LatLng": {
+              "fields": {
+                "latitude": {
+                  "type": "double",
+                  "id": 1
+                },
+                "longitude": {
+                  "type": "double",
+                  "id": 2
+                }
               }
             }
           }
         },
         "rpc": {
           "options": {
-            "cc_enable_arenas": true,
             "go_package": "google.golang.org/genproto/googleapis/rpc/status;status",
             "java_multiple_files": true,
             "java_outer_classname": "StatusProto",

--- a/packages/firestore/src/protos/update.sh
+++ b/packages/firestore/src/protos/update.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2017 Google Inc.
+# Copyright 2026 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,10 +17,16 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-# Variables
+# Verify dependencies
+for cmd in git patch npx; do
+  if ! command -v "$cmd" &> /dev/null; then
+    echo "Error: $cmd is required but not installed." >&2
+    exit 1
+  fi
+done
+
 PROTOS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-WORK_DIR=`mktemp -d`
-PBJS="$(npm bin)/pbjs"
+WORK_DIR=$(mktemp -d)
 
 # deletes the temp directory on exit
 function cleanup {
@@ -32,15 +38,15 @@ function cleanup {
 trap cleanup EXIT
 
 # Enter work dir
-pushd "$WORK_DIR"
+pushd "$WORK_DIR" > /dev/null
 
-# Clone necessary git repos.
+# Clone necessary git repos
 git clone --depth 1 https://github.com/googleapis/googleapis.git
 git clone --depth 1 https://github.com/google/protobuf.git
 
 # Copy necessary protos.
 mkdir -p "${PROTOS_DIR}/google/api"
-cp googleapis/google/api/{annotations.proto,http.proto,client.proto,field_behavior.proto} \
+cp googleapis/google/api/{annotations.proto,http.proto,client.proto,field_behavior.proto,launch_stage.proto,routing.proto,resource.proto} \
    "${PROTOS_DIR}/google/api/"
 
 mkdir -p "${PROTOS_DIR}/google/firestore/v1"
@@ -55,22 +61,17 @@ mkdir -p "${PROTOS_DIR}/google/type"
 cp googleapis/google/type/latlng.proto \
    "${PROTOS_DIR}/google/type/"
 
-# Hack in `verify` support
-ex "${PROTOS_DIR}/google/firestore/v1/write.proto" <<eof
-44 insert
-    // The name of a document on which to verify the \`current_document\`
-    // precondition.
-    // This only requires read access to the document.
-    string verify = 5;
+mkdir -p "${PROTOS_DIR}/google/protobuf"
+cp protobuf/src/google/protobuf/{any,descriptor,empty,struct,timestamp,wrappers}.proto \
+   "${PROTOS_DIR}/google/protobuf/"
 
-.
-xit
-eof
+popd > /dev/null
 
-"${PBJS}" --proto_path=. --target=json -o protos.json \
-  -r firestore_v1 \
-  "${PROTOS_DIR}/google/firestore/v1/*.proto" \
-  "${PROTOS_DIR}/google/protobuf/*.proto" "${PROTOS_DIR}/google/type/*.proto" \
-  "${PROTOS_DIR}/google/rpc/*.proto" "${PROTOS_DIR}/google/api/*.proto"
+# Apply patch for `verify` support
+if [ -f "${PROTOS_DIR}/verify.patch" ]; then
+  patch -f -d "${PROTOS_DIR}" -p1 < "${PROTOS_DIR}/verify.patch"
+  find "${PROTOS_DIR}" -name "*.orig" -delete
+fi
 
-cp protos.json "${PROTOS_DIR}/protos.json"
+# Run compile script to generate outputs
+bash "${PROTOS_DIR}/compile.sh"

--- a/packages/firestore/src/protos/verify.patch
+++ b/packages/firestore/src/protos/verify.patch
@@ -1,0 +1,15 @@
+--- a/google/firestore/v1/write.proto
++++ b/google/firestore/v1/write.proto
+@@ -38,6 +38,11 @@
+     // A document name to delete. In the format:
+     // `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+     string delete = 2;
+ 
++    // The name of a document on which to verify the `current_document`
++    // precondition.
++    // This only requires read access to the document.
++    string verify = 5;
++
+     // Applies a transformation to a document.
+     DocumentTransform transform = 6;
+   }


### PR DESCRIPTION
Improved `update.sh` and `compile.sh`. These scripts weren't working.

Key changes include:
- Replaced brittle line-number patching in `update.sh` with a `.patch` file for the verify field.
- Added dependency verification for required CLI tools (git, patch, npx).
- Restructured `update.sh` to selectively copy only necessary dependencies from `google/api` and `google/protobuf`.
- Improved path handling to ensure scripts work correctly regardless of the current working directory.
- Removed unused and untracked TypeScript declaration generation (`temp.d.ts`).
- Updated Firestore and dependency protobufs to their latest versions.
