### PR TITLE
docs(auth): pass auth to RecaptchaVerifier examples

### DIFF
--- a/packages/auth/src/platform_browser/providers/phone.ts
+++ b/packages/auth/src/platform_browser/providers/phone.ts
@@ -43,7 +43,7 @@ import { ProviderId, SignInMethod } from '../../model/enums';
  * @example
  * ```javascript
  * // 'recaptcha-container' is the ID of an element in the DOM.
- * const applicationVerifier = new RecaptchaVerifier('recaptcha-container');
+ * const applicationVerifier = new RecaptchaVerifier(auth, 'recaptcha-container');
  * const provider = new PhoneAuthProvider(auth);
  * const verificationId = await provider.verifyPhoneNumber('+16505550101', applicationVerifier);
  * // Obtain the verificationCode from the user.

--- a/packages/auth/src/platform_browser/strategies/phone.ts
+++ b/packages/auth/src/platform_browser/strategies/phone.ts
@@ -117,7 +117,7 @@ class ConfirmationResultImpl implements ConfirmationResult {
  * @example
  * ```javascript
  * // 'recaptcha-container' is the ID of an element in the DOM.
- * const applicationVerifier = new firebase.auth.RecaptchaVerifier('recaptcha-container');
+ * const applicationVerifier = new RecaptchaVerifier(auth, 'recaptcha-container');
  * const confirmationResult = await signInWithPhoneNumber(auth, phoneNumber, applicationVerifier);
  * // Obtain a verificationCode from the user.
  * const credential = await confirmationResult.confirm(verificationCode);
@@ -435,7 +435,7 @@ export async function _verifyPhoneNumber(
  * @example
  * ```
  * // 'recaptcha-container' is the ID of an element in the DOM.
- * const applicationVerifier = new RecaptchaVerifier('recaptcha-container');
+ * const applicationVerifier = new RecaptchaVerifier(auth, 'recaptcha-container');
  * const provider = new PhoneAuthProvider(auth);
  * const verificationId = await provider.verifyPhoneNumber('+16505550101', applicationVerifier);
  * // Obtain the verificationCode from the user.


### PR DESCRIPTION
## Problem
The generated Auth docs include `RecaptchaVerifier` examples that omit the required `auth` constructor argument, matching #7630.

## Root cause
The source JSDoc examples still used the old constructor shape, even though `RecaptchaVerifier` now takes `authExtern` as its first parameter.

## Solution
Update the phone auth examples to construct `RecaptchaVerifier(auth, 'recaptcha-container')`.

## Tests run
- `.\node_modules\.bin\prettier.cmd --check packages/auth/src/platform_browser/providers/phone.ts packages/auth/src/platform_browser/strategies/phone.ts`
- `..\..\node_modules\.bin\eslint.cmd -c .eslintrc.js src/platform_browser/providers/phone.ts src/platform_browser/strategies/phone.ts --ignore-path ../../.gitignore` from `packages/auth`
- `git diff --check`

Fixes #7630