### PR TITLE
fix(changelog-generator): fix postinstall failure

### DIFF
--- a/repo-scripts/changelog-generator/index.ts
+++ b/repo-scripts/changelog-generator/index.ts
@@ -94,7 +94,7 @@ async function getFixedIssueLink(
   prNumber: number,
   repo: string
 ): Promise<string> {
-  const response = await fetch(
+  const response = (await fetch(
     `https://api.github.com/repos/${repo}/pulls/${prNumber}`,
     {
       method: 'GET',
@@ -102,9 +102,9 @@ async function getFixedIssueLink(
         'Authorization': `Bearer ${process.env.GITHUB_TOKEN}`
       }
     }
-  ).then(data => data.json());
+  ).then(data => data.json())) as { body: string | null };
 
-  const body = (response as Response).body;
+  const body = response.body;
   if (!body) {
     return '';
   }

--- a/repo-scripts/changelog-generator/tsconfig.json
+++ b/repo-scripts/changelog-generator/tsconfig.json
@@ -5,6 +5,9 @@
     "lib": [
       "ESNext"
     ],
+    "types": [
+      "node"
+    ],
     "module": "CommonJS",
     "moduleResolution": "node",
     "esModuleInterop": true,


### PR DESCRIPTION
fix(changelog-generator): fix postinstall build failure
    
The fix has two parts:
    
1. Add `"types": ["node"]` to tsconfig.
    
2. Fix an incorrect type cast in `index.ts`. The parsed GitHub API response
    was being cast to the DOM `Response` type to access its `.body` property,
    which is wrong — `Response.body` is a `ReadableStream`, not a string. The
    actual value is the parsed JSON from the GitHub PR API, whose `body` field
    is `string | null` per the API schema. Updated the cast accordingly.
    
Resolves #9947

Hey there! So you want to contribute to a Firebase SDK? 
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here. 
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * Changes that affect the public API will require internal review. Before making a
    PR that changes the public API, we would suggest first proposing your change in an
    issue so that we can discuss it together.
