### PR TITLE
test(firestore): skip database source test that is timing out

### DIFF
--- a/packages/firestore/test/integration/api/pipeline.test.ts
+++ b/packages/firestore/test/integration/api/pipeline.test.ts
@@ -605,6 +605,7 @@ apiDescribe.skipClassic('Pipelines', persistence => {
       expectResults(snapshot, doc1.id, doc2.id);
     });
 
+    // eslint-disable-next-line no-restricted-properties
     it.skip('supports database as source', async () => {
       const randomId = Math.random().toString(16).slice(2);
       const doc1 = await addDoc(collection(randomCol, 'book1', 'sub'), {

--- a/packages/firestore/test/integration/api/pipeline.test.ts
+++ b/packages/firestore/test/integration/api/pipeline.test.ts
@@ -605,7 +605,7 @@ apiDescribe.skipClassic('Pipelines', persistence => {
       expectResults(snapshot, doc1.id, doc2.id);
     });
 
-    it('supports database as source', async () => {
+    it.skip('supports database as source', async () => {
       const randomId = Math.random().toString(16).slice(2);
       const doc1 = await addDoc(collection(randomCol, 'book1', 'sub'), {
         order: 1,

--- a/packages/firestore/test/lite/pipeline.test.ts
+++ b/packages/firestore/test/lite/pipeline.test.ts
@@ -605,6 +605,7 @@ describe.skipClassic('Firestore Pipelines', () => {
       expectResults(snapshot, doc1.id, doc2.id);
     });
 
+    // eslint-disable-next-line no-restricted-properties
     it.skip('supports database as source', async () => {
       const randomId = Math.random().toString(16).slice(2);
       const doc1 = await addDoc(collection(randomCol, 'book1', 'sub'), {

--- a/packages/firestore/test/lite/pipeline.test.ts
+++ b/packages/firestore/test/lite/pipeline.test.ts
@@ -605,7 +605,7 @@ describe.skipClassic('Firestore Pipelines', () => {
       expectResults(snapshot, doc1.id, doc2.id);
     });
 
-    it('supports database as source', async () => {
+    it.skip('supports database as source', async () => {
       const randomId = Math.random().toString(16).slice(2);
       const doc1 = await addDoc(collection(randomCol, 'book1', 'sub'), {
         order: 1,


### PR DESCRIPTION
The test database keeps growing, causing this tests execution time to keep growing, repeatedly exceeding new timeouts we set. 

For now, let's just skip this test.