### PR TITLE
fix(ai): format systemInstruction string in ChatSession constructor

### DIFF
--- a/.changeset/many-cherries-mix.md
+++ b/.changeset/many-cherries-mix.md
@@ -1,0 +1,5 @@
+---
+'@firebase/remote-config': patch
+---
+
+Support ABT realtime when variant value matches default value of parameter

--- a/.changeset/many-cherries-mix.md
+++ b/.changeset/many-cherries-mix.md
@@ -1,5 +1,0 @@
----
-'@firebase/remote-config': patch
----
-
-Support ABT realtime when variant value matches default value of parameter

--- a/.changeset/new-terms-draw.md
+++ b/.changeset/new-terms-draw.md
@@ -1,0 +1,6 @@
+---
+'@firebase/remote-config': patch
+'@firebase/ai': patch
+---
+
+Wrap params.systemInstruction with formatSystemInstruction() in the ChatSession constructor.

--- a/.changeset/new-terms-draw.md
+++ b/.changeset/new-terms-draw.md
@@ -1,5 +1,4 @@
 ---
-'@firebase/remote-config': patch
 '@firebase/ai': patch
 ---
 

--- a/packages/ai/src/methods/chat-session.test.ts
+++ b/packages/ai/src/methods/chat-session.test.ts
@@ -59,6 +59,44 @@ describe('ChatSession', () => {
   afterEach(() => {
     restore();
   });
+  it('formats systemInstruction if it is provided as a string', () => {
+    const chatSession = new ChatSession(
+      fakeApiSettings,
+      'a-model',
+      fakeChromeAdapter,
+      {
+        systemInstruction: 'be friendly'
+      }
+    );
+    expect(chatSession.params?.systemInstruction).to.deep.equal({
+      role: 'system',
+      parts: [{ text: 'be friendly' }]
+    });
+  });
+  it('leaves systemInstruction unchanged if it is already a Content object', () => {
+    const systemInstruction: Content = {
+      role: 'system',
+      parts: [{ text: 'be friendly' }]
+    };
+    const chatSession = new ChatSession(
+      fakeApiSettings,
+      'a-model',
+      fakeChromeAdapter,
+      { systemInstruction }
+    );
+    expect(chatSession.params?.systemInstruction).to.deep.equal(
+      systemInstruction
+    );
+  });
+  it('leaves systemInstruction as undefined if not provided', () => {
+    const chatSession = new ChatSession(
+      fakeApiSettings,
+      'a-model',
+      fakeChromeAdapter,
+      {}
+    );
+    expect(chatSession.params?.systemInstruction).to.be.undefined;
+  });
   describe('sendMessage()', () => {
     it('sends the correct params to generateContent()', async () => {
       const generateContentStub = stub(

--- a/packages/ai/src/methods/chat-session.test.ts
+++ b/packages/ai/src/methods/chat-session.test.ts
@@ -108,6 +108,10 @@ describe('ChatSession', () => {
         'a-model',
         fakeChromeAdapter,
         {
+          systemInstruction: {
+            role: 'system',
+            parts: [{ text: 'system instruction text' }]
+          },
           history: [
             { role: 'user', parts: [{ text: 'user turn 1' }] },
             { role: 'model', parts: [{ text: 'model turn 1' }] }
@@ -119,7 +123,12 @@ describe('ChatSession', () => {
       expect(generateContentStub).to.be.calledWith(
         fakeApiSettings,
         'a-model',
-        match.any,
+        match({
+          systemInstruction: {
+            role: 'system',
+            parts: [{ text: 'system instruction text' }]
+          }
+        }),
         match.any
       );
       expect(generateContentStub.args[0][2].contents).to.deep.equal([
@@ -268,6 +277,10 @@ describe('ChatSession', () => {
         'a-model',
         fakeChromeAdapter,
         {
+          systemInstruction: {
+            role: 'system',
+            parts: [{ text: 'system instruction text' }]
+          },
           history: [
             { role: 'user', parts: [{ text: 'user turn 1' }] },
             { role: 'model', parts: [{ text: 'model turn 1' }] }
@@ -279,7 +292,12 @@ describe('ChatSession', () => {
       expect(generateContentStreamStub).to.be.calledWith(
         fakeApiSettings,
         'a-model',
-        match.any,
+        match({
+          systemInstruction: {
+            role: 'system',
+            parts: [{ text: 'system instruction text' }]
+          }
+        }),
         match.any
       );
       expect(generateContentStreamStub.args[0][2].contents).to.deep.equal([

--- a/packages/ai/src/methods/chat-session.ts
+++ b/packages/ai/src/methods/chat-session.ts
@@ -57,12 +57,9 @@ export class ChatSession extends ChatSessionBase<
       this._history = params.history;
     }
     if (this.params?.systemInstruction != null) {
-      this.params = {
-        ...this.params,
-        systemInstruction: formatSystemInstruction(
-          this.params.systemInstruction
+       this.params.systemInstruction = formatSystemInstruction(
+        this.params.systemInstruction
         )
-      };
     }
   }
 

--- a/packages/ai/src/methods/chat-session.ts
+++ b/packages/ai/src/methods/chat-session.ts
@@ -57,9 +57,12 @@ export class ChatSession extends ChatSessionBase<
       this._history = params.history;
     }
     if (this.params?.systemInstruction != null) {
-       this.params.systemInstruction = formatSystemInstruction(
-        this.params.systemInstruction
-        );
+      this.params = {
+        ...this.params,
+        systemInstruction: formatSystemInstruction(
+          this.params.systemInstruction
+        )
+      };
     }
   }
 

--- a/packages/ai/src/methods/chat-session.ts
+++ b/packages/ai/src/methods/chat-session.ts
@@ -56,7 +56,7 @@ export class ChatSession extends ChatSessionBase<
       validateChatHistory(params.history);
       this._history = params.history;
     }
-    if (this.params?.systemInstruction) {
+    if (this.params?.systemInstruction != null) {
       this.params = {
         ...this.params,
         systemInstruction: formatSystemInstruction(

--- a/packages/ai/src/methods/chat-session.ts
+++ b/packages/ai/src/methods/chat-session.ts
@@ -59,7 +59,7 @@ export class ChatSession extends ChatSessionBase<
     if (this.params?.systemInstruction != null) {
        this.params.systemInstruction = formatSystemInstruction(
         this.params.systemInstruction
-        )
+        );
     }
   }
 

--- a/packages/ai/src/methods/chat-session.ts
+++ b/packages/ai/src/methods/chat-session.ts
@@ -31,6 +31,7 @@ import { ApiSettings } from '../types/internal';
 import { ChromeAdapter } from '../types/chrome-adapter';
 import { ChatSessionBase } from './chat-session-base';
 import { validateChatHistory } from './chat-session-helpers';
+import { formatSystemInstruction } from '../requests/request-helpers';
 
 /**
  * ChatSession class that enables sending chat messages and stores
@@ -54,6 +55,14 @@ export class ChatSession extends ChatSessionBase<
     if (params?.history) {
       validateChatHistory(params.history);
       this._history = params.history;
+    }
+    if (this.params?.systemInstruction) {
+      this.params = {
+        ...this.params,
+        systemInstruction: formatSystemInstruction(
+          this.params.systemInstruction
+        )
+      };
     }
   }
 


### PR DESCRIPTION
### Problem: 
`startChat()` wasn't working when `systemInstruction` was provided as a string. The `GenerativeModel` constructor correctly normalzies  `systemInstruction`via `formatSystemInstruction()`, but `ChatSessions` constructor did not, causing the raw string to be sent to the API which expects a `Content` object.

### Fix:
Wrap `params.systemInstruction` with `formatSystemInstruction()` in the `ChatSession` constructor.

### Testing:
- Added unit tests covering string input, Content Object input, and undefinded. 
- Manually verified with a real API call that the model correctly follows a string system instruction. 

Fixes #9006