### PR TITLE
fix(firestore): improved robustness and logging in query listen stream creation and re-creation

### DIFF
--- a/.changeset/selfish-dancers-mix.md
+++ b/.changeset/selfish-dancers-mix.md
@@ -1,0 +1,5 @@
+---
+"@firebase/firestore": patch
+---
+
+Improved robustness and logging in query listen stream creation and re-creation

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -749,6 +749,7 @@ function raiseWatchSnapshot(
 
   // Re-establish listens for the targets that have been invalidated by
   // existence filter mismatches.
+  // TODO ideally this would use a new remote target ID
   remoteEvent.targetMismatches.forEach((remoteTargetId, targetPurpose) => {
     const targetData = remoteStoreImpl.listenTargets.get(remoteTargetId);
     if (!targetData) {

--- a/packages/firestore/src/remote/watch_change.ts
+++ b/packages/firestore/src/remote/watch_change.ts
@@ -461,8 +461,7 @@ export class WatchChangeAggregator {
             { expectedCount }
           );
         }
-      }
-      {
+      } else {
         const currentSize = this.getCurrentDocumentCountForTarget(targetId);
         // Existence filter mismatch. Mark the documents as being in limbo, and
         // raise a snapshot with `isFromCache:true`.
@@ -707,6 +706,10 @@ export class WatchChangeAggregator {
 
     // skip unknown or inactive targets
     if (!targetState || !this.isActiveTarget(targetId)) {
+      logDebug(
+        LOG_TAG,
+        `addDocumentToTarget received document for unknown target (${targetId})`
+      );
       return;
     }
 
@@ -756,6 +759,10 @@ export class WatchChangeAggregator {
     // skip unknown target state, this indicates the target change is for
     // an old target
     if (!targetState) {
+      logDebug(
+        LOG_TAG,
+        `removeDocumentFromTarget received document for unknown target (${targetId})`
+      );
       return;
     }
 

--- a/packages/firestore/src/remote/watch_change.ts
+++ b/packages/firestore/src/remote/watch_change.ts
@@ -708,7 +708,7 @@ export class WatchChangeAggregator {
     if (!targetState || !this.isActiveTarget(targetId)) {
       logDebug(
         LOG_TAG,
-        `addDocumentToTarget received document for unknown target (${targetId})`
+        `addDocumentToTarget received document for unknown inactive target (${targetId})`
       );
       return;
     }
@@ -750,18 +750,14 @@ export class WatchChangeAggregator {
     key: DocumentKey,
     updatedDocument: MutableDocument | null
   ): void {
-    if (!this.isActiveTarget(targetId)) {
-      return;
-    }
-
     const targetState = this.targetStates.get(targetId);
 
     // skip unknown target state, this indicates the target change is for
     // an old target
-    if (!targetState) {
+    if (!targetState || !this.isActiveTarget(targetId)) {
       logDebug(
         LOG_TAG,
-        `removeDocumentFromTarget received document for unknown target (${targetId})`
+        `removeDocumentFromTarget received document for unknown or inactive target (${targetId})`
       );
       return;
     }

--- a/packages/firestore/src/remote/watch_change.ts
+++ b/packages/firestore/src/remote/watch_change.ts
@@ -292,7 +292,29 @@ const LOG_TAG = 'WatchChangeAggregator';
 export class WatchChangeAggregator {
   constructor(private metadataProvider: TargetMetadataProvider) {}
 
-  /** The internal state of all tracked targets. */
+  /**
+   * The internal state of all tracked targets.
+   *
+   * Targets have the following lifecycle of [states] within the WatchChangeAggregator:
+   * [unknown] -> recordPendingTargetRequest(t)
+   *           -> [pending]
+   *           -> handleTargetChange(t, Added)
+   *           -> [added / !pending]
+   *           -> recordPendingTargetRequest(t)
+   *           -> [pending]
+   *           -> handleTargetChange(t, Removed)
+   *           -> [unknown]
+   *
+   * A reset on an [added] target leaves the target in an [added] state.
+   * [added / !pending] -> handleTargetChange(t, Reset)
+   *                    -> [added / !pending]
+   *
+   * [active]: is a substate of [added], where also `remoteStore.listenTargets.has(t) === true`.
+   *           Generally it is expected that when a target is [active / !pending]
+   *           then it is also [active], but the implementation does not guarantee
+   *           this will always be true.
+   *
+   */
   private targetStates = new Map<RemoteTargetId, TargetState>();
 
   /** Keeps track of the documents to update since the last raised snapshot. */
@@ -310,11 +332,6 @@ export class WatchChangeAggregator {
   private pendingTargetResets = new SortedMap<RemoteTargetId, TargetPurpose>(
     primitiveComparator
   );
-
-  /** expose target states for testing */
-  get _targetStates(): Map<RemoteTargetId, TargetState> {
-    return this.targetStates;
-  }
 
   /**
    * Processes and adds the DocumentWatchChange to the current set of changes.

--- a/packages/firestore/src/remote/watch_change.ts
+++ b/packages/firestore/src/remote/watch_change.ts
@@ -115,7 +115,7 @@ export class WatchTargetChange {
 }
 
 /** Tracks the internal state of a Watch target. */
-class TargetState {
+export class TargetState {
   /**
    * The number of pending responses (adds or removes) that we are waiting on.
    * We only consider targets active that have no pending responses.
@@ -306,6 +306,11 @@ export class WatchChangeAggregator {
     primitiveComparator
   );
 
+  /** expose target states for testing */
+  get _targetStates(): Map<RemoteTargetId, TargetState> {
+    return this.targetStates;
+  }
+
   /**
    * Processes and adds the DocumentWatchChange to the current set of changes.
    */
@@ -330,7 +335,14 @@ export class WatchChangeAggregator {
   /** Processes and adds the WatchTargetChange to the current set of changes. */
   handleTargetChange(targetChange: WatchTargetChange): void {
     this.forEachTarget(targetChange, targetId => {
-      const targetState = this.ensureTargetState(targetId);
+      const targetState = this.targetStates.get(targetId);
+
+      // skip unknown target state, this indicates the target change is for
+      // an old target
+      if (!targetState) {
+        return;
+      }
+
       switch (targetChange.state) {
         case WatchTargetChangeState.NoChange:
           if (this.isActiveTarget(targetId)) {
@@ -440,7 +452,7 @@ export class WatchChangeAggregator {
             { expectedCount }
           );
         }
-      } else {
+      } else if (this.targetStates.get(targetId) !== undefined) {
         const currentSize = this.getCurrentDocumentCountForTarget(targetId);
         // Existence filter mismatch. Mark the documents as being in limbo, and
         // raise a snapshot with `isFromCache:true`.
@@ -681,7 +693,10 @@ export class WatchChangeAggregator {
     targetId: RemoteTargetId,
     document: MutableDocument
   ): void {
-    if (!this.isActiveTarget(targetId)) {
+    const targetState = this.targetStates.get(targetId);
+
+    // skip unknown or inactive targets
+    if (!targetState || !this.isActiveTarget(targetId)) {
       return;
     }
 
@@ -689,7 +704,6 @@ export class WatchChangeAggregator {
       ? ChangeType.Modified
       : ChangeType.Added;
 
-    const targetState = this.ensureTargetState(targetId);
     targetState.addDocumentChange(document.key, changeType);
 
     this.pendingDocumentUpdates = this.pendingDocumentUpdates.insert(
@@ -727,7 +741,14 @@ export class WatchChangeAggregator {
       return;
     }
 
-    const targetState = this.ensureTargetState(targetId);
+    const targetState = this.targetStates.get(targetId);
+
+    // skip unknown target state, this indicates the target change is for
+    // an old target
+    if (!targetState) {
+      return;
+    }
+
     if (this.targetContainsDocument(targetId, key)) {
       targetState.addDocumentChange(key, ChangeType.Removed);
     } else {
@@ -766,7 +787,13 @@ export class WatchChangeAggregator {
    * target as well as any accumulated changes.
    */
   private getCurrentDocumentCountForTarget(targetId: RemoteTargetId): number {
-    const targetState = this.ensureTargetState(targetId);
+    const targetState = this.targetStates.get(targetId);
+
+    // skip unknown target state
+    if (!targetState) {
+      return 0;
+    }
+
     const targetChange = targetState.toTargetChange();
     return (
       this.metadataProvider.getRemoteKeysForTarget(targetId).size +
@@ -781,17 +808,12 @@ export class WatchChangeAggregator {
    */
   recordPendingTargetRequest(targetId: RemoteTargetId): void {
     // For each request we get we need to record we need a response for it.
-    const targetState = this.ensureTargetState(targetId);
-    targetState.recordPendingTargetRequest();
-  }
-
-  private ensureTargetState(targetId: RemoteTargetId): TargetState {
-    let result = this.targetStates.get(targetId);
-    if (!result) {
-      result = new TargetState();
-      this.targetStates.set(targetId, result);
+    let targetState = this.targetStates.get(targetId);
+    if (!targetState) {
+      targetState = new TargetState();
+      this.targetStates.set(targetId, targetState);
     }
-    return result;
+    targetState.recordPendingTargetRequest();
   }
 
   private ensureDocumentTargetMapping(

--- a/packages/firestore/src/remote/watch_change.ts
+++ b/packages/firestore/src/remote/watch_change.ts
@@ -117,6 +117,11 @@ export class WatchTargetChange {
 /** Tracks the internal state of a Watch target. */
 export class TargetState {
   /**
+   * Track the targetId for logging.
+   */
+  constructor(private targetId: RemoteTargetId) {}
+
+  /**
    * The number of pending responses (adds or removes) that we are waiting on.
    * We only consider targets active that have no pending responses.
    */
@@ -244,7 +249,7 @@ export class TargetState {
       this.pendingResponses >= 0,
       0x0ca9,
       '`pendingResponses` is less than 0. This indicates that the SDK received more target acks from the server than expected. The SDK should not continue to operate.',
-      { pendingResponses: this.pendingResponses }
+      { pendingResponses: this.pendingResponses, targetId: this.targetId }
     );
   }
 
@@ -340,6 +345,10 @@ export class WatchChangeAggregator {
       // skip unknown target state, this indicates the target change is for
       // an old target
       if (!targetState) {
+        logDebug(
+          LOG_TAG,
+          `handleTargetChange received targetChange for untracked target ID (${targetId}) with state (${targetChange.state})`
+        );
         return;
       }
 
@@ -452,7 +461,8 @@ export class WatchChangeAggregator {
             { expectedCount }
           );
         }
-      } else if (this.targetStates.get(targetId) !== undefined) {
+      }
+      {
         const currentSize = this.getCurrentDocumentCountForTarget(targetId);
         // Existence filter mismatch. Mark the documents as being in limbo, and
         // raise a snapshot with `isFromCache:true`.
@@ -810,7 +820,11 @@ export class WatchChangeAggregator {
     // For each request we get we need to record we need a response for it.
     let targetState = this.targetStates.get(targetId);
     if (!targetState) {
-      targetState = new TargetState();
+      logDebug(
+        LOG_TAG,
+        `recordPendingTargetRequest set up tracking for target ID ${targetId}`
+      );
+      targetState = new TargetState(targetId);
       this.targetStates.set(targetId, targetState);
     }
     targetState.recordPendingTargetRequest();
@@ -865,7 +879,7 @@ export class WatchChangeAggregator {
     targetId: RemoteTargetId
   ): TargetData<RemoteTargetId> | null {
     const targetState = this.targetStates.get(targetId);
-    return targetState && targetState.isPending
+    return targetState === undefined || targetState.isPending
       ? null
       : this.metadataProvider.getTargetDataForTarget(targetId);
   }
@@ -880,7 +894,7 @@ export class WatchChangeAggregator {
       !this.targetStates.get(targetId)!.isPending,
       'Should only reset active targets'
     );
-    this.targetStates.set(targetId, new TargetState());
+    this.targetStates.set(targetId, new TargetState(targetId));
 
     // Trigger removal for any documents currently mapped to this target.
     // These removals will be part of the initial snapshot if Watch does not
@@ -890,6 +904,7 @@ export class WatchChangeAggregator {
       this.removeDocumentFromTarget(targetId, key, /*updatedDocument=*/ null);
     });
   }
+
   /**
    * Returns whether the LocalStore considers the document to be part of the
    * specified target.

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -118,7 +118,8 @@ import {
   TestNamedQuery,
   TestSnapshotVersion,
   unknownDoc,
-  version
+  version,
+  addWatchTargets
 } from '../../util/helpers';
 
 import { CountingQueryEngine } from './counting_query_engine';
@@ -1294,6 +1295,8 @@ function genericLocalStoreTests(
       getTargetDataForTarget: () => targetData as TargetData<RemoteTargetId>,
       getDatabaseId: () => persistenceHelpers.TEST_DATABASE_ID
     });
+    addWatchTargets(aggregator, [targetId]);
+
     aggregator.handleTargetChange(watchChange);
     const remoteEvent = aggregator.createRemoteEvent(version(1000));
     // This test does not use remote_store mapping of remote events,
@@ -1340,6 +1343,7 @@ function genericLocalStoreTests(
         getTargetDataForTarget: () => targetData as TargetData<RemoteTargetId>,
         getDatabaseId: () => persistenceHelpers.TEST_DATABASE_ID
       });
+      addWatchTargets(aggregator1, [targetId]);
       aggregator1.handleTargetChange(watchChange1);
       const remoteEvent1 = aggregator1.createRemoteEvent(version(1000));
       await localStoreApplyRemoteEventToLocalCache(
@@ -1357,6 +1361,7 @@ function genericLocalStoreTests(
         getTargetDataForTarget: () => targetData as TargetData<RemoteTargetId>,
         getDatabaseId: () => persistenceHelpers.TEST_DATABASE_ID
       });
+      addWatchTargets(aggregator2, [targetId]);
       aggregator2.handleTargetChange(watchChange2);
       const remoteEvent2 = aggregator2.createRemoteEvent(version(2000));
       await localStoreApplyRemoteEventToLocalCache(

--- a/packages/firestore/test/unit/remote/remote_event.test.ts
+++ b/packages/firestore/test/unit/remote/remote_event.test.ts
@@ -26,7 +26,6 @@ import { RemoteEvent, TargetChange } from '../../../src/remote/remote_event';
 import {
   DocumentWatchChange,
   ExistenceFilterChange,
-  TargetState,
   WatchChangeAggregator,
   WatchTargetChange,
   WatchTargetChangeState
@@ -42,7 +41,8 @@ import {
   updateMapping,
   version,
   key,
-  forEachNumber
+  forEachNumber,
+  addWatchTargets
 } from '../../util/helpers';
 import { TEST_DATABASE_ID } from '../local/persistence_test_helpers';
 
@@ -121,6 +121,10 @@ describe('RemoteEvent', () => {
       getDatabaseId: () => TEST_DATABASE_ID
     });
 
+    // Put all targets into the 'added' state
+    addWatchTargets(aggregator, targetIds);
+
+    // Move `outstandingResponses` targets into the 'pending' state
     if (options.outstandingResponses) {
       forEachNumber(options.outstandingResponses, (targetId, count) => {
         for (let i = 0; i < count; ++i) {
@@ -128,15 +132,6 @@ describe('RemoteEvent', () => {
         }
       });
     }
-
-    // ensure target states
-    targetIds.forEach(targetId => {
-      let targetState = aggregator._targetStates.get(targetId);
-      if (!targetState) {
-        targetState = new TargetState(targetId);
-        aggregator._targetStates.set(targetId, targetState);
-      }
-    });
 
     if (options.changes) {
       options.changes.forEach(change =>

--- a/packages/firestore/test/unit/remote/remote_event.test.ts
+++ b/packages/firestore/test/unit/remote/remote_event.test.ts
@@ -26,6 +26,7 @@ import { RemoteEvent, TargetChange } from '../../../src/remote/remote_event';
 import {
   DocumentWatchChange,
   ExistenceFilterChange,
+  TargetState,
   WatchChangeAggregator,
   WatchTargetChange,
   WatchTargetChangeState
@@ -127,6 +128,15 @@ describe('RemoteEvent', () => {
         }
       });
     }
+
+    // ensure target states
+    targetIds.forEach(targetId => {
+      let targetState = aggregator._targetStates.get(targetId);
+      if (!targetState) {
+        targetState = new TargetState();
+        aggregator._targetStates.set(targetId, targetState);
+      }
+    });
 
     if (options.changes) {
       options.changes.forEach(change =>

--- a/packages/firestore/test/unit/remote/remote_event.test.ts
+++ b/packages/firestore/test/unit/remote/remote_event.test.ts
@@ -133,7 +133,7 @@ describe('RemoteEvent', () => {
     targetIds.forEach(targetId => {
       let targetState = aggregator._targetStates.get(targetId);
       if (!targetState) {
-        targetState = new TargetState();
+        targetState = new TargetState(targetId);
         aggregator._targetStates.set(targetId, targetState);
       }
     });

--- a/packages/firestore/test/unit/specs/remote_store_spec.test.ts
+++ b/packages/firestore/test/unit/specs/remote_store_spec.test.ts
@@ -180,15 +180,46 @@ describeSpec('Remote store:', [], () => {
     }
   );
 
-  specTest('Handles ack of old target after re-listen', [], () => {
+  specTest('Handles ack of target after un-listen', [], () => {
     const query1 = query('collection');
     return spec()
       .ensureManualLruGC()
       .userListens(query1)
       .userUnlistens(query1)
-      .watchUsesTargetIndex(0)
       .watchAcks(query1)
       .expectActiveTargets();
+  });
+
+  specTest('Handles reset between listen and ack', [], () => {
+    const query1 = query('collection');
+    return spec()
+      .ensureManualLruGC()
+      .userListens(query1)
+      .watchResets(query1)
+      .watchAcks(query1);
+  });
+
+  specTest('Handles close between listen and ack', [], () => {
+    const query1 = query('collection');
+    return spec()
+      .ensureManualLruGC()
+      .userListens(query1)
+      .watchStreamCloses('unknown', { runBackoffTimer: true })
+      .expectEvents(query1, { fromCache: true })
+      .watchAcks(query1);
+  });
+
+  specTest('Handles listen, unlisten, listen, ack', [], () => {
+    const query1 = query('collection');
+    return spec()
+      .ensureManualLruGC()
+      .userListens(query1)
+      .userUnlistens(query1)
+      .userListens(query1)
+      .watchUsesTargetIndex(0)
+      .watchAcks(query1)
+      .watchUsesTargetIndex(1)
+      .expectActiveTargets({ query: query1 });
   });
 
   specTest(
@@ -196,17 +227,18 @@ describeSpec('Remote store:', [], () => {
     [],
     () => {
       const query1 = query('collection');
-      return (
-        spec()
+      return spec()
           .ensureManualLruGC()
           .userListens(query1)
           .userUnlistens(query1)
           .userListens(query1)
-          .watchStreamCloses(Code.UNAVAILABLE)
+          .watchStreamCloses(Code.UNAVAILABLE, {runBackoffTimer: true})
           .expectEvents(query1, { fromCache: true })
           .watchUsesTargetIndex(0)
           .watchAcks(query1)
-      );
+          .watchUsesTargetIndex(1)
+          .watchAcks(query1)
+          .expectActiveTargets({ query: query1 });
     }
   );
 });

--- a/packages/firestore/test/unit/specs/remote_store_spec.test.ts
+++ b/packages/firestore/test/unit/specs/remote_store_spec.test.ts
@@ -222,23 +222,19 @@ describeSpec('Remote store:', [], () => {
       .expectActiveTargets({ query: query1 });
   });
 
-  specTest(
-    'Handles stale ack after stream reopen',
-    [],
-    () => {
-      const query1 = query('collection');
-      return spec()
-          .ensureManualLruGC()
-          .userListens(query1)
-          .userUnlistens(query1)
-          .userListens(query1)
-          .watchStreamCloses(Code.UNAVAILABLE, {runBackoffTimer: true})
-          .expectEvents(query1, { fromCache: true })
-          .watchUsesTargetIndex(0)
-          .watchAcks(query1)
-          .watchUsesTargetIndex(1)
-          .watchAcks(query1)
-          .expectActiveTargets({ query: query1 });
-    }
-  );
+  specTest('Handles stale ack after stream reopen', [], () => {
+    const query1 = query('collection');
+    return spec()
+      .ensureManualLruGC()
+      .userListens(query1)
+      .userUnlistens(query1)
+      .userListens(query1)
+      .watchStreamCloses(Code.UNAVAILABLE, { runBackoffTimer: true })
+      .expectEvents(query1, { fromCache: true })
+      .watchUsesTargetIndex(0)
+      .watchAcks(query1)
+      .watchUsesTargetIndex(1)
+      .watchAcks(query1)
+      .expectActiveTargets({ query: query1 });
+  });
 });

--- a/packages/firestore/test/unit/specs/remote_store_spec.test.ts
+++ b/packages/firestore/test/unit/specs/remote_store_spec.test.ts
@@ -179,4 +179,34 @@ describeSpec('Remote store:', [], () => {
         .expectActiveTargets();
     }
   );
+
+  specTest('Handles ack of old target after re-listen', [], () => {
+    const query1 = query('collection');
+    return spec()
+      .ensureManualLruGC()
+      .userListens(query1)
+      .userUnlistens(query1)
+      .watchUsesTargetIndex(0)
+      .watchAcks(query1)
+      .expectActiveTargets();
+  });
+
+  specTest(
+    'Handles stale ack after stream reopen',
+    [],
+    () => {
+      const query1 = query('collection');
+      return (
+        spec()
+          .ensureManualLruGC()
+          .userListens(query1)
+          .userUnlistens(query1)
+          .userListens(query1)
+          .watchStreamCloses(Code.UNAVAILABLE)
+          .expectEvents(query1, { fromCache: true })
+          .watchUsesTargetIndex(0)
+          .watchAcks(query1)
+      );
+    }
+  );
 });

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -488,7 +488,7 @@ function ensureTargetData(
       targetIds.forEach(targetId => {
         let targetState = aggregator._targetStates.get(targetId);
         if (!targetState) {
-          targetState = new TargetState();
+          targetState = new TargetState(targetId);
           aggregator._targetStates.set(targetId, targetState);
         }
       });

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -109,6 +109,7 @@ import {
 import {
   DocumentWatchChange,
   ExistenceFilterChange,
+  TargetState,
   WatchChangeAggregator,
   WatchTargetChange,
   WatchTargetChangeState
@@ -427,6 +428,9 @@ export function noChangeEvent(
       targetData(targetId, TargetPurpose.Listen, 'foo'),
     getDatabaseId: () => TEST_DATABASE_ID
   });
+
+  ensureTargetData(aggregator, [targetId]);
+
   aggregator.handleTargetChange(
     new WatchTargetChange(
       WatchTargetChangeState.NoChange,
@@ -452,6 +456,9 @@ export function existenceFilterEvent(
       targetData(targetId, TargetPurpose.Listen, 'foo'),
     getDatabaseId: () => TEST_DATABASE_ID
   });
+
+  ensureTargetData(aggregator, [targetId]);
+
   aggregator.handleExistenceFilter(
     new ExistenceFilterChange(
       targetId,
@@ -461,6 +468,32 @@ export function existenceFilterEvent(
   return castRemoteEvent(
     aggregator.createRemoteEvent(version(snapshotVersion))
   );
+}
+
+/**
+ * Helper function to create target data within a WatchChangeAggregator.
+ * Since this data is only created by recordPendingTargetRequest, when
+ * recordPendingTargetRequest is not called by the tests, the test must ensure
+ * that this data is created, or else the target ID will be ignored.
+ * @param aggregator
+ * @param targetIdsCollections
+ */
+function ensureTargetData(
+  aggregator: WatchChangeAggregator,
+  ...targetIdsCollections: Array<number[] | undefined>
+): void {
+  // ensure target states
+  targetIdsCollections.forEach(targetIds => {
+    if (targetIds) {
+      targetIds.forEach(targetId => {
+        let targetState = aggregator._targetStates.get(targetId);
+        if (!targetState) {
+          targetState = new TargetState();
+          aggregator._targetStates.set(targetId, targetState);
+        }
+      });
+    }
+  });
 }
 
 export function docAddedRemoteEvent(
@@ -492,6 +525,8 @@ export function docAddedRemoteEvent(
     },
     getDatabaseId: () => TEST_DATABASE_ID
   });
+
+  ensureTargetData(aggregator, allTargets);
 
   let version = SnapshotVersion.min();
 
@@ -540,6 +575,14 @@ export function docUpdateRemoteEvent(
     },
     getDatabaseId: () => TEST_DATABASE_ID
   });
+
+  ensureTargetData(
+    aggregator,
+    updatedInTargets,
+    removedFromTargets,
+    limboTargets
+  );
+
   aggregator.handleDocumentChange(docChange);
   return castRemoteEvent(aggregator.createRemoteEvent(doc.version));
 }

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -22,11 +22,11 @@ import { Bound } from '../../src/core/bound';
 import { BundledDocuments } from '../../src/core/bundle';
 import { DatabaseId } from '../../src/core/database_info';
 import {
-  FieldFilter,
   CompositeFilter,
+  CompositeOperator,
+  FieldFilter,
   Filter,
-  Operator,
-  CompositeOperator
+  Operator
 } from '../../src/core/filter';
 import { Direction, OrderBy } from '../../src/core/order_by';
 import {
@@ -79,20 +79,20 @@ import {
 import { FieldMask } from '../../src/model/field_mask';
 import {
   DeleteMutation,
+  FieldTransform,
   MutationResult,
   PatchMutation,
   Precondition,
-  SetMutation,
-  FieldTransform
+  SetMutation
 } from '../../src/model/mutation';
 import { normalizeByteString } from '../../src/model/normalize';
 import { JsonObject, ObjectValue } from '../../src/model/object_value';
 import { FieldPath, ResourcePath } from '../../src/model/path';
 import { decodeBase64, encodeBase64 } from '../../src/platform/base64';
 import {
-  NamedQuery as ProtoNamedQuery,
   BundleMetadata as ProtoBundleMetadata,
-  LimitType as ProtoLimitType
+  LimitType as ProtoLimitType,
+  NamedQuery as ProtoNamedQuery
 } from '../../src/protos/firestore_bundle_proto';
 import * as api from '../../src/protos/firestore_proto_api';
 import { BloomFilter } from '../../src/remote/bloom_filter';
@@ -109,7 +109,6 @@ import {
 import {
   DocumentWatchChange,
   ExistenceFilterChange,
-  TargetState,
   WatchChangeAggregator,
   WatchTargetChange,
   WatchTargetChangeState
@@ -429,7 +428,7 @@ export function noChangeEvent(
     getDatabaseId: () => TEST_DATABASE_ID
   });
 
-  ensureTargetData(aggregator, [targetId]);
+  addWatchTargets(aggregator, [targetId]);
 
   aggregator.handleTargetChange(
     new WatchTargetChange(
@@ -457,7 +456,7 @@ export function existenceFilterEvent(
     getDatabaseId: () => TEST_DATABASE_ID
   });
 
-  ensureTargetData(aggregator, [targetId]);
+  addWatchTargets(aggregator, [targetId]);
 
   aggregator.handleExistenceFilter(
     new ExistenceFilterChange(
@@ -471,14 +470,12 @@ export function existenceFilterEvent(
 }
 
 /**
- * Helper function to create target data within a WatchChangeAggregator.
- * Since this data is only created by recordPendingTargetRequest, when
- * recordPendingTargetRequest is not called by the tests, the test must ensure
- * that this data is created, or else the target ID will be ignored.
+ * Helper function that simulates an add target message and server ack.
+ *
  * @param aggregator
- * @param targetIdsCollections
+ * @param targetIdsCollections - Simulate add targets messages for these.
  */
-function ensureTargetData(
+export function addWatchTargets(
   aggregator: WatchChangeAggregator,
   ...targetIdsCollections: Array<number[] | undefined>
 ): void {
@@ -486,11 +483,10 @@ function ensureTargetData(
   targetIdsCollections.forEach(targetIds => {
     if (targetIds) {
       targetIds.forEach(targetId => {
-        let targetState = aggregator._targetStates.get(targetId);
-        if (!targetState) {
-          targetState = new TargetState(targetId);
-          aggregator._targetStates.set(targetId, targetState);
-        }
+        aggregator.recordPendingTargetRequest(targetId);
+        aggregator.handleTargetChange(
+          new WatchTargetChange(WatchTargetChangeState.Added, [targetId])
+        );
       });
     }
   });
@@ -526,7 +522,7 @@ export function docAddedRemoteEvent(
     getDatabaseId: () => TEST_DATABASE_ID
   });
 
-  ensureTargetData(aggregator, allTargets);
+  addWatchTargets(aggregator, allTargets);
 
   let version = SnapshotVersion.min();
 
@@ -576,7 +572,7 @@ export function docUpdateRemoteEvent(
     getDatabaseId: () => TEST_DATABASE_ID
   });
 
-  ensureTargetData(
+  addWatchTargets(
     aggregator,
     updatedInTargets,
     removedFromTargets,


### PR DESCRIPTION
This pull request refactors the `WatchChangeAggregator` to handle `TargetState` more explicitly by removing the `ensureTargetState` method and requiring manual state management. The changes ensure that unknown or inactive targets are skipped safely across various event handlers. Debug logging was added to add visibility into any skipped targets. Additionally, new spec tests were added to cover stale acknowledgment scenarios.