### PR TITLE
fixing headers issue in FetchTransport instantiation

### DIFF
--- a/packages/crashlytics/src/logging/logger-provider.ts
+++ b/packages/crashlytics/src/logging/logger-provider.ts
@@ -97,7 +97,11 @@ class OTLPLogExporter
         JsonLogsSerializer,
         new FetchTransport({
           url: config.url!,
-          headers: new Headers(config.headers),
+          headers: new Headers(
+            typeof config.headers === 'object'
+              ? (config.headers as Record<string, string>)
+              : {}
+          ),
           dynamicHeaderProviders
         })
       )


### PR DESCRIPTION
The branch currently has an unresolved error for headers value in OTLPLogExporter constructor's FetchTransport instantiation:

Argument of type 'Record<string, string> | HeadersFactory | undefined' is not assignable to parameter of type 'HeadersInit | undefined'.
  Type 'HeadersFactory' is not assignable to type 'HeadersInit | undefined'
  
The type mismatch issue is fixed by making it consistent with what it is in the crashlytics-traces branch. config.headers is casted as a Record such that a HeadersFactory type cannot be passed into the Headers constructor.