### PR TITLE
feat(ai): Change getAI() to autoinitialize App Check

### DIFF
--- a/.changeset/late-bugs-marry.md
+++ b/.changeset/late-bugs-marry.md
@@ -1,6 +1,5 @@
 ---
 '@firebase/app-check': patch
-'@firebase/app-check-interop-types': patch
 '@firebase/ai': minor
 'firebase': minor
 ---

--- a/.changeset/late-bugs-marry.md
+++ b/.changeset/late-bugs-marry.md
@@ -1,4 +1,6 @@
 ---
+'@firebase/app-check': patch
+'@firebase/app-check-interop-types': patch
 '@firebase/ai': minor
 'firebase': minor
 ---

--- a/.changeset/late-bugs-marry.md
+++ b/.changeset/late-bugs-marry.md
@@ -1,0 +1,6 @@
+---
+'@firebase/ai': minor
+'firebase': minor
+---
+
+Changed `getAI()` to autoinitialize App Check if App Check has not already been initialized.

--- a/common/api-review/ai.api.md
+++ b/common/api-review/ai.api.md
@@ -42,6 +42,7 @@ export const AIErrorCode: {
     readonly NO_MODEL: "no-model";
     readonly NO_PROJECT_ID: "no-project-id";
     readonly PARSE_FAILED: "parse-failed";
+    readonly APP_CHECK_INITIALIZATION_FAILED: "app-check-initialization-failed";
     readonly UNSUPPORTED: "unsupported";
 };
 

--- a/packages/ai/integration/README.md
+++ b/packages/ai/integration/README.md
@@ -1,0 +1,20 @@
+## AI Logic integration tests
+
+These are AI Logic SDK integration tests against a live backend intended to be run locally during development and testing of the AI Logic SDK.
+
+### Setup
+
+You must have your own Firebase project with AI Logic enabled and App Check enabled with an App Check debug token created. Insert the project config into `FIREBASE_CONFIG` in `firebase-config.ts` and replace `INSERT_APP_CHECK_DEBUG_TOKEN_HERE` with your App Check debug token for that same project.
+
+### Running tests
+
+To run browser tests: `yarn test:integration`
+To run node tests: `yarn test:integration:node`
+
+Since this runs many tests on serveral models and may take a long time, you may want to run selected tests where the test description contains a specific string. An example:
+
+```
+yarn test:integration:node --reporter list --grep "gemini-3.1-flash-lite generateContent: google search grounding"
+```
+
+Note that the string here is a concatenation of the model, the "describe" block description, and the "it" block description. You may have to do a full test run first in order to find the exact string format you want to provide.

--- a/packages/ai/integration/constants.ts
+++ b/packages/ai/integration/constants.ts
@@ -25,9 +25,21 @@ import {
   getAI,
   getGenerativeModel
 } from '../src';
-import { FIREBASE_CONFIG } from './firebase-config';
+import { APP_CHECK_DEBUG_TOKEN, FIREBASE_CONFIG } from './firebase-config';
+import { CustomProvider, initializeAppCheck } from '@firebase/app-check';
+
+// This prepares App Check to init in debug mode.
+//@ts-ignore
+globalThis.FIREBASE_APPCHECK_DEBUG_TOKEN = APP_CHECK_DEBUG_TOKEN;
 
 const app = initializeApp(FIREBASE_CONFIG);
+initializeAppCheck(app, {
+  // Recaptcha provider can't be used in Node. A dummy provider must
+  // be provided even in debug mode or it will error.
+  provider: new CustomProvider({
+    getToken: () => Promise.resolve({ token: 'asdf', expireTimeMillis: 123 })
+  })
+});
 
 /**
  * Test config that all tests will be ran against.

--- a/packages/ai/integration/firebase-config.ts
+++ b/packages/ai/integration/firebase-config.ts
@@ -15,7 +15,9 @@
  * limitations under the License.
  */
 
+import { FirebaseOptions } from '@firebase/app';
+
 export const FIREBASE_CONFIG = {
   /** insert your Firebase project config here */
-};
+} as FirebaseOptions;
 export const APP_CHECK_DEBUG_TOKEN = 'INSERT_APP_CHECK_DEBUG_TOKEN_HERE';

--- a/packages/ai/integration/firebase-config.ts
+++ b/packages/ai/integration/firebase-config.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
-import * as config from '../../../config/ci.config.json';
-
-export const FIREBASE_CONFIG = config;
+export const FIREBASE_CONFIG = {
+  /** insert your Firebase project config here */
+};
+export const APP_CHECK_DEBUG_TOKEN = 'INSERT_APP_CHECK_DEBUG_TOKEN_HERE';

--- a/packages/ai/karma.conf.js
+++ b/packages/ai/karma.conf.js
@@ -32,7 +32,7 @@ module.exports = function (config) {
     // files to load into karma
     files: (() => {
       if (argv.integration) {
-        return ['integration/**'];
+        return ['integration/**/*.ts'];
       } else {
         return ['src/**/*.test.ts'];
       }

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "@firebase/app-check-interop-types": "0.3.4",
+    "@firebase/app-check": "0.11.4",
     "@firebase/component": "0.7.3",
     "@firebase/logger": "0.5.1",
     "@firebase/util": "1.15.1",

--- a/packages/ai/src/api.test.ts
+++ b/packages/ai/src/api.test.ts
@@ -34,6 +34,7 @@ import {
   TemplateImagenModel
 } from './api';
 import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import { stub, restore } from 'sinon';
 import { AI } from './public-types';
 import { GenerativeModel } from './models/generative-model';
@@ -43,10 +44,16 @@ import { AI_TYPE } from './constants';
 import { logger } from './logger';
 import sinonChai from 'sinon-chai';
 import * as appCheck from '@firebase/app-check';
-import { CustomProvider, initializeAppCheck } from '@firebase/app-check';
-import { deleteApp, FirebaseApp } from '@firebase/app';
+import {
+  CustomProvider,
+  initializeAppCheck,
+  ReCaptchaEnterpriseProvider
+} from '@firebase/app-check';
+import { _getProvider, deleteApp, FirebaseApp } from '@firebase/app';
+import { AIService } from './service';
 
 use(sinonChai);
+use(chaiAsPromised);
 
 const fakeAI: AI = {
   app: {
@@ -134,6 +141,33 @@ describe('Top level API', () => {
       getAI(app);
       expect(initStub).to.be.calledOnce;
     });
+    it(
+      'manually initializing App Check with custom options after autoinit' +
+        ' will throw a useful error',
+      () => {
+        getAI(app);
+        expect(() =>
+          initializeAppCheck(app, {
+            provider: new ReCaptchaEnterpriseProvider('OTHER_SITE_KEY')
+          })
+        ).to.throw('initialized by AI Logic SDK');
+      }
+    );
+    it(
+      'manually initializing App Check with custom options first causes' +
+        ' getAI() to use the already existing instance',
+      () => {
+        initializeAppCheck(app, {
+          provider: new ReCaptchaEnterpriseProvider('OTHER_SITE_KEY')
+        });
+        const internalAppCheck = _getProvider(
+          app,
+          'app-check-internal'
+        ).getImmediate();
+        const ai = getAI(app);
+        expect((ai as AIService).appCheck).to.equal(internalAppCheck);
+      }
+    );
   });
   it('getGenerativeModel throws if no model is provided', () => {
     try {

--- a/packages/ai/src/api.test.ts
+++ b/packages/ai/src/api.test.ts
@@ -34,7 +34,7 @@ import {
   TemplateImagenModel
 } from './api';
 import { expect, use } from 'chai';
-import { stub } from 'sinon';
+import { stub, restore } from 'sinon';
 import { AI } from './public-types';
 import { GenerativeModel } from './models/generative-model';
 import { GoogleAIBackend, VertexAIBackend } from './backend';
@@ -42,6 +42,9 @@ import { getFullApp } from '../test-utils/get-fake-firebase-services';
 import { AI_TYPE } from './constants';
 import { logger } from './logger';
 import sinonChai from 'sinon-chai';
+import * as appCheck from '@firebase/app-check';
+import { CustomProvider, initializeAppCheck } from '@firebase/app-check';
+import { deleteApp, FirebaseApp } from '@firebase/app';
 
 use(sinonChai);
 
@@ -61,17 +64,25 @@ const fakeAI: AI = {
 
 describe('Top level API', () => {
   describe('getAI()', () => {
+    let app: FirebaseApp;
+    beforeEach(() => {
+      app = getFullApp();
+    });
+    afterEach(async () => {
+      restore();
+      await deleteApp(app);
+    });
     it('works without options', () => {
-      const ai = getAI(getFullApp());
+      const ai = getAI(app);
       expect(ai.backend).to.be.instanceOf(GoogleAIBackend);
     });
     it('works with options: no backend, limited use token', () => {
-      const ai = getAI(getFullApp(), { useLimitedUseAppCheckTokens: true });
+      const ai = getAI(app, { useLimitedUseAppCheckTokens: true });
       expect(ai.backend).to.be.instanceOf(GoogleAIBackend);
       expect(ai.options?.useLimitedUseAppCheckTokens).to.be.true;
     });
     it('works with options: backend specified, limited use token', () => {
-      const ai = getAI(getFullApp(), {
+      const ai = getAI(app, {
         backend: new VertexAIBackend('us-central1'),
         useLimitedUseAppCheckTokens: true
       });
@@ -79,7 +90,7 @@ describe('Top level API', () => {
       expect(ai.options?.useLimitedUseAppCheckTokens).to.be.true;
     });
     it('works with options: appCheck option is falsy', () => {
-      const ai = getAI(getFullApp(), {
+      const ai = getAI(app, {
         backend: new VertexAIBackend('us-central1'),
         useLimitedUseAppCheckTokens: undefined
       });
@@ -87,11 +98,41 @@ describe('Top level API', () => {
       expect(ai.options?.useLimitedUseAppCheckTokens).to.be.false;
     });
     it('works with options: backend specified only', () => {
-      const ai = getAI(getFullApp(), {
+      const ai = getAI(app, {
         backend: new VertexAIBackend('us-central1')
       });
       expect(ai.backend).to.be.instanceOf(VertexAIBackend);
       expect(ai.options?.useLimitedUseAppCheckTokens).to.be.false;
+    });
+    it('if a default app check instance exists, do not initialize one', () => {
+      const initStub = stub(appCheck, '_initializeAppCheckInternal');
+      initializeAppCheck(app);
+      const ai = getAI(app);
+      expect(ai.backend).to.be.instanceOf(GoogleAIBackend);
+      expect(initStub).to.not.be.called;
+    });
+    it('if a custom app check instance exists, do not initialize one', async () => {
+      const initStub = stub(appCheck, '_initializeAppCheckInternal');
+      initializeAppCheck(app, {
+        provider: new CustomProvider({
+          getToken: () => Promise.resolve({ token: 'fsd', expireTimeMillis: 1 })
+        })
+      });
+      const ai = getAI(app);
+      expect(ai.backend).to.be.instanceOf(GoogleAIBackend);
+      expect(initStub).to.not.be.called;
+    });
+    it('if no app check instance exists, initializes one', () => {
+      const initStub = stub(appCheck, '_initializeAppCheckInternal');
+      const ai = getAI(app);
+      expect(ai.backend).to.be.instanceOf(GoogleAIBackend);
+      expect(initStub).calledWith('AI Logic SDK');
+    });
+    it('does not initialize app check twice if called twice', () => {
+      const initStub = stub(appCheck, '_initializeAppCheckInternal');
+      getAI(app);
+      getAI(app);
+      expect(initStub).to.be.calledOnce;
     });
   });
   it('getGenerativeModel throws if no model is provided', () => {

--- a/packages/ai/src/api.test.ts
+++ b/packages/ai/src/api.test.ts
@@ -49,7 +49,12 @@ import {
   initializeAppCheck,
   ReCaptchaEnterpriseProvider
 } from '@firebase/app-check';
-import { _getProvider, deleteApp, FirebaseApp } from '@firebase/app';
+import {
+  _getProvider,
+  deleteApp,
+  FirebaseApp,
+  FirebaseError
+} from '@firebase/app';
 import { AIService } from './service';
 
 use(sinonChai);
@@ -134,6 +139,13 @@ describe('Top level API', () => {
       const ai = getAI(app);
       expect(ai.backend).to.be.instanceOf(GoogleAIBackend);
       expect(initStub).calledWith('AI Logic SDK');
+    });
+    it('warns if no app check instance exists, and no sitekey in config', () => {
+      app.options.recaptchaSiteKey = undefined;
+      const warnStub = stub(console, 'warn');
+      getAI(app);
+      console.log(warnStub.args[0][0]);
+      expect(warnStub).to.be.calledWithMatch(/app-check-initialization-failed/);
     });
     it('does not initialize app check twice if called twice', () => {
       const initStub = stub(appCheck, '_initializeAppCheckInternal');

--- a/packages/ai/src/requests/request.ts
+++ b/packages/ai/src/requests/request.ts
@@ -278,6 +278,19 @@ export async function makeRequest(
           }
         );
       }
+      if (response.status === 401 && message.includes('App Check')) {
+        throw new AIError(
+          AIErrorCode.FETCH_ERROR,
+          `Error fetching from ${url}: [${response.status} ${response.statusText}]` +
+            ` This project has App Check enforced for AI Logic and this request` +
+            ` had an App Check error: ${message}`,
+          {
+            status: response.status,
+            statusText: response.statusText,
+            errorDetails
+          }
+        );
+      }
       throw new AIError(
         AIErrorCode.FETCH_ERROR,
         `Error fetching from ${url}: [${response.status} ${response.statusText}] ${message}`,

--- a/packages/ai/src/service.test.ts
+++ b/packages/ai/src/service.test.ts
@@ -14,29 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { getFullApp } from '../test-utils/get-fake-firebase-services';
 import { VertexAIBackend } from './backend';
 import { DEFAULT_LOCATION } from './constants';
 import { AIService } from './service';
 import { expect } from 'chai';
 
-const fakeApp = {
-  name: 'DEFAULT',
-  automaticDataCollectionEnabled: true,
-  options: {
-    apiKey: 'key',
-    projectId: 'my-project'
-  }
-};
-
 describe('AIService', () => {
   // TODO (dlarocque): move some of these tests to helpers.test.ts
   it('uses default location if not specified', () => {
-    const ai = new AIService(fakeApp, new VertexAIBackend());
+    const ai = new AIService(getFullApp(), new VertexAIBackend());
     expect(ai.location).to.equal(DEFAULT_LOCATION);
   });
   it('uses custom location if specified', () => {
     const ai = new AIService(
-      fakeApp,
+      getFullApp(),
       new VertexAIBackend('somewhere'),
       /* authProvider */ undefined,
       /* appCheckProvider */ undefined

--- a/packages/ai/src/service.ts
+++ b/packages/ai/src/service.ts
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-import { FirebaseApp, _FirebaseService } from '@firebase/app';
+import { FirebaseApp, FirebaseError, _FirebaseService } from '@firebase/app';
 import {
   AI,
+  AIErrorCode,
   AIOptions,
   ChromeAdapter,
   InferenceMode,
@@ -34,6 +35,7 @@ import {
 } from '@firebase/auth-interop-types';
 import { Backend, VertexAIBackend } from './backend';
 import { _initializeAppCheckInternal } from '@firebase/app-check';
+import { AIError } from './errors';
 
 export class AIService implements AI, _FirebaseService {
   auth: FirebaseAuthInternal | null;
@@ -54,8 +56,19 @@ export class AIService implements AI, _FirebaseService {
   ) {
     let appCheck = appCheckProvider?.getImmediate({ optional: true });
     if (!appCheck) {
-      _initializeAppCheckInternal('AI Logic SDK', this.app);
-      appCheck = appCheckProvider?.getImmediate({ optional: true });
+      try {
+        _initializeAppCheckInternal('AI Logic SDK', this.app);
+        appCheck = appCheckProvider?.getImmediate({ optional: true });
+      } catch (e) {
+        console.warn(
+          new AIError(
+            AIErrorCode.APP_CHECK_INITIALIZATION_FAILED,
+            `Unable to initialize App Check... Details: ${
+              (e as FirebaseError).message
+            }`
+          ).message
+        );
+      }
     }
     const auth = authProvider?.getImmediate({ optional: true });
     this.auth = auth || null;

--- a/packages/ai/src/service.ts
+++ b/packages/ai/src/service.ts
@@ -33,6 +33,7 @@ import {
   FirebaseAuthInternalName
 } from '@firebase/auth-interop-types';
 import { Backend, VertexAIBackend } from './backend';
+import { _initializeAppCheckInternal } from '@firebase/app-check';
 
 export class AIService implements AI, _FirebaseService {
   auth: FirebaseAuthInternal | null;
@@ -51,7 +52,11 @@ export class AIService implements AI, _FirebaseService {
       params?: OnDeviceParams
     ) => ChromeAdapter | undefined
   ) {
-    const appCheck = appCheckProvider?.getImmediate({ optional: true });
+    let appCheck = appCheckProvider?.getImmediate({ optional: true });
+    if (!appCheck) {
+      _initializeAppCheckInternal('AI Logic SDK', this.app);
+      appCheck = appCheckProvider?.getImmediate({ optional: true });
+    }
     const auth = authProvider?.getImmediate({ optional: true });
     this.auth = auth || null;
     this.appCheck = appCheck || null;

--- a/packages/ai/src/types/error.ts
+++ b/packages/ai/src/types/error.ts
@@ -102,6 +102,9 @@ export const AIErrorCode = {
   /** An error occurred while parsing. */
   PARSE_FAILED: 'parse-failed',
 
+  /** An error occurred while initializing App Check. */
+  APP_CHECK_INITIALIZATION_FAILED: 'app-check-initialization-failed',
+
   /** An error occurred due an attempt to use an unsupported feature. */
   UNSUPPORTED: 'unsupported'
 } as const;

--- a/packages/ai/test-utils/get-fake-firebase-services.ts
+++ b/packages/ai/test-utils/get-fake-firebase-services.ts
@@ -32,7 +32,8 @@ const fakeConfig = {
   authDomain: 'authDomain',
   messagingSenderId: 'messagingSenderId',
   databaseURL: 'databaseUrl',
-  storageBucket: 'storageBucket'
+  storageBucket: 'storageBucket',
+  recaptchaSiteKey: 'FAKE_SITE_KEY'
 };
 
 export function getFullApp(
@@ -40,7 +41,8 @@ export function getFullApp(
     appId?: string;
     apiKey?: string;
   },
-  factory: InstanceFactory<'AI'> = factoryNode
+  factory: InstanceFactory<'AI'> = factoryNode,
+  appName?: string
 ): FirebaseApp {
   _registerComponent(
     new Component(AI_TYPE, factory, ComponentType.PUBLIC).setMultipleInstances(
@@ -56,7 +58,7 @@ export function getFullApp(
       ComponentType.PUBLIC
     )
   );
-  const app = initializeApp({ ...fakeConfig, ...fakeAppParams });
+  const app = initializeApp({ ...fakeConfig, ...fakeAppParams }, appName);
   _addOrOverwriteComponent(
     app,
     //@ts-ignore

--- a/packages/app-check/package.json
+++ b/packages/app-check/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@firebase/util": "1.15.1",
+    "@firebase/app-check-interop-types": "0.3.4",
     "@firebase/component": "0.7.3",
     "@firebase/logger": "0.5.1",
     "tslib": "^2.1.0"

--- a/packages/app-check/src/factory.ts
+++ b/packages/app-check/src/factory.ts
@@ -17,7 +17,7 @@
 
 import { AppCheck } from './public-types';
 import { FirebaseApp, _FirebaseService } from '@firebase/app';
-import { FirebaseAppCheckInternal, ListenerType } from './types';
+import { ListenerType } from './types';
 import {
   getToken,
   getLimitedUseToken,
@@ -26,6 +26,7 @@ import {
 } from './internal-api';
 import { Provider } from '@firebase/component';
 import { getStateReference } from './state';
+import { FirebaseAppCheckInternal } from '@firebase/app-check-interop-types';
 
 /**
  * AppCheck Service class.

--- a/packages/app-check/src/types.ts
+++ b/packages/app-check/src/types.ts
@@ -18,25 +18,7 @@
 import { FirebaseApp } from '@firebase/app';
 import { PartialObserver } from '@firebase/util';
 import { AppCheckToken, AppCheckTokenListener } from './public-types';
-
-export interface FirebaseAppCheckInternal {
-  // Get the current AttestationToken. Attaches to the most recent in-flight request if one
-  // is present. Returns null if no token is present and no token requests are in-flight.
-  getToken(forceRefresh?: boolean): Promise<AppCheckTokenResult>;
-
-  // Get a Limited use Firebase App Check token. This method should be used
-  // only if you need to authorize requests to a non-Firebase backend. Returns null if no token is present and no token requests are in-flight.
-  getLimitedUseToken(): Promise<AppCheckTokenResult>;
-
-  // Registers a listener to changes in the token state. There can be more than one listener
-  // registered at the same time for one or more FirebaseAppAttestation instances. The
-  // listeners call back on the UI thread whenever the current token associated with this
-  // FirebaseAppAttestation changes.
-  addTokenListener(listener: AppCheckTokenListener): void;
-
-  // Unregisters a listener to changes in the token state.
-  removeTokenListener(listener: AppCheckTokenListener): void;
-}
+import { FirebaseAppCheckInternal } from '@firebase/app-check-interop-types';
 
 export interface AppCheckTokenObserver
   extends PartialObserver<AppCheckTokenResult> {


### PR DESCRIPTION
`getAI()` will autoinitialize App Check if App Check has not already been manually initialized by the developer.

In order to do this, we need to add
- A dependency on `@firebase/app-check`
- A call to `_initializeAppCheckInternal`. This is a wrapper around `initializeAppCheck` which adds a string that can be used in subsequent errors when `initializeAppCheck` is called again with different options, that makes it clear who the first caller was ("AI Logic SDK") since it is happening under the hood and may be difficult to debug otherwise.

### Cases:
1. If App Check has already been initialized by the developer, with whatever settings, `getAI()` will use that existing instance.
2. If App Check has not been initialized by the developer, `getAI()` will initialize App Check with default settings (passes no provider to App Check, App Check will then initialize with ReCAPTCHA Enterprise (its default), pulling the site key from the project config (new config setting).
3. If App Check has not been initialized by the developer, and there is no `recaptchaSiteKey` in the project config, `getAI()` will throw an error saying "FirebaseError: AppCheck: No attestation provider was passed to initializeAppCheck() and no ReCAPTCHA Enterprise site key was found in the Firebase config. (appCheck/no-provider).".
4. If `getAI()` successfully initializes App Check first, and then the developer subsequently calls `initializeAppCheck()` with different options (a different provider or `isTokenAutoRefreshEnabled` set to a different value), there will be an error explaining that the AI Logic SDK has already initialized App Check with different options.
5. If (4) but the second initialization has the same options as when `getAI()` initialized App Check, no error.

### Additional change to App Check:

Both `@firebase/app-check` and `@firebase/app-check-interop-types` had separate definitions of `FirebaseAppCheckInternal` and they were coming into conflict as both packages are now imported by AI Logic. I've changed app-check to depend on the definition in app-check-interop-types. I think this is correct because we don't want interop-types of a package to depend on the main package because interop-types packages are used by other products that have optional dependencies on the main package and should therefore not transitively depend on the main package. But the other way around should be fine. App Check can't be initialized without initializing the internal instance anyway, so it makes sense it should have a hard dependency on its own interop-types.