### PR TITLE
Add ability to pass in env var into initializeApp

### DIFF
--- a/.changeset/stupid-pans-shave.md
+++ b/.changeset/stupid-pans-shave.md
@@ -1,0 +1,5 @@
+---
+"@firebase/app": patch
+---
+
+Add ability to pass in a Node environment variable into `initializeApp` and `initializeServerApp`

--- a/.changeset/stupid-pans-shave.md
+++ b/.changeset/stupid-pans-shave.md
@@ -3,4 +3,4 @@
 "firebase": minor
 ---
 
-Add ability to pass in a Node environment variable into `initializeApp` and `initializeServerApp`
+Add option to pass Firebase config as a JSON string into `initializeApp` and `initializeServerApp`.

--- a/.changeset/stupid-pans-shave.md
+++ b/.changeset/stupid-pans-shave.md
@@ -1,5 +1,6 @@
 ---
 "@firebase/app": minor
+"firebase": minor
 ---
 
 Add ability to pass in a Node environment variable into `initializeApp` and `initializeServerApp`

--- a/.changeset/stupid-pans-shave.md
+++ b/.changeset/stupid-pans-shave.md
@@ -1,5 +1,5 @@
 ---
-"@firebase/app": patch
+"@firebase/app": minor
 ---
 
 Add ability to pass in a Node environment variable into `initializeApp` and `initializeServerApp`

--- a/common/api-review/app.api.md
+++ b/common/api-review/app.api.md
@@ -113,7 +113,7 @@ export function initializeApp(options: FirebaseOptions | string, config?: Fireba
 export function initializeApp(): FirebaseApp;
 
 // @public
-export function initializeServerApp(options: FirebaseOptions | FirebaseApp, config?: FirebaseServerAppSettings): FirebaseServerApp;
+export function initializeServerApp(options: FirebaseOptions | FirebaseApp | string, config?: FirebaseServerAppSettings): FirebaseServerApp;
 
 // @public
 export function initializeServerApp(config?: FirebaseServerAppSettings): FirebaseServerApp;

--- a/common/api-review/app.api.md
+++ b/common/api-review/app.api.md
@@ -104,7 +104,10 @@ export function _getProvider<T extends Name>(app: FirebaseApp, name: T): Provide
 export function initializeApp(options: FirebaseOptions, name?: string): FirebaseApp;
 
 // @public
-export function initializeApp(options: FirebaseOptions, config?: FirebaseAppSettings): FirebaseApp;
+export function initializeApp(jsonConfigString: string, name?: string): FirebaseApp;
+
+// @public
+export function initializeApp(options: FirebaseOptions | string, config?: FirebaseAppSettings): FirebaseApp;
 
 // @public
 export function initializeApp(): FirebaseApp;
@@ -114,6 +117,9 @@ export function initializeServerApp(options: FirebaseOptions | FirebaseApp, conf
 
 // @public
 export function initializeServerApp(config?: FirebaseServerAppSettings): FirebaseServerApp;
+
+// @public
+export function initializeServerApp(jsonConfigString: string): FirebaseServerApp;
 
 // @internal (undocumented)
 export function _isFirebaseApp(obj: FirebaseApp | FirebaseOptions | FirebaseAppSettings): obj is FirebaseApp;

--- a/common/api-review/app.api.md
+++ b/common/api-review/app.api.md
@@ -104,10 +104,13 @@ export function _getProvider<T extends Name>(app: FirebaseApp, name: T): Provide
 export function initializeApp(options: FirebaseOptions, name?: string): FirebaseApp;
 
 // @public
-export function initializeApp(jsonConfigString: string, name?: string): FirebaseApp;
+export function initializeApp(jsonConfigStr: string, name?: string): FirebaseApp;
 
 // @public
-export function initializeApp(options: FirebaseOptions | string, config?: FirebaseAppSettings): FirebaseApp;
+export function initializeApp(jsonConfigStr: string, config?: FirebaseAppSettings): FirebaseApp;
+
+// @public
+export function initializeApp(options: FirebaseOptions, config?: FirebaseAppSettings): FirebaseApp;
 
 // @public
 export function initializeApp(): FirebaseApp;

--- a/docs-devsite/app.firebaseserverapp.md
+++ b/docs-devsite/app.firebaseserverapp.md
@@ -12,7 +12,7 @@ https://github.com/firebase/firebase-js-sdk
 # FirebaseServerApp interface
 A [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface) holds the initialization information for a collection of services running in server environments.
 
-Do not call this constructor directly. Instead, use [initializeServerApp()](./app.md#initializeserverapp_30ab697) to create an app.
+Do not call this constructor directly. Instead, use [initializeServerApp()](./app.md#initializeserverapp_dc3e48f) to create an app.
 
 <b>Signature:</b>
 
@@ -26,7 +26,7 @@ export interface FirebaseServerApp extends FirebaseApp
 |  Property | Type | Description |
 |  --- | --- | --- |
 |  [name](./app.firebaseserverapp.md#firebaseserverappname) | string | There is no <code>getApp()</code> operation for <code>FirebaseServerApp</code>, so the name is not relevant for applications. However, it may be used internally, and is declared here so that <code>FirebaseServerApp</code> conforms to the <code>FirebaseApp</code> interface. |
-|  [settings](./app.firebaseserverapp.md#firebaseserverappsettings) | [FirebaseServerAppSettings](./app.firebaseserverappsettings.md#firebaseserverappsettings_interface) | The (read-only) configuration settings for this server app. These are the original parameters given in [initializeServerApp()](./app.md#initializeserverapp_30ab697)<!-- -->. |
+|  [settings](./app.firebaseserverapp.md#firebaseserverappsettings) | [FirebaseServerAppSettings](./app.firebaseserverappsettings.md#firebaseserverappsettings_interface) | The (read-only) configuration settings for this server app. These are the original parameters given in [initializeServerApp()](./app.md#initializeserverapp_dc3e48f)<!-- -->. |
 
 ## FirebaseServerApp.name
 
@@ -40,7 +40,7 @@ name: string;
 
 ## FirebaseServerApp.settings
 
-The (read-only) configuration settings for this server app. These are the original parameters given in [initializeServerApp()](./app.md#initializeserverapp_30ab697)<!-- -->.
+The (read-only) configuration settings for this server app. These are the original parameters given in [initializeServerApp()](./app.md#initializeserverapp_dc3e48f)<!-- -->.
 
 <b>Signature:</b>
 

--- a/docs-devsite/app.firebaseserverappsettings.md
+++ b/docs-devsite/app.firebaseserverappsettings.md
@@ -10,7 +10,7 @@ https://github.com/firebase/firebase-js-sdk
 {% endcomment %}
 
 # FirebaseServerAppSettings interface
-Configuration options given to [initializeServerApp()](./app.md#initializeserverapp_30ab697)
+Configuration options given to [initializeServerApp()](./app.md#initializeserverapp_dc3e48f)
 
 <b>Signature:</b>
 

--- a/docs-devsite/app.md
+++ b/docs-devsite/app.md
@@ -25,6 +25,9 @@ This package coordinates the communication between the different Firebase compon
 |  [initializeApp()](./app.md#initializeapp) | Creates and initializes a FirebaseApp instance. |
 |  <b>function(config, ...)</b> |
 |  [initializeServerApp(config)](./app.md#initializeserverapp_e7d0728) | Creates and initializes a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface) instance. |
+|  <b>function(jsonConfigString, ...)</b> |
+|  [initializeApp(jsonConfigString, name)](./app.md#initializeapp_2f4985a) | Creates and initializes a FirebaseApp instance. |
+|  [initializeServerApp(jsonConfigString)](./app.md#initializeserverapp_eaf0298) | Creates and initializes a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface) instance from a JSON config string. |
 |  <b>function(libraryKeyOrName, ...)</b> |
 |  [registerVersion(libraryKeyOrName, version, variant)](./app.md#registerversion_f673248) | Registers a library's name and version for platform logging purposes. |
 |  <b>function(logCallback, ...)</b> |
@@ -35,8 +38,8 @@ This package coordinates the communication between the different Firebase compon
 |  [getApp(name)](./app.md#getapp_1eaaff4) | Retrieves a [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface) instance.<!-- -->When called with no arguments, the default app is returned. When an app name is provided, the app corresponding to that name is returned.<!-- -->An exception is thrown if the app being retrieved has not yet been initialized. |
 |  <b>function(options, ...)</b> |
 |  [initializeApp(options, name)](./app.md#initializeapp_cb2f5e1) | Creates and initializes a [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface) instance.<!-- -->See [Add Firebase to your app](https://firebase.google.com/docs/web/setup#add_firebase_to_your_app) and [Initialize multiple projects](https://firebase.google.com/docs/web/setup#multiple-projects) for detailed documentation. |
-|  [initializeApp(options, config)](./app.md#initializeapp_079e917) | Creates and initializes a FirebaseApp instance. |
-|  [initializeServerApp(options, config)](./app.md#initializeserverapp_30ab697) | Creates and initializes a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface) instance.<!-- -->The <code>FirebaseServerApp</code> is similar to <code>FirebaseApp</code>, but is intended for execution in server side rendering environments only. Initialization will fail if invoked from a browser environment.<!-- -->See [Add Firebase to your app](https://firebase.google.com/docs/web/setup#add_firebase_to_your_app) and [Initialize multiple projects](https://firebase.google.com/docs/web/setup#multiple-projects) for detailed documentation. |
+|  [initializeApp(options, config)](./app.md#initializeapp_03d4ee0) | Creates and initializes a FirebaseApp instance. |
+|  [initializeServerApp(options, config)](./app.md#initializeserverapp_dc3e48f) | Creates and initializes a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface) instance.<!-- -->The <code>FirebaseServerApp</code> is similar to <code>FirebaseApp</code>, but is intended for execution in server side rendering environments only. Initialization will fail if invoked from a browser environment.<!-- -->See [Add Firebase to your app](https://firebase.google.com/docs/web/setup#add_firebase_to_your_app) and [Initialize multiple projects](https://firebase.google.com/docs/web/setup#multiple-projects) for detailed documentation. |
 
 ## Interfaces
 
@@ -45,8 +48,8 @@ This package coordinates the communication between the different Firebase compon
 |  [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface) | A [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface) holds the initialization information for a collection of services.<!-- -->Do not call this constructor directly. Instead, use [initializeApp()](./app.md#initializeapp_cb2f5e1) to create an app. |
 |  [FirebaseAppSettings](./app.firebaseappsettings.md#firebaseappsettings_interface) | Configuration options given to [initializeApp()](./app.md#initializeapp_cb2f5e1) |
 |  [FirebaseOptions](./app.firebaseoptions.md#firebaseoptions_interface) | Firebase configuration object. Contains a set of parameters required by services in order to successfully communicate with Firebase server APIs and to associate client data with your Firebase project and Firebase application. Typically this object is populated by the Firebase console at project setup. See also: [Learn about the Firebase config object](https://firebase.google.com/docs/web/setup#config-object)<!-- -->. |
-|  [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface) | A [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface) holds the initialization information for a collection of services running in server environments.<!-- -->Do not call this constructor directly. Instead, use [initializeServerApp()](./app.md#initializeserverapp_30ab697) to create an app. |
-|  [FirebaseServerAppSettings](./app.firebaseserverappsettings.md#firebaseserverappsettings_interface) | Configuration options given to [initializeServerApp()](./app.md#initializeserverapp_30ab697) |
+|  [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface) | A [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface) holds the initialization information for a collection of services running in server environments.<!-- -->Do not call this constructor directly. Instead, use [initializeServerApp()](./app.md#initializeserverapp_dc3e48f) to create an app. |
+|  [FirebaseServerAppSettings](./app.firebaseserverappsettings.md#firebaseserverappsettings_interface) | Configuration options given to [initializeServerApp()](./app.md#initializeserverapp_dc3e48f) |
 
 ## Variables
 
@@ -149,6 +152,71 @@ If invoked in an unsupported non-server environment such as a browser.
 If [FirebaseServerAppSettings.releaseOnDeref](./app.firebaseserverappsettings.md#firebaseserverappsettingsreleaseonderef) is defined but the runtime doesn't provide Finalization Registry support.
 
 If the `FIREBASE_OPTIONS` environment variable does not contain a valid project configuration required for auto-initialization.
+
+## function(jsonConfigString, ...)
+
+### initializeApp(jsonConfigString, name) {:#initializeapp_2f4985a}
+
+Creates and initializes a FirebaseApp instance.
+
+<b>Signature:</b>
+
+```typescript
+export declare function initializeApp(jsonConfigString: string, name?: string): FirebaseApp;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  jsonConfigString | string | A JSON string containing the app's configuration. |
+|  name | string | Optional name of the app to initialize. If no name is provided, the default is <code>&quot;[DEFAULT]&quot;</code>. |
+
+<b>Returns:</b>
+
+[FirebaseApp](./app.firebaseapp.md#firebaseapp_interface)
+
+The initialized app.
+
+#### Exceptions
+
+If the optional `name` parameter is malformed or empty.
+
+If a `FirebaseApp` already exists with the same name but with a different configuration.
+
+### Example
+
+
+```javascript
+
+// Initialize default app
+// Retrieve your own options values by adding a web app on
+// https://console.firebase.google.com
+initializeApp(process.env.FIREBASE_OPTIONS);
+
+```
+
+### initializeServerApp(jsonConfigString) {:#initializeserverapp_eaf0298}
+
+Creates and initializes a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface) instance from a JSON config string.
+
+<b>Signature:</b>
+
+```typescript
+export declare function initializeServerApp(jsonConfigString: string): FirebaseServerApp;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  jsonConfigString | string | A JSON string containing the app's configuration. |
+
+<b>Returns:</b>
+
+[FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)
+
+The initialized `FirebaseServerApp`<!-- -->.
 
 ## function(libraryKeyOrName, ...)
 
@@ -331,21 +399,21 @@ const otherApp = initializeApp({
 
 ```
 
-### initializeApp(options, config) {:#initializeapp_079e917}
+### initializeApp(options, config) {:#initializeapp_03d4ee0}
 
 Creates and initializes a FirebaseApp instance.
 
 <b>Signature:</b>
 
 ```typescript
-export declare function initializeApp(options: FirebaseOptions, config?: FirebaseAppSettings): FirebaseApp;
+export declare function initializeApp(options: FirebaseOptions | string, config?: FirebaseAppSettings): FirebaseApp;
 ```
 
 #### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  options | [FirebaseOptions](./app.firebaseoptions.md#firebaseoptions_interface) | Options to configure the app's services. |
+|  options | [FirebaseOptions](./app.firebaseoptions.md#firebaseoptions_interface) \| string | Options to configure the app's services. |
 |  config | [FirebaseAppSettings](./app.firebaseappsettings.md#firebaseappsettings_interface) | FirebaseApp Configuration |
 
 <b>Returns:</b>
@@ -358,7 +426,7 @@ If [FirebaseAppSettings.name](./app.firebaseappsettings.md#firebaseappsettingsna
 
 If a `FirebaseApp` already exists with the same name but with a different configuration.
 
-### initializeServerApp(options, config) {:#initializeserverapp_30ab697}
+### initializeServerApp(options, config) {:#initializeserverapp_dc3e48f}
 
 Creates and initializes a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface) instance.
 
@@ -369,14 +437,14 @@ See [Add Firebase to your app](https://firebase.google.com/docs/web/setup#add_fi
 <b>Signature:</b>
 
 ```typescript
-export declare function initializeServerApp(options: FirebaseOptions | FirebaseApp, config?: FirebaseServerAppSettings): FirebaseServerApp;
+export declare function initializeServerApp(options: FirebaseOptions | FirebaseApp | string, config?: FirebaseServerAppSettings): FirebaseServerApp;
 ```
 
 #### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  options | [FirebaseOptions](./app.firebaseoptions.md#firebaseoptions_interface) \| [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface) | <code>Firebase.AppOptions</code> to configure the app's services, or a a <code>FirebaseApp</code> instance which contains the <code>AppOptions</code> within. |
+|  options | [FirebaseOptions](./app.firebaseoptions.md#firebaseoptions_interface) \| [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface) \| string | <code>Firebase.AppOptions</code> to configure the app's services, or a a <code>FirebaseApp</code> instance which contains the <code>AppOptions</code> within. |
 |  config | [FirebaseServerAppSettings](./app.firebaseserverappsettings.md#firebaseserverappsettings_interface) | Optional <code>FirebaseServerApp</code> settings. |
 
 <b>Returns:</b>

--- a/packages/app/src/api.test.ts
+++ b/packages/app/src/api.test.ts
@@ -112,12 +112,6 @@ describe('API tests', () => {
       );
     });
 
-    it('throws when creating DEFAULT App with a json string that does not parse to an object', () => {
-      expect(() => initializeApp('1')).throws(
-        /Invalid FirebaseOptions JSON string./
-      );
-    });
-
     it('creates named and DEFAULT App', () => {
       const appName = 'MyApp';
       const app1 = initializeApp({});
@@ -291,17 +285,6 @@ describe('API tests', () => {
       expect(app.automaticDataCollectionEnabled).to.be.true;
       await deleteApp(app);
       expect((app as FirebaseServerAppImpl).isDeleted).to.be.true;
-    });
-
-    it('throws when creating FirebaseServerApp with a json string that does not parse to an object', () => {
-      if (isBrowser()) {
-        // FirebaseServerApp isn't supported for execution in browser environments.
-        return;
-      }
-
-      expect(() => initializeServerApp('1')).throws(
-        /Invalid FirebaseOptions JSON string./
-      );
     });
 
     it('creates FirebaseServerApp with string options and config object as second parameter', async () => {

--- a/packages/app/src/api.test.ts
+++ b/packages/app/src/api.test.ts
@@ -112,6 +112,12 @@ describe('API tests', () => {
       );
     });
 
+    it('throws when creating DEFAULT App with a json string that does not parse to an object', () => {
+      expect(() => initializeApp('1')).throws(
+        /Invalid FirebaseOptions JSON string./
+      );
+    });
+
     it('creates named and DEFAULT App', () => {
       const appName = 'MyApp';
       const app1 = initializeApp({});
@@ -287,6 +293,17 @@ describe('API tests', () => {
       expect((app as FirebaseServerAppImpl).isDeleted).to.be.true;
     });
 
+    it('throws when creating FirebaseServerApp with a json string that does not parse to an object', () => {
+      if (isBrowser()) {
+        // FirebaseServerApp isn't supported for execution in browser environments.
+        return;
+      }
+
+      expect(() => initializeServerApp('1')).throws(
+        /Invalid FirebaseOptions JSON string./
+      );
+    });
+
     it('creates FirebaseServerApp with string options and config object as second parameter', async () => {
       if (isBrowser()) {
         // FirebaseServerApp isn't supported for execution in browser environments.
@@ -316,9 +333,9 @@ describe('API tests', () => {
         return;
       }
 
-      expect(() =>
-        initializeServerApp('{invalid json', {})
-      ).throws(/Unable to parse FirebaseOptions JSON string/);
+      expect(() => initializeServerApp('{invalid json', {})).throws(
+        /Unable to parse FirebaseOptions JSON string/
+      );
     });
     it('creates FirebaseServerApp with options as first parameter and config object with automaticDataCollectionEnabled as second parameter', async () => {
       if (isBrowser()) {

--- a/packages/app/src/api.test.ts
+++ b/packages/app/src/api.test.ts
@@ -310,6 +310,16 @@ describe('API tests', () => {
       await deleteApp(app);
       expect((app as FirebaseServerAppImpl).isDeleted).to.be.true;
     });
+    it('throws when creating FirebaseServerApp with malformed JSON config string', () => {
+      if (isBrowser()) {
+        // FirebaseServerApp isn't supported for execution in browser environments.
+        return;
+      }
+
+      expect(() =>
+        initializeServerApp('{invalid json', {})
+      ).throws(/Unable to parse FirebaseOptions JSON string/);
+    });
     it('creates FirebaseServerApp with options as first parameter and config object with automaticDataCollectionEnabled as second parameter', async () => {
       if (isBrowser()) {
         // FirebaseServerApp isn't supported for execution in browser environments.

--- a/packages/app/src/api.test.ts
+++ b/packages/app/src/api.test.ts
@@ -62,10 +62,54 @@ describe('API tests', () => {
       expect(app.name).to.equal(DEFAULT_ENTRY_NAME);
     });
 
-    it('creates named App', () => {
+    it('creates named App with config object', () => {
       const appName = 'MyApp';
       const app = initializeApp({}, appName);
       expect(app.name).to.equal(appName);
+    });
+
+    it('creates named App with JSON config string', () => {
+      const appName = 'MyApp';
+      const config = {
+        apiKey: 'test1'
+      };
+      const app = initializeApp(JSON.stringify(config), appName);
+      expect(app.name).to.equal(appName);
+      expect(app.options).to.deep.equal(config);
+    });
+
+    it('creates DEFAULT App with JSON config string and config object', () => {
+      const config = {
+        apiKey: 'test1'
+      };
+      const app = initializeApp(JSON.stringify(config));
+      expect(app.name).to.equal(DEFAULT_ENTRY_NAME);
+      expect(app.options).to.deep.equal(config);
+    });
+    it('creates DEFAULT app with config object as the second parameter', () => {
+      const appName = 'myApp';
+      const config = {
+        apiKey: 'test1'
+      };
+      const app = initializeApp(JSON.stringify(config), {
+        name: appName,
+        automaticDataCollectionEnabled: true
+      });
+      expect(app.name).to.equal(appName);
+      expect(app.options).to.deep.equal(config);
+    });
+
+    it('throws when creating DEFAULT App with malformed JSON config string', () => {
+      expect(() => initializeApp('{invalid json')).throws(
+        /Unable to parse FirebaseOptions JSON string/
+      );
+    });
+
+    it('throws when creating named App with malformed JSON config string', () => {
+      const appName = 'MyApp';
+      expect(() => initializeApp('{invalid json', appName)).throws(
+        /Unable to parse FirebaseOptions JSON string/
+      );
     });
 
     it('creates named and DEFAULT App', () => {

--- a/packages/app/src/api.test.ts
+++ b/packages/app/src/api.test.ts
@@ -86,7 +86,7 @@ describe('API tests', () => {
       expect(app.name).to.equal(DEFAULT_ENTRY_NAME);
       expect(app.options).to.deep.equal(config);
     });
-    it('creates DEFAULT app with config object as the second parameter', () => {
+    it('creates named app with config object as the second parameter', () => {
       const appName = 'myApp';
       const config = {
         apiKey: 'test1'
@@ -287,29 +287,6 @@ describe('API tests', () => {
       expect((app as FirebaseServerAppImpl).isDeleted).to.be.true;
     });
 
-    it('creates FirebaseServerApp with string options and config object as second parameter', async () => {
-      if (isBrowser()) {
-        // FirebaseServerApp isn't supported for execution in browser environments.
-        return;
-      }
-
-      const options = {
-        apiKey: 'APIKEY'
-      };
-
-      const serverAppSettings: FirebaseServerAppSettings = {
-        automaticDataCollectionEnabled: true
-      };
-
-      const app = initializeServerApp(
-        JSON.stringify(options),
-        serverAppSettings
-      );
-      expect(app).to.not.equal(null);
-      expect(app.automaticDataCollectionEnabled).to.be.true;
-      await deleteApp(app);
-      expect((app as FirebaseServerAppImpl).isDeleted).to.be.true;
-    });
     it('throws when creating FirebaseServerApp with malformed JSON config string', () => {
       if (isBrowser()) {
         // FirebaseServerApp isn't supported for execution in browser environments.

--- a/packages/app/src/api.test.ts
+++ b/packages/app/src/api.test.ts
@@ -265,6 +265,75 @@ describe('API tests', () => {
       expect((app as FirebaseServerAppImpl).isDeleted).to.be.true;
     });
 
+    it('creates FirebaseServerApp with json config string', async () => {
+      if (isBrowser()) {
+        // FirebaseServerApp isn't supported for execution in browser environments.
+        return;
+      }
+
+      const options = {
+        apiKey: 'APIKEY'
+      };
+
+      const serverAppSettings: FirebaseServerAppSettings = {};
+
+      const app = initializeServerApp(
+        JSON.stringify(options),
+        serverAppSettings
+      );
+      expect(app).to.not.equal(null);
+      expect(app.automaticDataCollectionEnabled).to.be.true;
+      await deleteApp(app);
+      expect((app as FirebaseServerAppImpl).isDeleted).to.be.true;
+    });
+
+    it('creates FirebaseServerApp with string options and config object as second parameter', async () => {
+      if (isBrowser()) {
+        // FirebaseServerApp isn't supported for execution in browser environments.
+        return;
+      }
+
+      const options = {
+        apiKey: 'APIKEY'
+      };
+
+      const serverAppSettings: FirebaseServerAppSettings = {
+        automaticDataCollectionEnabled: true
+      };
+
+      const app = initializeServerApp(
+        JSON.stringify(options),
+        serverAppSettings
+      );
+      expect(app).to.not.equal(null);
+      expect(app.automaticDataCollectionEnabled).to.be.true;
+      await deleteApp(app);
+      expect((app as FirebaseServerAppImpl).isDeleted).to.be.true;
+    });
+    it('creates FirebaseServerApp with options as first parameter and config object with automaticDataCollectionEnabled as second parameter', async () => {
+      if (isBrowser()) {
+        // FirebaseServerApp isn't supported for execution in browser environments.
+        return;
+      }
+
+      const options = {
+        apiKey: 'APIKEY'
+      };
+
+      const serverAppSettings: FirebaseServerAppSettings = {
+        automaticDataCollectionEnabled: true
+      };
+
+      const app = initializeServerApp(
+        JSON.stringify(options),
+        serverAppSettings
+      );
+      expect(app).to.not.equal(null);
+      expect(app.automaticDataCollectionEnabled).to.be.true;
+      await deleteApp(app);
+      expect((app as FirebaseServerAppImpl).isDeleted).to.be.true;
+    });
+
     it('creates FirebaseServerApp with automaticDataCollectionEnabled', async () => {
       if (isBrowser()) {
         // FirebaseServerApp isn't supported for execution in browser environments.

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -198,13 +198,11 @@ export function initializeApp(
 ): FirebaseApp {
   let options: FirebaseOptions | undefined;
   if (typeof optionsOrJsonConfigString === 'string') {
-    let parsed: unknown = undefined;
     try {
-      parsed = JSON.parse(optionsOrJsonConfigString);
+      options = JSON.parse(optionsOrJsonConfigString);
     } catch (error) {
       throw ERROR_FACTORY.create(AppError.INVALID_JSON_CONFIG);
     }
-    options = parsed || undefined;
   } else {
     options = optionsOrJsonConfigString;
   }

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -51,7 +51,6 @@ import {
 } from '@firebase/logger';
 import {
   deepEqual,
-  FirebaseError,
   getDefaultAppConfig,
   isBrowser,
   isWebWorker
@@ -129,7 +128,7 @@ export function initializeApp(
  * initializeApp(process.env.FIREBASE_OPTIONS);
  * ```
  *
- * @param jsonConfigString - A JSON string containing the app's configuration.
+ * @param jsonConfigStr - A JSON string containing the app's configuration.
  * @param name - Optional name of the app to initialize. If no name
  *   is provided, the default is `"[DEFAULT]"`.
  *
@@ -142,8 +141,35 @@ export function initializeApp(
  * @public
  */
 export function initializeApp(
-  jsonConfigString: string,
+  jsonConfigStr: string,
   name?: string
+): FirebaseApp;
+/**
+ * Creates and initializes a FirebaseApp instance.
+ * @example
+ * ```javascript
+ *
+ * // Initialize default app
+ * // Retrieve your own options values by adding a web app on
+ * // https://console.firebase.google.com
+ * initializeApp(process.env.FIREBASE_OPTIONS);
+ * ```
+ *
+ * @param jsonConfigStr - A JSON string containing the app's configuration.
+ * @param name - Optional name of the app to initialize. If no name
+ *   is provided, the default is `"[DEFAULT]"`.
+ *
+ * @returns The initialized app.
+ *
+ * @throws If the optional `name` parameter is malformed or empty.
+ *
+ * @throws If a `FirebaseApp` already exists with the same name but with a different configuration.
+ *
+ * @public
+ */
+export function initializeApp(
+  jsonConfigStr: string,
+  config?: FirebaseAppSettings
 ): FirebaseApp;
 /**
  * Creates and initializes a FirebaseApp instance.
@@ -157,7 +183,7 @@ export function initializeApp(
  * @public
  */
 export function initializeApp(
-  options: FirebaseOptions | string,
+  options: FirebaseOptions,
   config?: FirebaseAppSettings
 ): FirebaseApp;
 /**
@@ -176,16 +202,7 @@ export function initializeApp(
     try {
       parsed = JSON.parse(optionsOrJsonConfigString);
     } catch (error) {
-      throw new FirebaseError(
-        AppError.INVALID_APP_ARGUMENT,
-        'Unable to parse FirebaseOptions JSON string.'
-      );
-    }
-    if (typeof parsed !== 'object') {
-      throw new FirebaseError(
-        AppError.INVALID_APP_ARGUMENT,
-        'Invalid FirebaseOptions JSON string.'
-      );
+      throw ERROR_FACTORY.create(AppError.INVALID_JSON_CONFIG);
     }
     options = parsed || undefined;
   } else {
@@ -336,16 +353,7 @@ export function initializeServerApp(
       try {
         parsed = JSON.parse(_options);
       } catch (error) {
-        throw new FirebaseError(
-          AppError.INVALID_APP_ARGUMENT,
-          'Unable to parse FirebaseOptions JSON string.'
-        );
-      }
-      if (typeof parsed !== 'object') {
-        throw new FirebaseError(
-          AppError.INVALID_APP_ARGUMENT,
-          'Invalid FirebaseOptions JSON string.'
-        );
+        throw ERROR_FACTORY.create(AppError.INVALID_JSON_CONFIG);
       }
       firebaseOptions = parsed || undefined;
     } else if (_isFirebaseApp(_options)) {

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -172,14 +172,22 @@ export function initializeApp(
 ): FirebaseApp {
   let options: FirebaseOptions | undefined;
   if (typeof optionsOrJsonConfigString === 'string') {
+    let parsed: unknown = undefined;
     try {
-      options = JSON.parse(optionsOrJsonConfigString);
+      parsed = JSON.parse(optionsOrJsonConfigString);
     } catch (error) {
       throw new FirebaseError(
         AppError.INVALID_APP_ARGUMENT,
         'Unable to parse FirebaseOptions JSON string.'
       );
     }
+    if (typeof parsed !== 'object') {
+      throw new FirebaseError(
+        AppError.INVALID_APP_ARGUMENT,
+        'Invalid FirebaseOptions JSON string.'
+      );
+    }
+    options = parsed || undefined;
   } else {
     options = optionsOrJsonConfigString;
   }
@@ -305,8 +313,6 @@ export function initializeServerApp(
 /**
  * Creates and initializes a {@link @firebase/app#FirebaseServerApp} instance from a JSON config string.
  * @param jsonConfigString - A JSON string containing the app's configuration.
- * @param name - Optional name of the app to initialize. If no name
- *   is provided, the default is `"[DEFAULT]"`.
  * @returns The initialized `FirebaseServerApp`.
  */
 export function initializeServerApp(
@@ -326,14 +332,22 @@ export function initializeServerApp(
 
   if (_options) {
     if (typeof _options === 'string') {
+      let parsed: unknown = undefined;
       try {
-        firebaseOptions = JSON.parse(_options);
-      } catch {
+        parsed = JSON.parse(_options);
+      } catch (error) {
         throw new FirebaseError(
           AppError.INVALID_APP_ARGUMENT,
           'Unable to parse FirebaseOptions JSON string.'
         );
       }
+      if (typeof parsed !== 'object') {
+        throw new FirebaseError(
+          AppError.INVALID_APP_ARGUMENT,
+          'Invalid FirebaseOptions JSON string.'
+        );
+      }
+      firebaseOptions = parsed || undefined;
     } else if (_isFirebaseApp(_options)) {
       firebaseOptions = _options.options;
     } else if (_isFirebaseServerAppSettings(_options)) {

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -280,7 +280,7 @@ export function initializeApp(
  * @public
  */
 export function initializeServerApp(
-  options: FirebaseOptions | FirebaseApp,
+  options: FirebaseOptions | FirebaseApp | string,
   config?: FirebaseServerAppSettings
 ): FirebaseServerApp;
 

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -51,6 +51,7 @@ import {
 } from '@firebase/logger';
 import {
   deepEqual,
+  FirebaseError,
   getDefaultAppConfig,
   isBrowser,
   isWebWorker
@@ -119,6 +120,33 @@ export function initializeApp(
 ): FirebaseApp;
 /**
  * Creates and initializes a FirebaseApp instance.
+ * @example
+ * ```javascript
+ *
+ * // Initialize default app
+ * // Retrieve your own options values by adding a web app on
+ * // https://console.firebase.google.com
+ * initializeApp(process.env.FIREBASE_OPTIONS);
+ * ```
+ *
+ * @param jsonConfigString - A JSON string containing the app's configuration.
+ * @param name - Optional name of the app to initialize. If no name
+ *   is provided, the default is `"[DEFAULT]"`.
+ *
+ * @returns The initialized app.
+ *
+ * @throws If the optional `name` parameter is malformed or empty.
+ *
+ * @throws If a `FirebaseApp` already exists with the same name but with a different configuration.
+ *
+ * @public
+ */
+export function initializeApp(
+  jsonConfigString: string,
+  name?: string
+): FirebaseApp;
+/**
+ * Creates and initializes a FirebaseApp instance.
  *
  * @param options - Options to configure the app's services.
  * @param config - FirebaseApp Configuration
@@ -129,7 +157,7 @@ export function initializeApp(
  * @public
  */
 export function initializeApp(
-  options: FirebaseOptions,
+  options: FirebaseOptions | string,
   config?: FirebaseAppSettings
 ): FirebaseApp;
 /**
@@ -139,10 +167,22 @@ export function initializeApp(
  */
 export function initializeApp(): FirebaseApp;
 export function initializeApp(
-  _options?: FirebaseOptions,
+  optionsOrJsonConfigString?: FirebaseOptions | string,
   rawConfig = {}
 ): FirebaseApp {
-  let options = _options;
+  let options: FirebaseOptions | undefined;
+  if (typeof optionsOrJsonConfigString === 'string') {
+    try {
+      options = JSON.parse(optionsOrJsonConfigString);
+    } catch (error) {
+      throw new FirebaseError(
+        AppError.INVALID_APP_ARGUMENT,
+        'Unable to parse FirebaseOptions JSON string.'
+      );
+    }
+  } else {
+    options = optionsOrJsonConfigString;
+  }
 
   if (typeof rawConfig !== 'object') {
     const name = rawConfig;
@@ -262,8 +302,18 @@ export function initializeServerApp(
 export function initializeServerApp(
   config?: FirebaseServerAppSettings
 ): FirebaseServerApp;
+/**
+ * Creates and initializes a {@link @firebase/app#FirebaseServerApp} instance from a JSON config string.
+ * @param jsonConfigString - A JSON string containing the app's configuration.
+ * @param name - Optional name of the app to initialize. If no name
+ *   is provided, the default is `"[DEFAULT]"`.
+ * @returns The initialized `FirebaseServerApp`.
+ */
 export function initializeServerApp(
-  _options?: FirebaseApp | FirebaseServerAppSettings | FirebaseOptions,
+  jsonConfigString: string
+): FirebaseServerApp;
+export function initializeServerApp(
+  _options?: FirebaseApp | FirebaseServerAppSettings | FirebaseOptions | string,
   _serverAppConfig: FirebaseServerAppSettings = {}
 ): FirebaseServerApp {
   if (isBrowser() && !isWebWorker()) {
@@ -275,7 +325,16 @@ export function initializeServerApp(
   let serverAppSettings: FirebaseServerAppSettings = _serverAppConfig || {};
 
   if (_options) {
-    if (_isFirebaseApp(_options)) {
+    if (typeof _options === 'string') {
+      try {
+        firebaseOptions = JSON.parse(_options);
+      } catch {
+        throw new FirebaseError(
+          AppError.INVALID_APP_ARGUMENT,
+          'Unable to parse FirebaseOptions JSON string.'
+        );
+      }
+    } else if (_isFirebaseApp(_options)) {
       firebaseOptions = _options.options;
     } else if (_isFirebaseServerAppSettings(_options)) {
       serverAppSettings = _options;

--- a/packages/app/src/errors.ts
+++ b/packages/app/src/errors.ts
@@ -31,7 +31,8 @@ export const enum AppError {
   IDB_WRITE = 'idb-set',
   IDB_DELETE = 'idb-delete',
   FINALIZATION_REGISTRY_NOT_SUPPORTED = 'finalization-registry-not-supported',
-  INVALID_SERVER_APP_ENVIRONMENT = 'invalid-server-app-environment'
+  INVALID_SERVER_APP_ENVIRONMENT = 'invalid-server-app-environment',
+  INVALID_JSON_CONFIG = 'invalid-json-config'
 }
 
 const ERRORS: ErrorMap<AppError> = {
@@ -61,7 +62,8 @@ const ERRORS: ErrorMap<AppError> = {
   [AppError.FINALIZATION_REGISTRY_NOT_SUPPORTED]:
     'FirebaseServerApp deleteOnDeref field defined but the JS runtime does not support FinalizationRegistry.',
   [AppError.INVALID_SERVER_APP_ENVIRONMENT]:
-    'FirebaseServerApp is not for use in browser environments.'
+    'FirebaseServerApp is not for use in browser environments.',
+  [AppError.INVALID_JSON_CONFIG]: 'Unable to parse FirebaseOptions JSON string.'
 };
 
 interface ErrorParams {


### PR DESCRIPTION
* Allowed json parse-able strings to be passed into `initializeApp` as so:
```ts
initializeApp(process.env.NEXT_PUBLIC_FIREBASE_CONFIG);
```