### PR TITLE
adding unit tests for tracing-provider.ts

### DIFF
--- a/packages/crashlytics/src/tracing/tracing-provider.test.ts
+++ b/packages/crashlytics/src/tracing/tracing-provider.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { OTLPTraceExporter } from './tracing-provider';
+import { OTLPExporterBase } from '@opentelemetry/otlp-exporter-base';
+
+describe('OTLPTraceExporter', () => {
+  let exporter: OTLPTraceExporter;
+  let mockAttrProvider: any;
+  let superStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    mockAttrProvider = {
+      getAttribute: sinon.stub().resolves(['dynamic_key', 'dynamic_value'])
+    };
+    exporter = new OTLPTraceExporter({ url: 'http://localhost' }, [], [mockAttrProvider]);
+
+    superStub = sinon.stub(OTLPExporterBase.prototype, 'export').callsFake((_spans, callback: any) => {
+      callback({ code: 0 });
+    });
+  });
+
+  afterEach(() => {
+    superStub.restore();
+  });
+
+  it('should fetch dynamic attributes from providers before exporting', async () => {
+    const mockSpan = { attributes: {} };
+    const callback = sinon.stub();
+
+    await exporter.export([mockSpan as any], callback);
+
+    expect(mockAttrProvider.getAttribute.calledOnce).to.be.true;
+  });
+
+  it('should inject resolved dynamic attributes into exported spans', async () => {
+    const mockSpan = { attributes: {} } as any;
+    const callback = sinon.stub();
+
+    await exporter.export([mockSpan], callback);
+
+    expect(mockSpan.attributes['dynamic_key']).to.equal('dynamic_value');
+  });
+});

--- a/packages/crashlytics/src/tracing/tracing-provider.test.ts
+++ b/packages/crashlytics/src/tracing/tracing-provider.test.ts
@@ -40,7 +40,7 @@ describe('createTracingProvider', () => {
     } as unknown as FirebaseApp;
 
     mockRootSpanContextManager = {
-      enable: () => { }
+      enable: () => {}
     } as RootSpanContextManager;
 
     mockCrashlyticsOptions = {} as CrashlyticsOptions;
@@ -61,11 +61,11 @@ describe('createTracingProvider', () => {
       global.window = { location: { hostname: 'localhost' } } as any;
       // @ts-ignore
       global.XMLHttpRequest = class {
-        open() { }
-        send() { }
+        open() {}
+        send() {}
       } as any;
       // @ts-ignore
-      global.fetch = async () => ({}) as any;
+      global.fetch = async () => ({} as any);
     });
 
     afterEach(() => {
@@ -79,7 +79,9 @@ describe('createTracingProvider', () => {
     });
 
     it('should use standard OTLP trace exporter when tracingUrl is the default localhost port 4318', () => {
-      const fetchTransportStub = sinon.stub(fetchTransportModule, 'FetchTransport').returns({} as any);
+      const fetchTransportStub = sinon
+        .stub(fetchTransportModule, 'FetchTransport')
+        .returns({} as any);
 
       mockCrashlyticsOptions.tracingUrl = 'http://localhost:4318';
 
@@ -94,7 +96,9 @@ describe('createTracingProvider', () => {
     });
 
     it('should use custom OTLPTraceExporter with region-specific endpoint when tracingUrl is a custom URL', () => {
-      const fetchTransportStub = sinon.stub(fetchTransportModule, 'FetchTransport').returns({} as any);
+      const fetchTransportStub = sinon
+        .stub(fetchTransportModule, 'FetchTransport')
+        .returns({} as any);
 
       mockCrashlyticsOptions.tracingUrl = 'https://custom-tracing.url';
       mockCrashlyticsOptions.region = 'us-central1';
@@ -107,7 +111,9 @@ describe('createTracingProvider', () => {
 
       expect(fetchTransportStub.calledOnce).to.be.true;
       const args = fetchTransportStub.firstCall.args[0];
-      expect(args.url).to.equal('https://custom-tracing.url/v1/projects/test-project/apps/test-app-id/locations/us-central1/traces');
+      expect(args.url).to.equal(
+        'https://custom-tracing.url/v1/projects/test-project/apps/test-app-id/locations/us-central1/traces'
+      );
     });
 
     it('should register Fetch and XMLHttpRequest instrumentations', () => {
@@ -136,11 +142,17 @@ describe('OTLPTraceExporter', () => {
     mockAttrProvider = {
       getAttribute: sinon.stub().resolves(['dynamic_key', 'dynamic_value'])
     };
-    exporter = new OTLPTraceExporter({ url: 'http://localhost' }, [], [mockAttrProvider]);
+    exporter = new OTLPTraceExporter(
+      { url: 'http://localhost' },
+      [],
+      [mockAttrProvider]
+    );
 
-    superStub = sinon.stub(OTLPExporterBase.prototype, 'export').callsFake((_spans, callback: any) => {
-      callback({ code: 0 });
-    });
+    superStub = sinon
+      .stub(OTLPExporterBase.prototype, 'export')
+      .callsFake((_spans, callback: any) => {
+        callback({ code: 0 });
+      });
   });
 
   afterEach(() => {
@@ -149,10 +161,16 @@ describe('OTLPTraceExporter', () => {
   });
 
   it('should create an OtlpNetworkExportDelegate with dynamicHeaderProviders', () => {
-    const fetchTransportStub = sinon.stub(fetchTransportModule, 'FetchTransport').returns({} as any);
+    const fetchTransportStub = sinon
+      .stub(fetchTransportModule, 'FetchTransport')
+      .returns({} as any);
     const mockHeaderProvider = { getHeader: sinon.stub() };
-    
-    new OTLPTraceExporter({ url: 'http://localhost' }, [mockHeaderProvider], []);
+
+    new OTLPTraceExporter(
+      { url: 'http://localhost' },
+      [mockHeaderProvider],
+      []
+    );
 
     expect(fetchTransportStub.calledOnce).to.be.true;
     const args = fetchTransportStub.firstCall.args[0];

--- a/packages/crashlytics/src/tracing/tracing-provider.test.ts
+++ b/packages/crashlytics/src/tracing/tracing-provider.test.ts
@@ -111,6 +111,7 @@ describe('createTracingProvider', () => {
     });
 
     it('should register Fetch and XMLHttpRequest instrumentations', () => {
+      // Note: AI claims there isn't a clear way to verify ignoreUrls so excluded it for the test
       const originalFetch = global.fetch;
       const originalOpen = global.XMLHttpRequest.prototype.open;
 

--- a/packages/crashlytics/src/tracing/tracing-provider.test.ts
+++ b/packages/crashlytics/src/tracing/tracing-provider.test.ts
@@ -144,15 +144,18 @@ describe('OTLPTraceExporter', () => {
 
   afterEach(() => {
     superStub.restore();
+    sinon.restore();
   });
 
-  it('should fetch dynamic attributes from providers before exporting', async () => {
-    const mockSpan = { attributes: {} };
-    const callback = sinon.stub();
+  it('should create an OtlpNetworkExportDelegate with dynamicHeaderProviders', () => {
+    const fetchTransportStub = sinon.stub(fetchTransportModule, 'FetchTransport').returns({} as any);
+    const mockHeaderProvider = { getHeader: sinon.stub() };
+    
+    new OTLPTraceExporter({ url: 'http://localhost' }, [mockHeaderProvider], []);
 
-    await exporter.export([mockSpan as any], callback);
-
-    expect(mockAttrProvider.getAttribute.calledOnce).to.be.true;
+    expect(fetchTransportStub.calledOnce).to.be.true;
+    const args = fetchTransportStub.firstCall.args[0];
+    expect(args.dynamicHeaderProviders).to.deep.equal([mockHeaderProvider]);
   });
 
   it('should inject resolved dynamic attributes into exported spans', async () => {

--- a/packages/crashlytics/src/tracing/tracing-provider.test.ts
+++ b/packages/crashlytics/src/tracing/tracing-provider.test.ts
@@ -17,8 +17,69 @@
 
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { OTLPTraceExporter } from './tracing-provider';
+import { trace } from '@opentelemetry/api';
+import { createTracingProvider, OTLPTraceExporter } from './tracing-provider';
+import { FirebaseApp } from '@firebase/app';
+import { RootSpanContextManager } from './root-span-context-manager';
+import { RESOURCE_ATTRIBUTE_KEYS } from '../constants';
 import { OTLPExporterBase } from '@opentelemetry/otlp-exporter-base';
+
+describe('createTracingProvider', () => {
+  let mockApp: FirebaseApp;
+  let mockContextManager: RootSpanContextManager;
+
+  beforeEach(() => {
+    mockApp = {
+      options: {
+        projectId: 'my-project',
+        appId: 'my-app-id',
+        apiKey: 'my-api-key'
+      }
+    } as unknown as FirebaseApp;
+
+    mockContextManager = {
+      startRootSpan: sinon.stub(),
+      getActiveRootSpan: sinon.stub(),
+      clearActiveRootSpan: sinon.stub(),
+      getActiveAppScreenId: sinon.stub(),
+      setActiveAppScreenId: sinon.stub(),
+      active: sinon.stub(),
+      enable: sinon.stub().returnsThis(),
+      disable: sinon.stub().returnsThis()
+    } as unknown as RootSpanContextManager;
+
+  });
+
+  afterEach(() => {
+    // @ts-ignore
+    delete global.window;
+    // @ts-ignore
+    delete global.XMLHttpRequest;
+    sinon.restore();
+  });
+
+  it('should return a default tracer provider when running in a server/Node environment', () => {
+    const provider = createTracingProvider(mockApp, mockContextManager, {});
+    expect(provider).to.equal(trace.getTracerProvider());
+  });
+
+  it('should construct resource with cloud resource ID containing project and region', () => {
+    // @ts-ignore
+    global.window = { location: { hostname: 'localhost' } } as any;
+    // @ts-ignore
+    global.XMLHttpRequest = class { };
+
+    const provider = createTracingProvider(mockApp, mockContextManager, { region: 'us-central1' });
+
+    // Peek into the internal _resource property
+    const resource = (provider as any)._resource;
+
+    expect(resource).to.exist;
+    expect(resource.attributes[RESOURCE_ATTRIBUTE_KEYS.CLOUD_RESOURCE_ID]).to.equal(
+      '//firebasetelemetry.googleapis.com/projects/my-project/locations/us-central1/'
+    );
+  });
+});
 
 describe('OTLPTraceExporter', () => {
   let exporter: OTLPTraceExporter;

--- a/packages/crashlytics/src/tracing/tracing-provider.test.ts
+++ b/packages/crashlytics/src/tracing/tracing-provider.test.ts
@@ -21,63 +21,108 @@ import { trace } from '@opentelemetry/api';
 import { createTracingProvider, OTLPTraceExporter } from './tracing-provider';
 import { FirebaseApp } from '@firebase/app';
 import { RootSpanContextManager } from './root-span-context-manager';
-import { RESOURCE_ATTRIBUTE_KEYS } from '../constants';
 import { OTLPExporterBase } from '@opentelemetry/otlp-exporter-base';
+import { CrashlyticsOptions } from '../public-types';
+import * as fetchTransportModule from '../fetch-transport';
 
 describe('createTracingProvider', () => {
   let mockApp: FirebaseApp;
-  let mockContextManager: RootSpanContextManager;
+  let mockRootSpanContextManager: RootSpanContextManager;
+  let mockCrashlyticsOptions: CrashlyticsOptions;
 
   beforeEach(() => {
     mockApp = {
       options: {
-        projectId: 'my-project',
-        appId: 'my-app-id',
-        apiKey: 'my-api-key'
+        projectId: 'test-project',
+        appId: 'test-app-id',
+        apiKey: 'test-api-key'
       }
     } as unknown as FirebaseApp;
 
-    mockContextManager = {
-      startRootSpan: sinon.stub(),
-      getActiveRootSpan: sinon.stub(),
-      clearActiveRootSpan: sinon.stub(),
-      getActiveAppScreenId: sinon.stub(),
-      setActiveAppScreenId: sinon.stub(),
-      active: sinon.stub(),
-      enable: sinon.stub().returnsThis(),
-      disable: sinon.stub().returnsThis()
-    } as unknown as RootSpanContextManager;
+    mockRootSpanContextManager = {
+      enable: () => { }
+    } as RootSpanContextManager;
 
-  });
-
-  afterEach(() => {
-    // @ts-ignore
-    delete global.window;
-    // @ts-ignore
-    delete global.XMLHttpRequest;
-    sinon.restore();
+    mockCrashlyticsOptions = {} as CrashlyticsOptions;
   });
 
   it('should return a default tracer provider when running in a server/Node environment', () => {
-    const provider = createTracingProvider(mockApp, mockContextManager, {});
+    const provider = createTracingProvider(
+      mockApp,
+      mockRootSpanContextManager,
+      mockCrashlyticsOptions
+    );
     expect(provider).to.equal(trace.getTracerProvider());
   });
 
-  it('should construct resource with cloud resource ID containing project and region', () => {
-    // @ts-ignore
-    global.window = { location: { hostname: 'localhost' } } as any;
-    // @ts-ignore
-    global.XMLHttpRequest = class { };
+  describe('when running in a browser environment', () => {
+    beforeEach(() => {
+      // @ts-ignore
+      global.window = { location: { hostname: 'localhost' } } as any;
+      // @ts-ignore
+      global.XMLHttpRequest = class {
+        open() { }
+        send() { }
+      } as any;
+      // @ts-ignore
+      global.fetch = async () => ({}) as any;
+    });
 
-    const provider = createTracingProvider(mockApp, mockContextManager, { region: 'us-central1' });
+    afterEach(() => {
+      // @ts-ignore
+      delete global.window;
+      // @ts-ignore
+      delete global.XMLHttpRequest;
+      // @ts-ignore
+      delete global.fetch;
+      sinon.restore();
+    });
 
-    // Peek into the internal _resource property
-    const resource = (provider as any)._resource;
+    it('should use standard OTLP trace exporter when tracingUrl is the default localhost port 4318', () => {
+      const fetchTransportStub = sinon.stub(fetchTransportModule, 'FetchTransport').returns({} as any);
 
-    expect(resource).to.exist;
-    expect(resource.attributes[RESOURCE_ATTRIBUTE_KEYS.CLOUD_RESOURCE_ID]).to.equal(
-      '//firebasetelemetry.googleapis.com/projects/my-project/locations/us-central1/'
-    );
+      mockCrashlyticsOptions.tracingUrl = 'http://localhost:4318';
+
+      const provider = createTracingProvider(
+        mockApp,
+        mockRootSpanContextManager,
+        mockCrashlyticsOptions
+      );
+
+      expect(fetchTransportStub.called).to.be.false;
+      expect(provider).to.be.ok;
+    });
+
+    it('should use custom OTLPTraceExporter with region-specific endpoint when tracingUrl is a custom URL', () => {
+      const fetchTransportStub = sinon.stub(fetchTransportModule, 'FetchTransport').returns({} as any);
+
+      mockCrashlyticsOptions.tracingUrl = 'https://custom-tracing.url';
+      mockCrashlyticsOptions.region = 'us-central1';
+
+      createTracingProvider(
+        mockApp,
+        mockRootSpanContextManager,
+        mockCrashlyticsOptions
+      );
+
+      expect(fetchTransportStub.calledOnce).to.be.true;
+      const args = fetchTransportStub.firstCall.args[0];
+      expect(args.url).to.equal('https://custom-tracing.url/v1/projects/test-project/apps/test-app-id/locations/us-central1/traces');
+    });
+
+    it('should register Fetch and XMLHttpRequest instrumentations', () => {
+      const originalFetch = global.fetch;
+      const originalOpen = global.XMLHttpRequest.prototype.open;
+
+      createTracingProvider(
+        mockApp,
+        mockRootSpanContextManager,
+        mockCrashlyticsOptions
+      );
+
+      expect(global.fetch).to.not.equal(originalFetch);
+      expect(global.XMLHttpRequest.prototype.open).to.not.equal(originalOpen);
+    });
   });
 });
 

--- a/packages/crashlytics/src/tracing/tracing-provider.ts
+++ b/packages/crashlytics/src/tracing/tracing-provider.ts
@@ -162,7 +162,7 @@ export function createTracingProvider(
   return provider;
 }
 
-class OTLPTraceExporter
+export class OTLPTraceExporter
   extends OTLPExporterBase<ReadableSpan[]>
   implements SpanExporter
 {


### PR DESCRIPTION

### createTracingProvider

- it('should return a default tracer provider when running in a server/Node environment')

- it('should use standard OTLP trace exporter when tracingUrl is the default localhost port 4318')

- it('should use custom OTLPTraceExporter with region-specific endpoint when tracingUrl is a custom URL')

- it('should register Fetch and XMLHttpRequest instrumentations')

### OTLPTraceExporter

- it('should create an OtlpNetworkExportDelegate with dynamicHeaderProviders')

- it('should inject resolved dynamic attributes into exported spans')

