### PR TITLE
test(firestore): extend database source test timeout to 30s

### DIFF
--- a/packages/firestore/test/integration/api/pipeline.test.ts
+++ b/packages/firestore/test/integration/api/pipeline.test.ts
@@ -623,7 +623,7 @@ apiDescribe.skipClassic('Pipelines', persistence => {
           .sort(ascending('order'))
       );
       expectResults(snapshot, doc1.id, doc2.id);
-    });
+    }).timeout(30_000);
   });
 
   describe('supported data types', () => {

--- a/packages/firestore/test/lite/pipeline.test.ts
+++ b/packages/firestore/test/lite/pipeline.test.ts
@@ -623,7 +623,7 @@ describe.skipClassic('Firestore Pipelines', () => {
           .sort(ascending('order'))
       );
       expectResults(snapshot, doc1.id, doc2.id);
-    }).timeout(30_000); // Returning all the documents in the database is slow.
+    }).timeout(30_000); // Database-wide pipelines can be slow to execute.
 
     it('can create pipeline from a query', async () => {
       const snapshot = await execute(

--- a/packages/firestore/test/lite/pipeline.test.ts
+++ b/packages/firestore/test/lite/pipeline.test.ts
@@ -623,7 +623,7 @@ describe.skipClassic('Firestore Pipelines', () => {
           .sort(ascending('order'))
       );
       expectResults(snapshot, doc1.id, doc2.id);
-    });
+    }).timeout(30_000); // Returning all the documents in the database is slow.
 
     it('can create pipeline from a query', async () => {
       const snapshot = await execute(


### PR DESCRIPTION
Extend the timeout of the database source pipeline test from 20s to 30s. This test is very slow and is exceeding the 20s timeout, causing the test to fail locally and in CI.
