### PR TITLE
docs(firestore): add missing `typescript` formatting to docs

### DIFF
--- a/.changeset/spicy-pens-explain.md
+++ b/.changeset/spicy-pens-explain.md
@@ -1,0 +1,6 @@
+---
+'firebase': patch
+'@firebase/firestore': patch
+---
+
+Add missing `typescript` code formatting to documentation.

--- a/docs-devsite/firestore_lite_pipelines.md
+++ b/docs-devsite/firestore_lite_pipelines.md
@@ -9048,7 +9048,7 @@ export declare function mapMerge(firstMap: Record<string, unknown> | Expression,
 ### Example
 
 
-```
+```typescript
 // Merges the map in the settings field with, a map literal, and a map in
 // that is conditionally returned by another expression
 mapMerge(field('settings'), { enabled: true }, conditional(field('isAdmin'), { admin: true}, {})
@@ -9724,10 +9724,9 @@ export declare function mapRemove(mapExpr: Expression, key: string): FunctionExp
 ### Example
 
 
-```
+```typescript
 // Removes the key 'baz' from the input map.
 mapRemove(map({foo: 'bar', baz: true}), 'baz');
-@example
 
 ```
 
@@ -9755,10 +9754,9 @@ export declare function mapRemove(mapExpr: Expression, keyExpr: Expression): Fun
 ### Example
 
 
-```
+```typescript
 // Removes the key 'baz' from the input map.
 mapRemove(map({foo: 'bar', baz: true}), constant('baz'));
-@example
 
 ```
 
@@ -10024,7 +10022,7 @@ export declare function mapMerge(mapField: string, secondMap: Record<string, unk
 ### Example
 
 
-```
+```typescript
 // Merges the map in the settings field with, a map literal, and a map in
 // that is conditionally returned by another expression
 mapMerge('settings', { enabled: true }, conditional(field('isAdmin'), { admin: true}, {})
@@ -10055,7 +10053,7 @@ export declare function mapRemove(mapField: string, key: string): FunctionExpres
 ### Example
 
 
-```
+```typescript
 // Removes the key 'city' field from the map in the address field of the input document.
 mapRemove('address', 'city');
 
@@ -10085,7 +10083,7 @@ export declare function mapRemove(mapField: string, keyExpr: Expression): Functi
 ### Example
 
 
-```
+```typescript
 // Removes the key 'city' field from the map in the address field of the input document.
 mapRemove('address', constant('city'));
 
@@ -12169,7 +12167,7 @@ export declare type OneOf<T> = {
 ### Example
 
 
-```
+```typescript
 type XorY = OneOf<{ x: unknown, y: unknown }>
 let a = { x: "foo" }           // OK
 let b = { y: "foo" }           // OK

--- a/docs-devsite/firestore_pipelines.md
+++ b/docs-devsite/firestore_pipelines.md
@@ -9053,7 +9053,7 @@ export declare function mapMerge(firstMap: Record<string, unknown> | Expression,
 ### Example
 
 
-```
+```typescript
 // Merges the map in the settings field with, a map literal, and a map in
 // that is conditionally returned by another expression
 mapMerge(field('settings'), { enabled: true }, conditional(field('isAdmin'), { admin: true}, {})
@@ -9750,10 +9750,9 @@ export declare function mapRemove(mapExpr: Expression, key: string): FunctionExp
 ### Example
 
 
-```
+```typescript
 // Removes the key 'baz' from the input map.
 mapRemove(map({foo: 'bar', baz: true}), 'baz');
-@example
 
 ```
 
@@ -9781,10 +9780,9 @@ export declare function mapRemove(mapExpr: Expression, keyExpr: Expression): Fun
 ### Example
 
 
-```
+```typescript
 // Removes the key 'baz' from the input map.
 mapRemove(map({foo: 'bar', baz: true}), constant('baz'));
-@example
 
 ```
 
@@ -10050,7 +10048,7 @@ export declare function mapMerge(mapField: string, secondMap: Record<string, unk
 ### Example
 
 
-```
+```typescript
 // Merges the map in the settings field with, a map literal, and a map in
 // that is conditionally returned by another expression
 mapMerge('settings', { enabled: true }, conditional(field('isAdmin'), { admin: true}, {})
@@ -10081,7 +10079,7 @@ export declare function mapRemove(mapField: string, key: string): FunctionExpres
 ### Example
 
 
-```
+```typescript
 // Removes the key 'city' field from the map in the address field of the input document.
 mapRemove('address', 'city');
 
@@ -10111,7 +10109,7 @@ export declare function mapRemove(mapField: string, keyExpr: Expression): Functi
 ### Example
 
 
-```
+```typescript
 // Removes the key 'city' field from the map in the address field of the input document.
 mapRemove('address', constant('city'));
 
@@ -12235,7 +12233,7 @@ export declare type OneOf<T> = {
 ### Example
 
 
-```
+```typescript
 type XorY = OneOf<{ x: unknown, y: unknown }>
 let a = { x: "foo" }           // OK
 let b = { y: "foo" }           // OK

--- a/packages/firestore/src/api/pipeline_impl.ts
+++ b/packages/firestore/src/api/pipeline_impl.ts
@@ -200,7 +200,7 @@ export function execute(
  * Creates and returns a new PipelineSource, which allows specifying the source stage of a {@link @firebase/firestore/pipelines#Pipeline}.
  *
  * @example
- * ```
+ * ```typescript
  * let myPipeline: Pipeline = firestore.pipeline().collection('books');
  * ```
  */

--- a/packages/firestore/src/lite-api/expressions.ts
+++ b/packages/firestore/src/lite-api/expressions.ts
@@ -4669,7 +4669,7 @@ export function isAbsent(value: Expression | string): BooleanExpression {
  * Creates an expression that removes a key from the map at the specified field name.
  *
  * @example
- * ```
+ * ```typescript
  * // Removes the key 'city' field from the map in the address field of the input document.
  * mapRemove('address', 'city');
  * ```
@@ -4683,10 +4683,9 @@ export function mapRemove(mapField: string, key: string): FunctionExpression;
  * Creates an expression that removes a key from the map produced by evaluating an expression.
  *
  * @example
- * ```
+ * ```typescript
  * // Removes the key 'baz' from the input map.
  * mapRemove(map({foo: 'bar', baz: true}), 'baz');
- * @example
  * ```
  *
  * @param mapExpr - An expression return a map value.
@@ -4698,7 +4697,7 @@ export function mapRemove(mapExpr: Expression, key: string): FunctionExpression;
  * Creates an expression that removes a key from the map at the specified field name.
  *
  * @example
- * ```
+ * ```typescript
  * // Removes the key 'city' field from the map in the address field of the input document.
  * mapRemove('address', constant('city'));
  * ```
@@ -4715,10 +4714,9 @@ export function mapRemove(
  * Creates an expression that removes a key from the map produced by evaluating an expression.
  *
  * @example
- * ```
+ * ```typescript
  * // Removes the key 'baz' from the input map.
  * mapRemove(map({foo: 'bar', baz: true}), constant('baz'));
- * @example
  * ```
  *
  * @param mapExpr - An expression return a map value.
@@ -4741,7 +4739,7 @@ export function mapRemove(
  * Creates an expression that merges multiple map values.
  *
  * @example
- * ```
+ * ```typescript
  * // Merges the map in the settings field with, a map literal, and a map in
  * // that is conditionally returned by another expression
  * mapMerge('settings', { enabled: true }, conditional(field('isAdmin'), { admin: true}, {})
@@ -4764,7 +4762,7 @@ export function mapMerge(
  * Creates an expression that merges multiple map values.
  *
  * @example
- * ```
+ * ```typescript
  * // Merges the map in the settings field with, a map literal, and a map in
  * // that is conditionally returned by another expression
  * mapMerge(field('settings'), { enabled: true }, conditional(field('isAdmin'), { admin: true}, {})

--- a/packages/firestore/src/lite-api/pipeline_impl.ts
+++ b/packages/firestore/src/lite-api/pipeline_impl.ts
@@ -141,7 +141,7 @@ export function execute(pipeline: Pipeline): Promise<PipelineSnapshot> {
  * Creates and returns a new PipelineSource, which allows specifying the source stage of a {@link @firebase/firestore/pipelines#Pipeline}.
  *
  * @example
- * ```
+ * ```typescript
  * let myPipeline: Pipeline = firestore.pipeline().collection('books');
  * ```
  */

--- a/packages/firestore/src/util/types.ts
+++ b/packages/firestore/src/util/types.ts
@@ -79,7 +79,7 @@ export interface DocumentLike {
  * property of the Type param T to be set.
  *
  * @example
- * ```
+ * ```typescript
  * type XorY = OneOf<{ x: unknown, y: unknown }>
  * let a = { x: "foo" }           // OK
  * let b = { y: "foo" }           // OK


### PR DESCRIPTION
Adds `typescript` code formatting to the code examples in docs, where they're missing.