### PR TITLE
fix(auth,app-check): Fix Auth/AppCheck ReCAPTCHA Enterprise conflict

### DIFF
--- a/.changeset/clever-frogs-burn.md
+++ b/.changeset/clever-frogs-burn.md
@@ -1,0 +1,6 @@
+---
+'@firebase/app-check': patch
+'@firebase/auth': patch
+---
+
+Fix error causing Auth and AppCheck conflict when both are using ReCAPTCHA Enterprise.

--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -18,7 +18,6 @@
     "typeRoots": [
       "../node_modules/@types"
     ],
-    "types": ["mocha", "node"],
     "plugins": [
       {
         "name": "tsec",

--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -18,6 +18,7 @@
     "typeRoots": [
       "../node_modules/@types"
     ],
+    "types": ["mocha", "node"],
     "plugins": [
       {
         "name": "tsec",

--- a/packages/app-check/src/recaptcha.ts
+++ b/packages/app-check/src/recaptcha.ts
@@ -173,7 +173,8 @@ function loadReCAPTCHAV3Script(onload: () => void): void {
 
 function loadReCAPTCHAEnterpriseScript(onload: () => void): void {
   const script = document.createElement('script');
-  script.src = RECAPTCHA_ENTERPRISE_URL;
+  // This param is required when we plan to render a widget explicitly.
+  script.src = RECAPTCHA_ENTERPRISE_URL + '?render=explicit';
   script.onload = onload;
   document.head.appendChild(script);
 }

--- a/packages/auth/src/core/credentials/email.test.ts
+++ b/packages/auth/src/core/credentials/email.test.ts
@@ -40,6 +40,7 @@ import * as jsHelpers from '../../platform_browser/load_js';
 import { ServerError } from '../../api/errors';
 import { _initializeRecaptchaConfig } from '../../platform_browser/recaptcha/recaptcha_enterprise_verifier';
 import assert from 'assert';
+import { mockLoadJS } from '../../../test/helpers/mock_loadjs';
 
 use(chaiAsPromised);
 
@@ -93,7 +94,7 @@ function mockRecaptchaEnterpriseTokenFailure(): mockFetch.Route | undefined {
     return;
   }
   // Mock recaptcha js loading method but not set window.recaptcha to simulate recaptcha token retrieval failure
-  sinon.stub(jsHelpers, '_loadJS').returns(Promise.resolve(new Event('')));
+  sinon.stub(jsHelpers, '_loadJS').callsFake(mockLoadJS);
   window.grecaptcha = undefined;
 
   return mockEndpointWithParams(
@@ -108,7 +109,7 @@ function mockRecaptchaEnterpriseTokenFailure(): mockFetch.Route | undefined {
 
 function mockRecaptchaEnterpriseTokenSuccess(action: string): void {
   // Mock recaptcha js loading method and manually set window.recaptcha
-  sinon.stub(jsHelpers, '_loadJS').returns(Promise.resolve(new Event('')));
+  sinon.stub(jsHelpers, '_loadJS').callsFake(mockLoadJS);
   const recaptcha = new MockGreCAPTCHATopLevel();
   window.grecaptcha = recaptcha;
   const stub = sinon.stub(recaptcha.enterprise, 'execute');
@@ -201,7 +202,7 @@ describe('core/credentials/email', () => {
             return;
           }
           mockRecaptchaEnterpriseEnablement(RECAPTCHA_MODE_ENFORCE);
-          sinon.stub(jsHelpers, '_loadJS').resolves();
+          sinon.stub(jsHelpers, '_loadJS').callsFake(mockLoadJS);
 
           await _initializeRecaptchaConfig(auth);
           const idTokenResponse = await credential._getIdTokenResponse(auth);
@@ -226,7 +227,7 @@ describe('core/credentials/email', () => {
             return;
           }
           mockRecaptchaEnterpriseEnablement(RECAPTCHA_MODE_OFF);
-          sinon.stub(jsHelpers, '_loadJS').resolves();
+          sinon.stub(jsHelpers, '_loadJS').callsFake(mockLoadJS);
 
           await _initializeRecaptchaConfig(auth);
           const idTokenResponse = await credential._getIdTokenResponse(auth);
@@ -357,7 +358,7 @@ describe('core/credentials/email', () => {
             return;
           }
           mockRecaptchaEnterpriseEnablement(RECAPTCHA_MODE_ENFORCE);
-          sinon.stub(jsHelpers, '_loadJS').resolves();
+          sinon.stub(jsHelpers, '_loadJS').callsFake(mockLoadJS);
 
           // proactively initialize config so that token fetch is attempted with the first request.
           await _initializeRecaptchaConfig(auth);

--- a/packages/auth/src/core/credentials/email.test.ts
+++ b/packages/auth/src/core/credentials/email.test.ts
@@ -201,6 +201,7 @@ describe('core/credentials/email', () => {
             return;
           }
           mockRecaptchaEnterpriseEnablement(RECAPTCHA_MODE_ENFORCE);
+          sinon.stub(jsHelpers, '_loadJS').resolves();
 
           await _initializeRecaptchaConfig(auth);
           const idTokenResponse = await credential._getIdTokenResponse(auth);
@@ -225,6 +226,7 @@ describe('core/credentials/email', () => {
             return;
           }
           mockRecaptchaEnterpriseEnablement(RECAPTCHA_MODE_OFF);
+          sinon.stub(jsHelpers, '_loadJS').resolves();
 
           await _initializeRecaptchaConfig(auth);
           const idTokenResponse = await credential._getIdTokenResponse(auth);
@@ -355,6 +357,7 @@ describe('core/credentials/email', () => {
             return;
           }
           mockRecaptchaEnterpriseEnablement(RECAPTCHA_MODE_ENFORCE);
+          sinon.stub(jsHelpers, '_loadJS').resolves();
 
           // proactively initialize config so that token fetch is attempted with the first request.
           await _initializeRecaptchaConfig(auth);

--- a/packages/auth/src/core/strategies/email_and_password.test.ts
+++ b/packages/auth/src/core/strategies/email_and_password.test.ts
@@ -189,6 +189,9 @@ describe('core/strategies/sendPasswordResetEmail', () => {
       if (typeof window === 'undefined') {
         return;
       }
+      // RecaptchaEnterpriseVerifier.verify() will always call _loadJS
+      // the first time it is called, and it must be stubbed for tests.
+      sinon.stub(jsHelpers, '_loadJS').resolves(new Event(''));
       const recaptcha = new MockGreCAPTCHATopLevel();
       window.grecaptcha = recaptcha;
       sinon
@@ -298,8 +301,7 @@ describe('core/strategies/sendPasswordResetEmail', () => {
         }
       );
 
-      // Mock recaptcha js loading method and manually set window.recaptcha
-      sinon.stub(jsHelpers, '_loadJS').returns(Promise.resolve(new Event('')));
+      // Manually set window.recaptcha
       const recaptcha = new MockGreCAPTCHATopLevel();
       window.grecaptcha = recaptcha;
       const stub = sinon.stub(recaptcha.enterprise, 'execute');

--- a/packages/auth/src/core/strategies/email_and_password.test.ts
+++ b/packages/auth/src/core/strategies/email_and_password.test.ts
@@ -51,6 +51,7 @@ import {
 } from './email_and_password';
 import { MockGreCAPTCHATopLevel } from '../../platform_browser/recaptcha/recaptcha_mock';
 import { _initializeRecaptchaConfig } from '../../platform_browser/recaptcha/recaptcha_enterprise_verifier';
+import { mockLoadJS } from '../../../test/helpers/mock_loadjs';
 
 use(chaiAsPromised);
 use(sinonChai);
@@ -191,7 +192,7 @@ describe('core/strategies/sendPasswordResetEmail', () => {
       }
       // RecaptchaEnterpriseVerifier.verify() will always call _loadJS
       // the first time it is called, and it must be stubbed for tests.
-      sinon.stub(jsHelpers, '_loadJS').resolves(new Event(''));
+      sinon.stub(jsHelpers, '_loadJS').callsFake(mockLoadJS);
       const recaptcha = new MockGreCAPTCHATopLevel();
       window.grecaptcha = recaptcha;
       sinon
@@ -726,7 +727,7 @@ describe('core/strategies/email_and_password/createUserWithEmailAndPassword', ()
       );
 
       // Mock recaptcha js loading method and manually set window.recaptcha
-      sinon.stub(jsHelpers, '_loadJS').returns(Promise.resolve(new Event('')));
+      sinon.stub(jsHelpers, '_loadJS').callsFake(mockLoadJS);
       const recaptcha = new MockGreCAPTCHATopLevel();
       window.grecaptcha = recaptcha;
       const stub = sinon.stub(recaptcha.enterprise, 'execute');
@@ -892,7 +893,7 @@ describe('password policy cache is updated in auth flows upon error', () => {
     // Initialize the reCAPTCHA config so the auth flows use reCAPTCHA.
     await _initializeRecaptchaConfig(auth);
 
-    sinon.stub(jsHelpers, '_loadJS').returns(Promise.resolve(new Event('')));
+    sinon.stub(jsHelpers, '_loadJS').callsFake(mockLoadJS);
     const recaptcha = new MockGreCAPTCHATopLevel();
     window.grecaptcha = recaptcha;
     const stub = sinon.stub(recaptcha.enterprise, 'execute');

--- a/packages/auth/src/core/strategies/email_link.test.ts
+++ b/packages/auth/src/core/strategies/email_link.test.ts
@@ -194,6 +194,7 @@ describe('core/strategies/sendSignInLinkToEmail', () => {
       if (typeof window === 'undefined') {
         return;
       }
+      sinon.stub(jsHelpers, '_loadJS').resolves(new Event(''));
       window.grecaptcha = recaptcha;
       sinon
         .stub(recaptcha.enterprise, 'execute')
@@ -339,8 +340,7 @@ describe('core/strategies/sendSignInLinkToEmail', () => {
         }
       );
 
-      // Mock recaptcha js loading method and manually set window.recaptcha
-      sinon.stub(jsHelpers, '_loadJS').returns(Promise.resolve(new Event('')));
+      // Manually set window.recaptcha
       const recaptcha = new MockGreCAPTCHATopLevel();
       window.grecaptcha = recaptcha;
       const stub = sinon.stub(recaptcha.enterprise, 'execute');

--- a/packages/auth/src/core/strategies/email_link.test.ts
+++ b/packages/auth/src/core/strategies/email_link.test.ts
@@ -47,6 +47,7 @@ import {
 import { MockGreCAPTCHATopLevel } from '../../platform_browser/recaptcha/recaptcha_mock';
 import * as jsHelpers from '../../platform_browser/load_js';
 import { _initializeRecaptchaConfig } from '../../platform_browser/recaptcha/recaptcha_enterprise_verifier';
+import { mockLoadJS } from '../../../test/helpers/mock_loadjs';
 
 use(chaiAsPromised);
 use(sinonChai);
@@ -194,7 +195,7 @@ describe('core/strategies/sendSignInLinkToEmail', () => {
       if (typeof window === 'undefined') {
         return;
       }
-      sinon.stub(jsHelpers, '_loadJS').resolves(new Event(''));
+      sinon.stub(jsHelpers, '_loadJS').callsFake(mockLoadJS);
       window.grecaptcha = recaptcha;
       sinon
         .stub(recaptcha.enterprise, 'execute')
@@ -274,11 +275,13 @@ describe('core/strategies/sendSignInLinkToEmail', () => {
 
       // // First verification should fail with 'wrong-site-key'
       stub
-        .withArgs('wrong-site-key', { action: 'signInWithEmailLink' })
+        .withArgs('wrong-site-key', {
+          action: RecaptchaActionName.GET_OOB_CODE
+        })
         .rejects();
       // Second verification should succeed with site key refreshed
       stub
-        .withArgs('site-key', { action: 'signInWithEmailLink' })
+        .withArgs('site-key', { action: 'verify' })
         .returns(Promise.resolve('recaptcha-response'));
 
       mockEndpointWithParams(
@@ -295,12 +298,13 @@ describe('core/strategies/sendSignInLinkToEmail', () => {
       mockEndpoint(Endpoint.SEND_OOB_CODE, {
         email
       });
-      expect(
+
+      await expect(
         sendSignInLinkToEmail(auth, email, {
           handleCodeInApp: true,
           url: 'continue-url'
         })
-      ).returned;
+      ).to.not.be.rejected;
     });
 
     it('calls fallback to recaptcha flow when receiving MISSING_RECAPTCHA_TOKEN error', async () => {

--- a/packages/auth/src/platform_browser/providers/phone.test.ts
+++ b/packages/auth/src/platform_browser/providers/phone.test.ts
@@ -39,6 +39,7 @@ import { PhoneAuthProvider } from './phone';
 import { FAKE_TOKEN } from '../recaptcha/recaptcha_enterprise_verifier';
 import { MockGreCAPTCHATopLevel } from '../recaptcha/recaptcha_mock';
 import { ApplicationVerifierInternal } from '../../model/application_verifier';
+import * as jsHelpers from '../load_js';
 
 use(chaiAsPromised);
 
@@ -76,6 +77,8 @@ describe('platform_browser/providers/phone', () => {
       if (typeof window === 'undefined') {
         return;
       }
+
+      sinon.stub(jsHelpers, '_loadJS').resolves(new Event(''));
       window.grecaptcha = recaptcha;
       sinon
         .stub(recaptcha.enterprise, 'execute')
@@ -157,6 +160,7 @@ describe('platform_browser/providers/phone', () => {
       if (typeof window === 'undefined') {
         return;
       }
+      sinon.stub(jsHelpers, '_loadJS').resolves(new Event(''));
       window.grecaptcha = recaptcha;
       sinon
         .stub(recaptcha.enterprise, 'execute')
@@ -200,6 +204,7 @@ describe('platform_browser/providers/phone', () => {
       if (typeof window === 'undefined') {
         return;
       }
+      sinon.stub(jsHelpers, '_loadJS').resolves(new Event(''));
       window.grecaptcha = recaptcha;
       sinon
         .stub(recaptcha.enterprise, 'execute')

--- a/packages/auth/src/platform_browser/providers/phone.test.ts
+++ b/packages/auth/src/platform_browser/providers/phone.test.ts
@@ -40,6 +40,7 @@ import { FAKE_TOKEN } from '../recaptcha/recaptcha_enterprise_verifier';
 import { MockGreCAPTCHATopLevel } from '../recaptcha/recaptcha_mock';
 import { ApplicationVerifierInternal } from '../../model/application_verifier';
 import * as jsHelpers from '../load_js';
+import { mockLoadJS } from '../../../test/helpers/mock_loadjs';
 
 use(chaiAsPromised);
 
@@ -78,7 +79,7 @@ describe('platform_browser/providers/phone', () => {
         return;
       }
 
-      sinon.stub(jsHelpers, '_loadJS').resolves(new Event(''));
+      sinon.stub(jsHelpers, '_loadJS').callsFake(mockLoadJS);
       window.grecaptcha = recaptcha;
       sinon
         .stub(recaptcha.enterprise, 'execute')
@@ -160,7 +161,7 @@ describe('platform_browser/providers/phone', () => {
       if (typeof window === 'undefined') {
         return;
       }
-      sinon.stub(jsHelpers, '_loadJS').resolves(new Event(''));
+      sinon.stub(jsHelpers, '_loadJS').callsFake(mockLoadJS);
       window.grecaptcha = recaptcha;
       sinon
         .stub(recaptcha.enterprise, 'execute')
@@ -204,7 +205,7 @@ describe('platform_browser/providers/phone', () => {
       if (typeof window === 'undefined') {
         return;
       }
-      sinon.stub(jsHelpers, '_loadJS').resolves(new Event(''));
+      sinon.stub(jsHelpers, '_loadJS').callsFake(mockLoadJS);
       window.grecaptcha = recaptcha;
       sinon
         .stub(recaptcha.enterprise, 'execute')

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.test.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.test.ts
@@ -33,6 +33,7 @@ import { testAuth, TestAuth } from '../../../test/helpers/mock_auth';
 import * as mockFetch from '../../../test/helpers/mock_fetch';
 import { ServerError } from '../../api/errors';
 import { AuthInternal } from '../../model/auth';
+import * as jsHelpers from '../load_js';
 
 import { MockGreCAPTCHATopLevel } from './recaptcha_mock';
 import {
@@ -112,6 +113,7 @@ describe('platform_browser/recaptcha/recaptcha_enterprise_verifier', () => {
     mockFetch.setUp();
     verifier = new RecaptchaEnterpriseVerifier(auth);
     recaptcha = new MockGreCAPTCHATopLevel();
+    sinon.stub(jsHelpers, '_loadJS').resolves();
     window.grecaptcha = recaptcha;
   });
 

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.test.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.test.ts
@@ -45,6 +45,7 @@ import {
 import { RecaptchaConfig } from './recaptcha';
 import { AuthErrorCode } from '../../core/errors';
 import { _createError } from '../../core/util/assert';
+import { mockLoadJS } from '../../../test/helpers/mock_loadjs';
 
 use(chaiAsPromised);
 use(sinonChai);
@@ -113,8 +114,7 @@ describe('platform_browser/recaptcha/recaptcha_enterprise_verifier', () => {
     mockFetch.setUp();
     verifier = new RecaptchaEnterpriseVerifier(auth);
     recaptcha = new MockGreCAPTCHATopLevel();
-    sinon.stub(jsHelpers, '_loadJS').resolves();
-    RecaptchaEnterpriseVerifier.scriptInjected = false;
+    sinon.stub(jsHelpers, '_loadJS').callsFake(mockLoadJS);
     window.grecaptcha = recaptcha;
   });
 

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.test.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.test.ts
@@ -114,6 +114,7 @@ describe('platform_browser/recaptcha/recaptcha_enterprise_verifier', () => {
     verifier = new RecaptchaEnterpriseVerifier(auth);
     recaptcha = new MockGreCAPTCHATopLevel();
     sinon.stub(jsHelpers, '_loadJS').resolves();
+    RecaptchaEnterpriseVerifier.scriptInjected = false;
     window.grecaptcha = recaptcha;
   });
 

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
@@ -157,6 +157,8 @@ export class RecaptchaEnterpriseVerifier {
           if (
             !forceRefresh &&
             isEnterprise(window.grecaptcha) &&
+            // If download has already been initiated, do not trigger another
+            // download, await the promise here.
             RecaptchaEnterpriseVerifier.scriptInjectionDeferred
           ) {
             await RecaptchaEnterpriseVerifier.scriptInjectionDeferred.promise;

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
@@ -47,6 +47,20 @@ export class RecaptchaEnterpriseVerifier {
   private readonly auth: AuthInternal;
 
   /**
+   * Detects if script tag has already been injected onto the page.
+   * Unfortunately this still results in duplicate script tags as this class is
+   * instantiated at least twice in the verifyPhoneNumber flow. This doesn't
+   * seem to cause any functionality issues, and other alternatives like
+   * detecting the script on the page seem to be prone to race conditions
+   * (as the script may exist but the widget may not be rendered).
+   * grecaptcha.ready() isn't reliable when more than one recaptcha script is on
+   * the page (as may be the case if App Check is also in use).
+   *
+   * TODO: Store this state higher up to avoid duplication.
+   */
+  private scriptInjected: boolean = false;
+
+  /**
    *
    * @param authExtern - The corresponding Firebase {@link Auth} instance.
    *
@@ -132,7 +146,11 @@ export class RecaptchaEnterpriseVerifier {
     return new Promise<string>((resolve, reject) => {
       retrieveSiteKey(this.auth)
         .then(siteKey => {
-          if (!forceRefresh && isEnterprise(window.grecaptcha)) {
+          if (
+            !forceRefresh &&
+            isEnterprise(window.grecaptcha) &&
+            this.scriptInjected
+          ) {
             retrieveRecaptchaToken(siteKey, resolve, reject);
           } else {
             if (typeof window === 'undefined') {
@@ -148,6 +166,7 @@ export class RecaptchaEnterpriseVerifier {
             jsHelpers
               ._loadJS(url)
               .then(() => {
+                this.scriptInjected = true;
                 retrieveRecaptchaToken(siteKey, resolve, reject);
               })
               .catch(error => {

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
@@ -34,10 +34,19 @@ import { AuthErrorCode } from '../../core/errors';
 import { StartPhoneMfaEnrollmentRequest } from '../../api/account_management/mfa';
 import { StartPhoneMfaSignInRequest } from '../../api/authentication/mfa';
 import { MockGreCAPTCHATopLevel } from './recaptcha_mock';
+import { Deferred } from '@firebase/util';
 
 export const RECAPTCHA_ENTERPRISE_VERIFIER_TYPE = 'recaptcha-enterprise';
 export const FAKE_TOKEN = 'NO_RECAPTCHA';
 
+export const RECAPTCHA_ENTERPRISE_ONLOAD_CALLBACK_NAME =
+  'onFirebaseAuthREInstanceReady';
+
+declare global {
+  interface Window {
+    [RECAPTCHA_ENTERPRISE_ONLOAD_CALLBACK_NAME]: () => void;
+  }
+}
 export class RecaptchaEnterpriseVerifier {
   /**
    * Identifies the type of application verifier (e.g. "recaptcha-enterprise").
@@ -47,15 +56,17 @@ export class RecaptchaEnterpriseVerifier {
   private readonly auth: AuthInternal;
 
   /**
-   * Detects if script tag has already been injected onto the page.
+   * Deferred that resolves when script tag has been injected onto the page
+   * and the script is ready (grecaptcha.ready() and script.onload are not
+   * reliable indicators, so this resolves when the global
+   * `window[RECAPTCHA_ENTERPRISE_ONLOAD_CALLBACK_NAME]()` callback provided to the recaptcha url param "onload"
+   * is triggered).
    * As a static variable this is applied to all instances of the class.
-   * This will cause an error if users try to create multiple Recaptcha
-   * Enterprise verifiers with different sitekeys, which should be an
+   * This will cause an error if users try to create multiple RecaptchaVerifiers
+   * with different Recaptcha Enterprise sitekeys, which should be an
    * unuspported use case.
-   *
-   * Leave public for testing.
    */
-  static scriptInjected: boolean = false;
+  private static scriptInjectionDeferred: Deferred<void> | null = null;
 
   /**
    *
@@ -142,12 +153,13 @@ export class RecaptchaEnterpriseVerifier {
 
     return new Promise<string>((resolve, reject) => {
       retrieveSiteKey(this.auth)
-        .then(siteKey => {
+        .then(async siteKey => {
           if (
             !forceRefresh &&
             isEnterprise(window.grecaptcha) &&
-            RecaptchaEnterpriseVerifier.scriptInjected
+            RecaptchaEnterpriseVerifier.scriptInjectionDeferred
           ) {
+            await RecaptchaEnterpriseVerifier.scriptInjectionDeferred.promise;
             retrieveRecaptchaToken(siteKey, resolve, reject);
           } else {
             if (typeof window === 'undefined') {
@@ -158,12 +170,31 @@ export class RecaptchaEnterpriseVerifier {
             }
             let url = jsHelpers._recaptchaEnterpriseScriptUrl();
             if (url.length !== 0) {
-              url += siteKey;
+              url +=
+                siteKey +
+                `&onload=${RECAPTCHA_ENTERPRISE_ONLOAD_CALLBACK_NAME}`;
             }
+            // Existence of deferred indicates download has been initiated.
+            RecaptchaEnterpriseVerifier.scriptInjectionDeferred =
+              new Deferred();
+
+            /**
+             * Script attached to global window object that will be called
+             * when the ReCAPTCHA Enterprise instance is ready.
+             * grecaptcha.ready() is not reliable when there are multiple
+             * scripts on the page, and script.onload only indicates the
+             * script has downloaded, not that it has initialized.
+             */
+            window[RECAPTCHA_ENTERPRISE_ONLOAD_CALLBACK_NAME] = () => {
+              RecaptchaEnterpriseVerifier.scriptInjectionDeferred?.resolve();
+            };
             jsHelpers
               ._loadJS(url)
+              .then(
+                () =>
+                  RecaptchaEnterpriseVerifier.scriptInjectionDeferred?.promise
+              )
               .then(() => {
-                RecaptchaEnterpriseVerifier.scriptInjected = true;
                 retrieveRecaptchaToken(siteKey, resolve, reject);
               })
               .catch(error => {

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
@@ -52,7 +52,7 @@ export class RecaptchaEnterpriseVerifier {
    * This will cause an error if users try to create multiple Recaptcha
    * Enterprise verifiers with different sitekeys, which should be an
    * unuspported use case.
-   * 
+   *
    * Leave public for testing.
    */
   static scriptInjected: boolean = false;

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
@@ -48,18 +48,14 @@ export class RecaptchaEnterpriseVerifier {
 
   /**
    * Detects if script tag has already been injected onto the page.
-   * Unfortunately this still results in duplicate script tags as this class is
-   * instantiated at least twice in the verifyPhoneNumber flow. This doesn't
-   * seem to cause any functionality issues, and other alternatives like
-   * detecting the script on the page seem to be prone to race conditions
-   * (as the script may exist but the widget may not be rendered).
-   * grecaptcha.ready() isn't reliable when more than one recaptcha script is on
-   * the page (as may be the case if App Check is also in use).
-   *
-   * TODO: Store this state higher up to avoid duplication, and probably
-   * make it a Deferred that resolves with the script onload event.
+   * As a static variable this is applied to all instances of the class.
+   * This will cause an error if users try to create multiple Recaptcha
+   * Enterprise verifiers with different sitekeys, which should be an
+   * unuspported use case.
+   * 
+   * Leave public for testing.
    */
-  private scriptInjected: boolean = false;
+  static scriptInjected: boolean = false;
 
   /**
    *
@@ -150,7 +146,7 @@ export class RecaptchaEnterpriseVerifier {
           if (
             !forceRefresh &&
             isEnterprise(window.grecaptcha) &&
-            this.scriptInjected
+            RecaptchaEnterpriseVerifier.scriptInjected
           ) {
             retrieveRecaptchaToken(siteKey, resolve, reject);
           } else {
@@ -167,7 +163,7 @@ export class RecaptchaEnterpriseVerifier {
             jsHelpers
               ._loadJS(url)
               .then(() => {
-                this.scriptInjected = true;
+                RecaptchaEnterpriseVerifier.scriptInjected = true;
                 retrieveRecaptchaToken(siteKey, resolve, reject);
               })
               .catch(error => {

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
@@ -56,7 +56,8 @@ export class RecaptchaEnterpriseVerifier {
    * grecaptcha.ready() isn't reliable when more than one recaptcha script is on
    * the page (as may be the case if App Check is also in use).
    *
-   * TODO: Store this state higher up to avoid duplication.
+   * TODO: Store this state higher up to avoid duplication, and probably
+   * make it a Deferred that resolves with the script onload event.
    */
   private scriptInjected: boolean = false;
 

--- a/packages/auth/src/platform_browser/strategies/phone.test.ts
+++ b/packages/auth/src/platform_browser/strategies/phone.test.ts
@@ -48,6 +48,7 @@ import { RecaptchaVerifier } from '../../platform_browser/recaptcha/recaptcha_ve
 import { PhoneAuthCredential } from '../../core/credentials/phone';
 import { FAKE_TOKEN } from '../recaptcha/recaptcha_enterprise_verifier';
 import { MockGreCAPTCHATopLevel } from '../../platform_browser/recaptcha/recaptcha_mock';
+import * as jsHelpers from '../load_js';
 
 import {
   _verifyPhoneNumber,
@@ -171,6 +172,8 @@ describe('platform_browser/strategies/phone', () => {
         return;
       }
       mockRecaptchaEnterpriseEnablement(EnforcementState.ENFORCE);
+      sinon.stub(jsHelpers, '_loadJS').resolves(new Event(''));
+
       await signInWithPhoneNumber(auth, '+15105550000', v2Verifier);
 
       expect(sendCodeEndpoint.calls[0].request).to.eql({
@@ -186,6 +189,7 @@ describe('platform_browser/strategies/phone', () => {
         return;
       }
       mockRecaptchaEnterpriseEnablement(EnforcementState.ENFORCE);
+      sinon.stub(jsHelpers, '_loadJS').resolves(new Event(''));
       await signInWithPhoneNumber(auth, '+15105550000');
 
       expect(sendCodeEndpoint.calls[0].request).to.eql({

--- a/packages/auth/src/platform_browser/strategies/phone.test.ts
+++ b/packages/auth/src/platform_browser/strategies/phone.test.ts
@@ -58,6 +58,7 @@ import {
   updatePhoneNumber,
   injectRecaptchaV2Token
 } from './phone';
+import { mockLoadJS } from '../../../test/helpers/mock_loadjs';
 
 use(chaiAsPromised);
 use(sinonChai);
@@ -172,7 +173,7 @@ describe('platform_browser/strategies/phone', () => {
         return;
       }
       mockRecaptchaEnterpriseEnablement(EnforcementState.ENFORCE);
-      sinon.stub(jsHelpers, '_loadJS').resolves(new Event(''));
+      sinon.stub(jsHelpers, '_loadJS').callsFake(mockLoadJS);
 
       await signInWithPhoneNumber(auth, '+15105550000', v2Verifier);
 
@@ -189,7 +190,7 @@ describe('platform_browser/strategies/phone', () => {
         return;
       }
       mockRecaptchaEnterpriseEnablement(EnforcementState.ENFORCE);
-      sinon.stub(jsHelpers, '_loadJS').resolves(new Event(''));
+      sinon.stub(jsHelpers, '_loadJS').callsFake(mockLoadJS);
       await signInWithPhoneNumber(auth, '+15105550000');
 
       expect(sendCodeEndpoint.calls[0].request).to.eql({

--- a/packages/auth/test/helpers/mock_loadjs.ts
+++ b/packages/auth/test/helpers/mock_loadjs.ts
@@ -1,4 +1,21 @@
-import { RECAPTCHA_ENTERPRISE_ONLOAD_CALLBACK_NAME } from "../../src/platform_browser/recaptcha/recaptcha_enterprise_verifier";
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RECAPTCHA_ENTERPRISE_ONLOAD_CALLBACK_NAME } from '../../src/platform_browser/recaptcha/recaptcha_enterprise_verifier';
 
 export const mockLoadJS = (): Promise<Event> => {
   if (typeof window[RECAPTCHA_ENTERPRISE_ONLOAD_CALLBACK_NAME] === 'function') {

--- a/packages/auth/test/helpers/mock_loadjs.ts
+++ b/packages/auth/test/helpers/mock_loadjs.ts
@@ -1,0 +1,8 @@
+import { RECAPTCHA_ENTERPRISE_ONLOAD_CALLBACK_NAME } from "../../src/platform_browser/recaptcha/recaptcha_enterprise_verifier";
+
+export const mockLoadJS = (): Promise<Event> => {
+  if (typeof window[RECAPTCHA_ENTERPRISE_ONLOAD_CALLBACK_NAME] === 'function') {
+    window[RECAPTCHA_ENTERPRISE_ONLOAD_CALLBACK_NAME]();
+  }
+  return Promise.resolve(new Event(''));
+};


### PR DESCRIPTION
Fixes #9405 

App Check and Auth (when using phone number verification) do not work when both are using ReCAPTCHA Enterprise in the same app. It causes an Auth error.

This bug was caused by two issues, one in Auth and one in App Check.

## Auth
The Auth SDK was detecting (with `isEnterprise()`) if a `window.grecaptcha.enterprise` object existed on the page, and if so, did not download the ReCAPTCHA Enterprise (abbreviated RCE from here on out) script, assuming it was ready to use.  Unfortunately, this check passes if it sees the ReCAPTCHA Enterprise instance downloaded by App Check (or any other source), which is not sufficient for Auth. In order for RCE to work the way Auth is set up to use it, Auth needs to initiate its own script download with the "render" param set to the user's RCE sitekey.

Auth needs to know when this script is ready (it has both finished downloading, AND has initialized) before it can call `grecaptcha.execute()`, or there will be an error (as in the issue linked above). It turns out that `grecaptcha.ready()` is not reliable when more than one RCE script is being loaded on the page, as it fires when any script is ready, even though the one you are calling `execute` on may not be ready. `script.onload` on the script tag used to download the script also isn't reliable, as there is a small delay between the download of the script and when it finishes its initialization on the page.

The one event that does seem reliable is a callback which must be placed on the global `window` namespace, and its name passed to the `onload` url param of the recaptcha script download url (not to be confused with `script.onload` on the script tag).

To track this, I have added a new static property: `RecaptchaEnterpriseVerifier.scriptInjectionDeferred`, a deferred object (a promise that can be resolved from outside). This deferred object is resolved when `window.onFirebaseAuthREInstanceReady()` (the new callback we create and pass to the onload url param) is called. Calls to `retrieveRecaptchaToken()` (which calls execute()) now `await` the resolution of this promise.

### Auth tests

Auth tests needed to be changed as almost all of them now call loadJS, which won't work in a test environment. loadJS has been stubbed in all relevant tests, and the stub calls `window.onFirebaseAuthREInstanceReady()` to ensure the deferred is resolved and the code can continue.

Also fixed an async test that was incorrect and did not await its result, causing a race condition with the next test.

## App Check
App Check does not include the sitekey in the url for downloading the RCE script, as part of its design to allow multiple sitekeys. Instead, it manually renders a widget. When you do this, you are supposed to set a `render=explicit` param on the url, which we didn't. It still worked by itself, but caused this clash with Auth.

When both of these changes are made, Auth and App Check both work together.