### PR TITLE
test(firestore): remove nightly conditional `get_field` tests

### DIFF
--- a/packages/firestore/test/integration/api/pipeline.test.ts
+++ b/packages/firestore/test/integration/api/pipeline.test.ts
@@ -24,7 +24,6 @@ import { FirebaseError } from '@firebase/util';
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
-import { logWarn } from '../../../src/util/log';
 import { addEqualityMatcher } from '../../util/equality_matcher';
 import { Deferred } from '../../util/promise';
 import {
@@ -6573,39 +6572,8 @@ apiDescribe.skipClassic('Pipelines', persistence => {
           .addFields(reviewsSub.toArrayExpression().as('reviews'))
           .select('title', 'reviews');
 
-        // TODO(dlarocque): Remove these target backend conditionals once the 'get_field' rename has rolled out to prod.
-        const host = firestore._getSettings().host;
-        const isProd = host === 'firestore.googleapis.com';
-        const isNightly = host === 'test-firestore.sandbox.googleapis.com';
-
-        if (isProd) {
-          // The execution of this pipeline is expected to result in a network error
-          // from the backend until the breaking change to rename the 'field' expression to
-          // 'get_field' has rolled out to prod.
-          try {
-            const results = await execute(ppl);
-
-            // If this is reached, the execution of the pipeline didn't throw an error, so the
-            // breaking change must have rolled out to prod. We can assert the newly expected behaviour.
-            logWarn(
-              "The 'get_field' expression rename has rolled out to the prod backend. Remove the target backend conditionals in this test."
-            );
-            expectResults(results, { title: '1984', reviews: ['Alice'] });
-          } catch (err: unknown) {
-            const error: Error = err as Error;
-            expect(error.message).to.equals(
-              "The function 'get_field' does not exist, did you mean 'field'?"
-            );
-          }
-        } else if (isNightly) {
-          const results = await execute(ppl);
-          expectResults(results, { title: '1984', reviews: ['Alice'] });
-        } else {
-          expect(false).to.equal(
-            true,
-            `This test is only expected to run against firestore.googleapis.com or test-firestore.sandbox.googleapis.com, but it instead ran against ${host}`
-          );
-        }
+        const results = await execute(ppl);
+        expectResults(results, { title: '1984', reviews: ['Alice'] });
       });
     });
 
@@ -6687,39 +6655,8 @@ apiDescribe.skipClassic('Pipelines', persistence => {
           .addFields(reviewsSub.toArrayExpression().as('reviews'))
           .select('title', 'reviews');
 
-        // TODO(dlarocque): Remove these target backend conditionals once the 'get_field' rename has rolled out to prod.
-        const host = firestore._getSettings().host;
-        const isProd = host === 'firestore.googleapis.com';
-        const isNightly = host === 'test-firestore.sandbox.googleapis.com';
-
-        if (isProd) {
-          // The execution of this pipeline is expected to result in a network error
-          // from the backend until the breaking change to rename the 'field' expression to
-          // 'get_field' has rolled out to prod.
-          try {
-            const results = await execute(ppl);
-
-            // If this is reached, the execution of the pipeline didn't throw an error, so the
-            // breaking change must have rolled out to prod. We can assert the newly expected behaviour.
-            logWarn(
-              "The 'get_field' expression rename has rolled out to the prod backend. Remove the target backend conditionals in this test."
-            );
-            expectResults(results, { title: '1984', reviews: [] });
-          } catch (err: unknown) {
-            const error: Error = err as Error;
-            expect(error.message).to.equals(
-              "The function 'get_field' does not exist, did you mean 'field'?"
-            );
-          }
-        } else if (isNightly) {
-          const results = await execute(ppl);
-          expectResults(results, { title: '1984', reviews: [] });
-        } else {
-          expect(false).to.equal(
-            true,
-            `This test is only expected to run against firestore.googleapis.com or test-firestore.sandbox.googleapis.com, but it instead ran against ${host}`
-          );
-        }
+        const results = await execute(ppl);
+        expectResults(results, { title: '1984', reviews: [] });
       });
     });
 

--- a/packages/firestore/test/lite/pipeline.test.ts
+++ b/packages/firestore/test/lite/pipeline.test.ts
@@ -53,7 +53,6 @@ import { FindNearestStageOptions } from '../../src/lite-api/stage_options';
 import { Timestamp } from '../../src/lite-api/timestamp';
 import { writeBatch } from '../../src/lite-api/write_batch';
 import { Code, FirestoreError } from '../../src/util/error';
-import { logWarn } from '../../src/util/log';
 import {
   getRunEnterpriseTests,
   getTargetBackend,
@@ -6445,39 +6444,8 @@ describe.skipClassic('Firestore Pipelines', () => {
           .addFields(reviewsSub.toArrayExpression().as('reviews'))
           .select('title', 'reviews');
 
-        // TODO(dlarocque): Remove these target backend conditionals once the 'get_field' rename has rolled out to prod.
-        const host = firestore._getSettings().host;
-        const isProd = host === 'firestore.googleapis.com';
-        const isNightly = host === 'test-firestore.sandbox.googleapis.com';
-
-        if (isProd) {
-          // The execution of this pipeline is expected to result in a network error
-          // from the backend until the breaking change to rename the 'field' expression to
-          // 'get_field' has rolled out to prod.
-          try {
-            const results = await execute(ppl);
-
-            // If this is reached, the execution of the pipeline didn't throw an error, so the
-            // breaking change must have rolled out to prod. We can assert the newly expected behaviour.
-            logWarn(
-              "The 'get_field' expression rename has rolled out to the prod backend. Remove the target backend conditionals in this test."
-            );
-            expectResults(results, { title: '1984', reviews: ['Alice'] });
-          } catch (err: unknown) {
-            const error: Error = err as Error;
-            expect(error.message).to.equals(
-              "Request failed with error: The function 'get_field' does not exist, did you mean 'field'?"
-            );
-          }
-        } else if (isNightly) {
-          const results = await execute(ppl);
-          expectResults(results, { title: '1984', reviews: ['Alice'] });
-        } else {
-          expect(false).to.equal(
-            true,
-            `This test is only expected to run against firestore.googleapis.com or test-firestore.sandbox.googleapis.com, but it instead ran against ${host}`
-          );
-        }
+        const results = await execute(ppl);
+        expectResults(results, { title: '1984', reviews: ['Alice'] });
       });
     });
 
@@ -6560,39 +6528,8 @@ describe.skipClassic('Firestore Pipelines', () => {
           .addFields(reviewsSub.toArrayExpression().as('reviews'))
           .select('title', 'reviews');
 
-        // TODO(dlarocque): Remove these target backend conditionals once the 'get_field' rename has rolled out to prod.
-        const host = firestore._getSettings().host;
-        const isProd = host === 'firestore.googleapis.com';
-        const isNightly = host === 'test-firestore.sandbox.googleapis.com';
-
-        if (isProd) {
-          // The execution of this pipeline is expected to result in a network error
-          // from the backend until the breaking change to rename the 'field' expression to
-          // 'get_field' has rolled out to prod.
-          try {
-            const results = await execute(ppl);
-
-            // If this is reached, the execution of the pipeline didn't throw an error, so the
-            // breaking change must have rolled out to prod. We can assert the newly expected behaviour.
-            logWarn(
-              "The 'get_field' expression rename has rolled out to the prod backend. Remove the target backend conditionals in this test."
-            );
-            expectResults(results, { title: '1984', reviews: [] });
-          } catch (err: unknown) {
-            const error: Error = err as Error;
-            expect(error.message).to.equals(
-              "Request failed with error: The function 'get_field' does not exist, did you mean 'field'?"
-            );
-          }
-        } else if (isNightly) {
-          const results = await execute(ppl);
-          expectResults(results, { title: '1984', reviews: [] });
-        } else {
-          expect(false).to.equal(
-            true,
-            `This test is only expected to run against firestore.googleapis.com or test-firestore.sandbox.googleapis.com, but it instead ran against ${host}`
-          );
-        }
+        const results = await execute(ppl);
+        expectResults(results, { title: '1984', reviews: [] });
       });
     });
 


### PR DESCRIPTION
Fixes the issue with the integration tests where getSettings is not defined.
