### PR TITLE
test(firestore): generate html coverage report

### DIFF
--- a/packages/firestore/scripts/run-tests.ts
+++ b/packages/firestore/scripts/run-tests.ts
@@ -73,6 +73,8 @@ let executable = nyc;
 let args = [
   '--reporter',
   'lcovonly',
+  '--reporter',
+  'html',
   mocha,
   '--require',
   babel,


### PR DESCRIPTION
Adds the `html` istanbul reporter.

This allows us to view the coverage report by opening `packages/firestore/coverage/index.html`.