### PR TITLE
Implement onSubChange for FID-based registration

### DIFF
--- a/packages/messaging/src/api/deleteToken.ts
+++ b/packages/messaging/src/api/deleteToken.ts
@@ -18,7 +18,7 @@
 import { ERROR_FACTORY, ErrorCode } from '../util/errors';
 
 import { MessagingService } from '../messaging-service';
-import { deleteTokenInternal } from '../internals/token-manager';
+import { revokeRegistrationInternal } from '../internals/token-manager';
 import { registerDefaultSw } from '../helpers/registerDefaultSw';
 
 export async function deleteToken(
@@ -32,5 +32,5 @@ export async function deleteToken(
     await registerDefaultSw(messaging);
   }
 
-  return deleteTokenInternal(messaging);
+  return revokeRegistrationInternal(messaging);
 }

--- a/packages/messaging/src/api/register.ts
+++ b/packages/messaging/src/api/register.ts
@@ -26,6 +26,7 @@ import {
   dbRemove,
   dbSetFidRegistration
 } from '../internals/idb-manager';
+import { notifyOnRegistered } from '../internals/token-manager';
 
 const FID_REGISTRATION_REFRESH_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
@@ -97,11 +98,7 @@ export async function register(
       throw ERROR_FACTORY.create(ErrorCode.INVALID_ON_REGISTERED_HANDLER);
     }
 
-    if (typeof handler === 'function') {
-      handler(fid);
-    } else {
-      handler.next(fid);
-    }
+    notifyOnRegistered(messaging, fid);
   });
   return messaging._registerNotifyChain;
 }

--- a/packages/messaging/src/helpers/fid-change-registration.test.ts
+++ b/packages/messaging/src/helpers/fid-change-registration.test.ts
@@ -17,7 +17,10 @@
 
 import '../testing/setup';
 
-import { subscribeFidChangeRegistration } from './fid-change-registration';
+import {
+  refreshFidRegistrationIfStored,
+  subscribeFidChangeRegistration
+} from './fid-change-registration';
 import { MessagingService } from '../messaging-service';
 import {
   getFakeAnalyticsProvider,
@@ -32,6 +35,68 @@ import * as idbManager from '../internals/idb-manager';
 import { Stub } from '../testing/sinon-types';
 import { _FirebaseInstallationsInternal } from '@firebase/installations';
 import { dbDelete } from '../internals/idb-manager';
+
+describe('refreshFidRegistrationIfStored', () => {
+  let messaging: MessagingService;
+  let requestCreateRegistrationStub: Stub<
+    typeof requestsModule.requestCreateRegistration
+  >;
+  let dbGetFidRegistrationStub: Stub<typeof idbManager.dbGetFidRegistration>;
+
+  beforeEach(() => {
+    const app = getFakeApp();
+    messaging = new MessagingService(
+      app,
+      {
+        getId: async () => 'fid-1',
+        getToken: async () => 'authToken'
+      },
+      getFakeAnalyticsProvider()
+    );
+    messaging.swRegistration =
+      new FakeServiceWorkerRegistration() as unknown as ServiceWorkerRegistration;
+
+    requestCreateRegistrationStub = stub(
+      requestsModule,
+      'requestCreateRegistration'
+    ).callsFake(async () => ({
+      responseFid: 'fid-1'
+    })) as Stub<typeof requestsModule.requestCreateRegistration>;
+
+    dbGetFidRegistrationStub = stub(
+      idbManager,
+      'dbGetFidRegistration'
+    ).resolves(undefined) as Stub<typeof idbManager.dbGetFidRegistration>;
+  });
+
+  afterEach(() => {
+    requestCreateRegistrationStub.restore();
+    dbGetFidRegistrationStub.restore();
+  });
+
+  it('re-registers with FCM when FID metadata exists and notifies onRegistered', async () => {
+    const onRegisteredSpy = stub();
+    messaging.onRegisteredHandler = onRegisteredSpy;
+    dbGetFidRegistrationStub.resolves({
+      fid: 'fid-1',
+      lastRegisterTime: Date.now()
+    });
+
+    await refreshFidRegistrationIfStored(messaging);
+
+    expect(requestCreateRegistrationStub).to.have.been.calledOnce;
+    expect(onRegisteredSpy).to.have.been.calledOnceWith('fid-1');
+  });
+
+  it('no-ops when the app instance was never registered with FCM', async () => {
+    messaging.onRegisteredHandler = stub();
+    dbGetFidRegistrationStub.resolves(undefined);
+
+    await refreshFidRegistrationIfStored(messaging);
+
+    expect(requestCreateRegistrationStub).to.not.have.been.called;
+  });
+});
 
 describe('subscribeFidChangeRegistration', () => {
   let messaging: MessagingService;

--- a/packages/messaging/src/helpers/fid-change-registration.ts
+++ b/packages/messaging/src/helpers/fid-change-registration.ts
@@ -21,8 +21,44 @@ import {
   onIdChange
 } from '@firebase/installations';
 import { register } from '../api/register';
-import { dbGetFidRegistration } from '../internals/idb-manager';
+import {
+  dbGet,
+  dbGetFidRegistration,
+  dbSetFidRegistration
+} from '../internals/idb-manager';
+import { registerFcmRegistrationWithFid } from '../internals/register-fid';
+import { notifyOnRegistered } from '../internals/token-manager';
 import { MessagingService } from '../messaging-service';
+import { updateVapidKey } from './updateVapidKey';
+
+/**
+ * Re-runs FCM FID registration when push subscription keys change (e.g. `pushsubscriptionchange`
+ * in the service worker). No-op if the app instance was never registered via `register()`.
+ * Best-effort: callers should catch failures when permission or push may be unavailable.
+ */
+export async function refreshFidRegistrationIfStored(
+  messaging: MessagingService
+): Promise<void> {
+  const stored = await dbGetFidRegistration(
+    messaging.firebaseDependencies
+  ).catch(() => undefined);
+  if (!stored) {
+    return;
+  }
+
+  const tokenDetails = await dbGet(messaging.firebaseDependencies).catch(
+    () => undefined
+  );
+  await updateVapidKey(messaging, tokenDetails?.subscriptionOptions?.vapidKey);
+
+  const fid = await messaging.firebaseDependencies.installations.getId();
+  await registerFcmRegistrationWithFid(messaging, fid);
+  await dbSetFidRegistration(messaging.firebaseDependencies, {
+    fid,
+    lastRegisterTime: Date.now()
+  });
+  notifyOnRegistered(messaging, fid);
+}
 
 /**
  * When the Firebase Installation ID changes, re-run `register()` so FCM registration and

--- a/packages/messaging/src/internals/token-manager.test.ts
+++ b/packages/messaging/src/internals/token-manager.test.ts
@@ -27,7 +27,7 @@ import {
   dbSetFidRegistration
 } from './idb-manager';
 import * as idbManager from './idb-manager';
-import { deleteTokenInternal, getTokenInternal } from './token-manager';
+import { getTokenInternal, revokeRegistrationInternal } from './token-manager';
 import {
   getFakeAnalyticsProvider,
   getFakeApp,
@@ -204,9 +204,9 @@ describe('Token Manager', () => {
     });
   });
 
-  describe('deleteToken', () => {
+  describe('revokeRegistrationInternal', () => {
     it('returns if there is no token in the db', async () => {
-      await deleteTokenInternal(messaging);
+      await revokeRegistrationInternal(messaging);
 
       expect(requestGetTokenStub).not.to.have.been.called;
       expect(requestUpdateTokenStub).not.to.have.been.called;
@@ -223,7 +223,7 @@ describe('Token Manager', () => {
       const onUnregisteredSpy = stub();
       messaging.onUnregisteredHandler = onUnregisteredSpy;
 
-      await deleteTokenInternal(messaging);
+      await revokeRegistrationInternal(messaging);
 
       expect(requestDeleteTokenStub).not.to.have.been.called;
       expect(requestDeleteRegistrationStub).to.have.been.calledOnceWith(
@@ -245,7 +245,7 @@ describe('Token Manager', () => {
       const onUnregisteredSpy = stub();
       messaging.onUnregisteredHandler = onUnregisteredSpy;
 
-      await expect(deleteTokenInternal(messaging)).to.be.rejectedWith(
+      await expect(revokeRegistrationInternal(messaging)).to.be.rejectedWith(
         'network'
       );
 
@@ -263,7 +263,7 @@ describe('Token Manager', () => {
       });
       messaging.onUnregisteredHandler = null;
 
-      await deleteTokenInternal(messaging);
+      await revokeRegistrationInternal(messaging);
 
       expect(requestDeleteRegistrationStub).to.have.been.calledOnceWith(
         messaging.firebaseDependencies,
@@ -278,7 +278,7 @@ describe('Token Manager', () => {
       );
       await dbSet(messaging.firebaseDependencies, tokenDetails);
 
-      await deleteTokenInternal(messaging);
+      await revokeRegistrationInternal(messaging);
 
       expect(await dbGet(messaging.firebaseDependencies)).to.be.undefined;
       expect(requestGetTokenStub).not.to.have.been.called;
@@ -296,7 +296,7 @@ describe('Token Manager', () => {
         'dbRemoveFidRegistration'
       ).resolves();
 
-      await deleteTokenInternal(messaging);
+      await revokeRegistrationInternal(messaging);
 
       expect(dbRemoveFidStub).to.have.been.calledOnceWith(
         messaging.firebaseDependencies

--- a/packages/messaging/src/internals/token-manager.ts
+++ b/packages/messaging/src/internals/token-manager.ts
@@ -132,10 +132,11 @@ async function revokeFidRegistrationIfStored(
 }
 
 /**
- * This method deletes the token from the database, unsubscribes the token from FCM, and unregisters
- * the push subscription if it exists.
+ * Revokes the app's FCM registration: legacy token (getToken/deleteToken) and/or FID-based
+ * registration (register/unregister), clears local caches, notifies onUnregistered when a stored
+ * FID existed, then unsubscribes the push subscription when present.
  */
-export async function deleteTokenInternal(
+export async function revokeRegistrationInternal(
   messaging: MessagingService
 ): Promise<boolean> {
   const tokenDetails = await dbGet(messaging.firebaseDependencies);
@@ -242,7 +243,25 @@ async function removeFidRegistrationBestEffort(
   }
 }
 
-function notifyOnUnregistered(messaging: MessagingService, fid: string): void {
+export function notifyOnRegistered(
+  messaging: MessagingService,
+  fid: string
+): void {
+  const handler = messaging.onRegisteredHandler;
+  if (!handler) {
+    return;
+  }
+  if (typeof handler === 'function') {
+    handler(fid);
+  } else {
+    handler.next(fid);
+  }
+}
+
+export function notifyOnUnregistered(
+  messaging: MessagingService,
+  fid: string
+): void {
   const handler = messaging.onUnregisteredHandler;
   if (!handler) {
     return;

--- a/packages/messaging/src/listeners/sw-listeners.test.ts
+++ b/packages/messaging/src/listeners/sw-listeners.test.ts
@@ -17,7 +17,9 @@
 
 import '../testing/setup';
 
+import * as fidChangeRegistrationModule from '../helpers/fid-change-registration';
 import * as tokenManagementModule from '../internals/token-manager';
+import * as idbManager from '../internals/idb-manager';
 
 import {
   CONSOLE_CAMPAIGN_ANALYTICS_ENABLED,
@@ -103,9 +105,13 @@ describe('SwController', () => {
   let eventListenerMap: Map<string, Function>;
   let messaging: MessagingService;
   let getTokenStub: Stub<(typeof tokenManagementModule)['getTokenInternal']>;
-  let deleteTokenStub: Stub<
-    (typeof tokenManagementModule)['deleteTokenInternal']
+  let revokeRegistrationStub: Stub<
+    (typeof tokenManagementModule)['revokeRegistrationInternal']
   >;
+  let refreshFidRegistrationStub: Stub<
+    (typeof fidChangeRegistrationModule)['refreshFidRegistrationIfStored']
+  >;
+  let dbGetFidRegistrationStub: Stub<typeof idbManager.dbGetFidRegistration>;
 
   beforeEach(() => {
     mockServiceWorker();
@@ -125,10 +131,18 @@ describe('SwController', () => {
     getTokenStub = stub(tokenManagementModule, 'getTokenInternal').resolves(
       'token-value'
     );
-    deleteTokenStub = stub(
+    revokeRegistrationStub = stub(
       tokenManagementModule,
-      'deleteTokenInternal'
+      'revokeRegistrationInternal'
     ).resolves(true);
+    refreshFidRegistrationStub = stub(
+      fidChangeRegistrationModule,
+      'refreshFidRegistrationIfStored'
+    ).resolves();
+    dbGetFidRegistrationStub = stub(
+      idbManager,
+      'dbGetFidRegistration'
+    ).resolves(undefined) as Stub<typeof idbManager.dbGetFidRegistration>;
 
     messaging = new MessagingService(
       getFakeApp(),
@@ -148,6 +162,8 @@ describe('SwController', () => {
   });
 
   afterEach(() => {
+    refreshFidRegistrationStub.restore();
+    dbGetFidRegistrationStub.restore();
     restoreServiceWorker();
   });
 
@@ -493,7 +509,7 @@ describe('SwController', () => {
   });
 
   describe('onSubChange', () => {
-    it('calls deleteToken if there is no new subscription', async () => {
+    it('revokes registration if there is no new subscription', async () => {
       const event = makeFakePushSubscriptionChangeEvent({
         oldSubscription: new FakePushSubscription(),
         newSubscription: null
@@ -501,11 +517,11 @@ describe('SwController', () => {
 
       await callEventListener(event);
 
-      expect(deleteTokenStub).to.have.been.called;
+      expect(revokeRegistrationStub).to.have.been.called;
       expect(getTokenStub).not.to.have.been.called;
     });
 
-    it('calls deleteToken and getToken if subscription changed', async () => {
+    it('revokes registration and getToken if subscription changed', async () => {
       const event = makeFakePushSubscriptionChangeEvent({
         oldSubscription: new FakePushSubscription(),
         newSubscription: new FakePushSubscription()
@@ -513,8 +529,26 @@ describe('SwController', () => {
 
       await callEventListener(event);
 
-      expect(deleteTokenStub).to.have.been.called;
+      expect(revokeRegistrationStub).to.have.been.called;
       expect(getTokenStub).to.have.been.called;
+      expect(refreshFidRegistrationStub).not.to.have.been.called;
+    });
+
+    it('refreshes FID registration when subscription changed and register() metadata exists', async () => {
+      dbGetFidRegistrationStub.resolves({
+        fid: 'fid-in-db',
+        lastRegisterTime: Date.now()
+      });
+      const event = makeFakePushSubscriptionChangeEvent({
+        oldSubscription: new FakePushSubscription(),
+        newSubscription: new FakePushSubscription()
+      });
+
+      await callEventListener(event);
+
+      expect(refreshFidRegistrationStub).to.have.been.calledOnce;
+      expect(revokeRegistrationStub).not.to.have.been.called;
+      expect(getTokenStub).not.to.have.been.called;
     });
   });
 

--- a/packages/messaging/src/listeners/sw-listeners.ts
+++ b/packages/messaging/src/listeners/sw-listeners.ts
@@ -29,12 +29,13 @@ import {
   WindowClient
 } from '../util/sw-types';
 import {
-  deleteTokenInternal,
-  getTokenInternal
+  getTokenInternal,
+  revokeRegistrationInternal
 } from '../internals/token-manager';
 
 import { MessagingService } from '../messaging-service';
-import { dbGet } from '../internals/idb-manager';
+import { dbGet, dbGetFidRegistration } from '../internals/idb-manager';
+import { refreshFidRegistrationIfStored } from '../helpers/fid-change-registration';
 import { externalizePayload } from '../helpers/externalizePayload';
 import { isConsoleMessage } from '../helpers/is-console-message';
 import { sleep } from '../helpers/sleep';
@@ -54,15 +55,30 @@ export async function onSubChange(
   event: PushSubscriptionChangeEvent,
   messaging: MessagingService
 ): Promise<void> {
+  if (!messaging.swRegistration) {
+    messaging.swRegistration = self.registration;
+  }
+
   const { newSubscription } = event;
   if (!newSubscription) {
-    // Subscription revoked, delete token
-    await deleteTokenInternal(messaging);
+    // Subscription revoked: legacy token and FID register/unregister paths both flow through
+    // revokeRegistrationInternal (server revoke + onUnregistered when applicable).
+    await revokeRegistrationInternal(messaging);
+    return;
+  }
+
+  const storedFid = await dbGetFidRegistration(
+    messaging.firebaseDependencies
+  ).catch(() => undefined);
+  if (storedFid) {
+    await refreshFidRegistrationIfStored(messaging).catch(() => {
+      // Best-effort: push subscription may be unavailable after rotation.
+    });
     return;
   }
 
   const tokenDetails = await dbGet(messaging.firebaseDependencies);
-  await deleteTokenInternal(messaging);
+  await revokeRegistrationInternal(messaging);
 
   messaging.vapidKey =
     tokenDetails?.subscriptionOptions?.vapidKey ?? DEFAULT_VAPID_KEY;


### PR DESCRIPTION
This make onSubChange forward compatible with the register/unregister new API by making the behavior for fid symmetric to that of token.

This is a patch to https://github.com/firebase/firebase-js-sdk/pull/9917 that includes a minor release changeset thus skipping a changeset of its own.