### PR TITLE
Instantiate a RootSpanContextManager and save it on CrashlyticsService

### DIFF
--- a/packages/crashlytics/src/api.test.ts
+++ b/packages/crashlytics/src/api.test.ts
@@ -39,6 +39,7 @@ import { registerCrashlytics } from './register';
 import { _FirebaseInstallationsInternal } from '@firebase/installations';
 import { AUTO_CONSTANTS } from './auto-constants';
 import { CrashlyticsInternal } from './types';
+import { RootSpanContextManager } from './tracing/root-span-context-manager';
 
 const PROJECT_ID = 'my-project';
 const APP_ID = 'my-appid';
@@ -74,6 +75,11 @@ const fakeTracingProvider = {
   shutdown: () => Promise.resolve()
 } as unknown as TracerProvider;
 
+const fakeContextManager = {
+  getRootSpan: () => undefined,
+  setRootSpan: () => {}
+} as unknown as RootSpanContextManager;
+
 const fakeCrashlytics: CrashlyticsInternal = {
   app: {
     name: 'DEFAULT',
@@ -84,7 +90,8 @@ const fakeCrashlytics: CrashlyticsInternal = {
     }
   },
   loggerProvider: fakeLoggerProvider,
-  tracingProvider: fakeTracingProvider
+  tracingProvider: fakeTracingProvider,
+  contextManager: fakeContextManager
 };
 
 describe('Top level API', () => {
@@ -180,6 +187,25 @@ describe('Top level API', () => {
       expect(() => {
         getCrashlytics(app, {});
       }).to.throw('getCrashlytics() cannot be called with different options');
+    });
+  });
+
+  describe('Multi-App Isolation', () => {
+    it('should provide different instances of RootSpanContextManager for different apps', () => {
+      const app1 = getFakeApp();
+      const app2 = initializeApp({ projectId: 'p2', appId: 'a2' }, 'app2');
+
+      const crash1 = getCrashlytics(app1);
+      const crash2 = getCrashlytics(app2);
+
+      const manager1 = (crash1 as CrashlyticsInternal).contextManager;
+      const manager2 = (crash2 as CrashlyticsInternal).contextManager;
+
+      expect(manager1).to.be.instanceOf(RootSpanContextManager);
+      expect(manager2).to.be.instanceOf(RootSpanContextManager);
+      expect(manager1).to.not.equal(manager2);
+
+      deleteApp(app2);
     });
   });
 
@@ -334,7 +360,8 @@ describe('Top level API', () => {
       const crashlytics = new CrashlyticsService(
         fakeCrashlytics.app,
         fakeLoggerProvider,
-        fakeTracingProvider
+        fakeTracingProvider,
+        fakeContextManager
       );
       crashlytics.options = {
         appVersion: '1.0.0'
@@ -502,3 +529,4 @@ function getFakeApp(): FirebaseApp {
   );
   return app;
 }
+

--- a/packages/crashlytics/src/helpers.test.ts
+++ b/packages/crashlytics/src/helpers.test.ts
@@ -28,6 +28,7 @@ import {
 import { AUTO_CONSTANTS } from './auto-constants';
 import { CrashlyticsService } from './service';
 import { CrashlyticsInternal } from './types';
+import { RootSpanContextManager } from './tracing/root-span-context-manager';
 
 const MOCK_SESSION_ID = '00000000-0000-0000-0000-000000000000';
 
@@ -43,6 +44,15 @@ describe('helpers', () => {
     getLogger: (): Logger => {
       return {
         emit: (logRecord: LogRecord) => {
+          const rootSpan = fakeContextManager.getRootSpan();
+          if (rootSpan) {
+            const spanContext = rootSpan.spanContext();
+            logRecord.attributes = {
+              ...logRecord.attributes,
+              [CRASHLYTICS_ATTRIBUTE_KEYS.TRACE_ID]: spanContext.traceId,
+              [CRASHLYTICS_ATTRIBUTE_KEYS.SPAN_ID]: spanContext.spanId
+            };
+          }
           emittedLogs.push(logRecord);
         }
       };
@@ -75,6 +85,13 @@ describe('helpers', () => {
     shutdown: () => Promise.resolve()
   } as unknown as TracerProvider;
 
+  const fakeContextManager = {
+    getRootSpan: () => ({
+      spanContext: () => ({ traceId: 'my-trace', spanId: 'my-span' })
+    }),
+    setRootSpan: () => {}
+  } as unknown as RootSpanContextManager;
+
   const fakeCrashlytics: CrashlyticsInternal = {
     app: {
       name: 'DEFAULT',
@@ -85,7 +102,8 @@ describe('helpers', () => {
       }
     },
     loggerProvider: fakeLoggerProvider,
-    tracingProvider: fakeTracingProvider
+    tracingProvider: fakeTracingProvider,
+    contextManager: fakeContextManager
   };
 
   beforeEach(() => {
@@ -166,7 +184,8 @@ describe('helpers', () => {
       const telemetryWithVersion = new CrashlyticsService(
         fakeCrashlytics.app,
         fakeLoggerProvider,
-        fakeTracingProvider
+        fakeTracingProvider,
+        fakeContextManager
       );
       telemetryWithVersion.options = { appVersion: '9.9.9' };
 
@@ -218,3 +237,4 @@ describe('helpers', () => {
     }
   });
 });
+

--- a/packages/crashlytics/src/helpers.ts
+++ b/packages/crashlytics/src/helpers.ts
@@ -25,7 +25,7 @@ import {
 import { Crashlytics, CrashlyticsOptions } from './public-types';
 import { CrashlyticsService } from './service';
 import { CrashlyticsInternal } from './types';
-import { rootSpanContextManager } from './tracing/root-span-context-manager';
+import { RootSpanContextManager } from './tracing/root-span-context-manager';
 import type { Span } from '@opentelemetry/api';
 
 /**
@@ -98,12 +98,11 @@ export function startNewSession(crashlytics: Crashlytics): void {
  * @param rootSpanName - The name of the root span.
  */
 export function startNewTrace(crashlytics: Crashlytics, rootSpanName: string): Span {
-  const tracer = (crashlytics as CrashlyticsInternal).tracingProvider.getTracer(
-    CRASHLYTICS_TRACER_NAME
-  );
-  const previousRootSpan = rootSpanContextManager.getRootSpan();
+  const { contextManager, tracingProvider } = crashlytics as CrashlyticsInternal;
+  const tracer = tracingProvider.getTracer(CRASHLYTICS_TRACER_NAME);
+  const previousRootSpan = contextManager.getRootSpan();
   const newRootSpan = tracer.startSpan(rootSpanName);
-  rootSpanContextManager.setRootSpan(newRootSpan);
+  contextManager.setRootSpan(newRootSpan);
   if (previousRootSpan) {
     // TODO: Add logic to also end all child spans 
     previousRootSpan.end();
@@ -116,17 +115,18 @@ export function startNewTrace(crashlytics: Crashlytics, rootSpanName: string): S
  * may trigger at the same time, but flushing only occurs once per batch.
  */
 export function registerListeners(crashlytics: Crashlytics): void {
+  const { contextManager } = crashlytics as CrashlyticsInternal;
   if (typeof window !== 'undefined' && typeof document !== 'undefined') {
     window.addEventListener('visibilitychange', async () => {
       if (document.visibilityState === 'hidden') {
         // TODO: Update this with idleness logic instead
-        rootSpanContextManager.getRootSpan()?.end();
+        contextManager.getRootSpan()?.end();
         await flush(crashlytics);
       }
     });
     window.addEventListener('pagehide', async () => {
         // TODO: Update this with idleness logic instead
-      rootSpanContextManager.getRootSpan()?.end();
+      contextManager.getRootSpan()?.end();
       await flush(crashlytics);
     });
   }

--- a/packages/crashlytics/src/helpers.ts
+++ b/packages/crashlytics/src/helpers.ts
@@ -62,8 +62,7 @@ export function getSessionId(): string | undefined {
  */
 export function startNewSession(crashlytics: Crashlytics): void {
   // Cast to CrashlyticsInternal to access internal loggerProvider
-  const { loggerProvider, tracingProvider } =
-    crashlytics as CrashlyticsInternal;
+  const { loggerProvider } = crashlytics as CrashlyticsInternal;
 
   if (
     typeof sessionStorage !== 'undefined' &&

--- a/packages/crashlytics/src/register.node.ts
+++ b/packages/crashlytics/src/register.node.ts
@@ -27,6 +27,7 @@ import { CrashlyticsService } from './service';
 import { createLoggerProvider } from './logging/logger-provider';
 import { createTracingProvider } from './tracing/tracing-provider';
 import { CrashlyticsOptions } from './public-types';
+import { RootSpanContextManager } from './tracing/root-span-context-manager';
 
 export function registerCrashlytics(): void {
   _registerComponent(
@@ -38,9 +39,19 @@ export function registerCrashlytics(): void {
         // getImmediate for FirebaseApp will always succeed
         const app = container.getProvider('app').getImmediate();
         const loggerProvider = createLoggerProvider(app, crashlyticsOptions);
-        const tracingProvider = createTracingProvider(app, crashlyticsOptions);
+        const contextManager = new RootSpanContextManager();
+        const tracingProvider = createTracingProvider(
+          app,
+          contextManager,
+          crashlyticsOptions
+        );
 
-        return new CrashlyticsService(app, loggerProvider, tracingProvider);
+        return new CrashlyticsService(
+          app,
+          loggerProvider,
+          tracingProvider,
+          contextManager
+        );
       },
       ComponentType.PUBLIC
     ).setMultipleInstances(true)

--- a/packages/crashlytics/src/register.ts
+++ b/packages/crashlytics/src/register.ts
@@ -30,6 +30,7 @@ import { InstallationIdProvider } from './logging/installation-id-provider';
 import { CRASHLYTICS_TYPE } from './constants';
 import { getSessionId, registerListeners, startNewSession } from './helpers';
 import { CrashlyticsOptions } from './public-types';
+import { RootSpanContextManager } from './tracing/root-span-context-manager';
 
 // We only import types from this package elsewhere in the `telemetry` package, so this
 // explicit import is needed here to prevent this module from being tree-shaken out.
@@ -59,8 +60,10 @@ export function registerCrashlytics(): void {
           dynamicAttributeProviders
         );
 
+        const contextManager = new RootSpanContextManager();
         const tracingProvider = createTracingProvider(
           app,
+          contextManager,
           crashlyticsOptions,
           dynamicHeaderProviders,
           dynamicAttributeProviders
@@ -69,7 +72,8 @@ export function registerCrashlytics(): void {
         const crashlyticsService = new CrashlyticsService(
           app,
           loggerProvider,
-          tracingProvider
+          tracingProvider,
+          contextManager
         );
 
         // Immediately track this as a new client session (if one doesn't exist yet)

--- a/packages/crashlytics/src/service.ts
+++ b/packages/crashlytics/src/service.ts
@@ -19,6 +19,7 @@ import { _FirebaseService, FirebaseApp } from '@firebase/app';
 import { Crashlytics, CrashlyticsOptions } from './public-types';
 import { LoggerProvider } from '@opentelemetry/sdk-logs';
 import { TracerProvider } from '@opentelemetry/api';
+import { RootSpanContextManager } from './tracing/root-span-context-manager';
 
 export class CrashlyticsService implements Crashlytics, _FirebaseService {
   private _options?: CrashlyticsOptions;
@@ -27,7 +28,8 @@ export class CrashlyticsService implements Crashlytics, _FirebaseService {
   constructor(
     public app: FirebaseApp,
     public loggerProvider: LoggerProvider,
-    public tracingProvider: TracerProvider | null
+    public tracingProvider: TracerProvider | null,
+    public contextManager: RootSpanContextManager
   ) {}
 
   _delete(): Promise<void> {

--- a/packages/crashlytics/src/tracing/root-span-context-manager.ts
+++ b/packages/crashlytics/src/tracing/root-span-context-manager.ts
@@ -21,7 +21,7 @@ import { ZoneContextManager } from '@opentelemetry/context-zone';
 /**
  * A custom ContextManager that ensures the latest active root span is the default parent.
  */
-class RootSpanContextManager extends ZoneContextManager {
+export class RootSpanContextManager extends ZoneContextManager {
   private _rootSpan: Span | undefined;
 
   setRootSpan(span: Span | undefined): void {
@@ -41,19 +41,3 @@ class RootSpanContextManager extends ZoneContextManager {
     return context;
   }
 }
-
-const rootSpanContextManagerKey = Symbol.for("firebase.crashlytics.rootSpanContextManager");
-
-function getRootSpanContextManager(): RootSpanContextManager {
-  const globalObj = globalThis as any;
-  if (!globalObj[rootSpanContextManagerKey]) {
-    globalObj[rootSpanContextManagerKey] = new RootSpanContextManager();
-  }
-  return globalObj[rootSpanContextManagerKey];
-}
-
-/**
- * Global instance of the RootSpanContextManager.
- * @internal
- */
-export const rootSpanContextManager = getRootSpanContextManager();

--- a/packages/crashlytics/src/tracing/tracing-provider.ts
+++ b/packages/crashlytics/src/tracing/tracing-provider.ts
@@ -41,7 +41,7 @@ import { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
 import { DynamicHeaderProvider, DynamicAttributeProvider } from '../types';
 import { FirebaseApp } from '@firebase/app';
 import { FirebaseSpanProcessor } from './firebase-span-processor';
-import { rootSpanContextManager } from './root-span-context-manager';
+import { RootSpanContextManager } from './root-span-context-manager';
 import { JsonTraceSerializer } from '@opentelemetry/otlp-transformer';
 import { FetchTransport } from '../fetch-transport';
 import { RESOURCE_ATTRIBUTE_KEYS } from '../constants';
@@ -54,6 +54,7 @@ import { CrashlyticsOptions } from '../public-types';
  */
 export function createTracingProvider(
   app: FirebaseApp,
+  rootSpanContextManager: RootSpanContextManager,
   crashlyticsOptions: CrashlyticsOptions,
   dynamicHeaderProviders: DynamicHeaderProvider[] = [],
   dynamicAttributeProviders: DynamicAttributeProvider[] = []

--- a/packages/crashlytics/src/tracing/tracing-provider.ts
+++ b/packages/crashlytics/src/tracing/tracing-provider.ts
@@ -21,7 +21,7 @@ import {
   ExportResult,
   W3CTraceContextPropagator
 } from '@opentelemetry/core';
-import { TracerProvider, trace, context } from '@opentelemetry/api';
+import { TracerProvider, trace } from '@opentelemetry/api';
 import {
   WebTracerProvider,
   BatchSpanProcessor,
@@ -41,7 +41,7 @@ import { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
 import { DynamicHeaderProvider, DynamicAttributeProvider } from '../types';
 import { FirebaseApp } from '@firebase/app';
 import { FirebaseSpanProcessor } from './firebase-span-processor';
-import { RootSpanContextManager } from './root-span-context-manager';
+import type { RootSpanContextManager } from './root-span-context-manager';
 import { JsonTraceSerializer } from '@opentelemetry/otlp-transformer';
 import { FetchTransport } from '../fetch-transport';
 import { RESOURCE_ATTRIBUTE_KEYS } from '../constants';

--- a/packages/crashlytics/src/types.ts
+++ b/packages/crashlytics/src/types.ts
@@ -18,6 +18,7 @@
 import { LoggerProvider } from '@opentelemetry/sdk-logs';
 import { TracerProvider } from '@opentelemetry/api';
 import { Crashlytics } from './public-types';
+import { RootSpanContextManager } from './tracing/root-span-context-manager';
 
 /**
  * An internal interface for the Crashlytics service.
@@ -27,6 +28,7 @@ import { Crashlytics } from './public-types';
 export interface CrashlyticsInternal extends Crashlytics {
   loggerProvider: LoggerProvider;
   tracingProvider: TracerProvider;
+  contextManager: RootSpanContextManager;
 }
 
 type KeyValuePair = [key: string, value: string];


### PR DESCRIPTION
This is the more Firebase idiomatic way to address the "multiple context managers" issue and ultimately replaces the global singleton approach. This works because _registerComponent is a factory function and is guaranteed to be called once. When we save the RootSpanContextManager object reference on CrashlyticsService, all module callers of RootSpanContextManager will end up with the same instance.