### PR TITLE
fix(app-check): Fix getLimitedUseToken()

### DIFF
--- a/.changeset/spicy-roses-applaud.md
+++ b/.changeset/spicy-roses-applaud.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app-check': patch
+---
+
+Fix a bug where `getLimitedUseToken()` did not correctly get a limited use token because it did not send the `limited_use` param.

--- a/common/api-review/app-check.api.md
+++ b/common/api-review/app-check.api.md
@@ -81,7 +81,7 @@ export { PartialObserver }
 export class ReCaptchaEnterpriseProvider implements AppCheckProvider {
     constructor(_siteKey: string);
     // @internal
-    getToken(): Promise<AppCheckTokenInternal>;
+    getToken(isLimitedUse?: boolean): Promise<AppCheckTokenInternal>;
     // @internal (undocumented)
     initialize(app: FirebaseApp): void;
     // @internal (undocumented)
@@ -92,7 +92,7 @@ export class ReCaptchaEnterpriseProvider implements AppCheckProvider {
 export class ReCaptchaV3Provider implements AppCheckProvider {
     constructor(_siteKey: string);
     // @internal
-    getToken(): Promise<AppCheckTokenInternal>;
+    getToken(isLimitedUse?: boolean): Promise<AppCheckTokenInternal>;
     // @internal (undocumented)
     initialize(app: FirebaseApp): void;
     // @internal (undocumented)

--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -18,6 +18,7 @@
     "typeRoots": [
       "../node_modules/@types"
     ],
+    "types": ["mocha"],
     "plugins": [
       {
         "name": "tsec",

--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -18,7 +18,6 @@
     "typeRoots": [
       "../node_modules/@types"
     ],
-    "types": ["mocha"],
     "plugins": [
       {
         "name": "tsec",

--- a/packages/app-check/src/client.ts
+++ b/packages/app-check/src/client.ts
@@ -37,7 +37,7 @@ interface AppCheckResponse {
 
 interface AppCheckRequest {
   url: string;
-  body: { [key: string]: string };
+  body: { [key: string]: string | boolean };
 }
 
 export async function exchangeToken(

--- a/packages/app-check/src/internal-api.test.ts
+++ b/packages/app-check/src/internal-api.test.ts
@@ -720,7 +720,7 @@ describe('internal api', () => {
       });
       const token = await getLimitedUseToken(appCheck as AppCheckService);
 
-      expect(customProviderSpy).to.be.called;
+      expect(customProviderSpy).to.be.calledWith(true);
       expect(token).to.deep.equal({
         token: 'fake-custom-app-check-token'
       });
@@ -757,6 +757,9 @@ describe('internal api', () => {
       expect(exchangeTokenStub.args[0][0].body['recaptcha_v3_token']).to.equal(
         fakeRecaptchaToken
       );
+
+      expect(exchangeTokenStub.args[0][0].body['limited_use']).to.equal(true);
+
       expect(token).to.deep.equal({ token: fakeRecaptchaAppCheckToken.token });
     });
 
@@ -778,6 +781,8 @@ describe('internal api', () => {
       expect(
         exchangeTokenStub.args[0][0].body['recaptcha_enterprise_token']
       ).to.equal(fakeRecaptchaToken);
+
+      expect(exchangeTokenStub.args[0][0].body['limited_use']).to.equal(true);
       expect(token).to.deep.equal({ token: fakeRecaptchaAppCheckToken.token });
     });
 
@@ -798,6 +803,7 @@ describe('internal api', () => {
       expect(exchangeTokenStub.args[0][0].body['debug_token']).to.equal(
         'my-debug-token'
       );
+      expect(exchangeTokenStub.args[0][0].body['limited_use']).to.equal(true);
       expect(token).to.deep.equal({ token: fakeRecaptchaAppCheckToken.token });
     });
   });

--- a/packages/app-check/src/internal-api.ts
+++ b/packages/app-check/src/internal-api.ts
@@ -238,14 +238,16 @@ export async function getLimitedUseToken(
 
   if (isDebugMode()) {
     const debugToken = await getDebugToken();
+    const request = getExchangeDebugTokenRequest(app, debugToken);
+    request.body['limited_use'] = true;
     const { token } = await exchangeToken(
-      getExchangeDebugTokenRequest(app, debugToken),
+      request,
       appCheck.heartbeatServiceProvider
     );
     return { token };
   } else {
     // provider is definitely valid since we ensure AppCheck was activated
-    const { token } = await provider!.getToken();
+    const { token } = await provider!.getToken(true /* isLimitedUse */);
     return { token };
   }
 }

--- a/packages/app-check/src/providers.test.ts
+++ b/packages/app-check/src/providers.test.ts
@@ -53,7 +53,7 @@ describe('ReCaptchaV3Provider', () => {
   });
   it('getToken() gets a token from the exchange endpoint', async () => {
     const provider = new ReCaptchaV3Provider('fake-site-key');
-    stub(client, 'exchangeToken').resolves({
+    const exchangeStub = stub(client, 'exchangeToken').resolves({
       token: 'fake-exchange-token',
       issuedAtTimeMillis: 0,
       expireTimeMillis: 10
@@ -61,6 +61,28 @@ describe('ReCaptchaV3Provider', () => {
     provider.initialize(app);
     getStateReference(app).reCAPTCHAState!.succeeded = true;
     const token = await provider.getToken();
+    expect(exchangeStub.args[0][0].body['recaptcha_v3_token']).to.equal(
+      'fake-recaptcha-token'
+    );
+    expect(exchangeStub.args[0][0].body['limited_use']).to.be.undefined;
+    exchangeStub.restore();
+    expect(token.token).to.equal('fake-exchange-token');
+  });
+  it('getToken(true) gets a limited use token from the exchange endpoint', async () => {
+    const provider = new ReCaptchaV3Provider('fake-site-key');
+    const exchangeStub = stub(client, 'exchangeToken').resolves({
+      token: 'fake-exchange-token',
+      issuedAtTimeMillis: 0,
+      expireTimeMillis: 10
+    });
+    provider.initialize(app);
+    getStateReference(app).reCAPTCHAState!.succeeded = true;
+    const token = await provider.getToken(true);
+    expect(exchangeStub.args[0][0].body['recaptcha_v3_token']).to.equal(
+      'fake-recaptcha-token'
+    );
+    expect(exchangeStub.args[0][0].body['limited_use']).to.be.true;
+    exchangeStub.restore();
     expect(token.token).to.equal('fake-exchange-token');
   });
   it('getToken() throttles 1d on 403', async () => {
@@ -140,7 +162,7 @@ describe('ReCaptchaEnterpriseProvider', () => {
   });
   it('getToken() gets a token from the exchange endpoint', async () => {
     const provider = new ReCaptchaEnterpriseProvider('fake-site-key');
-    stub(client, 'exchangeToken').resolves({
+    const exchangeStub = stub(client, 'exchangeToken').resolves({
       token: 'fake-exchange-token',
       issuedAtTimeMillis: 0,
       expireTimeMillis: 10
@@ -148,6 +170,28 @@ describe('ReCaptchaEnterpriseProvider', () => {
     provider.initialize(app);
     getStateReference(app).reCAPTCHAState!.succeeded = true;
     const token = await provider.getToken();
+    expect(exchangeStub.args[0][0].body['recaptcha_enterprise_token']).to.equal(
+      'fake-recaptcha-token'
+    );
+    expect(exchangeStub.args[0][0].body['limited_use']).to.be.undefined;
+    exchangeStub.restore();
+    expect(token.token).to.equal('fake-exchange-token');
+  });
+  it('getToken(true) gets a token from the exchange endpoint', async () => {
+    const provider = new ReCaptchaEnterpriseProvider('fake-site-key');
+    const exchangeStub = stub(client, 'exchangeToken').resolves({
+      token: 'fake-exchange-token',
+      issuedAtTimeMillis: 0,
+      expireTimeMillis: 10
+    });
+    provider.initialize(app);
+    getStateReference(app).reCAPTCHAState!.succeeded = true;
+    const token = await provider.getToken(true);
+    expect(exchangeStub.args[0][0].body['limited_use']).to.be.true;
+    expect(exchangeStub.args[0][0].body['recaptcha_enterprise_token']).to.equal(
+      'fake-recaptcha-token'
+    );
+    exchangeStub.restore();
     expect(token.token).to.equal('fake-exchange-token');
   });
   it('getToken() throttles 1d on 403', async () => {

--- a/packages/app-check/src/providers.ts
+++ b/packages/app-check/src/providers.ts
@@ -63,7 +63,9 @@ export class ReCaptchaV3Provider implements AppCheckProvider {
    * Returns an App Check token.
    * @internal
    */
-  async getToken(isLimitedUse: boolean = true): Promise<AppCheckTokenInternal> {
+  async getToken(
+    isLimitedUse: boolean = false
+  ): Promise<AppCheckTokenInternal> {
     throwIfThrottled(this._throttleData);
 
     // Top-level `getToken()` has already checked that App Check is initialized

--- a/packages/app-check/src/providers.ts
+++ b/packages/app-check/src/providers.ts
@@ -63,7 +63,7 @@ export class ReCaptchaV3Provider implements AppCheckProvider {
    * Returns an App Check token.
    * @internal
    */
-  async getToken(): Promise<AppCheckTokenInternal> {
+  async getToken(isLimitedUse: boolean = true): Promise<AppCheckTokenInternal> {
     throwIfThrottled(this._throttleData);
 
     // Top-level `getToken()` has already checked that App Check is initialized
@@ -80,10 +80,14 @@ export class ReCaptchaV3Provider implements AppCheckProvider {
     }
     let result;
     try {
-      result = await exchangeToken(
-        getExchangeRecaptchaV3TokenRequest(this._app!, attestedClaimsToken),
-        this._heartbeatServiceProvider!
+      const request = getExchangeRecaptchaV3TokenRequest(
+        this._app!,
+        attestedClaimsToken
       );
+      if (isLimitedUse) {
+        request.body['limited_use'] = true;
+      }
+      result = await exchangeToken(request, this._heartbeatServiceProvider!);
     } catch (e) {
       if (
         (e as FirebaseError).code?.includes(AppCheckError.FETCH_STATUS_ERROR)
@@ -154,7 +158,9 @@ export class ReCaptchaEnterpriseProvider implements AppCheckProvider {
    * Returns an App Check token.
    * @internal
    */
-  async getToken(): Promise<AppCheckTokenInternal> {
+  async getToken(
+    isLimitedUse: boolean = false
+  ): Promise<AppCheckTokenInternal> {
     throwIfThrottled(this._throttleData);
     // Top-level `getToken()` has already checked that App Check is initialized
     // and therefore this._app and this._heartbeatServiceProvider are available.
@@ -170,13 +176,14 @@ export class ReCaptchaEnterpriseProvider implements AppCheckProvider {
     }
     let result;
     try {
-      result = await exchangeToken(
-        getExchangeRecaptchaEnterpriseTokenRequest(
-          this._app!,
-          attestedClaimsToken
-        ),
-        this._heartbeatServiceProvider!
+      const request = getExchangeRecaptchaEnterpriseTokenRequest(
+        this._app!,
+        attestedClaimsToken
       );
+      if (isLimitedUse) {
+        request.body['limited_use'] = true;
+      }
+      result = await exchangeToken(request, this._heartbeatServiceProvider!);
     } catch (e) {
       if (
         (e as FirebaseError).code?.includes(AppCheckError.FETCH_STATUS_ERROR)

--- a/packages/app-check/src/types.ts
+++ b/packages/app-check/src/types.ts
@@ -71,7 +71,7 @@ export interface AppCheckProvider {
    * Returns an App Check token.
    * @internal
    */
-  getToken: () => Promise<AppCheckTokenInternal>;
+  getToken: (isLimitedUse?: boolean) => Promise<AppCheckTokenInternal>;
   /**
    * @internal
    */


### PR DESCRIPTION
`getLimitedUseToken()` was not sending the `limited_use: true` param in the request body, which is required to get a limited use token.

See internal bug b/515052496

It has not worked since initial implementation https://github.com/firebase/firebase-js-sdk/pull/7169