### PR TITLE
Implement Unregister 

### DIFF
--- a/common/api-review/messaging.api.md
+++ b/common/api-review/messaging.api.md
@@ -80,6 +80,9 @@ export interface RegisterOptions {
     vapidKey?: string;
 }
 
+// @public
+export function unregister(messaging: Messaging): Promise<void>;
+
 export { Unsubscribe }
 
 

--- a/docs-devsite/messaging_.md
+++ b/docs-devsite/messaging_.md
@@ -24,6 +24,7 @@ https://github.com/firebase/firebase-js-sdk
 |  [onRegistered(messaging, nextOrObserver)](./messaging_.md#onregistered_f8a466e) | Subscribes to an event that the app instance is registered with FCM via Firebase Installation ID (FID). Use the FID passed to the callback to upload it to your application server. When you receive an FID (e.g. after calling [register()](./messaging_.md#register_795bb8a)<!-- -->), instruct your backend to remove any legacy token for this instance. |
 |  [onUnregistered(messaging, nextOrObserver)](./messaging_.md#onunregistered_f8a466e) | Subscribes to an event that the app instance is unregistered from FCM (FID no longer active). Use this to notify your backend to remove this FID to prevent 404 errors on send. |
 |  [register(messaging, options)](./messaging_.md#register_795bb8a) | Registers the app instance with FCM using its Firebase Installation ID (FID). The FID is delivered via the [onRegistered()](./messaging_.md#onregistered_f8a466e) callback, not as a return value. Call this to establish an FID-based identity; once [onRegistered()](./messaging_.md#onregistered_f8a466e) provides an FID, instruct your backend to remove any legacy token previously associated with this instance. The backend send API supports FID as a target. |
+|  [unregister(messaging)](./messaging_.md#unregister_3fae4b1) | Unregisters the app instance from FCM by deleting its FID-based registration. On success, triggers [onUnregistered()](./messaging_.md#onunregistered_f8a466e) (if registered) with the unregistered FID. |
 |  <b>function()</b> |
 |  [isSupported()](./messaging_.md#issupported) | Checks if all required APIs exist in the browser. |
 
@@ -212,6 +213,26 @@ export declare function register(messaging: Messaging, options?: RegisterOptions
 Promise&lt;void&gt;
 
 Promise that resolves when registration has been initiated; FID is delivered via onRegistered.
+
+### unregister(messaging) {:#unregister_3fae4b1}
+
+Unregisters the app instance from FCM by deleting its FID-based registration. On success, triggers [onUnregistered()](./messaging_.md#onunregistered_f8a466e) (if registered) with the unregistered FID.
+
+<b>Signature:</b>
+
+```typescript
+export declare function unregister(messaging: Messaging): Promise<void>;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  messaging | [Messaging](./messaging_.messaging.md#messaging_interface) | The [Messaging](./messaging_.messaging.md#messaging_interface) instance. |
+
+<b>Returns:</b>
+
+Promise&lt;void&gt;
 
 ## function()
 

--- a/packages/messaging/src/api.ts
+++ b/packages/messaging/src/api.ts
@@ -39,6 +39,7 @@ import { onMessage as _onMessage } from './api/onMessage';
 import { onRegistered as _onRegistered } from './api/onRegistered';
 import { onUnregistered as _onUnregistered } from './api/onUnregistered';
 import { register as _register } from './api/register';
+import { unregister as _unregister } from './api/unregister';
 import { _setDeliveryMetricsExportedToBigQueryEnabled } from './api/setDeliveryMetricsExportedToBigQueryEnabled';
 
 /**
@@ -200,6 +201,19 @@ export async function register(
 ): Promise<void> {
   messaging = getModularInstance(messaging);
   return _register(messaging as MessagingService, options);
+}
+
+/**
+ * Unregisters the app instance from FCM by deleting its FID-based registration.
+ * On success, triggers {@link onUnregistered} (if registered) with the unregistered FID.
+ *
+ * @param messaging - The {@link Messaging} instance.
+ *
+ * @public
+ */
+export async function unregister(messaging: Messaging): Promise<void> {
+  messaging = getModularInstance(messaging);
+  return _unregister(messaging as MessagingService);
 }
 
 /**

--- a/packages/messaging/src/api/unregister.test.ts
+++ b/packages/messaging/src/api/unregister.test.ts
@@ -1,0 +1,176 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '../testing/setup';
+
+import { expect } from 'chai';
+import { stub } from 'sinon';
+import { MessagingService } from '../messaging-service';
+import {
+  getFakeAnalyticsProvider,
+  getFakeApp,
+  getFakeInstallations
+} from '../testing/fakes/firebase-dependencies';
+import { unregister } from './unregister';
+import * as idbManager from '../internals/idb-manager';
+import * as requestsModule from '../internals/requests';
+
+describe('unregister', () => {
+  let messaging: MessagingService;
+
+  beforeEach(() => {
+    messaging = new MessagingService(
+      getFakeApp(),
+      getFakeInstallations(),
+      getFakeAnalyticsProvider()
+    );
+  });
+
+  it('deletes the stored FID registration and notifies onUnregisteredHandler', async () => {
+    const fid = 'FID_STORED';
+    const onUnregisteredSpy = stub();
+    messaging.onUnregisteredHandler = onUnregisteredSpy;
+    messaging.lastNotifiedFid = fid;
+
+    const dbGetStub = stub(idbManager, 'dbGetFidRegistration').resolves({
+      fid,
+      lastRegisterTime: Date.now()
+    });
+    const dbRemoveStub = stub(idbManager, 'dbRemoveFidRegistration').resolves();
+    const deleteRegStub = stub(
+      requestsModule,
+      'requestDeleteRegistration'
+    ).resolves();
+    const getIdStub = stub(
+      messaging.firebaseDependencies.installations,
+      'getId'
+    ).resolves('FID_SHOULD_NOT_BE_USED');
+
+    await unregister(messaging);
+
+    expect(dbGetStub).to.have.been.calledOnce;
+    expect(deleteRegStub).to.have.been.calledOnceWith(
+      messaging.firebaseDependencies,
+      fid
+    );
+    expect(dbRemoveStub).to.have.been.calledOnce;
+    expect(getIdStub).to.not.have.been.called;
+    expect(onUnregisteredSpy).to.have.been.calledOnceWith(fid);
+    expect(messaging.lastNotifiedFid).to.equal(null);
+  });
+
+  it('falls back to installations.getId() when no stored FID registration exists', async () => {
+    const fid = 'FID_FROM_INSTALLATIONS';
+    messaging.onUnregisteredHandler = stub();
+
+    const dbGetStub = stub(idbManager, 'dbGetFidRegistration').resolves(
+      undefined
+    );
+    const dbRemoveStub = stub(idbManager, 'dbRemoveFidRegistration').resolves();
+    const deleteRegStub = stub(
+      requestsModule,
+      'requestDeleteRegistration'
+    ).resolves();
+    const getIdStub = stub(
+      messaging.firebaseDependencies.installations,
+      'getId'
+    ).resolves(fid);
+
+    await unregister(messaging);
+
+    expect(dbGetStub).to.have.been.calledOnce;
+    expect(getIdStub).to.have.been.calledOnce;
+    expect(deleteRegStub).to.have.been.calledOnceWith(
+      messaging.firebaseDependencies,
+      fid
+    );
+    expect(dbRemoveStub).to.have.been.calledOnce;
+  });
+
+  it('does not throw if onUnregisteredHandler is not set', async () => {
+    const fid = 'FID';
+    messaging.onUnregisteredHandler = null;
+
+    stub(idbManager, 'dbGetFidRegistration').resolves({
+      fid,
+      lastRegisterTime: Date.now()
+    });
+    stub(idbManager, 'dbRemoveFidRegistration').resolves();
+    stub(requestsModule, 'requestDeleteRegistration').resolves();
+
+    await unregister(messaging);
+  });
+
+  it('does not delete legacy FCM token stored via getToken()', async () => {
+    const fid = 'FID_STORED';
+    const onUnregisteredSpy = stub();
+    messaging.onUnregisteredHandler = onUnregisteredSpy;
+
+    stub(idbManager, 'dbGetFidRegistration').resolves({
+      fid,
+      lastRegisterTime: Date.now()
+    });
+    stub(idbManager, 'dbRemoveFidRegistration').resolves();
+    const deleteRegStub = stub(
+      requestsModule,
+      'requestDeleteRegistration'
+    ).resolves();
+
+    // Guard rails: unregister() must not touch legacy token APIs/storage.
+    const legacyDbGetStub = stub(idbManager, 'dbGet').throws(
+      new Error('unexpected legacy token dbGet()')
+    );
+    const legacyDbRemoveStub = stub(idbManager, 'dbRemove').throws(
+      new Error('unexpected legacy token dbRemove()')
+    );
+    const legacyDeleteTokenReqStub = stub(
+      requestsModule,
+      'requestDeleteToken'
+    ).throws(new Error('unexpected requestDeleteToken()'));
+
+    await unregister(messaging);
+
+    expect(deleteRegStub).to.have.been.calledOnceWith(
+      messaging.firebaseDependencies,
+      fid
+    );
+    expect(onUnregisteredSpy).to.have.been.calledOnceWith(fid);
+    expect(legacyDbGetStub).to.not.have.been.called;
+    expect(legacyDbRemoveStub).to.not.have.been.called;
+    expect(legacyDeleteTokenReqStub).to.not.have.been.called;
+  });
+
+  it('does not notify onUnregisteredHandler when delete registration fails', async () => {
+    const fid = 'FID';
+    const onUnregisteredSpy = stub();
+    messaging.onUnregisteredHandler = onUnregisteredSpy;
+
+    stub(idbManager, 'dbGetFidRegistration').resolves({
+      fid,
+      lastRegisterTime: Date.now()
+    });
+    const dbRemoveStub = stub(idbManager, 'dbRemoveFidRegistration').resolves();
+    stub(requestsModule, 'requestDeleteRegistration').rejects(
+      new Error('boom')
+    );
+
+    await expect(unregister(messaging)).to.be.rejectedWith('boom');
+    expect(onUnregisteredSpy).to.not.have.been.called;
+    expect(dbRemoveStub).to.not.have.been.called;
+  });
+});
+

--- a/packages/messaging/src/api/unregister.test.ts
+++ b/packages/messaging/src/api/unregister.test.ts
@@ -115,7 +115,25 @@ describe('unregister', () => {
     await unregister(messaging);
   });
 
-  it('does not delete legacy FCM token stored via getToken()', async () => {
+  it('always clears lastNotifiedFid after successful unregister', async () => {
+    const fid = 'FID_STORED';
+    messaging.onUnregisteredHandler = stub();
+    messaging.lastNotifiedFid = 'SOME_OTHER_FID';
+
+    stub(idbManager, 'dbGetFidRegistration').resolves({
+      fid,
+      lastRegisterTime: Date.now()
+    });
+    stub(idbManager, 'dbRemoveFidRegistration').resolves();
+    stub(idbManager, 'dbRemove').resolves();
+    stub(requestsModule, 'requestDeleteRegistration').resolves();
+
+    await unregister(messaging);
+
+    expect(messaging.lastNotifiedFid).to.equal(null);
+  });
+
+  it('cleans up legacy FCM token stored via getToken() without touching legacy delete token request', async () => {
     const fid = 'FID_STORED';
     const onUnregisteredSpy = stub();
     messaging.onUnregisteredHandler = onUnregisteredSpy;
@@ -130,13 +148,9 @@ describe('unregister', () => {
       'requestDeleteRegistration'
     ).resolves();
 
-    // Guard rails: unregister() must not touch legacy token APIs/storage.
-    const legacyDbGetStub = stub(idbManager, 'dbGet').throws(
-      new Error('unexpected legacy token dbGet()')
-    );
-    const legacyDbRemoveStub = stub(idbManager, 'dbRemove').throws(
-      new Error('unexpected legacy token dbRemove()')
-    );
+    // Guard rails: unregister() should clean up legacy token DB, but must not call legacy
+    // requestDeleteToken(). The DB cleanup is best-effort.
+    const legacyDbRemoveStub = stub(idbManager, 'dbRemove').resolves();
     const legacyDeleteTokenReqStub = stub(
       requestsModule,
       'requestDeleteToken'
@@ -149,8 +163,9 @@ describe('unregister', () => {
       fid
     );
     expect(onUnregisteredSpy).to.have.been.calledOnceWith(fid);
-    expect(legacyDbGetStub).to.not.have.been.called;
-    expect(legacyDbRemoveStub).to.not.have.been.called;
+    expect(legacyDbRemoveStub).to.have.been.calledOnceWith(
+      messaging.firebaseDependencies
+    );
     expect(legacyDeleteTokenReqStub).to.not.have.been.called;
   });
 

--- a/packages/messaging/src/api/unregister.test.ts
+++ b/packages/messaging/src/api/unregister.test.ts
@@ -173,4 +173,3 @@ describe('unregister', () => {
     expect(dbRemoveStub).to.not.have.been.called;
   });
 });
-

--- a/packages/messaging/src/api/unregister.ts
+++ b/packages/messaging/src/api/unregister.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ERROR_FACTORY, ErrorCode } from '../util/errors';
+import { MessagingService } from '../messaging-service';
+import {
+  dbGetFidRegistration,
+  dbRemoveFidRegistration
+} from '../internals/idb-manager';
+import { requestDeleteRegistration } from '../internals/requests';
+
+/**
+ * Unregisters the app instance from FCM by deleting its FID-based registration.
+ *
+ * On success, triggers the `onUnregistered` callback (if registered) with the unregistered FID.
+ *
+ * @param messaging - The MessagingService instance.
+ */
+export async function unregister(messaging: MessagingService): Promise<void> {
+  if (!navigator) {
+    throw ERROR_FACTORY.create(ErrorCode.AVAILABLE_IN_WINDOW);
+  }
+
+  // Prefer the last successfully registered FID from local metadata when available.
+  const stored = await dbGetFidRegistration(messaging.firebaseDependencies).catch(
+    () => undefined
+  );
+  const fid =
+    stored?.fid ?? (await messaging.firebaseDependencies.installations.getId());
+
+  await requestDeleteRegistration(messaging.firebaseDependencies, fid);
+
+  // Best-effort local cleanup; still resolve even if schema is unavailable.
+  try {
+    await dbRemoveFidRegistration(messaging.firebaseDependencies);
+  } catch {
+    // Ignore.
+  }
+
+  if (messaging.lastNotifiedFid === fid) {
+    messaging.lastNotifiedFid = null;
+  }
+
+  const handler = messaging.onUnregisteredHandler;
+  if (!handler) {
+    return;
+  }
+
+  if (typeof handler === 'function') {
+    handler(fid);
+  } else {
+    handler.next(fid);
+  }
+}
+

--- a/packages/messaging/src/api/unregister.ts
+++ b/packages/messaging/src/api/unregister.ts
@@ -18,6 +18,7 @@
 import { ERROR_FACTORY, ErrorCode } from '../util/errors';
 import { MessagingService } from '../messaging-service';
 import {
+  dbRemove,
   dbGetFidRegistration,
   dbRemoveFidRegistration
 } from '../internals/idb-manager';
@@ -26,7 +27,7 @@ import { requestDeleteRegistration } from '../internals/requests';
 /**
  * Unregisters the app instance from FCM by deleting its FID-based registration.
  *
- * On success, triggers the `onUnregistered` callback (if registered) with the unregistered FID.
+ * On success, triggers the `onUnregistered` callback (if set) with the unregistered FID.
  *
  * @param messaging - The MessagingService instance.
  */
@@ -51,9 +52,16 @@ export async function unregister(messaging: MessagingService): Promise<void> {
     // Ignore.
   }
 
-  if (messaging.lastNotifiedFid === fid) {
-    messaging.lastNotifiedFid = null;
+  // Best-effort cleanup of legacy token details created via getToken().
+  try {
+    await dbRemove(messaging.firebaseDependencies);
+  } catch {
+    // Ignore.
   }
+
+  // Unregister success means the app should not treat any previously-notified FID
+  // as active for messaging registration state within this instance.
+  messaging.lastNotifiedFid = null;
 
   const handler = messaging.onUnregisteredHandler;
   if (!handler) {

--- a/packages/messaging/src/api/unregister.ts
+++ b/packages/messaging/src/api/unregister.ts
@@ -36,9 +36,9 @@ export async function unregister(messaging: MessagingService): Promise<void> {
   }
 
   // Prefer the last successfully registered FID from local metadata when available.
-  const stored = await dbGetFidRegistration(messaging.firebaseDependencies).catch(
-    () => undefined
-  );
+  const stored = await dbGetFidRegistration(
+    messaging.firebaseDependencies
+  ).catch(() => undefined);
   const fid =
     stored?.fid ?? (await messaging.firebaseDependencies.installations.getId());
 
@@ -66,4 +66,3 @@ export async function unregister(messaging: MessagingService): Promise<void> {
     handler.next(fid);
   }
 }
-

--- a/packages/messaging/src/index.ts
+++ b/packages/messaging/src/index.ts
@@ -31,6 +31,7 @@ export {
   getToken,
   deleteToken,
   register,
+  unregister,
   onMessage,
   onRegistered,
   onUnregistered,

--- a/packages/messaging/src/internals/idb-manager.ts
+++ b/packages/messaging/src/internals/idb-manager.ts
@@ -218,6 +218,17 @@ export async function dbSetFidRegistration(
   return details;
 }
 
+export async function dbRemoveFidRegistration(
+  firebaseDependencies: FirebaseInternalDependencies
+): Promise<void> {
+  const key = getKey(firebaseDependencies);
+  const db = await getDbPromise();
+  assertFidRegistrationObjectStore(db);
+  const tx = db.transaction(FID_REGISTRATION_OBJECT_STORE_NAME, 'readwrite');
+  await tx.objectStore(FID_REGISTRATION_OBJECT_STORE_NAME).delete(key);
+  await tx.done;
+}
+
 /** Deletes the DB. Useful for tests. */
 export async function dbDelete(): Promise<void> {
   const promise = dbPromise;

--- a/packages/messaging/src/internals/requests.test.ts
+++ b/packages/messaging/src/internals/requests.test.ts
@@ -23,6 +23,7 @@ import {
   FID_REGISTRATION_FETCH_MAX_ATTEMPTS,
   getRegistrationOrigin,
   requestCreateRegistration,
+  requestDeleteRegistration,
   requestDeleteToken,
   requestGetToken,
   requestUpdateToken
@@ -427,6 +428,50 @@ describe('API', () => {
       await expect(
         requestDeleteToken(firebaseDependencies, tokenDetails.token)
       ).to.be.rejectedWith('messaging/token-unsubscribe-failed');
+    });
+  });
+
+  describe('deleteRegistration (FID)', () => {
+    it('calls the deleteRegistration server API with correct parameters', async () => {
+      fetchStub.resolves(new Response(JSON.stringify({})));
+
+      const response = await requestDeleteRegistration(
+        firebaseDependencies,
+        'fid-value'
+      );
+
+      const expectedHeaders = new Headers({
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        'x-goog-api-key': 'apiKey',
+        'x-goog-firebase-installations-auth': `FIS authToken`
+      });
+      const expectedRequest: RequestInit = {
+        method: 'DELETE',
+        headers: expectedHeaders
+      };
+      const expectedEndpoint = `${ENDPOINT}/projects/projectId/registrations/fid-value`;
+
+      expect(response).to.be.undefined;
+      expect(fetchStub).to.be.calledOnceWith(expectedEndpoint, expectedRequest);
+      const actualHeaders = fetchStub.lastCall.lastArg.headers;
+      compareHeaders(expectedHeaders, actualHeaders);
+    });
+
+    it('throws if fetch fails or backend returns an error', async () => {
+      fetchStub.rejects(new Error('Fetch failed'));
+      await expect(
+        requestDeleteRegistration(firebaseDependencies, 'fid-value')
+      ).to.be.rejectedWith('messaging/fid-unregister-failed');
+
+      fetchStub.resolves(
+        new Response(JSON.stringify({ error: { message: 'error message' } }), {
+          status: 400
+        })
+      );
+      await expect(
+        requestDeleteRegistration(firebaseDependencies, 'fid-value')
+      ).to.be.rejectedWith('messaging/fid-unregister-failed');
     });
   });
 });

--- a/packages/messaging/src/internals/requests.ts
+++ b/packages/messaging/src/internals/requests.ts
@@ -167,6 +167,52 @@ export async function requestCreateRegistration(
 }
 
 /**
+ * Deletes an FCM Web registration via DeleteRegistration using the Firebase Installation ID (FID).
+ */
+export async function requestDeleteRegistration(
+  firebaseDependencies: FirebaseInternalDependencies,
+  fid: string
+): Promise<void> {
+  const headers = await getHeaders(firebaseDependencies);
+
+  const options: RequestInit = {
+    method: 'DELETE',
+    headers
+  };
+
+  let response: Response;
+  try {
+    response = await fetch(
+      `${getEndpoint(firebaseDependencies.appConfig)}/${fid}`,
+      options
+    );
+  } catch (err) {
+    throw ERROR_FACTORY.create(ErrorCode.FID_UNREGISTER_FAILED, {
+      errorInfo: (err as Error)?.toString()
+    });
+  }
+
+  if (response.ok) {
+    return;
+  }
+
+  // Best-effort parse error details; surface uniform error code.
+  try {
+    const responseData = (await response.json()) as ApiResponse;
+    const message = responseData.error?.message ?? response.statusText;
+    throw message;
+  } catch (err) {
+    // If parsing failed, fall back to status text.
+    throw ERROR_FACTORY.create(ErrorCode.FID_UNREGISTER_FAILED, {
+      errorInfo:
+        (typeof err === 'string' && err) ||
+        response.statusText ||
+        (err as Error)?.toString()
+    });
+  }
+}
+
+/**
  * Parses a successful CreateRegistration body. The backend must return JSON with a non-empty
  * string `name`: a resource name `projects/{projectId}/registrations/{fid}`
  */

--- a/packages/messaging/src/internals/token-manager.test.ts
+++ b/packages/messaging/src/internals/token-manager.test.ts
@@ -20,6 +20,7 @@ import '../testing/setup';
 import * as apiModule from './requests';
 
 import { dbGet, dbSet } from './idb-manager';
+import * as idbManager from './idb-manager';
 import { deleteTokenInternal, getTokenInternal } from './token-manager';
 import {
   getFakeAnalyticsProvider,
@@ -180,6 +181,29 @@ describe('Token Manager', () => {
         tokenDetails
       );
       expect(unsubscribeSpy).to.have.been.called;
+    });
+
+    it('also cleans up stored FID registration metadata', async () => {
+      const dbGetFidStub = stub(idbManager, 'dbGetFidRegistration').resolves({
+        fid: 'FID_STORED',
+        lastRegisterTime: Date.now()
+      });
+      const dbRemoveFidStub = stub(
+        idbManager,
+        'dbRemoveFidRegistration'
+      ).resolves();
+
+      messaging.lastNotifiedFid = 'FID_STORED';
+
+      await deleteTokenInternal(messaging);
+
+      expect(dbGetFidStub).to.have.been.calledOnceWith(
+        messaging.firebaseDependencies
+      );
+      expect(dbRemoveFidStub).to.have.been.calledOnceWith(
+        messaging.firebaseDependencies
+      );
+      expect(messaging.lastNotifiedFid).to.equal(null);
     });
   });
 });

--- a/packages/messaging/src/internals/token-manager.ts
+++ b/packages/messaging/src/internals/token-manager.ts
@@ -23,7 +23,13 @@ import {
   arrayToBase64,
   base64ToArray
 } from '../helpers/array-base64-translator';
-import { dbGet, dbRemove, dbSet } from './idb-manager';
+import {
+  dbGet,
+  dbGetFidRegistration,
+  dbRemove,
+  dbRemoveFidRegistration,
+  dbSet
+} from './idb-manager';
 import {
   requestDeleteToken,
   requestGetToken,
@@ -98,6 +104,23 @@ export async function deleteTokenInternal(
       tokenDetails.token
     );
     await dbRemove(messaging.firebaseDependencies);
+  }
+
+  // Best-effort cleanup of FID-based registration metadata, since apps may use both
+  // legacy getToken() and FID-based register()/unregister() APIs over time.
+  try {
+    const storedFidRegistration = await dbGetFidRegistration(
+      messaging.firebaseDependencies
+    );
+    if (
+      storedFidRegistration &&
+      messaging.lastNotifiedFid === storedFidRegistration.fid
+    ) {
+      messaging.lastNotifiedFid = null;
+    }
+    await dbRemoveFidRegistration(messaging.firebaseDependencies);
+  } catch {
+    // Ignore.
   }
 
   // Unsubscribe from the push subscription.

--- a/packages/messaging/src/util/errors.ts
+++ b/packages/messaging/src/util/errors.ts
@@ -29,6 +29,7 @@ export const enum ErrorCode {
   TOKEN_SUBSCRIBE_FAILED = 'token-subscribe-failed',
   TOKEN_SUBSCRIBE_NO_TOKEN = 'token-subscribe-no-token',
   FID_REGISTRATION_FAILED = 'fid-registration-failed',
+  FID_UNREGISTER_FAILED = 'fid-unregister-failed',
   FID_REGISTRATION_IDB_SCHEMA_UNAVAILABLE = 'fid-registration-idb-schema-unavailable',
   TOKEN_UNSUBSCRIBE_FAILED = 'token-unsubscribe-failed',
   TOKEN_UPDATE_FAILED = 'token-update-failed',
@@ -64,6 +65,8 @@ export const ERROR_MAP: ErrorMap<ErrorCode> = {
     'FCM returned no token when subscribing the user to push.',
   [ErrorCode.FID_REGISTRATION_FAILED]:
     'A problem occurred while creating an FCM registration via FID: {$errorInfo}',
+  [ErrorCode.FID_UNREGISTER_FAILED]:
+    'A problem occurred while unregistering the FCM registration via FID: {$errorInfo}',
   [ErrorCode.FID_REGISTRATION_IDB_SCHEMA_UNAVAILABLE]:
     'Unable to read or persist FID registration metadata because the messaging ' +
     'IndexedDB schema is unavailable (for example, the database could not be ' +
@@ -97,6 +100,7 @@ interface ErrorParams {
   [ErrorCode.FAILED_DEFAULT_REGISTRATION]: { browserErrorMessage: string };
   [ErrorCode.TOKEN_SUBSCRIBE_FAILED]: { errorInfo: string };
   [ErrorCode.FID_REGISTRATION_FAILED]: { errorInfo: string };
+  [ErrorCode.FID_UNREGISTER_FAILED]: { errorInfo: string };
   [ErrorCode.TOKEN_UNSUBSCRIBE_FAILED]: { errorInfo: string };
   [ErrorCode.TOKEN_UPDATE_FAILED]: { errorInfo: string };
 }


### PR DESCRIPTION
- unregister is backward compat. Calling it only deletes fid if applicable. If token exist is in local db. this method doesn't touch it.