### PR TITLE
feat(ai): honor responseJsonSchema in chrome adapter

### DIFF
--- a/packages/ai/src/methods/chrome-adapter-browser.test.ts
+++ b/packages/ai/src/methods/chrome-adapter-browser.test.ts
@@ -573,6 +573,42 @@ describe('ChromeAdapter', () => {
         promptOptions
       );
     });
+    it('honors responseJsonSchema in generationConfig', async () => {
+      const languageModel = {
+        prompt: (_p: LanguageModelMessage[]) => Promise.resolve('')
+      } as LanguageModel;
+      const languageModelProvider = {
+        create: () => Promise.resolve(languageModel)
+      } as LanguageModel;
+      const promptOutput = '{}';
+      const promptStub = stub(languageModel, 'prompt').resolves(promptOutput);
+      const adapter = new ChromeAdapterImpl(
+        languageModelProvider,
+        InferenceMode.PREFER_ON_DEVICE
+      );
+      const responseJsonSchema = { type: 'object', properties: {} };
+      const request = {
+        contents: [{ role: 'user', parts: [{ text: 'anything' }] }],
+        generationConfig: {
+          responseJsonSchema
+        }
+      } as GenerateContentRequest;
+      await adapter.generateContent(request);
+      expect(promptStub).to.have.been.calledOnceWith(
+        [
+          {
+            role: request.contents[0].role,
+            content: [
+              {
+                type: 'text',
+                value: request.contents[0].parts[0].text
+              }
+            ]
+          }
+        ],
+        { responseConstraint: responseJsonSchema }
+      );
+    });
     it('normalizes roles', async () => {
       const languageModel = {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -791,6 +827,43 @@ describe('ChromeAdapter', () => {
           }
         ],
         promptOptions
+      );
+    });
+    it('honors responseJsonSchema in generationConfig', async () => {
+      const languageModel = {
+        promptStreaming: _p => new ReadableStream()
+      } as LanguageModel;
+      const languageModelProvider = {
+        create: () => Promise.resolve(languageModel)
+      } as LanguageModel;
+      const promptStub = stub(languageModel, 'promptStreaming').returns(
+        new ReadableStream()
+      );
+      const adapter = new ChromeAdapterImpl(
+        languageModelProvider,
+        InferenceMode.PREFER_ON_DEVICE
+      );
+      const responseJsonSchema = { type: 'object', properties: {} };
+      const request = {
+        contents: [{ role: 'user', parts: [{ text: 'anything' }] }],
+        generationConfig: {
+          responseJsonSchema
+        }
+      } as GenerateContentRequest;
+      await adapter.generateContentStream(request);
+      expect(promptStub).to.have.been.calledOnceWith(
+        [
+          {
+            role: request.contents[0].role,
+            content: [
+              {
+                type: 'text',
+                value: request.contents[0].parts[0].text
+              }
+            ]
+          }
+        ],
+        { responseConstraint: responseJsonSchema }
       );
     });
     it('normalizes roles', async () => {

--- a/packages/ai/src/methods/chrome-adapter.ts
+++ b/packages/ai/src/methods/chrome-adapter.ts
@@ -156,10 +156,11 @@ export class ChromeAdapterImpl implements ChromeAdapter {
     const contents = await Promise.all(
       request.contents.map(ChromeAdapterImpl.toLanguageModelMessage)
     );
-    const text = await session.prompt(
-      contents,
-      this.onDeviceParams.promptOptions
-    );
+    const promptOptions = { ...this.onDeviceParams.promptOptions };
+    if (request.generationConfig?.responseJsonSchema) {
+      promptOptions.responseConstraint = request.generationConfig.responseJsonSchema;
+    }
+    const text = await session.prompt(contents, promptOptions);
     return ChromeAdapterImpl.toResponse(text);
   }
 
@@ -179,10 +180,11 @@ export class ChromeAdapterImpl implements ChromeAdapter {
     const contents = await Promise.all(
       request.contents.map(ChromeAdapterImpl.toLanguageModelMessage)
     );
-    const stream = session.promptStreaming(
-      contents,
-      this.onDeviceParams.promptOptions
-    );
+    const promptOptions = { ...this.onDeviceParams.promptOptions };
+    if (request.generationConfig?.responseJsonSchema) {
+      promptOptions.responseConstraint = request.generationConfig.responseJsonSchema;
+    }
+    const stream = session.promptStreaming(contents, promptOptions);
     return ChromeAdapterImpl.toStreamResponse(stream);
   }
 


### PR DESCRIPTION
This PR adds support for structured JSON output in the Chrome on-device adapter by honoring the responseJsonSchema configuration.

Changes:

- Updated `ChromeAdapterImpl` in `packages/ai/src/methods/chrome-adapter.ts` to map `request.generationConfig.responseJsonSchema` to the `responseConstraint` option when calling the Chrome Prompt API (`prompt` and `promptStreaming`).
 - Added unit tests in `chrome-adapter-browser.test.ts` to verify that the schema is correctly passed through to the underlying browser API.
 - Tested in a sample app update in https://github.com/firebase/quickstart-js/pull/998