### PR TITLE
feat(ai): Deprecate Google Maps Grounding `enableWidget`

### DIFF
--- a/.changeset/lemon-eagles-teach.md
+++ b/.changeset/lemon-eagles-teach.md
@@ -1,0 +1,5 @@
+---
+'@firebase/ai': patch
+---
+
+Marked `GoogleMaps.enableWidget` as deprecated.

--- a/.changeset/lemon-eagles-teach.md
+++ b/.changeset/lemon-eagles-teach.md
@@ -2,4 +2,4 @@
 '@firebase/ai': patch
 ---
 
-Marked `GoogleMaps.enableWidget` as deprecated.
+Deprecated `GoogleMaps.enableWidget`, following the announcement by the Grounding for Google Maps service.

--- a/common/api-review/ai.api.md
+++ b/common/api-review/ai.api.md
@@ -699,7 +699,7 @@ export interface GoogleAIGenerateContentResponse {
 
 // @public
 export interface GoogleMaps {
-    // (undocumented)
+    // @deprecated (undocumented)
     enableWidget?: boolean;
 }
 

--- a/docs-devsite/ai.googlemaps.md
+++ b/docs-devsite/ai.googlemaps.md
@@ -26,6 +26,13 @@ export interface GoogleMaps
 
 ## GoogleMaps.enableWidget
 
+> Warning: This API is now obsolete.
+> 
+> The `enableWidget` feature has been deprecated by the Grounding for Google Maps service.
+> 
+> If true, include the widget context token in the response.
+> 
+
 <b>Signature:</b>
 
 ```typescript

--- a/packages/ai/src/types/requests.ts
+++ b/packages/ai/src/types/requests.ts
@@ -556,8 +556,11 @@ export interface GoogleSearch {}
  * @public
  */
 export interface GoogleMaps {
-  /*
-   *  If true, include the widget context token in the response.
+  /**
+   * @deprecated The `enableWidget` feature has been deprecated by the Grounding for Google Maps
+   * service.
+   *
+   * If true, include the widget context token in the response.
    */
   enableWidget?: boolean;
 }


### PR DESCRIPTION
### Discussion

Marks the `enableWidget` field of the `GoogleMaps` interface as deprecated.

### Testing

None.

### API Changes

See `Discussion` above.
