### PR TITLE
Unify react router error boundaries and prevent duplicate logs

### DIFF
--- a/packages/crashlytics/src/api.test.ts
+++ b/packages/crashlytics/src/api.test.ts
@@ -27,7 +27,6 @@ import {
 import {
   FirebaseApp,
   initializeApp,
-  _registerComponent,
   _addOrOverwriteComponent,
   deleteApp
 } from '@firebase/app';
@@ -465,7 +464,14 @@ describe('Top level API', () => {
 
 function getFakeApp(): FirebaseApp {
   registerCrashlytics();
-  _registerComponent(
+  const app = initializeApp({
+    projectId: PROJECT_ID,
+    appId: APP_ID,
+    apiKey: API_KEY
+  });
+  _addOrOverwriteComponent(
+    app,
+    //@ts-ignore
     new Component(
       'installations-internal',
       () =>
@@ -476,7 +482,9 @@ function getFakeApp(): FirebaseApp {
       ComponentType.PUBLIC
     )
   );
-  _registerComponent(
+  _addOrOverwriteComponent(
+    app,
+    //@ts-ignore
     new Component(
       'app-check-internal',
       () => {
@@ -485,11 +493,6 @@ function getFakeApp(): FirebaseApp {
       ComponentType.PUBLIC
     )
   );
-  const app = initializeApp({
-    projectId: PROJECT_ID,
-    appId: APP_ID,
-    apiKey: API_KEY
-  });
   _addOrOverwriteComponent(
     app,
     //@ts-ignore
@@ -498,7 +501,8 @@ function getFakeApp(): FirebaseApp {
       // @ts-ignore
       () => {
         return {
-          triggerHeartbeat: () => {}
+          triggerHeartbeat: () => {},
+          getHeartbeatsHeader: async () => ''
         };
       },
       ComponentType.PUBLIC

--- a/packages/crashlytics/src/api.ts
+++ b/packages/crashlytics/src/api.ts
@@ -16,13 +16,13 @@
  */
 
 import { _getProvider, FirebaseApp, getApp } from '@firebase/app';
-import { CRASHLYTICS_TYPE } from './constants';
+import { ALREADY_LOGGED_FLAG, CRASHLYTICS_TYPE } from './constants';
+import { CrashlyticsInternal, ErrorWithSymbol } from './types';
 import { Crashlytics, CrashlyticsOptions } from './public-types';
 import { Provider } from '@firebase/component';
 import { AnyValueMap, SeverityNumber } from '@opentelemetry/api-logs';
 import { CrashlyticsService } from './service';
 import { flush, setCommonLogAttributes } from './helpers';
-import { CrashlyticsInternal } from './types';
 import { deepEqual } from '@firebase/util';
 
 declare module '@firebase/component' {
@@ -91,6 +91,14 @@ export function recordError(
   error: unknown,
   attributes?: AnyValueMap
 ): void {
+  if (error && typeof error === 'object') {
+    try {
+      (error as ErrorWithSymbol)[ALREADY_LOGGED_FLAG] = true;
+    } catch (e) {
+      // Ignore if frozen
+    }
+  }
+
   // Cast to CrashlyticsInternal to access internal loggerProvider
   const logger = (crashlytics as CrashlyticsInternal).loggerProvider.getLogger(
     'error-logger'
@@ -139,3 +147,49 @@ export function recordError(
 }
 
 export { flush };
+
+/**
+ * Registers global event listeners for uncaught errors and promise rejections.
+ * Automatically avoids double logging if the error was already logged.
+ *
+ * @internal
+ */
+export function registerGlobalErrorListeners(
+  crashlytics: Crashlytics
+): () => void {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const errorListener = (event: ErrorEvent): void => {
+    if (event.error && (event.error as ErrorWithSymbol)[ALREADY_LOGGED_FLAG]) {
+      return;
+    }
+    recordError(crashlytics, event.error);
+  };
+
+  const unhandledRejectionListener = (event: PromiseRejectionEvent): void => {
+    if (
+      event.reason &&
+      (event.reason as ErrorWithSymbol)[ALREADY_LOGGED_FLAG]
+    ) {
+      return;
+    }
+    recordError(crashlytics, event.reason);
+  };
+
+  try {
+    window.addEventListener('error', errorListener);
+    window.addEventListener('unhandledrejection', unhandledRejectionListener);
+  } catch (error) {
+    console.warn(`Firebase Crashlytics was not initialized:\n`, error);
+  }
+
+  return () => {
+    window.removeEventListener('error', errorListener);
+    window.removeEventListener(
+      'unhandledrejection',
+      unhandledRejectionListener
+    );
+  };
+}

--- a/packages/crashlytics/src/constants.ts
+++ b/packages/crashlytics/src/constants.ts
@@ -24,6 +24,9 @@ export const DEFAULT_TELEMETRY_REGION = 'global';
 /** Key for storing the session ID in sessionStorage. */
 export const CRASHLYTICS_SESSION_ID_KEY = 'firebasecrashlytics.sessionid';
 
+/** Symbol for the internal flag indicating an error has already been logged. */
+export const ALREADY_LOGGED_FLAG = Symbol('firebase_crashlytics_logged');
+
 /** Label keys that we write in all telemetry signal entries. */
 export const CRASHLYTICS_ATTRIBUTE_KEYS = {
   APP_VERSION: 'app.build_id',

--- a/packages/crashlytics/src/react-router/index.test.tsx
+++ b/packages/crashlytics/src/react-router/index.test.tsx
@@ -170,4 +170,23 @@ describe('CrashlyticsRoutes', () => {
 
     consoleErrorStub.restore();
   });
+
+  it('registers frameworkAttributesProvider and cleans up on unmount', () => {
+    const { unmount } = render(
+      <MemoryRouter initialEntries={['/users/123']}>
+        <CrashlyticsRoutes firebaseApp={fakeApp}>
+          <Route path="/users/:id" element={<div>User Profile</div>} />
+        </CrashlyticsRoutes>
+      </MemoryRouter>
+    );
+
+    const crashlyticsService = fakeCrashlytics as any;
+    expect(crashlyticsService.frameworkAttributesProvider).to.be.a('function');
+    expect(crashlyticsService.frameworkAttributesProvider()).to.deep.equal({
+      [FRAMEWORK_ATTRIBUTE_KEYS.ROUTE_PATH]: '/users/:id'
+    });
+
+    unmount();
+    expect(crashlyticsService.frameworkAttributesProvider).to.be.undefined;
+  });
 });

--- a/packages/crashlytics/src/react-router/index.ts
+++ b/packages/crashlytics/src/react-router/index.ts
@@ -17,8 +17,13 @@
 
 import { FirebaseApp } from '@firebase/app';
 import { registerCrashlytics } from '../register';
-import { recordError, getCrashlytics } from '../api';
+import {
+  recordError,
+  getCrashlytics,
+  registerGlobalErrorListeners
+} from '../api';
 import { CrashlyticsOptions } from '../public-types';
+
 import React from 'react';
 import {
   Routes as RoutesRR,
@@ -29,6 +34,7 @@ import {
 } from 'react-router-dom';
 import { CrashlyticsErrorBoundary } from './types';
 import { FRAMEWORK_ATTRIBUTE_KEYS } from '../constants';
+import { CrashlyticsService } from '../service';
 
 registerCrashlytics();
 
@@ -103,6 +109,20 @@ export function CrashlyticsRoutes({
   const pattern = pathFromRoot.startsWith('/')
     ? pathFromRoot
     : `/${pathFromRoot}`;
+
+  React.useEffect(() => {
+    const crashlyticsService = crashlytics as CrashlyticsService;
+    crashlyticsService.frameworkAttributesProvider = () => ({
+      [FRAMEWORK_ATTRIBUTE_KEYS.ROUTE_PATH]: pattern
+    });
+    return () => {
+      crashlyticsService.frameworkAttributesProvider = undefined;
+    };
+  }, [crashlytics, pattern]);
+
+  React.useEffect(() => {
+    return registerGlobalErrorListeners(crashlytics);
+  }, [crashlytics]);
 
   const onError = (error: Error): void => {
     recordError(crashlytics, error, {

--- a/packages/crashlytics/src/react/index.test.tsx
+++ b/packages/crashlytics/src/react/index.test.tsx
@@ -58,37 +58,50 @@ class TestErrorBoundary extends React.Component<
 
 describe('FirebaseCrashlytics', () => {
   let getCrashlyticsStub: sinon.SinonStub;
-  let recordErrorStub: sinon.SinonStub;
+  let emitStub: sinon.SinonStub;
   let fakeApp: FirebaseApp;
   let fakeCrashlytics: Crashlytics;
 
   beforeEach(() => {
     fakeApp = { name: 'fakeApp' } as FirebaseApp;
-    fakeCrashlytics = {} as Crashlytics;
+    emitStub = stub();
+    fakeCrashlytics = {
+      app: {
+        options: {}
+      },
+      loggerProvider: {
+        getLogger: stub().returns({
+          emit: emitStub
+        })
+      }
+    } as unknown as Crashlytics;
 
     getCrashlyticsStub = stub(crashlytics, 'getCrashlytics').returns(
       fakeCrashlytics
     );
-    recordErrorStub = stub(crashlytics, 'recordError');
   });
 
   afterEach(() => {
     restore();
   });
 
-  it('captures window errors', done => {
+  it('captures window errors', () => {
+    const prevOnError = window.onerror;
+    window.onerror = () => true;
+
     render(<FirebaseCrashlytics firebaseApp={fakeApp} />);
     const error = new Error('test error');
-    window.onerror = () => {
-      // Prevent error from bubbling up to test suite
-    };
-    window.addEventListener('error', (event: ErrorEvent) => {
-      // Registers another listener (sequential) to confirm behaviour.
-      expect(getCrashlyticsStub).to.have.been.calledWith(fakeApp);
-      expect(recordErrorStub).to.have.been.calledWith(fakeCrashlytics, error);
-      done();
-    });
+
     window.dispatchEvent(new ErrorEvent('error', { error }));
+
+    expect(getCrashlyticsStub).to.have.been.calledWith(fakeApp);
+    expect(emitStub).to.have.been.calledOnce;
+    const log = emitStub.firstCall.args[0];
+    expect(log.body).to.equal('test error');
+    expect(log.attributes['error.type']).to.equal('Error');
+    expect(log.attributes['error.stack']).to.be.a('string');
+
+    window.onerror = prevOnError;
   });
 
   it('captures unhandled promise rejections', () => {
@@ -96,20 +109,31 @@ describe('FirebaseCrashlytics', () => {
     const reason = new Error('test rejection');
     const promise = Promise.reject(reason);
     promise.catch(() => {});
+
     window.dispatchEvent(
       new PromiseRejectionEvent('unhandledrejection', { reason, promise })
     );
+
     expect(getCrashlyticsStub).to.have.been.calledWith(fakeApp);
-    expect(recordErrorStub).to.have.been.calledWith(fakeCrashlytics, reason);
+    expect(emitStub).to.have.been.calledOnce;
+    const log = emitStub.firstCall.args[0];
+    expect(log.body).to.equal('test rejection');
+    expect(log.attributes['error.type']).to.equal('Error');
+    expect(log.attributes['error.stack']).to.be.a('string');
   });
 
-  // it('ignores errors that have already been logged by Crashlytics', () => {
-  //   render(<FirebaseCrashlytics firebaseApp={fakeApp} />);
-  //   const error = new Error('already logged error');
-  //   (error as ErrorWithSymbol)[ALREADY_LOGGED_FLAG] = true;
+  it('ignores errors that have already been logged by Crashlytics', () => {
+    const prevOnError = window.onerror;
+    window.onerror = () => true;
 
-  //   window.dispatchEvent(new ErrorEvent('error', { error }));
+    render(<FirebaseCrashlytics firebaseApp={fakeApp} />);
+    const error = new Error('already logged error');
+    (error as ErrorWithSymbol)[ALREADY_LOGGED_FLAG] = true;
 
-  //   expect(recordErrorStub).to.not.have.been.called;
-  // });
+    window.dispatchEvent(new ErrorEvent('error', { error }));
+
+    expect(emitStub).to.not.have.been.called;
+
+    window.onerror = prevOnError;
+  });
 });

--- a/packages/crashlytics/src/react/index.test.tsx
+++ b/packages/crashlytics/src/react/index.test.tsx
@@ -25,6 +25,8 @@ import { Crashlytics } from '../public-types';
 import { FirebaseCrashlytics } from '.';
 import React from 'react';
 import { render } from '@testing-library/react';
+import { ALREADY_LOGGED_FLAG } from '../constants';
+import { ErrorWithSymbol } from '../types';
 
 use(sinonChai);
 use(chaiAsPromised);
@@ -100,4 +102,14 @@ describe('FirebaseCrashlytics', () => {
     expect(getCrashlyticsStub).to.have.been.calledWith(fakeApp);
     expect(recordErrorStub).to.have.been.calledWith(fakeCrashlytics, reason);
   });
+
+  // it('ignores errors that have already been logged by Crashlytics', () => {
+  //   render(<FirebaseCrashlytics firebaseApp={fakeApp} />);
+  //   const error = new Error('already logged error');
+  //   (error as ErrorWithSymbol)[ALREADY_LOGGED_FLAG] = true;
+
+  //   window.dispatchEvent(new ErrorEvent('error', { error }));
+
+  //   expect(recordErrorStub).to.not.have.been.called;
+  // });
 });

--- a/packages/crashlytics/src/react/index.ts
+++ b/packages/crashlytics/src/react/index.ts
@@ -17,7 +17,7 @@
 
 import { FirebaseApp } from '@firebase/app';
 import { registerCrashlytics } from '../register';
-import { recordError, getCrashlytics } from '../api';
+import { getCrashlytics, registerGlobalErrorListeners } from '../api';
 import { CrashlyticsOptions } from '../public-types';
 import { useEffect } from 'react';
 
@@ -78,33 +78,7 @@ export function FirebaseCrashlytics({
 }): null {
   useEffect(() => {
     const crashlytics = getCrashlytics(firebaseApp, crashlyticsOptions);
-
-    if (typeof window === 'undefined') {
-      return;
-    }
-
-    const errorListener = (event: ErrorEvent): void => {
-      recordError(crashlytics, event.error, {});
-    };
-
-    const unhandledRejectionListener = (event: PromiseRejectionEvent): void => {
-      recordError(crashlytics, event.reason, {});
-    };
-
-    try {
-      window.addEventListener('error', errorListener);
-      window.addEventListener('unhandledrejection', unhandledRejectionListener);
-    } catch (error) {
-      // Log the error here, but don't die.
-      console.warn(`Firebase Crashlytics was not initialized:\n`, error);
-    }
-    return () => {
-      window.removeEventListener('error', errorListener);
-      window.removeEventListener(
-        'unhandledrejection',
-        unhandledRejectionListener
-      );
-    };
+    return registerGlobalErrorListeners(crashlytics);
   }, [firebaseApp, crashlyticsOptions]);
 
   return null;

--- a/packages/crashlytics/src/service.ts
+++ b/packages/crashlytics/src/service.ts
@@ -43,7 +43,9 @@ export class CrashlyticsService implements Crashlytics, _FirebaseService {
     return this._frameworkAttributesProvider;
   }
 
-  set frameworkAttributesProvider(provider: () => Record<string, string>) {
+  set frameworkAttributesProvider(
+    provider: (() => Record<string, string>) | undefined
+  ) {
     this._frameworkAttributesProvider = provider;
   }
 }

--- a/packages/crashlytics/src/types.ts
+++ b/packages/crashlytics/src/types.ts
@@ -17,6 +17,7 @@
 
 import { LoggerProvider } from '@opentelemetry/sdk-logs';
 import { Crashlytics } from './public-types';
+import { ALREADY_LOGGED_FLAG } from './constants';
 
 /**
  * An internal interface for the Crashlytics service.
@@ -75,4 +76,13 @@ export interface DynamicHeaderProvider {
    * or null if no header is to be added.
    */
   getHeader(): Promise<HttpHeader | null>;
+}
+
+/**
+ * An internal interface for error objects that have been flagged as already logged.
+ *
+ * @internal
+ */
+export interface ErrorWithSymbol extends Error {
+  [ALREADY_LOGGED_FLAG]?: boolean;
 }


### PR DESCRIPTION
This PR addresses two primary issues in the React / React Router Crashlytics wrappers:

1. **Lack of Global Error Tracking in React Router**: Previously, developers using `<CrashlyticsRoutes>` had to separately declare `<FirebaseCrashlytics>` to capture global uncaught errors (async tasks, event handlers, promise rejections).
2. **Duplicate Logging**: When using both boundaries (or even just `<CrashlyticsRoutes>` on its own), errors caught by the React Error Boundary were re-thrown to avoid swallowing them. Upon bubbling up to the window, the global listener caught and recorded them a second time, producing duplicate error logs in Crashlytics.

#### Proposed Changes:

- **Unified Listening in `<CrashlyticsRoutes>`**: Abstracted global window error/rejection listener setup to a shared helper `registerGlobalErrorListeners` in `api.ts`. Both `<FirebaseCrashlytics>` and `<CrashlyticsRoutes>` now register global listeners using this shared utility. 
- **Duplicate Error Prevention**: Inside `recordError`, we now safely tag logged error objects with a private `__firebase_crashlytics_logged__ = true` flag inside a `try...catch` block.
- **De-duplication Check**: The shared `registerGlobalErrorListeners` now ignores any error that has the `__firebase_crashlytics_logged__` flag set, preventing double-logging of re-thrown errors from React Error Boundaries.
