### PR TITLE
fix(messaging): wire Firelog delivery metrics flush (startLoggingService)

### DIFF
--- a/.changeset/yellow-mirrors-wave.md
+++ b/.changeset/yellow-mirrors-wave.md
@@ -1,0 +1,5 @@
+---
+'@firebase/messaging': minor
+---
+
+Fix delivery metrics Firelog flushing when BigQuery export is enabled by starting the logging service when toggling export on or staging a log event, and by scheduling the first flush immediately (next timer tick) instead of waiting a full LOG_INTERVAL_IN_MS.

--- a/.changeset/yellow-mirrors-wave.md
+++ b/.changeset/yellow-mirrors-wave.md
@@ -1,5 +1,5 @@
 ---
-'@firebase/messaging': minor
+'@firebase/messaging': patch
 ---
 
-Fix delivery metrics Firelog flushing when BigQuery export is enabled by starting the logging service when toggling export on or staging a log event, and by scheduling the first flush immediately (next timer tick) instead of waiting a full LOG_INTERVAL_IN_MS.
+Fix delivery metrics Firelog flushing when BigQuery export is enabled: schedule the first flush immediately (next timer tick) instead of waiting a full `LOG_INTERVAL_IN_MS`, start processing only when there are queued events (so enabling export with an empty queue does not arm a day-long idle timer that blocks later `stageLog` flushes), and ensure staging a log starts the service when needed. When export is disabled, clear any queued events and cancel pending flush timers immediately (rather than waiting for the background loop).

--- a/packages/messaging/src/api/setDeliveryMetricsExportedToBigQueryEnabled.ts
+++ b/packages/messaging/src/api/setDeliveryMetricsExportedToBigQueryEnabled.ts
@@ -15,7 +15,10 @@
  * limitations under the License.
  */
 
-import { startLoggingService } from '../helpers/logToFirelog';
+import {
+  startLoggingService,
+  stopLoggingServiceAndClearQueue
+} from '../helpers/logToFirelog';
 import { Messaging } from '../interfaces/public-types';
 import { MessagingService } from '../messaging-service';
 
@@ -27,5 +30,7 @@ export function _setDeliveryMetricsExportedToBigQueryEnabled(
   messagingService.deliveryMetricsExportedToBigQueryEnabled = enable;
   if (enable) {
     startLoggingService(messagingService);
+  } else {
+    stopLoggingServiceAndClearQueue(messagingService);
   }
 }

--- a/packages/messaging/src/api/setDeliveryMetricsExportedToBigQueryEnabled.ts
+++ b/packages/messaging/src/api/setDeliveryMetricsExportedToBigQueryEnabled.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { startLoggingService } from '../helpers/logToFirelog';
 import { Messaging } from '../interfaces/public-types';
 import { MessagingService } from '../messaging-service';
 
@@ -22,6 +23,9 @@ export function _setDeliveryMetricsExportedToBigQueryEnabled(
   messaging: Messaging,
   enable: boolean
 ): void {
-  (messaging as MessagingService).deliveryMetricsExportedToBigQueryEnabled =
-    enable;
+  const messagingService = messaging as MessagingService;
+  messagingService.deliveryMetricsExportedToBigQueryEnabled = enable;
+  if (enable) {
+    startLoggingService(messagingService);
+  }
 }

--- a/packages/messaging/src/helpers/logToFirelog.test.ts
+++ b/packages/messaging/src/helpers/logToFirelog.test.ts
@@ -63,6 +63,10 @@ describe('logToFirelog', () => {
   });
 
   describe('_dispatchLogEvents', () => {
+    beforeEach(() => {
+      messaging.deliveryMetricsExportedToBigQueryEnabled = true;
+    });
+
     it('dispatches queue successfully ', async () => {
       // set up
       fetchStub.resolves(new Response(JSON.stringify(getSuccessResponse())));
@@ -222,6 +226,18 @@ describe('logToFirelog', () => {
   });
 
   describe('startLoggingService', () => {
+    it('does not start when the queue is empty (avoids idle timer blocking later stageLog)', async () => {
+      fetchStub.resolves(new Response(JSON.stringify(getSuccessResponse())));
+      messaging.deliveryMetricsExportedToBigQueryEnabled = true;
+      messaging.logEvents = [];
+
+      LogModule.startLoggingService(messaging);
+
+      await new Promise<void>(resolve => setTimeout(resolve, 50));
+      expect(fetchStub).to.not.have.been.called;
+      expect(messaging.isLogServiceStarted).to.be.false;
+    });
+
     it('dispatches first queued batch promptly', async () => {
       fetchStub.resolves(new Response(JSON.stringify(getSuccessResponse())));
       messaging.deliveryMetricsExportedToBigQueryEnabled = true;
@@ -287,6 +303,55 @@ describe('logToFirelog', () => {
       expect(fetchStub).to.have.been.called;
       expect(messaging.logEvents).to.be.empty;
       expect(messaging.deliveryMetricsExportedToBigQueryEnabled).to.be.true;
+    });
+
+    it('clears queued events immediately when disabling export without waiting LOG_INTERVAL_IN_MS', async () => {
+      const clock = useFakeTimers();
+      fetchStub.resolves(new Response(JSON.stringify(getSuccessResponse())));
+      messaging.deliveryMetricsExportedToBigQueryEnabled = true;
+      messaging.logEvents.push(getFakeLogEvent());
+
+      LogModule.startLoggingService(messaging);
+      await clock.tickAsync(INITIAL_FLUSH_FAKE_TICK_MS);
+      expect(fetchStub).to.have.been.calledOnce;
+      expect(messaging.logEvents).to.be.empty;
+
+      messaging.logEvents.push(getFakeLogEvent());
+      _setDeliveryMetricsExportedToBigQueryEnabled(messaging, false);
+
+      expect(messaging.logEvents).to.be.empty;
+      expect(messaging.isLogServiceStarted).to.be.false;
+
+      await clock.tickAsync(LOG_INTERVAL_IN_MS);
+      expect(fetchStub).to.have.been.calledOnce;
+
+      clock.restore();
+    });
+
+    it('does not arm idle polling when enabling export with an empty queue; stageLog still flushes', async () => {
+      fetchStub.resolves(new Response(JSON.stringify(getSuccessResponse())));
+      messaging.logEvents = [];
+      messaging.deliveryMetricsExportedToBigQueryEnabled = false;
+
+      _setDeliveryMetricsExportedToBigQueryEnabled(messaging, true);
+
+      await new Promise<void>(resolve => setTimeout(resolve, 50));
+      expect(fetchStub).to.not.have.been.called;
+      expect(messaging.isLogServiceStarted).to.be.false;
+
+      const internalPayload: MessagePayloadInternal = {
+        from: '1234567890',
+        fcmMessageId: 'mid',
+        productId: 0,
+        notification: { title: 't' },
+        collapse_key: ''
+      };
+
+      await LogModule.stageLog(messaging, internalPayload);
+
+      await new Promise<void>(resolve => setTimeout(resolve, 50));
+      expect(fetchStub).to.have.been.called;
+      expect(messaging.logEvents).to.be.empty;
     });
   });
 });

--- a/packages/messaging/src/helpers/logToFirelog.test.ts
+++ b/packages/messaging/src/helpers/logToFirelog.test.ts
@@ -202,7 +202,7 @@ describe('logToFirelog', () => {
       // assert
       setTimeout(() => {
         expect(messaging.logEvents.length).to.equal(0);
-        expect(messaging.isLogServiceStarted).to.be.false;
+        expect(messaging.logQueue.state).to.equal('stopped');
         done();
       }, 1000);
     });
@@ -235,7 +235,7 @@ describe('logToFirelog', () => {
 
       await new Promise<void>(resolve => setTimeout(resolve, 50));
       expect(fetchStub).to.not.have.been.called;
-      expect(messaging.isLogServiceStarted).to.be.false;
+      expect(messaging.logQueue.state).to.equal('stopped');
     });
 
     it('dispatches first queued batch promptly', async () => {
@@ -320,7 +320,7 @@ describe('logToFirelog', () => {
       _setDeliveryMetricsExportedToBigQueryEnabled(messaging, false);
 
       expect(messaging.logEvents).to.be.empty;
-      expect(messaging.isLogServiceStarted).to.be.false;
+      expect(messaging.logQueue.state).to.equal('stopped');
 
       await clock.tickAsync(LOG_INTERVAL_IN_MS);
       expect(fetchStub).to.have.been.calledOnce;
@@ -337,7 +337,7 @@ describe('logToFirelog', () => {
 
       await new Promise<void>(resolve => setTimeout(resolve, 50));
       expect(fetchStub).to.not.have.been.called;
-      expect(messaging.isLogServiceStarted).to.be.false;
+      expect(messaging.logQueue.state).to.equal('stopped');
 
       const internalPayload: MessagePayloadInternal = {
         from: '1234567890',

--- a/packages/messaging/src/helpers/logToFirelog.test.ts
+++ b/packages/messaging/src/helpers/logToFirelog.test.ts
@@ -344,7 +344,9 @@ describe('logToFirelog', () => {
         fcmMessageId: 'mid',
         productId: 0,
         notification: { title: 't' },
+        /* eslint-disable camelcase */
         collapse_key: ''
+        /* eslint-enable camelcase */
       };
 
       await LogModule.stageLog(messaging, internalPayload);

--- a/packages/messaging/src/helpers/logToFirelog.test.ts
+++ b/packages/messaging/src/helpers/logToFirelog.test.ts
@@ -24,14 +24,22 @@ import {
   getFakeLogEvent,
   getSuccessResponse
 } from '../testing/fakes/logging-object';
-import { restore, stub } from 'sinon';
+import { restore, stub, useFakeTimers } from 'sinon';
 
-import { MAX_NUMBER_OF_EVENTS_PER_LOG_REQUEST } from '../util/constants';
+import { _setDeliveryMetricsExportedToBigQueryEnabled } from '../api/setDeliveryMetricsExportedToBigQueryEnabled';
+import { MessagePayloadInternal } from '../interfaces/internal-message-payload';
+import {
+  LOG_INTERVAL_IN_MS,
+  MAX_NUMBER_OF_EVENTS_PER_LOG_REQUEST
+} from '../util/constants';
 import { MessagingService } from '../messaging-service';
 import { Stub } from '../testing/sinon-types';
 import { getFakeMessagingService } from '../testing/fakes/messaging-service';
 
 const LOG_ENDPOINT = 'https://play.google.com/log?format=json_proto3';
+
+/** Enough fake time for INITIAL_LOG_FLUSH_DELAY_MS (0) timers + fetch microtasks */
+const INITIAL_FLUSH_FAKE_TICK_MS = 10;
 
 const FCM_TRANSPORT_KEY = LogModule._mergeStrings(
   'AzSCbw63g1R0nCw85jG8',
@@ -210,6 +218,75 @@ describe('logToFirelog', () => {
         expect(messaging.logEvents.length).to.equal(0);
         done();
       }, 1000);
+    });
+  });
+
+  describe('startLoggingService', () => {
+    it('dispatches first queued batch promptly', async () => {
+      fetchStub.resolves(new Response(JSON.stringify(getSuccessResponse())));
+      messaging.deliveryMetricsExportedToBigQueryEnabled = true;
+      messaging.logEvents.push(getFakeLogEvent());
+
+      LogModule.startLoggingService(messaging);
+
+      await new Promise<void>(resolve => setTimeout(resolve, 50));
+      expect(fetchStub).to.have.been.called;
+      expect(messaging.logEvents).to.be.empty;
+    });
+
+    it('after first flush, waits LOG_INTERVAL_IN_MS before next dispatch', async () => {
+      const clock = useFakeTimers();
+      fetchStub.resolves(new Response(JSON.stringify(getSuccessResponse())));
+      messaging.deliveryMetricsExportedToBigQueryEnabled = true;
+      messaging.logEvents.push(getFakeLogEvent());
+
+      LogModule.startLoggingService(messaging);
+      await clock.tickAsync(INITIAL_FLUSH_FAKE_TICK_MS);
+      expect(fetchStub).to.have.been.calledOnce;
+
+      messaging.logEvents.push(getFakeLogEvent());
+      await clock.tickAsync(LOG_INTERVAL_IN_MS);
+      expect(fetchStub).to.have.been.calledTwice;
+      expect(messaging.logEvents).to.be.empty;
+
+      clock.restore();
+    });
+  });
+
+  describe('stageLog', () => {
+    it('starts logging service so first delivery metrics flush promptly', async () => {
+      fetchStub.resolves(new Response(JSON.stringify(getSuccessResponse())));
+      messaging.deliveryMetricsExportedToBigQueryEnabled = true;
+
+      const internalPayload: MessagePayloadInternal = {
+        from: '1234567890',
+        fcmMessageId: 'mid',
+        productId: 0,
+        notification: { title: 't' },
+        /* eslint-disable camelcase */
+        collapse_key: ''
+        /* eslint-enable camelcase */
+      };
+
+      await LogModule.stageLog(messaging, internalPayload);
+
+      await new Promise<void>(resolve => setTimeout(resolve, 50));
+      expect(fetchStub).to.have.been.called;
+      expect(messaging.logEvents).to.be.empty;
+    });
+  });
+
+  describe('_setDeliveryMetricsExportedToBigQueryEnabled integration', () => {
+    it('starts logging service when enabling export', async () => {
+      fetchStub.resolves(new Response(JSON.stringify(getSuccessResponse())));
+      messaging.logEvents.push(getFakeLogEvent());
+
+      _setDeliveryMetricsExportedToBigQueryEnabled(messaging, true);
+
+      await new Promise<void>(resolve => setTimeout(resolve, 50));
+      expect(fetchStub).to.have.been.called;
+      expect(messaging.logEvents).to.be.empty;
+      expect(messaging.deliveryMetricsExportedToBigQueryEnabled).to.be.true;
     });
   });
 });

--- a/packages/messaging/src/helpers/logToFirelog.test.ts
+++ b/packages/messaging/src/helpers/logToFirelog.test.ts
@@ -86,6 +86,42 @@ describe('logToFirelog', () => {
       expect(messaging.logEvents).to.be.empty;
     });
 
+    it('does not lose events enqueued during an in-flight dispatch', async () => {
+      const clock = useFakeTimers();
+
+      let resolveFetch: ((value: Response) => void) | undefined;
+      fetchStub.callsFake(() => {
+        return new Promise<Response>(resolve => {
+          resolveFetch = resolve;
+        });
+      });
+
+      const initialEvent = getFakeLogEvent();
+      const lateEvent = getFakeLogEvent();
+      messaging.logEvents.push(initialEvent);
+
+      const dispatchPromise = LogModule._dispatchLogEvents(messaging);
+
+      // Enqueue while dispatch is in-flight.
+      messaging.logEvents.push(lateEvent);
+
+      resolveFetch?.(new Response(JSON.stringify(getSuccessResponse())));
+      await dispatchPromise;
+
+      // First request drains only the swapped queue; the late event remains queued.
+      expect(fetchStub).to.have.been.calledOnce;
+      expect(messaging.logEvents).to.have.length(1);
+
+      // The follow-up flush should be scheduled ASAP (0ms).
+      fetchStub.resolves(new Response(JSON.stringify(getSuccessResponse())));
+      await clock.tickAsync(INITIAL_FLUSH_FAKE_TICK_MS);
+
+      expect(fetchStub).to.have.been.calledTwice;
+      expect(messaging.logEvents).to.be.empty;
+
+      clock.restore();
+    });
+
     it('Retries at most max retries times', async () => {
       // set up
       fetchStub.rejects(new Error('err'));

--- a/packages/messaging/src/helpers/logToFirelog.ts
+++ b/packages/messaging/src/helpers/logToFirelog.ts
@@ -47,9 +47,12 @@ const FCM_TRANSPORT_KEY = _mergeStrings(
 );
 
 export function startLoggingService(messaging: MessagingService): void {
-  if (!messaging.isLogServiceStarted && messaging.logEvents.length > 0) {
+  // Start only if not already scheduled/in-flight and there is work to do.
+  if (
+    messaging.logQueue.state === 'stopped' &&
+    messaging.logEvents.length > 0
+  ) {
     _processQueue(messaging, INITIAL_LOG_FLUSH_DELAY_MS);
-    messaging.isLogServiceStarted = true;
   }
 }
 
@@ -57,12 +60,11 @@ export function startLoggingService(messaging: MessagingService): void {
 export function stopLoggingServiceAndClearQueue(
   messaging: MessagingService
 ): void {
-  if (messaging.logQueueTimerId !== undefined) {
-    clearTimeout(messaging.logQueueTimerId);
-    messaging.logQueueTimerId = undefined;
+  if (messaging.logQueue.state === 'scheduled') {
+    clearTimeout(messaging.logQueue.timerId);
   }
+  messaging.logQueue = { state: 'stopped' };
   messaging.logEvents = [];
-  messaging.isLogServiceStarted = false;
 }
 
 /**
@@ -74,26 +76,29 @@ export function _processQueue(
   messaging: MessagingService,
   offsetInMs: number
 ): void {
-  if (messaging.logQueueTimerId !== undefined) {
-    clearTimeout(messaging.logQueueTimerId);
-    messaging.logQueueTimerId = undefined;
+  if (messaging.logQueue.state === 'scheduled') {
+    clearTimeout(messaging.logQueue.timerId);
   }
-  messaging.logQueueTimerId = setTimeout(async () => {
-    messaging.logQueueTimerId = undefined;
-    if (!messaging.deliveryMetricsExportedToBigQueryEnabled) {
-      // flush events and terminate logging service
-      messaging.logEvents = [];
-      messaging.isLogServiceStarted = false;
+  messaging.logQueue = { state: 'stopped' };
 
-      return;
-    }
+  if (!messaging.deliveryMetricsExportedToBigQueryEnabled) {
+    messaging.logEvents = [];
+    return;
+  }
 
-    if (!messaging.logEvents.length) {
-      return _processQueue(messaging, LOG_INTERVAL_IN_MS);
-    }
+  messaging.logQueue = {
+    state: 'scheduled',
+    timerId: setTimeout(async () => {
+      // Mark in-flight so stageLog/startLoggingService won't schedule duplicates mid-dispatch.
+      messaging.logQueue = { state: 'flushing' };
 
-    await _dispatchLogEvents(messaging);
-  }, offsetInMs);
+      if (!messaging.logEvents.length) {
+        return _processQueue(messaging, LOG_INTERVAL_IN_MS);
+      }
+
+      await _dispatchLogEvents(messaging);
+    }, offsetInMs)
+  };
 }
 
 export async function _dispatchLogEvents(
@@ -104,12 +109,6 @@ export async function _dispatchLogEvents(
     i < n;
     i += MAX_NUMBER_OF_EVENTS_PER_LOG_REQUEST
   ) {
-    if (!messaging.deliveryMetricsExportedToBigQueryEnabled) {
-      messaging.logEvents = [];
-      messaging.isLogServiceStarted = false;
-      return;
-    }
-
     const batch = messaging.logEvents.slice(
       i,
       i + MAX_NUMBER_OF_EVENTS_PER_LOG_REQUEST
@@ -171,8 +170,6 @@ export async function _dispatchLogEvents(
   // schedule for next logging
   if (messaging.deliveryMetricsExportedToBigQueryEnabled) {
     _processQueue(messaging, LOG_INTERVAL_IN_MS);
-  } else {
-    messaging.isLogServiceStarted = false;
   }
 }
 

--- a/packages/messaging/src/helpers/logToFirelog.ts
+++ b/packages/messaging/src/helpers/logToFirelog.ts
@@ -38,6 +38,9 @@ import { MessagingService } from '../messaging-service';
 
 const LOG_ENDPOINT = 'https://play.google.com/log?format=json_proto3';
 
+/** First flush ASAP (next timer turn); `_dispatchLogEvents` reschedules with `LOG_INTERVAL_IN_MS`. */
+const INITIAL_LOG_FLUSH_DELAY_MS = 0;
+
 const FCM_TRANSPORT_KEY = _mergeStrings(
   'AzSCbw63g1R0nCw85jG8',
   'Iaya3yLKwmgvh7cF0q4'
@@ -45,7 +48,7 @@ const FCM_TRANSPORT_KEY = _mergeStrings(
 
 export function startLoggingService(messaging: MessagingService): void {
   if (!messaging.isLogServiceStarted) {
-    _processQueue(messaging, LOG_INTERVAL_IN_MS);
+    _processQueue(messaging, INITIAL_LOG_FLUSH_DELAY_MS);
     messaging.isLogServiceStarted = true;
   }
 }
@@ -161,6 +164,7 @@ export async function stageLog(
   );
 
   createAndEnqueueLogEvent(messaging, fcmEvent, internalPayload.productId);
+  startLoggingService(messaging);
 }
 
 function createFcmEvent(

--- a/packages/messaging/src/helpers/logToFirelog.ts
+++ b/packages/messaging/src/helpers/logToFirelog.ts
@@ -47,10 +47,25 @@ const FCM_TRANSPORT_KEY = _mergeStrings(
 );
 
 export function startLoggingService(messaging: MessagingService): void {
-  if (!messaging.isLogServiceStarted) {
+  if (
+    !messaging.isLogServiceStarted &&
+    messaging.logEvents.length > 0
+  ) {
     _processQueue(messaging, INITIAL_LOG_FLUSH_DELAY_MS);
     messaging.isLogServiceStarted = true;
   }
+}
+
+/** Clears queued Firelog events, cancels any pending flush timer, and stops the logging loop. */
+export function stopLoggingServiceAndClearQueue(
+  messaging: MessagingService
+): void {
+  if (messaging.logQueueTimerId !== undefined) {
+    clearTimeout(messaging.logQueueTimerId);
+    messaging.logQueueTimerId = undefined;
+  }
+  messaging.logEvents = [];
+  messaging.isLogServiceStarted = false;
 }
 
 /**
@@ -62,7 +77,12 @@ export function _processQueue(
   messaging: MessagingService,
   offsetInMs: number
 ): void {
-  setTimeout(async () => {
+  if (messaging.logQueueTimerId !== undefined) {
+    clearTimeout(messaging.logQueueTimerId);
+    messaging.logQueueTimerId = undefined;
+  }
+  messaging.logQueueTimerId = setTimeout(async () => {
+    messaging.logQueueTimerId = undefined;
     if (!messaging.deliveryMetricsExportedToBigQueryEnabled) {
       // flush events and terminate logging service
       messaging.logEvents = [];
@@ -87,9 +107,21 @@ export async function _dispatchLogEvents(
     i < n;
     i += MAX_NUMBER_OF_EVENTS_PER_LOG_REQUEST
   ) {
-    const logRequest = _createLogRequest(
-      messaging.logEvents.slice(i, i + MAX_NUMBER_OF_EVENTS_PER_LOG_REQUEST)
+    if (!messaging.deliveryMetricsExportedToBigQueryEnabled) {
+      messaging.logEvents = [];
+      messaging.isLogServiceStarted = false;
+      return;
+    }
+
+    const batch = messaging.logEvents.slice(
+      i,
+      i + MAX_NUMBER_OF_EVENTS_PER_LOG_REQUEST
     );
+    if (!batch.length) {
+      break;
+    }
+
+    const logRequest = _createLogRequest(batch);
 
     let retryCount = 0,
       response = {} as Response;
@@ -140,7 +172,11 @@ export async function _dispatchLogEvents(
 
   messaging.logEvents = [];
   // schedule for next logging
-  _processQueue(messaging, LOG_INTERVAL_IN_MS);
+  if (messaging.deliveryMetricsExportedToBigQueryEnabled) {
+    _processQueue(messaging, LOG_INTERVAL_IN_MS);
+  } else {
+    messaging.isLogServiceStarted = false;
+  }
 }
 
 function isRetriableError(response: Response): boolean {

--- a/packages/messaging/src/helpers/logToFirelog.ts
+++ b/packages/messaging/src/helpers/logToFirelog.ts
@@ -104,12 +104,16 @@ export function _processQueue(
 export async function _dispatchLogEvents(
   messaging: MessagingService
 ): Promise<void> {
+  // Swap the queue to avoid losing events added during an in-flight dispatch.
+  const eventsToSend = messaging.logEvents;
+  messaging.logEvents = [];
+
   for (
-    let i = 0, n = messaging.logEvents.length;
+    let i = 0, n = eventsToSend.length;
     i < n;
     i += MAX_NUMBER_OF_EVENTS_PER_LOG_REQUEST
   ) {
-    const batch = messaging.logEvents.slice(
+    const batch = eventsToSend.slice(
       i,
       i + MAX_NUMBER_OF_EVENTS_PER_LOG_REQUEST
     );
@@ -166,11 +170,11 @@ export async function _dispatchLogEvents(
     } while (retryCount < MAX_RETRIES);
   }
 
-  messaging.logEvents = [];
-  // schedule for next logging
-  if (messaging.deliveryMetricsExportedToBigQueryEnabled) {
-    _processQueue(messaging, LOG_INTERVAL_IN_MS);
-  }
+  // Schedule next flush. If new events arrived during this dispatch, flush ASAP.
+  _processQueue(
+    messaging,
+    messaging.logEvents.length ? INITIAL_LOG_FLUSH_DELAY_MS : LOG_INTERVAL_IN_MS
+  );
 }
 
 function isRetriableError(response: Response): boolean {

--- a/packages/messaging/src/helpers/logToFirelog.ts
+++ b/packages/messaging/src/helpers/logToFirelog.ts
@@ -47,10 +47,7 @@ const FCM_TRANSPORT_KEY = _mergeStrings(
 );
 
 export function startLoggingService(messaging: MessagingService): void {
-  if (
-    !messaging.isLogServiceStarted &&
-    messaging.logEvents.length > 0
-  ) {
+  if (!messaging.isLogServiceStarted && messaging.logEvents.length > 0) {
     _processQueue(messaging, INITIAL_LOG_FLUSH_DELAY_MS);
     messaging.isLogServiceStarted = true;
   }

--- a/packages/messaging/src/listeners/sw-listeners.test.ts
+++ b/packages/messaging/src/listeners/sw-listeners.test.ts
@@ -24,6 +24,7 @@ import {
   CONSOLE_CAMPAIGN_ID,
   CONSOLE_CAMPAIGN_NAME,
   CONSOLE_CAMPAIGN_TIME,
+  FCM_LOG_SOURCE,
   FCM_MSG
 } from '../util/constants';
 import { DeepPartial, ValueOf, Writable } from 'ts-essentials';
@@ -33,6 +34,7 @@ import {
   mockServiceWorker,
   restoreServiceWorker
 } from '../testing/fakes/service-worker';
+import { getSuccessResponse } from '../testing/fakes/logging-object';
 import {
   MessagePayloadInternal,
   MessageType
@@ -52,11 +54,18 @@ import {
 import { onNotificationClick, onPush, onSubChange } from './sw-listeners';
 import { spy, stub } from 'sinon';
 
+import * as LogToFirelog from '../helpers/logToFirelog';
+
 import { MessagingService } from '../messaging-service';
 import { Stub } from '../testing/sinon-types';
 import { expect } from 'chai';
 
 const LOCAL_HOST = self.location.host;
+const FIRELOG_ENDPOINT = 'https://play.google.com/log?format=json_proto3';
+const FCM_TRANSPORT_KEY = LogToFirelog._mergeStrings(
+  'AzSCbw63g1R0nCw85jG8',
+  'Iaya3yLKwmgvh7cF0q4'
+);
 const TEST_LINK = 'https://' + LOCAL_HOST + '/test-link.org';
 const TEST_CLICK_ACTION = 'https://' + LOCAL_HOST + '/test-click-action.org';
 
@@ -264,6 +273,52 @@ describe('SwController', () => {
       expect(warnStub).to.have.been.calledOnceWith(
         'This browser only supports 1 actions. The remaining actions will not be displayed.'
       );
+    });
+
+    it('POSTs Firelog delivery metrics after onPush when BigQuery export is enabled', async () => {
+      const fetchStub = stub(window, 'fetch').resolves(
+        new Response(JSON.stringify(getSuccessResponse()))
+      );
+      messaging.deliveryMetricsExportedToBigQueryEnabled = true;
+
+      await callEventListener(
+        makeEvent('push', {
+          data: {
+            json: () => DISPLAY_MESSAGE
+          }
+        })
+      );
+
+      await new Promise<void>(resolve => setTimeout(resolve, 50));
+
+      expect(fetchStub).to.have.been.calledOnce;
+      const [url, init] = fetchStub.getCall(0).args;
+      expect(url).to.equal(FIRELOG_ENDPOINT.concat('&key=', FCM_TRANSPORT_KEY));
+      expect(init).to.deep.include({ method: 'POST' });
+      const body = JSON.parse((init as RequestInit).body as string) as {
+        log_source: string;
+        log_event: unknown[];
+      };
+      expect(body.log_source).to.equal(FCM_LOG_SOURCE.toString());
+      expect(body.log_event).to.have.length(1);
+    });
+
+    it('does not POST to Firelog from onPush when BigQuery export is disabled', async () => {
+      const fetchStub = stub(window, 'fetch').resolves(
+        new Response(JSON.stringify(getSuccessResponse()))
+      );
+      messaging.deliveryMetricsExportedToBigQueryEnabled = false;
+
+      await callEventListener(
+        makeEvent('push', {
+          data: {
+            json: () => DISPLAY_MESSAGE
+          }
+        })
+      );
+
+      await new Promise<void>(resolve => setTimeout(resolve, 50));
+      expect(fetchStub).to.not.have.been.called;
     });
   });
 

--- a/packages/messaging/src/listeners/sw-listeners.ts
+++ b/packages/messaging/src/listeners/sw-listeners.ts
@@ -79,7 +79,11 @@ export async function onPush(
     return;
   }
 
-  // Log to Firelog if the user opted in.
+  /*
+   * Log to Firelog based on user consent. Rather than calling startLoggingService once when
+   * deliveryMetricsExportedToBigQueryEnabled is toggled, we now call stageLog for every received push.
+   * This ensures the first telemetry event is uploaded immediately upon enabling the flag, simplifying debugging.
+   */
   if (messaging.deliveryMetricsExportedToBigQueryEnabled) {
     await stageLog(messaging, internalPayload);
   }

--- a/packages/messaging/src/listeners/sw-listeners.ts
+++ b/packages/messaging/src/listeners/sw-listeners.ts
@@ -79,7 +79,7 @@ export async function onPush(
     return;
   }
 
-  // log to Firelog with user consent
+  // Log to Firelog if the user opted in.
   if (messaging.deliveryMetricsExportedToBigQueryEnabled) {
     await stageLog(messaging, internalPayload);
   }

--- a/packages/messaging/src/messaging-service.ts
+++ b/packages/messaging/src/messaging-service.ts
@@ -44,6 +44,7 @@ export class MessagingService implements _FirebaseService {
 
   logEvents: LogEvent[] = [];
   isLogServiceStarted: boolean = false;
+  logQueueTimerId?: ReturnType<typeof setTimeout>;
 
   constructor(
     app: FirebaseApp,
@@ -61,6 +62,10 @@ export class MessagingService implements _FirebaseService {
   }
 
   _delete(): Promise<void> {
+    if (this.logQueueTimerId !== undefined) {
+      clearTimeout(this.logQueueTimerId);
+      this.logQueueTimerId = undefined;
+    }
     return Promise.resolve();
   }
 }

--- a/packages/messaging/src/messaging-service.ts
+++ b/packages/messaging/src/messaging-service.ts
@@ -43,8 +43,13 @@ export class MessagingService implements _FirebaseService {
     null;
 
   logEvents: LogEvent[] = [];
-  isLogServiceStarted: boolean = false;
-  logQueueTimerId?: ReturnType<typeof setTimeout>;
+  /**
+   * Single source of truth for the logging loop lifecycle.
+   *
+   * `scheduled` holds the active timer id; `flushing` indicates an async dispatch
+   * is in progress (prevents duplicate starts); `stopped` means idle.
+   */
+  logQueue: LogQueueState = { state: 'stopped' };
 
   constructor(
     app: FirebaseApp,
@@ -62,10 +67,15 @@ export class MessagingService implements _FirebaseService {
   }
 
   _delete(): Promise<void> {
-    if (this.logQueueTimerId !== undefined) {
-      clearTimeout(this.logQueueTimerId);
-      this.logQueueTimerId = undefined;
+    if (this.logQueue.state === 'scheduled') {
+      clearTimeout(this.logQueue.timerId);
     }
+    this.logQueue = { state: 'stopped' };
     return Promise.resolve();
   }
 }
+
+export type LogQueueState =
+  | { state: 'stopped' }
+  | { state: 'scheduled'; timerId: ReturnType<typeof setTimeout> }
+  | { state: 'flushing' };


### PR DESCRIPTION
### Intent

Ship a fix so **FCM Web delivery metrics / Firelog logging actually runs** after developers enable **`experimentalSetDeliveryMetricsExportedToBigQueryEnabled`**. Today **`stageLog`** only queues events in memory; **`startLoggingService`** was never started from production code, so **`_processQueue` → `_dispatchLogEvents`** never fired and **no POST to `play.google.com/log`** occurred. This PR wires **`startLoggingService`** from **`stageLog`** and when enabling export, uses an **immediate first flush** (`INITIAL_LOG_FLUSH_DELAY_MS = 0`) for easier verification while keeping **subsequent batches on `LOG_INTERVAL_IN_MS`** after dispatch.

---

### Summary

- **`stageLog`**: call **`startLoggingService(messaging)`** after enqueueing (idempotent).
- **`_setDeliveryMetricsExportedToBigQueryEnabled(..., true)`**: call **`startLoggingService`** so the flush loop arms when users opt in.
- **`startLoggingService`**: first **`_processQueue`** delay **`0`**; **`_dispatchLogEvents`** still reschedules with **`LOG_INTERVAL_IN_MS`** (24h).

---

### Root cause

**`startLoggingService`** had **zero production call sites**; only **`stageLog`** appended to **`logEvents`**, so Firelog **`fetch`** never ran.


b/503660323