### PR TITLE
fix(remote-config): support object values in defaultConfig types

### DIFF
--- a/.changeset/fix-remote-config-default-config-types.md
+++ b/.changeset/fix-remote-config-default-config-types.md
@@ -1,0 +1,5 @@
+---
+"@firebase/remote-config-types": patch
+---
+
+Support object values in defaultConfig type

--- a/packages/remote-config-types/index.d.ts
+++ b/packages/remote-config-types/index.d.ts
@@ -24,7 +24,7 @@ export interface RemoteConfig {
   /**
    * Object containing default values for configs.
    */
-  defaultConfig: { [key: string]: string | number | boolean };
+defaultConfig: { [key: string]: string | number | boolean | Record<string, unknown> };
 
   /**
    * The Unix timestamp in milliseconds of the last <i>successful</i> fetch, or negative one if


### PR DESCRIPTION
 Fixes #6106

  The `defaultConfig` type currently only accepts `string | number | boolean` values,
  but Firebase Remote Config supports JSON object values as defaults.
  This adds `Record<string, unknown>` to the union type so TypeScript
  no longer rejects object values.