### PR TITLE
chore: fix e2e tests for functions and AI

### DIFF
--- a/e2e/smoke-tests/sample-apps/compat.js
+++ b/e2e/smoke-tests/sample-apps/compat.js
@@ -87,7 +87,7 @@ async function authLogout() {
 async function callFunctions() {
   console.log('[FUNCTIONS] start');
   const functions = firebase.functions();
-  const callTest = functions.httpsCallable('callTest');
+  const callTest = functions.httpsCallable('callTestv2');
   try {
     const result = await callTest({ data: 'blah' });
     console.log('[FUNCTIONS] result:', result.data);

--- a/e2e/smoke-tests/sample-apps/modular.js
+++ b/e2e/smoke-tests/sample-apps/modular.js
@@ -126,7 +126,7 @@ async function authLogout(app) {
 async function callFunctions(app) {
   console.log('[FUNCTIONS] start');
   const functions = getFunctions(app);
-  let callTest = httpsCallable(functions, 'callTest');
+  let callTest = httpsCallable(functions, 'callTestv2');
   try {
     const result = await callTest({ data: 'blah' });
     console.log('[FUNCTIONS] result (by name):', result.data);
@@ -142,7 +142,7 @@ async function callFunctions(app) {
   }
   callTest = httpsCallableFromURL(
     functions,
-    `https://us-central-${app.options.projectId}.cloudfunctions.net/callTest`
+    `https://us-central-${app.options.projectId}.cloudfunctions.net/callTestv2`
   );
   try {
     const result = await callTest({ data: 'blah' });

--- a/e2e/smoke-tests/sample-apps/modular.js
+++ b/e2e/smoke-tests/sample-apps/modular.js
@@ -142,7 +142,7 @@ async function callFunctions(app) {
   }
   callTest = httpsCallableFromURL(
     functions,
-    `https://us-central-${app.options.projectId}.cloudfunctions.net/callTestv2`
+    `https://us-central1-${app.options.projectId}.cloudfunctions.net/callTestv2`
   );
   try {
     const result = await callTest({ data: 'blah' });

--- a/e2e/smoke-tests/tests/compat.test.ts
+++ b/e2e/smoke-tests/tests/compat.test.ts
@@ -74,7 +74,7 @@ describe('COMPAT', () => {
       functions = firebase.functions();
     });
     it('httpsCallable()', async () => {
-      const callTest = functions.httpsCallable('callTest');
+      const callTest = functions.httpsCallable('callTestv2');
       const result = await callTest({ data: 'blah' });
       expect(result.data.word).toBe('hellooo');
     });

--- a/e2e/smoke-tests/tests/modular.test.ts
+++ b/e2e/smoke-tests/tests/modular.test.ts
@@ -313,7 +313,7 @@ describe('MODULAR', () => {
     it('getVertexAI()', () => {
       ai = getAI(app, { backend: new VertexAIBackend() });
     });
-    it('getGenerativeModel() and countTokens()', async () => {
+    it('getGenerativeModel()', async () => {
       const model = getGenerativeModel(ai, { model: 'gemini-2.5-flash' });
       expect(model.model).toMatch(/gemini-2.5-flash$/);
     });

--- a/e2e/smoke-tests/tests/modular.test.ts
+++ b/e2e/smoke-tests/tests/modular.test.ts
@@ -145,7 +145,7 @@ describe('MODULAR', () => {
     it('httpsCallable()', async () => {
       const callTest = httpsCallable<{ data: string }, { word: string }>(
         functions,
-        'callTest'
+        'callTestv2'
       );
       const result = await callTest({ data: 'blah' });
       expect(result.data.word).toBe('hellooo');
@@ -154,7 +154,7 @@ describe('MODULAR', () => {
     it('httpsCallableFromURL()', async () => {
       const callTest = httpsCallableFromURL<{ data: string }, { word: string }>(
         functions,
-        `https://us-central1-${app.options.projectId}.cloudfunctions.net/callTest`
+        `https://us-central1-${app.options.projectId}.cloudfunctions.net/callTestv2`
       );
       const result = await callTest({ data: 'blah' });
       expect(result.data.word).toBe('hellooo');
@@ -316,8 +316,6 @@ describe('MODULAR', () => {
     it('getGenerativeModel() and countTokens()', async () => {
       const model = getGenerativeModel(ai, { model: 'gemini-2.5-flash' });
       expect(model.model).toMatch(/gemini-2.5-flash$/);
-      const result = await model.countTokens('abcdefg');
-      expect(result.totalTokens).toBeTruthy;
     });
   });
 


### PR DESCRIPTION
Update e2e tests to work with recent changes to:
- functions - moved test project to v2 functions, with new names
- ai - disabled AI on project temporarily to prevent abuse until we can move onto a private project