### PR TITLE
chore: migrate test functions to v2

### DIFF
--- a/config/functions/index.js
+++ b/config/functions/index.js
@@ -16,7 +16,6 @@
  */
 
 const assert = require('assert');
-const cors = require('cors')({ origin: true });
 const { onRequest, onCall } = require('firebase-functions/v2/https');
 
 /*
@@ -24,135 +23,114 @@ const { onRequest, onCall } = require('firebase-functions/v2/https');
  * not all implemented as tests in the JS SDK yet.
  */
 
-exports.dataTestv2 = onRequest((request, response) => {
-  cors(request, response, () => {
-    assert.deepEqual(request.body, {
-      data: {
-        bool: true,
-        int: 2,
-        // TODO(klimt): Should we add an API for encoding longs?
-        /*long: {
+exports.dataTestv2 = onRequest({ cors: true }, (request, response) => {
+  assert.deepEqual(request.body, {
+    data: {
+      bool: true,
+      int: 2,
+      // TODO(klimt): Should we add an API for encoding longs?
+      /*long: {
           value: '3',
           '@type': 'type.googleapis.com/google.protobuf.Int64Value',
         },*/
-        str: 'four',
-        array: [5, 6],
-        null: null
+      str: 'four',
+      array: [5, 6],
+      null: null
+    }
+  });
+  response.send({
+    data: {
+      message: 'stub response',
+      code: 42,
+      long: {
+        value: '420',
+        '@type': 'type.googleapis.com/google.protobuf.Int64Value'
       }
-    });
-    response.send({
-      data: {
-        message: 'stub response',
-        code: 42,
+    }
+  });
+});
+
+exports.scalarTestv2 = onRequest({ cors: true }, (request, response) => {
+  assert.deepEqual(request.body, { data: 17 });
+  response.send({ data: 76 });
+});
+
+exports.tokenTestv2 = onRequest({ cors: true }, (request, response) => {
+  assert.equal(request.get('Authorization'), 'Bearer token');
+  assert.deepEqual(request.body, { data: {} });
+  response.send({ data: {} });
+});
+
+exports.instanceIdTestv2 = onRequest({ cors: true }, (request, response) => {
+  assert.equal(request.get('Firebase-Instance-ID-Token'), 'iid');
+  assert.deepEqual(request.body, { data: {} });
+  response.send({ data: {} });
+});
+
+exports.appCheckTestv2 = onRequest({ cors: true }, (request, response) => {
+  const token = request.get('X-Firebase-AppCheck');
+  assert.equal(token !== undefined, true);
+  assert.deepEqual(request.body, { data: {} });
+  response.send({ data: { token } });
+});
+
+exports.nullTestv2 = onRequest({ cors: true }, (request, response) => {
+  assert.deepEqual(request.body, { data: null });
+  response.send({ data: null });
+});
+
+exports.missingResultTestv2 = onRequest({ cors: true }, (request, response) => {
+  assert.deepEqual(request.body, { data: null });
+  response.send({});
+});
+
+exports.unhandledErrorTestv2 = onRequest(
+  { cors: true },
+  (request, response) => {
+    // Fail in a way that the client shouldn't see.
+    throw 'nope';
+  }
+);
+
+exports.unknownErrorTestv2 = onRequest({ cors: true }, (request, response) => {
+  // Send an http error with a body with an explicit code.
+  response.status(400).send({
+    error: {
+      status: 'THIS_IS_NOT_VALID',
+      message: 'this should be ignored'
+    }
+  });
+});
+
+exports.explicitErrorTestv2 = onRequest({ cors: true }, (request, response) => {
+  // Send an http error with a body with an explicit code.
+  response.status(400).send({
+    error: {
+      status: 'OUT_OF_RANGE',
+      message: 'explicit nope',
+      details: {
+        start: 10,
+        end: 20,
         long: {
-          value: '420',
+          value: '30',
           '@type': 'type.googleapis.com/google.protobuf.Int64Value'
         }
       }
-    });
+    }
   });
 });
 
-exports.scalarTestv2 = onRequest((request, response) => {
-  cors(request, response, () => {
-    assert.deepEqual(request.body, { data: 17 });
-    response.send({ data: 76 });
-  });
+exports.httpErrorTestv2 = onRequest({ cors: true }, (request, response) => {
+  // Send an http error with no body.
+  response.status(400).send();
 });
 
-exports.tokenTestv2 = onRequest((request, response) => {
-  cors(request, response, () => {
-    assert.equal(request.get('Authorization'), 'Bearer token');
-    assert.deepEqual(request.body, { data: {} });
-    response.send({ data: {} });
-  });
-});
-
-exports.instanceIdTestv2 = onRequest((request, response) => {
-  cors(request, response, () => {
-    assert.equal(request.get('Firebase-Instance-ID-Token'), 'iid');
-    assert.deepEqual(request.body, { data: {} });
-    response.send({ data: {} });
-  });
-});
-
-exports.appCheckTestv2 = onRequest((request, response) => {
-  cors(request, response, () => {
-    const token = request.get('X-Firebase-AppCheck');
-    assert.equal(token !== undefined, true);
-    assert.deepEqual(request.body, { data: {} });
-    response.send({ data: { token } });
-  });
-});
-
-exports.nullTestv2 = onRequest((request, response) => {
-  cors(request, response, () => {
-    assert.deepEqual(request.body, { data: null });
-    response.send({ data: null });
-  });
-});
-
-exports.missingResultTestv2 = onRequest((request, response) => {
-  cors(request, response, () => {
-    assert.deepEqual(request.body, { data: null });
-    response.send({});
-  });
-});
-
-exports.unhandledErrorTestv2 = onRequest((request, response) => {
-  cors(request, response, () => {
-    // Fail in a way that the client shouldn't see.
-    throw 'nope';
-  });
-});
-
-exports.unknownErrorTestv2 = onRequest((request, response) => {
-  cors(request, response, () => {
-    // Send an http error with a body with an explicit code.
-    response.status(400).send({
-      error: {
-        status: 'THIS_IS_NOT_VALID',
-        message: 'this should be ignored'
-      }
-    });
-  });
-});
-
-exports.explicitErrorTestv2 = onRequest((request, response) => {
-  cors(request, response, () => {
-    // Send an http error with a body with an explicit code.
-    response.status(400).send({
-      error: {
-        status: 'OUT_OF_RANGE',
-        message: 'explicit nope',
-        details: {
-          start: 10,
-          end: 20,
-          long: {
-            value: '30',
-            '@type': 'type.googleapis.com/google.protobuf.Int64Value'
-          }
-        }
-      }
-    });
-  });
-});
-
-exports.httpErrorTestv2 = onRequest((request, response) => {
-  cors(request, response, () => {
-    // Send an http error with no body.
-    response.status(400).send();
-  });
-});
-
-exports.timeoutTestv2 = onRequest((request, response) => {
-  cors(request, response, () => {
-    // Wait for longer than 500ms.
-    setTimeout(() => response.send({ data: true }), 500);
-  });
+exports.timeoutTestv2 = onRequest({ cors: true }, (request, response) => {
+  // Wait for longer than 500ms.
+  setTimeout(() => response.send({ data: true }), 500);
 });
 
 // Used by E2E test.
-exports.callTestv2 = onCall((data, context) => {
+exports.callTestv2 = onCall(request => {
   return { word: 'hellooo' };
 });

--- a/config/functions/index.js
+++ b/config/functions/index.js
@@ -17,14 +17,14 @@
 
 const assert = require('assert');
 const cors = require('cors')({ origin: true });
-const functions = require('firebase-functions/v1');
+const { onRequest, onCall } = require('firebase-functions/v2/https');
 
 /*
  * These backend test helpers are copied from the iOS and Android SDKs, but are
  * not all implemented as tests in the JS SDK yet.
  */
 
-exports.dataTest = functions.https.onRequest((request, response) => {
+exports.dataTestv2 = onRequest((request, response) => {
   cors(request, response, () => {
     assert.deepEqual(request.body, {
       data: {
@@ -53,14 +53,14 @@ exports.dataTest = functions.https.onRequest((request, response) => {
   });
 });
 
-exports.scalarTest = functions.https.onRequest((request, response) => {
+exports.scalarTestv2 = onRequest((request, response) => {
   cors(request, response, () => {
     assert.deepEqual(request.body, { data: 17 });
     response.send({ data: 76 });
   });
 });
 
-exports.tokenTest = functions.https.onRequest((request, response) => {
+exports.tokenTestv2 = onRequest((request, response) => {
   cors(request, response, () => {
     assert.equal(request.get('Authorization'), 'Bearer token');
     assert.deepEqual(request.body, { data: {} });
@@ -68,7 +68,7 @@ exports.tokenTest = functions.https.onRequest((request, response) => {
   });
 });
 
-exports.instanceIdTest = functions.https.onRequest((request, response) => {
+exports.instanceIdTestv2 = onRequest((request, response) => {
   cors(request, response, () => {
     assert.equal(request.get('Firebase-Instance-ID-Token'), 'iid');
     assert.deepEqual(request.body, { data: {} });
@@ -76,7 +76,7 @@ exports.instanceIdTest = functions.https.onRequest((request, response) => {
   });
 });
 
-exports.appCheckTest = functions.https.onRequest((request, response) => {
+exports.appCheckTestv2 = onRequest((request, response) => {
   cors(request, response, () => {
     const token = request.get('X-Firebase-AppCheck');
     assert.equal(token !== undefined, true);
@@ -85,28 +85,28 @@ exports.appCheckTest = functions.https.onRequest((request, response) => {
   });
 });
 
-exports.nullTest = functions.https.onRequest((request, response) => {
+exports.nullTestv2 = onRequest((request, response) => {
   cors(request, response, () => {
     assert.deepEqual(request.body, { data: null });
     response.send({ data: null });
   });
 });
 
-exports.missingResultTest = functions.https.onRequest((request, response) => {
+exports.missingResultTestv2 = onRequest((request, response) => {
   cors(request, response, () => {
     assert.deepEqual(request.body, { data: null });
     response.send({});
   });
 });
 
-exports.unhandledErrorTest = functions.https.onRequest((request, response) => {
+exports.unhandledErrorTestv2 = onRequest((request, response) => {
   cors(request, response, () => {
     // Fail in a way that the client shouldn't see.
     throw 'nope';
   });
 });
 
-exports.unknownErrorTest = functions.https.onRequest((request, response) => {
+exports.unknownErrorTestv2 = onRequest((request, response) => {
   cors(request, response, () => {
     // Send an http error with a body with an explicit code.
     response.status(400).send({
@@ -118,7 +118,7 @@ exports.unknownErrorTest = functions.https.onRequest((request, response) => {
   });
 });
 
-exports.explicitErrorTest = functions.https.onRequest((request, response) => {
+exports.explicitErrorTestv2 = onRequest((request, response) => {
   cors(request, response, () => {
     // Send an http error with a body with an explicit code.
     response.status(400).send({
@@ -138,14 +138,14 @@ exports.explicitErrorTest = functions.https.onRequest((request, response) => {
   });
 });
 
-exports.httpErrorTest = functions.https.onRequest((request, response) => {
+exports.httpErrorTestv2 = onRequest((request, response) => {
   cors(request, response, () => {
     // Send an http error with no body.
     response.status(400).send();
   });
 });
 
-exports.timeoutTest = functions.https.onRequest((request, response) => {
+exports.timeoutTestv2 = onRequest((request, response) => {
   cors(request, response, () => {
     // Wait for longer than 500ms.
     setTimeout(() => response.send({ data: true }), 500);
@@ -153,6 +153,6 @@ exports.timeoutTest = functions.https.onRequest((request, response) => {
 });
 
 // Used by E2E test.
-exports.callTest = functions.https.onCall((data, context) => {
+exports.callTestv2 = onCall((data, context) => {
   return { word: 'hellooo' };
 });

--- a/packages/functions-compat/src/callable.test.ts
+++ b/packages/functions-compat/src/callable.test.ts
@@ -73,7 +73,7 @@ describe('Firebase Functions > Call', () => {
       null: null
     };
 
-    const func = functions.httpsCallable('dataTest');
+    const func = functions.httpsCallable('dataTestv2');
     const result = await func(data);
 
     expect(result.data).to.deep.equal({
@@ -85,14 +85,14 @@ describe('Firebase Functions > Call', () => {
 
   it('scalars', async () => {
     const functions = createTestService(app, region);
-    const func = functions.httpsCallable('scalarTest');
+    const func = functions.httpsCallable('scalarTestv2');
     const result = await func(17);
     expect(result.data).to.equal(76);
   });
 
   it('null', async () => {
     const functions = createTestService(app, region);
-    const func = functions.httpsCallable('nullTest');
+    const func = functions.httpsCallable('nullTestv2');
     let result = await func(null);
     expect(result.data).to.be.null;
 
@@ -103,7 +103,7 @@ describe('Firebase Functions > Call', () => {
 
   it('missing result', async () => {
     const functions = createTestService(app, region);
-    const func = functions.httpsCallable('missingResultTest');
+    const func = functions.httpsCallable('missingResultTestv2');
     await expectError(
       func(),
       'functions/internal',
@@ -113,19 +113,19 @@ describe('Firebase Functions > Call', () => {
 
   it('unhandled error', async () => {
     const functions = createTestService(app, region);
-    const func = functions.httpsCallable('unhandledErrorTest');
+    const func = functions.httpsCallable('unhandledErrorTestv2');
     await expectError(func(), 'functions/internal', 'internal');
   });
 
   it('unknown error', async () => {
     const functions = createTestService(app, region);
-    const func = functions.httpsCallable('unknownErrorTest');
+    const func = functions.httpsCallable('unknownErrorTestv2');
     await expectError(func(), 'functions/internal', 'internal');
   });
 
   it('explicit error', async () => {
     const functions = createTestService(app, region);
-    const func = functions.httpsCallable('explicitErrorTest');
+    const func = functions.httpsCallable('explicitErrorTestv2');
     await expectError(func(), 'functions/out-of-range', 'explicit nope', {
       start: 10,
       end: 20,
@@ -135,13 +135,13 @@ describe('Firebase Functions > Call', () => {
 
   it('http error', async () => {
     const functions = createTestService(app, region);
-    const func = functions.httpsCallable('httpErrorTest');
+    const func = functions.httpsCallable('httpErrorTestv2');
     await expectError(func(), 'functions/invalid-argument', 'invalid-argument');
   });
 
   it('timeout', async () => {
     const functions = createTestService(app, region);
-    const func = functions.httpsCallable('timeoutTest', { timeout: 10 });
+    const func = functions.httpsCallable('timeoutTestv2', { timeout: 10 });
     await expectError(
       func(),
       'functions/deadline-exceeded',

--- a/packages/functions/src/callable.test.ts
+++ b/packages/functions/src/callable.test.ts
@@ -86,7 +86,7 @@ describe('Firebase Functions > Call', () => {
     app = makeFakeApp({ projectId, messagingSenderId });
   });
 
-  it.only('simple data', async () => {
+  it('simple data', async () => {
     const functions = createTestService(app, region);
     // TODO(klimt): Should we add an API to create a "long" in JS?
     const data = {

--- a/packages/functions/src/callable.test.ts
+++ b/packages/functions/src/callable.test.ts
@@ -405,7 +405,7 @@ describe('Firebase Functions > Stream', () => {
 
     const func = httpsCallable<Record<string, any>, string, string>(
       functions,
-      'errTestv2'
+      'errTest'
     );
     const streamResult = await func.stream({});
 

--- a/packages/functions/src/callable.test.ts
+++ b/packages/functions/src/callable.test.ts
@@ -86,7 +86,7 @@ describe('Firebase Functions > Call', () => {
     app = makeFakeApp({ projectId, messagingSenderId });
   });
 
-  it('simple data', async () => {
+  it.only('simple data', async () => {
     const functions = createTestService(app, region);
     // TODO(klimt): Should we add an API to create a "long" in JS?
     const data = {
@@ -100,7 +100,7 @@ describe('Firebase Functions > Call', () => {
     const func = httpsCallable<
       Record<string, any>,
       { message: string; code: number; long: number }
-    >(functions, 'dataTest');
+    >(functions, 'dataTestv2');
     const result = await func(data);
 
     expect(result.data).to.deep.equal({
@@ -112,7 +112,7 @@ describe('Firebase Functions > Call', () => {
 
   it('scalars', async () => {
     const functions = createTestService(app, region);
-    const func = httpsCallable<number, number>(functions, 'scalarTest');
+    const func = httpsCallable<number, number>(functions, 'scalarTestv2');
     const result = await func(17);
     expect(result.data).to.equal(76);
   });
@@ -134,7 +134,7 @@ describe('Firebase Functions > Call', () => {
 
     // Stub out the internals to get an auth token.
     const stub = sinon.stub(authMock, 'getToken').callThrough();
-    const func = httpsCallable(functions, 'tokenTest');
+    const func = httpsCallable(functions, 'tokenTestv2');
     const result = await func({});
     expect(result.data).to.deep.equal({});
 
@@ -167,7 +167,7 @@ describe('Firebase Functions > Call', () => {
 
     // Stub out the internals to get an app check token.
     const stub = sinon.stub(appCheckMock, 'getToken').callThrough();
-    const func = httpsCallable(functions, 'appCheckTest');
+    const func = httpsCallable(functions, 'appCheckTestv2');
     const result = await func({});
     expect(result.data).to.deep.equal({ token: 'app-check-token' });
 
@@ -200,7 +200,7 @@ describe('Firebase Functions > Call', () => {
 
     // Stub out the internals to get an app check token.
     const stub = sinon.stub(appCheckMock, 'getLimitedUseToken').callThrough();
-    const func = httpsCallable(functions, 'appCheckTest', {
+    const func = httpsCallable(functions, 'appCheckTestv2', {
       limitedUseAppCheckTokens: true
     });
     const result = await func({});
@@ -244,7 +244,7 @@ describe('Firebase Functions > Call', () => {
     const stub = sinon.stub(messagingMock, 'getToken').callThrough();
     sinon.stub(Notification, 'permission').value('granted');
 
-    const func = httpsCallable(functions, 'instanceIdTest');
+    const func = httpsCallable(functions, 'instanceIdTestv2');
     const result = await func({});
     expect(result.data).to.deep.equal({});
 
@@ -254,7 +254,7 @@ describe('Firebase Functions > Call', () => {
 
   it('null', async () => {
     const functions = createTestService(app, region);
-    const func = httpsCallable(functions, 'nullTest');
+    const func = httpsCallable(functions, 'nullTestv2');
     let result = await func(null);
     expect(result.data).to.be.null;
 
@@ -265,25 +265,25 @@ describe('Firebase Functions > Call', () => {
 
   it('missing result', async () => {
     const functions = createTestService(app, region);
-    const func = httpsCallable(functions, 'missingResultTest');
+    const func = httpsCallable(functions, 'missingResultTestv2');
     await expectError(func(), 'internal', 'Response is missing data field.');
   });
 
   it('unhandled error', async () => {
     const functions = createTestService(app, region);
-    const func = httpsCallable(functions, 'unhandledErrorTest');
+    const func = httpsCallable(functions, 'unhandledErrorTestv2');
     await expectError(func(), 'internal', 'internal');
   });
 
   it('unknown error', async () => {
     const functions = createTestService(app, region);
-    const func = httpsCallable(functions, 'unknownErrorTest');
+    const func = httpsCallable(functions, 'unknownErrorTestv2');
     await expectError(func(), 'internal', 'internal');
   });
 
   it('explicit error', async () => {
     const functions = createTestService(app, region);
-    const func = httpsCallable(functions, 'explicitErrorTest');
+    const func = httpsCallable(functions, 'explicitErrorTestv2');
     await expectError(func(), 'out-of-range', 'explicit nope', {
       start: 10,
       end: 20,
@@ -293,13 +293,13 @@ describe('Firebase Functions > Call', () => {
 
   it('http error', async () => {
     const functions = createTestService(app, region);
-    const func = httpsCallable(functions, 'httpErrorTest');
+    const func = httpsCallable(functions, 'httpErrorTestv2');
     await expectError(func(), 'invalid-argument', 'invalid-argument');
   });
 
   it('timeout', async () => {
     const functions = createTestService(app, region);
-    const func = httpsCallable(functions, 'timeoutTest', { timeout: 10 });
+    const func = httpsCallable(functions, 'timeoutTestv2', { timeout: 10 });
     await expectError(func(), 'deadline-exceeded', 'deadline-exceeded');
   });
 });
@@ -405,7 +405,7 @@ describe('Firebase Functions > Stream', () => {
 
     const func = httpsCallable<Record<string, any>, string, string>(
       functions,
-      'errTest'
+      'errTestv2'
     );
     const streamResult = await func.stream({});
 


### PR DESCRIPTION
Migrate the test functions we use in our functions SDK integration tests from v1 to v2. This is overdue and we should clean up in preparation for migrating to a new test project.

You can't overwrite v1 functions with v2 functions of the same name so I've renamed all the functions and changed the live backend tests to call the v2 functions.