### PR TITLE
chore(ci): make Firestore integration tests optional

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -214,6 +214,7 @@ jobs:
     - name: Run unit tests
       run: |
         yarn lerna run test:all:ci --scope '@firebase/firestore*' --stream --concurrency 1
+      continue-on-error: true
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}
         EXPERIMENTAL_MODE: true
@@ -264,6 +265,7 @@ jobs:
       working-directory: integration/firestore
     - run: xvfb-run yarn karma:singlerun
       working-directory: integration/firestore
+      continue-on-error: true
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}
 

--- a/.github/workflows/test-changed-firestore-integration.yml
+++ b/.github/workflows/test-changed-firestore-integration.yml
@@ -84,3 +84,4 @@ jobs:
       run: yarn build:changed firestore-integration
     - name: Run tests if firestore or its dependencies has changed
       run: yarn test:changed firestore-integration
+      continue-on-error: true

--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -102,6 +102,7 @@ jobs:
         run: cp config/ci.config.json config/project.json
       - name: Run compat tests
         run: cd packages/firestore-compat && yarn run test:ci
+        continue-on-error: true
 
   test-chrome:
     name: Test Firestore
@@ -130,6 +131,7 @@ jobs:
         run: cp config/ci.config.json config/project.json
       - name: Run tests
         run: cd packages/firestore && yarn run ${{ matrix.test-name }}
+        continue-on-error: ${{ matrix.test-name != 'test:travis' }}
         env:
           EXPERIMENTAL_MODE: true
 
@@ -163,6 +165,7 @@ jobs:
           echo $INTEG_TESTS_GOOGLE_SERVICES > config/project.json
       - name: Run tests
         run: cd packages/firestore && yarn run ${{ matrix.test-name }}
+        continue-on-error: true
         env:
           EXPERIMENTAL_MODE: true
 
@@ -189,6 +192,7 @@ jobs:
         run: cp config/ci.config.json config/project.json
       - name: Run compat tests
         run: cd packages/firestore-compat && xvfb-run yarn run test:ci
+        continue-on-error: true
         env:
           BROWSERS: 'Firefox'
 
@@ -217,6 +221,7 @@ jobs:
         run: cp config/ci.config.json config/project.json
       - name: Run tests
         run: cd packages/firestore && xvfb-run yarn run ${{ matrix.test-name }}
+        continue-on-error: ${{ matrix.test-name != 'test:travis' }}
         env:
           BROWSERS: 'Firefox'
           EXPERIMENTAL_MODE: true
@@ -243,6 +248,7 @@ jobs:
           npx playwright install webkit
       - name: Run compat tests
         run: cd packages/firestore-compat && yarn run test:ci
+        continue-on-error: true
         env:
           BROWSERS: 'WebkitHeadless'
 
@@ -274,6 +280,7 @@ jobs:
           npx playwright install webkit
       - name: Run tests
         run: cd packages/firestore && yarn run ${{ matrix.test-name }}
+        continue-on-error: true
         env:
           BROWSERS: 'WebkitHeadless'
           EXPERIMENTAL_MODE: true
@@ -283,8 +290,8 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     name: Check all required tests results
-    needs: [build, test-chrome, compat-test-chrome]
+    needs: [build]
     steps:
       - name: Check test matrix
-        if: needs.build.result == 'failure' || needs.test-chrome.result == 'failure' || needs.compat-test-chrome.result == 'failure'
+        if: needs.build.result == 'failure'
         run: exit 1


### PR DESCRIPTION
Makes all Firestore integration tests that hit the production backend optional (continue-on-error: true) so they don't block pull requests when the backend has issues.