### PR TITLE
feat(data-connect): add prefer resume over execute optimization to stream transport

### DIFF
--- a/packages/data-connect/src/network/stream/streamTransport.ts
+++ b/packages/data-connect/src/network/stream/streamTransport.ts
@@ -261,10 +261,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     observer: SubscribeObserver<Data>
   ): void {
     this.activeInvokeSubscribeRequests.set(mapKey, subscribeBody);
-    this.subscribeObservers.set(
-      requestId,
-      observer as SubscribeObserver<unknown>
-    );
+    this.subscribeObservers.set(requestId, observer);
   }
 
   /**
@@ -544,9 +541,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     const existingQueued = this.queuedInvokeQueryRequests.get(mapKey);
     if (existingQueued) {
       // only queue one request per mapKey - return existing queued request promise
-      return existingQueued.responsePromise as Promise<
-        DataConnectResponse<Data>
-      >;
+      return existingQueued.responsePromise;
     }
 
     let resolveFn: (response: DataConnectResponse<Data>) => void;
@@ -605,7 +600,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     if (activeSubscription) {
       // resume!
       requestId = activeSubscription.requestId;
-      requestBody = { requestId, resume: {} } as ResumeStreamRequest;
+      requestBody = { requestId, resume: {} };
       this.resumeRequestPromises.set(requestId, {
         responsePromise,
         resolveFn: resolveFn!,
@@ -617,7 +612,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       requestBody = {
         requestId,
         execute: { operationName: queryName, variables }
-      } as ExecuteStreamRequest<Variables>;
+      };
       this.executeRequestPromises.set(requestId, {
         responsePromise,
         resolveFn: resolveFn!,
@@ -733,10 +728,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       const requestId = existingSubscribe.requestId;
       if (this.pendingCancellations.has(requestId)) {
         this.pendingCancellations.delete(requestId);
-        this.subscribeObservers.set(
-          requestId,
-          observer as SubscribeObserver<unknown>
-        );
+        this.subscribeObservers.set(requestId, observer);
       }
     } else {
       const requestId = this.nextRequestId();

--- a/packages/data-connect/src/network/stream/streamTransport.ts
+++ b/packages/data-connect/src/network/stream/streamTransport.ts
@@ -730,12 +730,15 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     const mapKey = this.getMapKey(queryName, variables);
     const existingSubscribe = this.activeInvokeSubscribeRequests.get(mapKey);
 
-    // if this query is pending cancellation, cancel the cancellation! 
+    // if this query is pending cancellation, cancel the cancellation!
     if (existingSubscribe) {
       const requestId = existingSubscribe.requestId;
       if (this.pendingCancellations.has(requestId)) {
         this.pendingCancellations.delete(requestId);
-        this.subscribeObservers.set(requestId, observer as SubscribeObserver<unknown>);
+        this.subscribeObservers.set(
+          requestId,
+          observer as SubscribeObserver<unknown>
+        );
       }
     } else {
       const requestId = this.nextRequestId();
@@ -864,7 +867,11 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       if (observer) {
         // it's possible that this query was pending cancellation with it's observers deleted but
         // an active resume request. so only call onData() if the observer still exists
-        await observer.onData(response);
+        try {
+          await observer.onData(response);
+        } catch (e) {
+          logError(`Error in observer callback: ${e}`);
+        }
       }
       const resumePromise = this.resumeRequestPromises.get(requestId);
       if (resumePromise) {

--- a/packages/data-connect/src/network/stream/streamTransport.ts
+++ b/packages/data-connect/src/network/stream/streamTransport.ts
@@ -343,7 +343,9 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
 
   /**
    * Attempt to close the connection. Will only close if there are no active requests preventing it
-   * from doing so. Does not respect any {@linkcode closeTimeout} or {@linkcode pendingClose}.
+   * from doing so.
+   * @param skipTimeout If true, the close timeout will be ignored (but we will still check for active
+   * requests). Defaults to `false`.
    */
   private async attemptClose(skipTimeout: boolean = false): Promise<void> {
     if (!skipTimeout && (!this.pendingClose || !this.closeTimeoutFinished)) {
@@ -654,14 +656,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
 
     const queuedRequestPromise = this.queuedInvokeQueryRequests.get(mapKey);
     if (!queuedRequestPromise) {
-      if (
-        !this.hasActiveSubscriptions &&
-        !this.hasActiveExecuteRequests &&
-        this.pendingClose &&
-        this.closeTimeoutFinished
-      ) {
-        void this.attemptClose();
-      }
+      void this.attemptClose(false);
       return;
     }
 
@@ -701,14 +696,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     );
     responsePromise = responsePromise.finally(() => {
       this.cleanupInvokeMutationRequest(requestId, mapKey);
-      if (
-        !this.hasActiveSubscriptions &&
-        !this.hasActiveExecuteRequests &&
-        this.pendingClose &&
-        this.closeTimeoutFinished
-      ) {
-        void this.attemptClose();
-      }
+      void this.attemptClose(false);
     });
 
     // asynchronous, fire and forget
@@ -804,8 +792,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
    * should close the stream due to inactivity.
    */
   private cancelSubscription(requestId: string, mapKey: string): void {
-    this.activeInvokeSubscribeRequests.delete(mapKey);
-    this.subscribeObservers.delete(requestId);
+    this.cleanupInvokeSubscribeRequest(requestId, mapKey);
     const cancelBody: CancelStreamRequest = {
       requestId,
       cancel: {}

--- a/packages/data-connect/src/network/stream/streamTransport.ts
+++ b/packages/data-connect/src/network/stream/streamTransport.ts
@@ -45,7 +45,9 @@ const FIRST_REQUEST_ID = 1;
 const IDLE_CONNECTION_TIMEOUT_MS = 60 * 1000; // 1 minute
 
 /**
- * A promise returned to the user when invoking an operation, and the functions that resolve/reject it.
+ * A promise returned to the user when invoking an operation via {@linkcode AbstractDataConnectStreamTransport.invokeQuery | invokeQuery}
+ * or {@linkcode AbstractDataConnectStreamTransport.invokeMutation | invokeMutation} and the functions
+ * that resolve/reject it.
  * @internal
  */
 export interface InvokeOperationPromise<Data> {
@@ -169,10 +171,20 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
   >();
 
   /**
-   * Map of active {@linkcode invokeQuery} and {@linkcode invokeMutation} RequestIds and their
+   * Map of active {@linkcode ExecuteStreamRequest} RequestIds from {@linkcode invokeQuery} and {@linkcode invokeMutation},
+   * and their corresponding {@linkcode InvokeOperationPromise}.
+   */
+  private executeRequestPromises = new Map<
+    string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    InvokeOperationPromise<any>
+  >();
+
+  /**
+   * Map of active {@linkcode ResumeStreamRequest} RequestIds from {@linkcode invokeQuery}, and their
    * corresponding {@linkcode InvokeOperationPromise}.
    */
-  private invokeOperationPromises = new Map<
+  private resumeRequestPromises = new Map<
     string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     InvokeOperationPromise<any>
@@ -182,6 +194,15 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
    * Map of active {@linkcode invokeSubscribe} RequestIds and their corresponding {@linkcode SubscribeObserver}.
    */
   private subscribeObservers = new Map<string, SubscribeObserver<unknown>>();
+
+  /**
+   * Map of subscribe RequestIds to deferred unsubscription requests. Used when a client unsubscribes
+   * while a resume request is actively pending.
+   */
+  private pendingCancellations = new Map<
+    string,
+    { operationName: string; variables: unknown }
+  >();
 
   /** current close timeout from setTimeout(), if any */
   private closeTimeout: NodeJS.Timeout | null = null;
@@ -223,7 +244,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     const activeRequests = this.activeInvokeMutationRequests.get(mapKey) || [];
     activeRequests.push(executeBody);
     this.activeInvokeMutationRequests.set(mapKey, activeRequests);
-    this.invokeOperationPromises.set(requestId, executeRequestPromise);
+    this.executeRequestPromises.set(requestId, executeRequestPromise);
 
     return executeRequestPromise;
   }
@@ -252,7 +273,8 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
    */
   private cleanupInvokeQueryRequest(requestId: string, mapKey: string): void {
     this.activeInvokeQueryRequests.delete(mapKey);
-    this.invokeOperationPromises.delete(requestId);
+    this.executeRequestPromises.delete(requestId);
+    this.resumeRequestPromises.delete(requestId);
   }
 
   /**
@@ -274,7 +296,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
         this.activeInvokeMutationRequests.delete(mapKey);
       }
     }
-    this.invokeOperationPromises.delete(requestId);
+    this.executeRequestPromises.delete(requestId);
   }
 
   /**
@@ -321,7 +343,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
 
   /**
    * Attempt to close the connection. Will only close if there are no active requests preventing it
-   * from doing so. Does not respect any {@linkcode closeTimeout}.
+   * from doing so. Does not respect any {@linkcode closeTimeout} or {@linkcode pendingClose}.
    */
   private async attemptClose(): Promise<void> {
     if (this.hasActiveSubscriptions || this.hasActiveExecuteRequests) {
@@ -375,14 +397,19 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       this.queuedInvokeQueryRequests.delete(mapKey);
       rejectFn(error);
     }
-    for (const [requestId, { rejectFn }] of this.invokeOperationPromises) {
-      this.invokeOperationPromises.delete(requestId);
+    for (const [requestId, { rejectFn }] of this.executeRequestPromises) {
+      this.executeRequestPromises.delete(requestId);
+      rejectFn(error);
+    }
+    for (const [requestId, { rejectFn }] of this.resumeRequestPromises) {
+      this.resumeRequestPromises.delete(requestId);
       rejectFn(error);
     }
     for (const [requestId, observer] of this.subscribeObservers) {
       this.subscribeObservers.delete(requestId);
       observer.onDisconnect(code, reason);
     }
+    this.pendingCancellations.clear();
   }
 
   /**
@@ -536,7 +563,8 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
   }
 
   /**
-   * Executes a query.
+   * Executes or resumes a query. Does not check for any active requests which may be overwritten by
+   * this request - this should be handled by the caller.
    */
   private executeOrResumeQuery<Data, Variables>(
     queryName: string,
@@ -544,11 +572,14 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     mapKey: string,
     queuedInvokeOperationPromise?: InvokeOperationPromise<Data>
   ): Promise<DataConnectResponse<Data>> {
+    const activeSubscription = this.activeInvokeSubscribeRequests.get(mapKey);
+
     let resolveFn: (response: DataConnectResponse<Data>) => void;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let rejectFn: (reason: any) => void;
     let responsePromise: Promise<DataConnectResponse<Data>>;
 
+    // track the existing queued promise if one exists - otherwise create a new one
     if (queuedInvokeOperationPromise) {
       resolveFn = queuedInvokeOperationPromise.resolveFn;
       rejectFn = queuedInvokeOperationPromise.rejectFn;
@@ -562,21 +593,35 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       );
     }
 
-    const requestId = this.nextRequestId();
-    const requestBody = {
-      requestId,
-      execute: { operationName: queryName, variables }
-    } as ExecuteStreamRequest<Variables>;
+    let requestId: string;
+    let requestBody: ExecuteStreamRequest<Variables> | ResumeStreamRequest;
 
-    this.invokeOperationPromises.set(requestId, {
-      responsePromise,
-      resolveFn: resolveFn!,
-      rejectFn: rejectFn!
-    });
+    if (activeSubscription) {
+      // resume!
+      requestId = activeSubscription.requestId;
+      requestBody = { requestId, resume: {} } as ResumeStreamRequest;
+      this.resumeRequestPromises.set(requestId, {
+        responsePromise,
+        resolveFn: resolveFn!,
+        rejectFn: rejectFn!
+      });
+    } else {
+      // execute!
+      requestId = this.nextRequestId();
+      requestBody = {
+        requestId,
+        execute: { operationName: queryName, variables }
+      } as ExecuteStreamRequest<Variables>;
+      this.executeRequestPromises.set(requestId, {
+        responsePromise,
+        resolveFn: resolveFn!,
+        rejectFn: rejectFn!
+      });
+    }
 
     this.activeInvokeQueryRequests.set(mapKey, requestBody);
 
-    void responsePromise.finally(() => {
+    responsePromise = responsePromise.finally(() => {
       this.onInvokeQueryRequestFulfilled(
         queryName,
         variables,
@@ -608,6 +653,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       if (
         !this.hasActiveSubscriptions &&
         !this.hasActiveExecuteRequests &&
+        this.pendingClose &&
         this.closeTimeoutFinished
       ) {
         void this.attemptClose();
@@ -654,6 +700,7 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       if (
         !this.hasActiveSubscriptions &&
         !this.hasActiveExecuteRequests &&
+        this.pendingClose &&
         this.closeTimeoutFinished
       ) {
         void this.attemptClose();
@@ -681,38 +728,41 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     variables: Variables
   ): void {
     const mapKey = this.getMapKey(queryName, variables);
+    const existingSubscribe = this.activeInvokeSubscribeRequests.get(mapKey);
 
-    if (this.activeInvokeSubscribeRequests.has(mapKey)) {
-      // de-duplicate subscribe requests
-      // the Query Layer also de-dupes subscribe requests, but this is here for good measure.
-      // note that we do not multiplex observers here, that is handled by the Query Layer.
-      return;
+    // if this query is pending cancellation, cancel the cancellation! 
+    if (existingSubscribe) {
+      const requestId = existingSubscribe.requestId;
+      if (this.pendingCancellations.has(requestId)) {
+        this.pendingCancellations.delete(requestId);
+        this.subscribeObservers.set(requestId, observer as SubscribeObserver<unknown>);
+      }
+    } else {
+      const requestId = this.nextRequestId();
+      const activeRequestKey = { operationName: queryName, variables };
+      const subscribeBody: SubscribeStreamRequest<Variables> = {
+        requestId,
+        subscribe: activeRequestKey
+      };
+
+      this.trackInvokeSubscribeRequest<Data>(
+        requestId,
+        mapKey,
+        subscribeBody,
+        observer
+      );
+
+      // asynchronous, fire and forget
+      this.sendRequestMessage<Variables>(subscribeBody).catch(err => {
+        observer.onError(err instanceof Error ? err : new Error(String(err)));
+        this.cleanupInvokeSubscribeRequest(requestId, mapKey);
+        if (!this.hasActiveSubscriptions) {
+          this.closeAfterTimeout();
+        }
+      });
     }
-
     // if we are waiting to close the stream, cancel closing!
     this.cancelClose();
-    const requestId = this.nextRequestId();
-    const activeRequestKey = { operationName: queryName, variables };
-    const subscribeBody: SubscribeStreamRequest<Variables> = {
-      requestId,
-      subscribe: activeRequestKey
-    };
-
-    this.trackInvokeSubscribeRequest<Data>(
-      requestId,
-      mapKey,
-      subscribeBody,
-      observer
-    );
-
-    // asynchronous, fire and forget
-    this.sendRequestMessage<Variables>(subscribeBody).catch(err => {
-      observer.onError(err instanceof Error ? err : new Error(String(err)));
-      this.cleanupInvokeSubscribeRequest(requestId, mapKey);
-      if (!this.hasActiveSubscriptions) {
-        this.closeAfterTimeout();
-      }
-    });
   }
 
   /**
@@ -729,12 +779,30 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       return;
     }
     const requestId = subscribeRequest.requestId;
+
+    this.subscribeObservers.delete(requestId);
+    const resumePromise = this.resumeRequestPromises.get(requestId);
+    if (resumePromise) {
+      this.pendingCancellations.set(requestId, {
+        operationName: queryName,
+        variables
+      });
+      return;
+    }
+    this.cancelSubscription(requestId, mapKey);
+  }
+
+  /**
+   * Cancels a subscription, cleans up the request tracking data structures, and checks to see if we
+   * should close the stream due to inactivity.
+   */
+  private cancelSubscription(requestId: string, mapKey: string): void {
+    this.activeInvokeSubscribeRequests.delete(mapKey);
+    this.subscribeObservers.delete(requestId);
     const cancelBody: CancelStreamRequest = {
       requestId,
       cancel: {}
     };
-
-    this.cleanupInvokeSubscribeRequest(requestId, mapKey);
 
     // asynchronous, fire and forget
     this.sendRequestMessage(cancelBody).catch(err => {
@@ -784,33 +852,67 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
     requestId: string,
     response: DataConnectResponse<Data>
   ): Promise<void> {
-    if (this.invokeOperationPromises.has(requestId)) {
-      // don't clean up the tracking maps here, they're handled automatically when the execute promise settles
+    if (this.executeRequestPromises.has(requestId)) {
       const { resolveFn, rejectFn } =
-        this.invokeOperationPromises.get(requestId)!;
-      if (response.errors && response.errors.length) {
-        const failureResponse: DataConnectOperationFailureResponse = {
-          errors: response.errors as [],
-          data: response.data as Record<string, unknown>
-        };
-        const stringified = JSON.stringify(response.errors);
-        rejectFn(
-          new DataConnectOperationError(
-            'DataConnect error while performing request: ' + stringified,
-            failureResponse
-          )
-        );
-      } else {
-        resolveFn(response);
+        this.executeRequestPromises.get(requestId)!;
+      this.handleInvokeOperationResponse(resolveFn, rejectFn, response);
+    } else if (
+      this.subscribeObservers.has(requestId) ||
+      this.resumeRequestPromises.has(requestId)
+    ) {
+      const observer = this.subscribeObservers.get(requestId);
+      if (observer) {
+        // it's possible that this query was pending cancellation with it's observers deleted but
+        // an active resume request. so only call onData() if the observer still exists
+        await observer.onData(response);
       }
-    } else if (this.subscribeObservers.has(requestId)) {
-      const observer = this.subscribeObservers.get(requestId)!;
-      await observer.onData(response);
+      const resumePromise = this.resumeRequestPromises.get(requestId);
+      if (resumePromise) {
+        this.resumeRequestPromises.delete(requestId);
+        const { resolveFn, rejectFn } = resumePromise;
+        this.handleInvokeOperationResponse(resolveFn, rejectFn, response);
+
+        const deferredCancel = this.pendingCancellations.get(requestId);
+        if (deferredCancel) {
+          this.pendingCancellations.delete(requestId);
+          const mapKey = this.getMapKey(
+            deferredCancel.operationName,
+            deferredCancel.variables
+          );
+          this.cancelSubscription(requestId, mapKey);
+        }
+      }
     } else {
-      throw new DataConnectError(
-        Code.OTHER,
+      console.warn(
         `Stream response contained unrecognized requestId '${requestId}'`
       );
+    }
+  }
+
+  /**
+   * Handles an invoke operation response, resolving or rejecting the promise returned to the user
+   * Does not handle any cleanup for requests - this should be handled by the caller or the promise's
+   * finally() block.
+   */
+  private handleInvokeOperationResponse<Data>(
+    resolveFn: (value: DataConnectResponse<Data>) => void,
+    rejectFn: (reason: unknown) => void,
+    response: DataConnectResponse<Data>
+  ): void {
+    if (response.errors && response.errors.length) {
+      const failureResponse: DataConnectOperationFailureResponse = {
+        errors: response.errors as [],
+        data: response.data as Record<string, unknown>
+      };
+      const stringified = JSON.stringify(response.errors);
+      rejectFn(
+        new DataConnectOperationError(
+          'DataConnect error while performing request: ' + stringified,
+          failureResponse
+        )
+      );
+    } else {
+      resolveFn(response);
     }
   }
 }

--- a/packages/data-connect/src/network/stream/streamTransport.ts
+++ b/packages/data-connect/src/network/stream/streamTransport.ts
@@ -654,6 +654,12 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
   ): void {
     this.cleanupInvokeQueryRequest(requestId, mapKey);
 
+    const deferredCancel = this.pendingCancellations.get(requestId);
+    if (deferredCancel) {
+      this.pendingCancellations.delete(requestId);
+      this.cancelSubscription(requestId, mapKey);
+    }
+
     const queuedRequestPromise = this.queuedInvokeQueryRequests.get(mapKey);
     if (!queuedRequestPromise) {
       void this.attemptClose(false);
@@ -855,33 +861,23 @@ export abstract class AbstractDataConnectStreamTransport extends AbstractDataCon
       this.resumeRequestPromises.has(requestId)
     ) {
       const observer = this.subscribeObservers.get(requestId);
+      const resumePromise = this.resumeRequestPromises.get(requestId);
+
+      if (resumePromise) {
+        this.resumeRequestPromises.delete(requestId);
+        const { resolveFn, rejectFn } = resumePromise;
+        this.handleInvokeOperationResponse(resolveFn, rejectFn, response);
+      }
+
       if (observer) {
-        // it's possible that this query was pending cancellation with it's observers deleted but
-        // an active resume request. so only call onData() if the observer still exists
         try {
           await observer.onData(response);
         } catch (e) {
           logError(`Error in observer callback: ${e}`);
         }
       }
-      const resumePromise = this.resumeRequestPromises.get(requestId);
-      if (resumePromise) {
-        this.resumeRequestPromises.delete(requestId);
-        const { resolveFn, rejectFn } = resumePromise;
-        this.handleInvokeOperationResponse(resolveFn, rejectFn, response);
-
-        const deferredCancel = this.pendingCancellations.get(requestId);
-        if (deferredCancel) {
-          this.pendingCancellations.delete(requestId);
-          const mapKey = this.getMapKey(
-            deferredCancel.operationName,
-            deferredCancel.variables
-          );
-          this.cancelSubscription(requestId, mapKey);
-        }
-      }
     } else {
-      console.warn(
+      logError(
         `Stream response contained unrecognized requestId '${requestId}'`
       );
     }

--- a/packages/data-connect/src/network/stream/websocket.ts
+++ b/packages/data-connect/src/network/stream/websocket.ts
@@ -336,6 +336,6 @@ export class WebSocketTransport extends AbstractDataConnectStreamTransport {
         'WebSocket message did not include requestId'
       );
     }
-    return result as DataConnectStreamResponse<Data>;
+    return result;
   }
 }

--- a/packages/data-connect/test/unit/streamTransport.test.ts
+++ b/packages/data-connect/test/unit/streamTransport.test.ts
@@ -1270,8 +1270,8 @@ describe('AbstractDataConnectStreamTransport', () => {
         extensions: {}
       };
 
-      it('should log a warning if an unrecognized requestId is received', async () => {
-        const logWarnStub = sinon.stub(console, 'warn');
+      it('should log an error if an unrecognized requestId is received', async () => {
+        const logErrorStub = sinon.stub(logger, 'logError');
         const unknownRequestId = 'unknown-999';
         const response: DataConnectResponse<unknown> = {
           data: {},
@@ -1279,11 +1279,11 @@ describe('AbstractDataConnectStreamTransport', () => {
           extensions: {}
         };
         await transport.invokeHandleResponse(unknownRequestId, response);
-        expect(logWarnStub).to.have.been.calledOnce;
-        expect(logWarnStub).to.have.been.calledWithMatch(
+        expect(logErrorStub).to.have.been.calledOnce;
+        expect(logErrorStub).to.have.been.calledWithMatch(
           `Stream response contained unrecognized requestId '${unknownRequestId}'`
         );
-        logWarnStub.restore();
+        logErrorStub.restore();
       });
 
       describe('invokeQuery tracking', async () => {

--- a/packages/data-connect/test/unit/streamTransport.test.ts
+++ b/packages/data-connect/test/unit/streamTransport.test.ts
@@ -142,7 +142,12 @@ interface TransportWithInternals {
     Array<ExecuteStreamRequest<unknown>>
   >;
   activeInvokeSubscribeRequests: Map<string, SubscribeStreamRequest<unknown>>;
-  invokeOperationPromises: Map<string, InvokeOperationPromise<unknown>>;
+  executeRequestPromises: Map<string, InvokeOperationPromise<unknown>>;
+  resumeRequestPromises: Map<string, InvokeOperationPromise<unknown>>;
+  pendingCancellations: Map<
+    string,
+    { operationName: string; variables: unknown }
+  >;
   subscribeObservers: Map<string, unknown>;
   getMapKey(operationName: string, variables?: unknown): string;
   invokeQuery<_Data, Variables>(
@@ -442,7 +447,7 @@ describe('AbstractDataConnectStreamTransport', () => {
           expect(request?.execute?.variables).to.deep.equal(variables1);
 
           const requestId = request!.requestId;
-          expect(transport.invokeOperationPromises.has(requestId)).to.be.true;
+          expect(transport.executeRequestPromises.has(requestId)).to.be.true;
 
           expect(sendMessageSpy).to.have.been.calledOnce;
           const sentMessage = sendMessageSpy.firstCall.args[0];
@@ -465,215 +470,414 @@ describe('AbstractDataConnectStreamTransport', () => {
           expect(transport.activeInvokeQueryRequests.has(mapKey)).to.be.false;
 
           const requestId = sendMessageStub.firstCall.args[0].requestId;
-          expect(transport.invokeOperationPromises.has(requestId)).to.be.false;
+          expect(transport.executeRequestPromises.has(requestId)).to.be.false;
         });
 
-        describe('de-duplication', () => {
-          it('should send the first request and queue subsequent requests when they are identical', async () => {
-            const sendMessageSpy = sinon.spy(transport, 'sendMessage');
+        describe('optimizations', () => {
+          describe('prefer resume over execute when executing already subscribed queries', () => {
+            // TODO: VERIFY
+            it('should send a resume payload if there is an active subscription', async () => {
+              const sendMessageSpy = sinon.spy(transport, 'sendMessage');
+              const observer = {
+                onData: sinon.spy(),
+                onDisconnect: sinon.spy(),
+                onError: sinon.spy()
+              };
 
-            const promises = [];
-            for (let i = 1; i <= 20; i++) {
-              promises.push(transport.invokeQuery(queryName1, variables1));
-            }
-            const mapKey = transport.getMapKey(queryName1, variables1);
+              transport.invokeSubscribe(observer, queryName1, variables1);
+              expect(sendMessageSpy).to.have.been.calledOnce;
+              const subscribeMessage = sendMessageSpy.firstCall.args[0];
+              expect(subscribeMessage.subscribe).to.not.be.undefined;
+              const subscribeRequestId = subscribeMessage.requestId;
 
-            expect(sendMessageSpy).to.have.been.calledOnce;
-            const sentMessage = sendMessageSpy.firstCall.args[0];
-            expect(sentMessage.execute?.operationName).to.equal(queryName1);
+              const queryPromise = transport.invokeQuery(
+                queryName1,
+                variables1
+              );
+              expect(sendMessageSpy).to.have.been.calledTwice;
+              const resumeMessage = sendMessageSpy.secondCall.args[0];
+              expect(resumeMessage.resume).to.not.be.undefined;
+              expect(resumeMessage.requestId).to.equal(subscribeRequestId);
 
-            expect(transport.activeInvokeQueryRequests.has(mapKey)).to.be.true;
-            const activeRequest =
-              transport.activeInvokeQueryRequests.get(mapKey);
-            expect(activeRequest?.execute?.operationName).to.equal(queryName1);
+              const response = {
+                data: { result: '1' },
+                errors: [],
+                extensions: {}
+              };
+              await transport.invokeHandleResponse(
+                subscribeRequestId,
+                response
+              );
+              expect(await queryPromise).to.deep.equal(response);
+            });
 
-            const queuedMap = transport.queuedInvokeQueryRequests;
-            expect(queuedMap.has(mapKey)).to.be.true;
+            // TODO: VERIFY
+            it('should resolve resume promise even if observer callback throws', async () => {
+              sinon.stub(transport, 'sendMessage').resolves();
+              const observer = {
+                onData: sinon.stub().throws(new Error('Callback crashed')),
+                onDisconnect: sinon.spy(),
+                onError: sinon.spy()
+              };
 
-            // promises 1 and 2 should be different, but 2-20 should be the same!
-            expect(promises[0]).to.not.equal(promises[1]);
-            for (let i = 1; i < 20; i++) {
-              expect(promises[i]).to.equal(promises[1]);
-            }
+              transport.invokeSubscribe(observer, queryName1, variables1);
+              const subscribeRequestId =
+                transport.activeInvokeSubscribeRequests.get(
+                  transport.getMapKey(queryName1, variables1)
+                )!.requestId;
+
+              const queryPromise = transport.invokeQuery(
+                queryName1,
+                variables1
+              );
+
+              const response = {
+                data: { result: '1' },
+                errors: [],
+                extensions: {}
+              };
+
+              await transport.invokeHandleResponse(
+                subscribeRequestId,
+                response
+              );
+              const result = await queryPromise;
+              expect(result).to.deep.equal(response);
+            });
           });
 
-          it('should resolve only the first request when it completes', async () => {
-            sinon.stub(transport, 'sendMessage').resolves();
+          describe('de-duplication of identical requests', () => {
+            it('should send the first request and queue subsequent requests when they are identical', async () => {
+              const sendMessageSpy = sinon.spy(transport, 'sendMessage');
 
-            const promises = [];
-            for (let i = 1; i <= 20; i++) {
-              promises.push(transport.invokeQuery(queryName1, variables1));
-            }
+              const promises = [];
+              for (let i = 1; i <= 20; i++) {
+                promises.push(transport.invokeQuery(queryName1, variables1));
+              }
+              const mapKey = transport.getMapKey(queryName1, variables1);
 
-            const mapKey = transport.getMapKey(queryName1, variables1);
-            const activeRequest =
-              transport.activeInvokeQueryRequests.get(mapKey);
-            const requestId1 = activeRequest!.requestId;
+              expect(sendMessageSpy).to.have.been.calledOnce;
+              const sentMessage = sendMessageSpy.firstCall.args[0];
+              expect(sentMessage.execute?.operationName).to.equal(queryName1);
 
-            const response1 = {
-              data: { result: '1' },
-              errors: [],
-              extensions: {}
-            };
+              expect(transport.activeInvokeQueryRequests.has(mapKey)).to.be
+                .true;
+              const activeRequest =
+                transport.activeInvokeQueryRequests.get(mapKey);
+              expect(activeRequest?.execute?.operationName).to.equal(
+                queryName1
+              );
 
-            await transport.invokeHandleResponse(requestId1, response1);
+              const queuedMap = transport.queuedInvokeQueryRequests;
+              expect(queuedMap.has(mapKey)).to.be.true;
 
-            // verify promise 1 resolved, but other promises are not yet settled
-            const result1 = await promises[0];
-            expect(result1).to.deep.equal(response1);
-            for (let i = 1; i < 20; i++) {
-              await expectIsNotSettled(promises[i], 100);
-            }
-          });
+              // promises 1 and 2 should be different, but 2-20 should be the same!
+              expect(promises[0]).to.not.equal(promises[1]);
+              for (let i = 1; i < 20; i++) {
+                expect(promises[i]).to.equal(promises[1]);
+              }
+            });
 
-          it('should send the next request and clear queue when first request completes', async () => {
-            const sendMessageSpy = sinon.spy(transport, 'sendMessage');
+            it('should resolve only the first request when it completes', async () => {
+              sinon.stub(transport, 'sendMessage').resolves();
 
-            const promises = [];
-            for (let i = 1; i <= 20; i++) {
-              promises.push(transport.invokeQuery(queryName1, variables1));
-            }
+              const promises = [];
+              for (let i = 1; i <= 20; i++) {
+                promises.push(transport.invokeQuery(queryName1, variables1));
+              }
 
-            const mapKey = transport.getMapKey(queryName1, variables1);
-            const activeRequest =
-              transport.activeInvokeQueryRequests.get(mapKey);
-            const requestId1 = activeRequest!.requestId;
+              const mapKey = transport.getMapKey(queryName1, variables1);
+              const activeRequest =
+                transport.activeInvokeQueryRequests.get(mapKey);
+              const requestId1 = activeRequest!.requestId;
 
-            const response1 = {
-              data: { result: '1' },
-              errors: [],
-              extensions: {}
-            };
+              const response1 = {
+                data: { result: '1' },
+                errors: [],
+                extensions: {}
+              };
 
-            await transport.invokeHandleResponse(requestId1, response1);
+              await transport.invokeHandleResponse(requestId1, response1);
 
-            // verify queued request was popped + sent
-            expect(transport.queuedInvokeQueryRequests.has(mapKey)).to.be.false;
-            expect(transport.activeInvokeQueryRequests.has(mapKey)).to.be.true;
-            expect(sendMessageSpy).to.have.been.calledTwice;
-            const secondSentMessage = sendMessageSpy.secondCall.args[0];
-            expect(secondSentMessage.execute?.operationName).to.equal(
-              queryName1
-            );
-            expect(secondSentMessage.requestId).to.not.equal(requestId1);
-          });
+              // verify promise 1 resolved, but other promises are not yet settled
+              const result1 = await promises[0];
+              expect(result1).to.deep.equal(response1);
+              for (let i = 1; i < 20; i++) {
+                await expectIsNotSettled(promises[i], 100);
+              }
+            });
 
-          it('should send the next request even if the first request fails with response errors', async () => {
-            const sendMessageSpy = sinon.spy(transport, 'sendMessage');
+            it('should send the next request and clear queue when first request completes', async () => {
+              const sendMessageSpy = sinon.spy(transport, 'sendMessage');
 
-            const promises = [];
-            for (let i = 1; i <= 20; i++) {
-              promises.push(transport.invokeQuery(queryName1, variables1));
-            }
+              const promises = [];
+              for (let i = 1; i <= 20; i++) {
+                promises.push(transport.invokeQuery(queryName1, variables1));
+              }
 
-            const mapKey = transport.getMapKey(queryName1, variables1);
-            const activeRequest =
-              transport.activeInvokeQueryRequests.get(mapKey);
-            const requestId1 = activeRequest!.requestId;
-            const promise1 = promises[0];
-            expect(transport.activeInvokeQueryRequests.has(mapKey)).to.be.true;
-            expect(transport.queuedInvokeQueryRequests.has(mapKey)).to.be.true;
+              const mapKey = transport.getMapKey(queryName1, variables1);
+              const activeRequest =
+                transport.activeInvokeQueryRequests.get(mapKey);
+              const requestId1 = activeRequest!.requestId;
 
-            const errorResponse = {
-              data: null,
-              errors: [new Error('Query failed')],
-              extensions: {}
-            };
-            await transport.invokeHandleResponse(requestId1, errorResponse);
+              const response1 = {
+                data: { result: '1' },
+                errors: [],
+                extensions: {}
+              };
 
-            await expect(promise1).to.be.rejectedWith(
-              /DataConnect error while performing request/
-            );
-            expect(transport.queuedInvokeQueryRequests.has(mapKey)).to.be.false;
-            expect(transport.activeInvokeQueryRequests.has(mapKey)).to.be.true;
-            expect(sendMessageSpy).to.have.been.calledTwice;
+              await transport.invokeHandleResponse(requestId1, response1);
 
-            // queued request should not be affected by the failure of request 1
-            const secondSentMessage = sendMessageSpy.secondCall.args[0];
-            expect(secondSentMessage.execute?.operationName).to.equal(
-              queryName1
-            );
-            expect(secondSentMessage.requestId).to.not.equal(requestId1);
-            await expectIsNotSettled(promises[1], 100);
-            const activeRequest2 =
-              transport.activeInvokeQueryRequests.get(mapKey);
-            const requestId2 = activeRequest2!.requestId;
-            const response2 = {
-              data: { result: '2' },
-              errors: [],
-              extensions: {}
-            };
-            await transport.invokeHandleResponse(requestId2, response2);
-            const result2 = await promises[1];
-            expect(result2).to.deep.equal(response2);
-          });
+              // verify queued request was popped + sent
+              expect(transport.queuedInvokeQueryRequests.has(mapKey)).to.be
+                .false;
+              expect(transport.activeInvokeQueryRequests.has(mapKey)).to.be
+                .true;
+              expect(sendMessageSpy).to.have.been.calledTwice;
+              const secondSentMessage = sendMessageSpy.secondCall.args[0];
+              expect(secondSentMessage.execute?.operationName).to.equal(
+                queryName1
+              );
+              expect(secondSentMessage.requestId).to.not.equal(requestId1);
+            });
 
-          it('should send the next request even if the first request fails with errors', async () => {
-            const sendMessageStub = sinon.stub(transport, 'sendMessage');
-            sendMessageStub.onFirstCall().rejects(expectedError);
-            sendMessageStub.onSecondCall().resolves();
+            it('should send the next request even if the first request fails with response errors', async () => {
+              const sendMessageSpy = sinon.spy(transport, 'sendMessage');
 
-            const promises = [];
-            for (let i = 1; i <= 20; i++) {
-              promises.push(transport.invokeQuery(queryName1, variables1));
-            }
+              const promises = [];
+              for (let i = 1; i <= 20; i++) {
+                promises.push(transport.invokeQuery(queryName1, variables1));
+              }
 
-            const mapKey = transport.getMapKey(queryName1, variables1);
-            const activeRequest =
-              transport.activeInvokeQueryRequests.get(mapKey);
-            const requestId1 = activeRequest!.requestId;
+              const mapKey = transport.getMapKey(queryName1, variables1);
+              const activeRequest =
+                transport.activeInvokeQueryRequests.get(mapKey);
+              const requestId1 = activeRequest!.requestId;
+              const promise1 = promises[0];
+              expect(transport.activeInvokeQueryRequests.has(mapKey)).to.be
+                .true;
+              expect(transport.queuedInvokeQueryRequests.has(mapKey)).to.be
+                .true;
 
-            await expect(promises[0]).to.be.rejectedWith(expectedError);
-            expect(transport.queuedInvokeQueryRequests.has(mapKey)).to.be.false;
-            expect(transport.activeInvokeQueryRequests.has(mapKey)).to.be.true;
-            expect(sendMessageStub).to.have.been.calledTwice;
+              const errorResponse = {
+                data: null,
+                errors: [new Error('Query failed')],
+                extensions: {}
+              };
+              await transport.invokeHandleResponse(requestId1, errorResponse);
 
-            const secondSentMessage = sendMessageStub.secondCall.args[0];
-            expect(secondSentMessage.execute?.operationName).to.equal(
-              queryName1
-            );
-            expect(secondSentMessage.requestId).to.not.equal(requestId1);
-          });
+              await expect(promise1).to.be.rejectedWith(
+                /DataConnect error while performing request/
+              );
+              expect(transport.queuedInvokeQueryRequests.has(mapKey)).to.be
+                .false;
+              expect(transport.activeInvokeQueryRequests.has(mapKey)).to.be
+                .true;
+              expect(sendMessageSpy).to.have.been.calledTwice;
 
-          it('should resolve all waiting promises when a queued request completes', async () => {
-            sinon.stub(transport, 'sendMessage').resolves();
+              // queued request should not be affected by the failure of request 1
+              const secondSentMessage = sendMessageSpy.secondCall.args[0];
+              expect(secondSentMessage.execute?.operationName).to.equal(
+                queryName1
+              );
+              expect(secondSentMessage.requestId).to.not.equal(requestId1);
+              await expectIsNotSettled(promises[1], 100);
+              const activeRequest2 =
+                transport.activeInvokeQueryRequests.get(mapKey);
+              const requestId2 = activeRequest2!.requestId;
+              const response2 = {
+                data: { result: '2' },
+                errors: [],
+                extensions: {}
+              };
+              await transport.invokeHandleResponse(requestId2, response2);
+              const result2 = await promises[1];
+              expect(result2).to.deep.equal(response2);
+            });
 
-            const promises = [];
-            for (let i = 1; i <= 20; i++) {
-              promises.push(transport.invokeQuery(queryName1, variables1));
-            }
+            it('should send the next request even if the first request fails with errors', async () => {
+              const sendMessageStub = sinon.stub(transport, 'sendMessage');
+              sendMessageStub.onFirstCall().rejects(expectedError);
+              sendMessageStub.onSecondCall().resolves();
 
-            const mapKey = transport.getMapKey(queryName1, variables1);
-            const activeRequest1 =
-              transport.activeInvokeQueryRequests.get(mapKey);
-            const requestId1 = activeRequest1!.requestId;
-            const response1 = {
-              data: { result: '1' },
-              errors: [],
-              extensions: {}
-            };
-            await transport.invokeHandleResponse(requestId1, response1);
+              const promises = [];
+              for (let i = 1; i <= 20; i++) {
+                promises.push(transport.invokeQuery(queryName1, variables1));
+              }
 
-            const activeRequest2 =
-              transport.activeInvokeQueryRequests.get(mapKey);
-            const requestId2 = activeRequest2!.requestId;
-            expect(requestId2).to.not.equal(requestId1);
+              const mapKey = transport.getMapKey(queryName1, variables1);
+              const activeRequest =
+                transport.activeInvokeQueryRequests.get(mapKey);
+              const requestId1 = activeRequest!.requestId;
 
-            const response2 = {
-              data: { result: '2' },
-              errors: [],
-              extensions: {}
-            };
+              await expect(promises[0]).to.be.rejectedWith(expectedError);
+              expect(transport.queuedInvokeQueryRequests.has(mapKey)).to.be
+                .false;
+              expect(transport.activeInvokeQueryRequests.has(mapKey)).to.be
+                .true;
+              expect(sendMessageStub).to.have.been.calledTwice;
 
-            await transport.invokeHandleResponse(requestId2, response2);
+              const secondSentMessage = sendMessageStub.secondCall.args[0];
+              expect(secondSentMessage.execute?.operationName).to.equal(
+                queryName1
+              );
+              expect(secondSentMessage.requestId).to.not.equal(requestId1);
+            });
 
-            // verify all queued promises resolved to response2, and nothing active or in queue
-            for (let i = 1; i < 20; i++) {
-              const result = await promises[i];
-              expect(result).to.deep.equal(response2);
-            }
-            expect(transport.activeInvokeQueryRequests.has(mapKey)).to.be.false;
-            expect(transport.queuedInvokeQueryRequests.has(mapKey)).to.be.false;
+            it('should resolve all waiting promises when a queued request completes', async () => {
+              sinon.stub(transport, 'sendMessage').resolves();
+
+              const promises = [];
+              for (let i = 1; i <= 20; i++) {
+                promises.push(transport.invokeQuery(queryName1, variables1));
+              }
+
+              const mapKey = transport.getMapKey(queryName1, variables1);
+              const activeRequest1 =
+                transport.activeInvokeQueryRequests.get(mapKey);
+              const requestId1 = activeRequest1!.requestId;
+              const response1 = {
+                data: { result: '1' },
+                errors: [],
+                extensions: {}
+              };
+              await transport.invokeHandleResponse(requestId1, response1);
+
+              const activeRequest2 =
+                transport.activeInvokeQueryRequests.get(mapKey);
+              const requestId2 = activeRequest2!.requestId;
+              expect(requestId2).to.not.equal(requestId1);
+
+              const response2 = {
+                data: { result: '2' },
+                errors: [],
+                extensions: {}
+              };
+
+              await transport.invokeHandleResponse(requestId2, response2);
+
+              // verify all queued promises resolved to response2, and nothing active or in queue
+              for (let i = 1; i < 20; i++) {
+                const result = await promises[i];
+                expect(result).to.deep.equal(response2);
+              }
+              expect(transport.activeInvokeQueryRequests.has(mapKey)).to.be
+                .false;
+              expect(transport.queuedInvokeQueryRequests.has(mapKey)).to.be
+                .false;
+            });
+
+            // TODO: VERIFY
+            it('should de-duplicate identical resume requests', async () => {
+              sinon.stub(transport, 'sendMessage').resolves();
+              const observer = {
+                onData: sinon.spy(),
+                onDisconnect: sinon.spy(),
+                onError: sinon.spy()
+              };
+
+              transport.invokeSubscribe(observer, queryName1, variables1);
+
+              const promises = [];
+              for (let i = 1; i <= 20; i++) {
+                promises.push(transport.invokeQuery(queryName1, variables1));
+              }
+              const mapKey = transport.getMapKey(queryName1, variables1);
+              const queuedMap = transport.queuedInvokeQueryRequests;
+              expect(queuedMap.has(mapKey)).to.be.true;
+
+              // promises 1 and 2 should be different, but 2-20 should be the same!
+              expect(promises[0]).to.not.equal(promises[1]);
+              for (let i = 1; i < 20; i++) {
+                expect(promises[i]).to.equal(promises[1]);
+              }
+            });
+
+            // TODO: VERIFY
+            it('should execute first, and then pop as resume if subscribed while waiting', async () => {
+              const sendMessageSpy = sinon.spy(transport, 'sendMessage');
+
+              const queryPromise1 = transport.invokeQuery(
+                queryName1,
+                variables1
+              );
+              expect(sendMessageSpy).to.have.been.calledOnce;
+              const executeMessage = sendMessageSpy.firstCall.args[0];
+              expect(executeMessage.execute).to.not.be.undefined;
+              const executeRequestId = executeMessage.requestId;
+
+              void transport.invokeQuery(queryName1, variables1);
+              expect(sendMessageSpy).to.have.been.calledOnce;
+
+              const observer = {
+                onData: sinon.spy(),
+                onDisconnect: sinon.spy(),
+                onError: sinon.spy()
+              };
+              transport.invokeSubscribe(observer, queryName1, variables1);
+              expect(sendMessageSpy).to.have.been.calledTwice;
+              const subscribeRequestId =
+                sendMessageSpy.secondCall.args[0].requestId;
+
+              const response1 = {
+                data: { result: '1' },
+                errors: [],
+                extensions: {}
+              };
+              await transport.invokeHandleResponse(executeRequestId, response1);
+              await queryPromise1;
+
+              expect(sendMessageSpy).to.have.been.calledThrice;
+              const resumeMessage = sendMessageSpy.thirdCall.args[0];
+              expect(resumeMessage.resume).to.not.be.undefined;
+              expect(resumeMessage.requestId).to.equal(subscribeRequestId);
+            });
+
+            // TODO: VERIFY
+            it('should resume first, and then pop as execute if unsubscribed while waiting', async () => {
+              const sendMessageSpy = sinon.spy(transport, 'sendMessage');
+              const observer = {
+                onData: sinon.spy(),
+                onDisconnect: sinon.spy(),
+                onError: sinon.spy()
+              };
+
+              transport.invokeSubscribe(observer, queryName1, variables1);
+              expect(sendMessageSpy).to.have.been.calledOnce;
+              const subscribeRequestId =
+                sendMessageSpy.firstCall.args[0].requestId;
+
+              const queryPromise1 = transport.invokeQuery(
+                queryName1,
+                variables1
+              );
+              expect(sendMessageSpy).to.have.been.calledTwice;
+
+              void transport.invokeQuery(queryName1, variables1);
+              expect(sendMessageSpy).to.have.been.calledTwice;
+
+              transport.invokeUnsubscribe(queryName1, variables1);
+              expect(sendMessageSpy).to.have.been.calledTwice;
+
+              const response1 = {
+                data: { result: '1' },
+                errors: [],
+                extensions: {}
+              };
+              await transport.invokeHandleResponse(
+                subscribeRequestId,
+                response1
+              );
+              await queryPromise1;
+
+              expect(sendMessageSpy.callCount).to.equal(4);
+              const cancelMessage = sendMessageSpy.getCall(2).args[0];
+              expect(cancelMessage.cancel).to.not.be.undefined;
+
+              const executeMessage = sendMessageSpy.getCall(3).args[0];
+              expect(executeMessage.execute).to.not.be.undefined;
+              expect(executeMessage.requestId).to.not.equal(subscribeRequestId);
+            });
           });
         });
       });
@@ -693,7 +897,7 @@ describe('AbstractDataConnectStreamTransport', () => {
           expect(requests).to.have.lengthOf(1);
           expect(requests![0].execute?.operationName).to.equal(mutationName1);
           const requestId = requests![0].requestId;
-          expect(transport.invokeOperationPromises.has(requestId)).to.be.true;
+          expect(transport.executeRequestPromises.has(requestId)).to.be.true;
 
           expect(sendMessageSpy).to.have.been.calledOnce;
           const sentMessage = sendMessageSpy.firstCall.args[0];
@@ -720,7 +924,7 @@ describe('AbstractDataConnectStreamTransport', () => {
             .false;
 
           const requestId = sendMessageStub.firstCall.args[0].requestId;
-          expect(transport.invokeOperationPromises.has(requestId)).to.be.false;
+          expect(transport.executeRequestPromises.has(requestId)).to.be.false;
         });
 
         describe('de-duplication', () => {
@@ -806,11 +1010,11 @@ describe('AbstractDataConnectStreamTransport', () => {
 
             expect(transport.activeInvokeMutationRequests.has(mapKey)).to.be
               .false;
-            expect(transport.invokeOperationPromises.has(requestId1)).to.be
+            expect(transport.executeRequestPromises.has(requestId1)).to.be
               .false;
-            expect(transport.invokeOperationPromises.has(requestId2)).to.be
+            expect(transport.executeRequestPromises.has(requestId2)).to.be
               .false;
-            expect(transport.invokeOperationPromises.has(requestId3)).to.be
+            expect(transport.executeRequestPromises.has(requestId3)).to.be
               .false;
           });
         });
@@ -957,6 +1161,80 @@ describe('AbstractDataConnectStreamTransport', () => {
           expect(transport.subscribeObservers.has(subscribeRequestId)).to.be
             .false;
         });
+
+        // TODO: VERIFY
+        it('should defer cancellation if there is a pending resume request', async () => {
+          const sendMessageSpy = sinon.spy(transport, 'sendMessage');
+          const observer = {
+            onData: sinon.spy(),
+            onDisconnect: sinon.spy(),
+            onError: sinon.spy()
+          };
+
+          transport.invokeSubscribe(observer, queryName1, variables1);
+          const subscribeRequestId = sendMessageSpy.firstCall.args[0].requestId;
+
+          const queryPromise = transport.invokeQuery(queryName1, variables1);
+          expect(sendMessageSpy).to.have.been.calledTwice;
+
+          // Unsubscribe while resume is pending
+          transport.invokeUnsubscribe(queryName1, variables1);
+          // Should NOT have sent cancel message yet
+          expect(sendMessageSpy).to.have.been.calledTwice;
+
+          const response = {
+            data: { result: '1' },
+            errors: [],
+            extensions: {}
+          };
+          await transport.invokeHandleResponse(subscribeRequestId, response);
+          expect(await queryPromise).to.deep.equal(response);
+
+          // Now cancel message should be sent
+          expect(sendMessageSpy).to.have.been.calledThrice;
+          const cancelMessage = sendMessageSpy.thirdCall.args[0];
+          expect(cancelMessage.cancel).to.not.be.undefined;
+          expect(cancelMessage.requestId).to.equal(subscribeRequestId);
+        });
+
+        // TODO: VERIFY
+        it('should resurrect a subscription if re-subscribed while pending cancellation', async () => {
+          sinon.stub(transport, 'sendMessage').resolves();
+          const observer1 = {
+            onData: sinon.spy(),
+            onDisconnect: sinon.spy(),
+            onError: sinon.spy()
+          };
+          const observer2 = {
+            onData: sinon.spy(),
+            onDisconnect: sinon.spy(),
+            onError: sinon.spy()
+          };
+
+          transport.invokeSubscribe(observer1, queryName1, variables1);
+          const subscribeRequestId =
+            transport.activeInvokeSubscribeRequests.get(
+              transport.getMapKey(queryName1, variables1)
+            )!.requestId;
+
+          // Start a resume to put it in flight
+          void transport.invokeQuery(queryName1, variables1);
+
+          // Unsubscribe -> goes to pendingCancellations
+          transport.invokeUnsubscribe(queryName1, variables1);
+          expect(transport.pendingCancellations.has(subscribeRequestId)).to.be
+            .true;
+          expect(transport.subscribeObservers.has(subscribeRequestId)).to.be
+            .false;
+
+          // Re-subscribe -> should resurrect!
+          transport.invokeSubscribe(observer2, queryName1, variables1);
+          expect(transport.pendingCancellations.has(subscribeRequestId)).to.be
+            .false;
+          expect(transport.subscribeObservers.get(subscribeRequestId)).to.equal(
+            observer2
+          );
+        });
       });
     });
 
@@ -992,20 +1270,20 @@ describe('AbstractDataConnectStreamTransport', () => {
         extensions: {}
       };
 
-      it('should throw an error if an unrecognized requestId is received', async () => {
+      it('should log a warning if an unrecognized requestId is received', async () => {
+        const logWarnStub = sinon.stub(console, 'warn');
         const unknownRequestId = 'unknown-999';
         const response: DataConnectResponse<unknown> = {
           data: {},
           errors: [],
           extensions: {}
         };
-        const errorPromise = transport.invokeHandleResponse(
-          unknownRequestId,
-          response
-        );
-        await expect(errorPromise).to.be.rejectedWith(
+        await transport.invokeHandleResponse(unknownRequestId, response);
+        expect(logWarnStub).to.have.been.calledOnce;
+        expect(logWarnStub).to.have.been.calledWithMatch(
           `Stream response contained unrecognized requestId '${unknownRequestId}'`
         );
+        logWarnStub.restore();
       });
 
       describe('invokeQuery tracking', async () => {
@@ -1102,15 +1380,15 @@ describe('AbstractDataConnectStreamTransport', () => {
           await transport.invokeHandleResponse(requestId1, errorResponse);
           expect(transport.activeInvokeQueryRequests.has(expectedKey1)).to.be
             .false;
-          expect(transport.invokeOperationPromises.has(requestId1)).to.be.false;
+          expect(transport.executeRequestPromises.has(requestId1)).to.be.false;
           expect(transport.activeInvokeQueryRequests.has(expectedKey2)).to.be
             .true;
-          expect(transport.invokeOperationPromises.has(requestId2)).to.be.true;
+          expect(transport.executeRequestPromises.has(requestId2)).to.be.true;
 
           await transport.invokeHandleResponse(requestId2, errorResponse);
           expect(transport.activeInvokeQueryRequests.has(expectedKey2)).to.be
             .false;
-          expect(transport.invokeOperationPromises.has(requestId2)).to.be.false;
+          expect(transport.executeRequestPromises.has(requestId2)).to.be.false;
         });
       });
 
@@ -1165,16 +1443,16 @@ describe('AbstractDataConnectStreamTransport', () => {
 
           await transport.invokeHandleResponse(requestId1, response1);
           await mutationPromise1;
-          expect(transport.invokeOperationPromises.has(requestId1)).to.be.false;
+          expect(transport.executeRequestPromises.has(requestId1)).to.be.false;
           expect(transport.activeInvokeMutationRequests.has(expectedKey1)).to.be
             .false;
-          expect(transport.invokeOperationPromises.has(requestId2)).to.be.true;
+          expect(transport.executeRequestPromises.has(requestId2)).to.be.true;
           expect(transport.activeInvokeMutationRequests.has(expectedKey2)).to.be
             .true;
 
           await transport.invokeHandleResponse(requestId2, response2);
           await mutationPromise2;
-          expect(transport.invokeOperationPromises.has(requestId2)).to.be.false;
+          expect(transport.executeRequestPromises.has(requestId2)).to.be.false;
           expect(transport.activeInvokeMutationRequests.has(expectedKey2)).to.be
             .false;
         });
@@ -1228,15 +1506,15 @@ describe('AbstractDataConnectStreamTransport', () => {
           await transport.invokeHandleResponse(requestId1, errorResponse);
           expect(transport.activeInvokeMutationRequests.has(expectedKey1)).to.be
             .false;
-          expect(transport.invokeOperationPromises.has(requestId1)).to.be.false;
+          expect(transport.executeRequestPromises.has(requestId1)).to.be.false;
           expect(transport.activeInvokeMutationRequests.has(expectedKey2)).to.be
             .true;
-          expect(transport.invokeOperationPromises.has(requestId2)).to.be.true;
+          expect(transport.executeRequestPromises.has(requestId2)).to.be.true;
 
           await transport.invokeHandleResponse(requestId2, errorResponse);
           expect(transport.activeInvokeMutationRequests.has(expectedKey2)).to.be
             .false;
-          expect(transport.invokeOperationPromises.has(requestId2)).to.be.false;
+          expect(transport.executeRequestPromises.has(requestId2)).to.be.false;
         });
       });
 

--- a/packages/data-connect/test/unit/streamTransport.test.ts
+++ b/packages/data-connect/test/unit/streamTransport.test.ts
@@ -475,7 +475,6 @@ describe('AbstractDataConnectStreamTransport', () => {
 
         describe('optimizations', () => {
           describe('prefer resume over execute when executing already subscribed queries', () => {
-            // TODO: VERIFY
             it('should send a resume payload if there is an active subscription', async () => {
               const sendMessageSpy = sinon.spy(transport, 'sendMessage');
               const observer = {
@@ -511,7 +510,6 @@ describe('AbstractDataConnectStreamTransport', () => {
               expect(await queryPromise).to.deep.equal(response);
             });
 
-            // TODO: VERIFY
             it('should resolve resume promise even if observer callback throws', async () => {
               sinon.stub(transport, 'sendMessage').resolves();
               const observer = {
@@ -767,7 +765,6 @@ describe('AbstractDataConnectStreamTransport', () => {
                 .false;
             });
 
-            // TODO: VERIFY
             it('should de-duplicate identical resume requests', async () => {
               sinon.stub(transport, 'sendMessage').resolves();
               const observer = {
@@ -793,7 +790,6 @@ describe('AbstractDataConnectStreamTransport', () => {
               }
             });
 
-            // TODO: VERIFY
             it('should execute first, and then pop as resume if subscribed while waiting', async () => {
               const sendMessageSpy = sinon.spy(transport, 'sendMessage');
 
@@ -833,7 +829,6 @@ describe('AbstractDataConnectStreamTransport', () => {
               expect(resumeMessage.requestId).to.equal(subscribeRequestId);
             });
 
-            // TODO: VERIFY
             it('should resume first, and then pop as execute if unsubscribed while waiting', async () => {
               const sendMessageSpy = sinon.spy(transport, 'sendMessage');
               const observer = {
@@ -1162,7 +1157,6 @@ describe('AbstractDataConnectStreamTransport', () => {
             .false;
         });
 
-        // TODO: VERIFY
         it('should defer cancellation if there is a pending resume request', async () => {
           const sendMessageSpy = sinon.spy(transport, 'sendMessage');
           const observer = {
@@ -1197,7 +1191,6 @@ describe('AbstractDataConnectStreamTransport', () => {
           expect(cancelMessage.requestId).to.equal(subscribeRequestId);
         });
 
-        // TODO: VERIFY
         it('should resurrect a subscription if re-subscribed while pending cancellation', async () => {
           sinon.stub(transport, 'sendMessage').resolves();
           const observer1 = {


### PR DESCRIPTION
## Description
✨ Implement the "resume over execute" optimization to reduce network overhead for active subscriptions.

## Changes
- Modified query flow to automatically switch from `execute` to `resume` wire payloads when active subscriptions exist.
  - Queued requests to execute a query will check at the time their queue pops whether they should be `execute` or `resume` messages - regardless of whether they would have been `execute` or `resume` at the time they were queued.
- Added `resumeRequestPromises` map to track resume operations in flight.
- Added `pendingCancellations` state tracking to buffer unsubscriptions during pending execution streams. Re-subscribing will cancel these pending cancellations.
- Guarded subscription observers within fault-tolerant error blocks to isolate user-code crashes.

## Testing
- Added internal verification constraints for resume de-duplication strategies.
- Added test modules covering dynamic deferred cancellations and resurrection bindings.