### PR TITLE
adding span name and url_template attributes

### DIFF
--- a/packages/crashlytics/src/constants.ts
+++ b/packages/crashlytics/src/constants.ts
@@ -45,8 +45,19 @@ export const RESOURCE_ATTRIBUTE_KEYS = {
 export const COMMON_SPAN_ATTRIBUTE_KEYS = {
   GCP_RESOURCE_NAME: 'gcp.resource.name',
   GCP_FIREBASE_SESSION_ID: 'gcp.firebase.session_id',
-  GCP_FIREBASE_APP_VERSION: 'gcp.firebase.app_version'
+  GCP_FIREBASE_APP_VERSION: 'gcp.firebase.app_version',
 };
+
+export const HTTP_SPAN_ATTRIBUTE_KEYS = {
+  HTTP_REQUEST_METHOD: 'http.request.method',
+  URL_TEMPLATE: 'url.template'
+};
+
+/** Scope names of request instrumentation used for collecting spans  **/
+export const REQUEST_SCOPE_NAMES = new Set<string>([
+  "@opentelemetry/instrumentation-fetch",
+  "@opentelemetry/instrumentation-xml-http-request"
+])
 
 /**
  * Label keys that we write in log entries stemming from web framework wrappers.

--- a/packages/crashlytics/src/constants.ts
+++ b/packages/crashlytics/src/constants.ts
@@ -45,7 +45,7 @@ export const RESOURCE_ATTRIBUTE_KEYS = {
 export const COMMON_SPAN_ATTRIBUTE_KEYS = {
   GCP_RESOURCE_NAME: 'gcp.resource.name',
   GCP_FIREBASE_SESSION_ID: 'gcp.firebase.session_id',
-  GCP_FIREBASE_APP_VERSION: 'gcp.firebase.app_version',
+  GCP_FIREBASE_APP_VERSION: 'gcp.firebase.app_version'
 };
 
 export const HTTP_SPAN_ATTRIBUTE_KEYS = {

--- a/packages/crashlytics/src/tracing/firebase-span-processor.ts
+++ b/packages/crashlytics/src/tracing/firebase-span-processor.ts
@@ -18,7 +18,7 @@
 import { Context, Span } from '@opentelemetry/api';
 import { SpanProcessor, ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { getAppVersion, getSessionId } from '../helpers';
-import { COMMON_SPAN_ATTRIBUTE_KEYS } from '../constants';
+import { COMMON_SPAN_ATTRIBUTE_KEYS, HTTP_SPAN_ATTRIBUTE_KEYS } from '../constants';
 import { CrashlyticsOptions } from '../public-types';
 import { FirebaseOptions } from '@firebase/app';
 
@@ -50,6 +50,10 @@ export class FirebaseSpanProcessor implements SpanProcessor {
     span.setAttribute(
       COMMON_SPAN_ATTRIBUTE_KEYS.GCP_FIREBASE_APP_VERSION,
       getAppVersion(this.crashlyticsOptions)
+    );
+    span.setAttribute(
+      HTTP_SPAN_ATTRIBUTE_KEYS.URL_TEMPLATE,
+      `/v1/projects/${this.firebaseOptions.projectId}`
     );
   }
 

--- a/packages/crashlytics/src/tracing/tracing-provider.ts
+++ b/packages/crashlytics/src/tracing/tracing-provider.ts
@@ -44,7 +44,7 @@ import { FirebaseSpanProcessor } from './firebase-span-processor';
 import type { RootSpanContextManager } from './root-span-context-manager';
 import { JsonTraceSerializer } from '@opentelemetry/otlp-transformer';
 import { FetchTransport } from '../fetch-transport';
-import { RESOURCE_ATTRIBUTE_KEYS } from '../constants';
+import { HTTP_SPAN_ATTRIBUTE_KEYS, REQUEST_SCOPE_NAMES, RESOURCE_ATTRIBUTE_KEYS } from '../constants';
 import { CrashlyticsOptions } from '../public-types';
 
 /**
@@ -201,6 +201,13 @@ class OTLPTraceExporter
 
     if (Object.keys(attributesToApply).length > 0) {
       spans.forEach(span => {
+        const scope = span.instrumentationScope;
+        if (REQUEST_SCOPE_NAMES.has(scope.name)) {
+          const method = span.attributes[HTTP_SPAN_ATTRIBUTE_KEYS.HTTP_REQUEST_METHOD];
+          const urlTemplate = span.attributes[HTTP_SPAN_ATTRIBUTE_KEYS.URL_TEMPLATE];
+          (span as any).name = `${method} ${urlTemplate}`;
+        }
+
         Object.assign(span.attributes, attributesToApply);
       });
     }


### PR DESCRIPTION
Adding the url.template span attribute in order to set the span name to the low cardinality ${method} ${urlTemplate} for captured network requests via the fetch and xhr instrumentation tools.