### PR TITLE
changing firebase telemetry server endpoint for future change

### DIFF
--- a/packages/crashlytics/src/tracing/tracing-provider.ts
+++ b/packages/crashlytics/src/tracing/tracing-provider.ts
@@ -90,7 +90,7 @@ export function createTracingProvider(
       }
     });
   } else {
-    otlpEndpoint = `${tracingUrl}/v1/projects/${projectId}/locations/global/apps/${appId}/traces`;
+    otlpEndpoint = `${tracingUrl}/v1/projects/${projectId}/apps/${appId}/locations/global/traces`;
     traceExporter = new OTLPTraceExporter(
       {
         url: otlpEndpoint,


### PR DESCRIPTION
Adjusting future endpoint path for firebase telemetry server

Proxy server doesn't seem to depend on this path and current resource and span attributes don't seem to depend on it either.