### PR TITLE
fix(auth): allow longer reCAPTCHA language tags

### DIFF
--- a/.changeset/fix-auth-recaptcha-language-tags.md
+++ b/.changeset/fix-auth-recaptcha-language-tags.md
@@ -1,0 +1,7 @@
+---
+'@firebase/auth': patch
+'@firebase/auth-compat': patch
+'firebase': patch
+---
+
+Allow the reCAPTCHA V2 loader to accept longer browser language tags such as `en-GB-oxendict`.

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_loader.test.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_loader.test.ts
@@ -149,6 +149,18 @@ describe('platform_browser/recaptcha/recaptcha_loader', () => {
           'auth/argument-error'
         );
       });
+
+      it('accepts long browser language tags', async () => {
+        const promise = loader.load(auth, 'en-GB-oxendict');
+        expect(jsHelpers._loadJS).to.have.been.calledWithMatch(
+          /hl=en-GB-oxendict/
+        );
+        jsLoader.reject();
+        await expect(promise).to.be.rejectedWith(
+          FirebaseError,
+          'auth/internal-error'
+        );
+      });
     });
   });
 });

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_loader.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_loader.ts
@@ -125,7 +125,7 @@ export class ReCaptchaLoaderImpl implements ReCaptchaLoader {
 }
 
 function isHostLanguageValid(hl: string): boolean {
-  return hl.length <= 6 && /^\s*[a-zA-Z0-9\-]*\s*$/.test(hl);
+  return /^\s*[a-zA-Z0-9-]*\s*$/.test(hl);
 }
 
 export class MockReCaptchaLoaderImpl implements ReCaptchaLoader {


### PR DESCRIPTION
## Problem
`auth.useDeviceLanguage()` can set `auth.languageCode` to real browser language tags longer than six characters, such as `en-GB-oxendict`. The reCAPTCHA V2 loader rejects those values as `auth/argument-error` before loading the script.

## Root cause
`isHostLanguageValid()` enforced `hl.length <= 6`, which only fits short tags like `en` or `en-GB` and rejects valid longer browser language tags.

## Solution
Remove the arbitrary six-character limit while preserving the existing alphanumeric/hyphen/whitespace whitelist, and add a regression test that verifies `en-GB-oxendict` is accepted and passed through as the `hl` parameter.

## Tests run
- `corepack yarn install --frozen-lockfile --ignore-engines` (Node 24 requires ignoring engines; optional `re2` native build failed but install completed)
- `corepack yarn --cwd packages/auth build:deps`
- `..\..\node_modules\.bin\eslint.cmd -c .eslintrc.js src/platform_browser/recaptcha/recaptcha_loader.ts src/platform_browser/recaptcha/recaptcha_loader.test.ts --ignore-path ../../.gitignore` from `packages/auth`
- `.\node_modules\.bin\prettier.cmd --check packages/auth/src/platform_browser/recaptcha/recaptcha_loader.ts packages/auth/src/platform_browser/recaptcha/recaptcha_loader.test.ts .changeset/fix-auth-recaptcha-language-tags.md`
- `corepack yarn --cwd packages/auth test:browser:unit -- --grep recaptcha_loader` (10 tests passed)
- `git diff --check`

Fixes #8357