### PR TITLE
fix(remoteconfig) Stopping last running experiment must call updateActiveExperiments

### DIFF
--- a/.changeset/olive-beans-know.md
+++ b/.changeset/olive-beans-know.md
@@ -1,0 +1,5 @@
+---
+'@firebase/remote-config': patch
+---
+
+Call update experiment when the last running experiment is stopped

--- a/packages/remote-config/src/api.ts
+++ b/packages/remote-config/src/api.ts
@@ -112,11 +112,9 @@ export async function activate(remoteConfig: RemoteConfig): Promise<boolean> {
     return false;
   }
   const experiment = new Experiment(rc);
-  const updateActiveExperiments = lastSuccessfulFetchResponse.experiments
-    ? experiment.updateActiveExperiments(
-        lastSuccessfulFetchResponse.experiments
-      )
-    : Promise.resolve();
+  const updateActiveExperiments = experiment.updateActiveExperiments(
+    lastSuccessfulFetchResponse.experiments || []
+  );
   await Promise.all([
     rc._storageCache.setActiveConfig(lastSuccessfulFetchResponse.config),
     rc._storage.setActiveConfigEtag(lastSuccessfulFetchResponse.eTag),

--- a/packages/remote-config/test/api.test.ts
+++ b/packages/remote-config/test/api.test.ts
@@ -37,6 +37,7 @@ import { Component, ComponentType } from '@firebase/component';
 import { FirebaseInstallations } from '@firebase/installations-types';
 import { openDatabase, APP_NAMESPACE_STORE } from '../src/storage/storage';
 import { ERROR_FACTORY, ErrorCode } from '../src/errors';
+import { Experiment } from '../src/abt/experiment';
 import { RemoteConfig as RemoteConfigImpl } from '../src/remote_config';
 
 const fakeFirebaseConfig = {
@@ -170,6 +171,26 @@ describe('Remote Config API', () => {
     });
     await ensureInitialized(rc);
     expect(getString(rc, 'foobar')).to.equal('hello world');
+  });
+
+  it('calls updateActiveExperiments with empty experiments if no experiments are available in fetch response', async () => {
+    const rc = getRemoteConfig(app);
+    const responseWithoutExperiments: FetchResponse = {
+      ...STUB_FETCH_RESPONSE,
+      experiments: undefined
+    };
+    setFetchResponse(responseWithoutExperiments);
+    const updateActiveExperimentsStub = sinon.stub(
+      Experiment.prototype,
+      'updateActiveExperiments'
+    );
+    try {
+      await fetchAndActivate(rc);
+      await ensureInitialized(rc);
+      expect(updateActiveExperimentsStub).to.have.been.calledWith([]);
+    } finally {
+      updateActiveExperimentsStub.restore();
+    }
   });
 
   describe('onConfigUpdate', () => {


### PR DESCRIPTION
**Context**: Currently, experiments are updated at activation only if the fetch response explicitly contains an experiments payload.


**Problem**: When the last running experiment is stopped, the fetch response returns experiments as undefined. This causes the client to skip the update call entirely, meaning the local state never registers that the experiment was stopped.

**Fix**: If fetch response does not contain experiments, pass an empty list to update