### PR TITLE
UI Render Spans Refactor

### DIFF
--- a/packages/crashlytics/src/tracing/root-span-context-manager.test.ts
+++ b/packages/crashlytics/src/tracing/root-span-context-manager.test.ts
@@ -578,8 +578,8 @@ describe('RootSpanContextManager', () => {
 
       // Second UI Render span ended backdated to 130 + UI_RENDER_QUIESCENCE_WINDOW_MS
       expect(secondUiSpan).to.not.equal(firstUiSpan);
-      expect(secondUiSpan.end.calledWith(130 + UI_RENDER_QUIESCENCE_WINDOW_MS)).to
-        .be.true;
+      expect(secondUiSpan.end.calledWith(130 + UI_RENDER_QUIESCENCE_WINDOW_MS))
+        .to.be.true;
     });
 
     it('should create two ui render spans if two raf cycles are separated by the quiescence period but the render quiescence timer callback execution is delayed', () => {
@@ -634,7 +634,6 @@ describe('RootSpanContextManager', () => {
       clock.tick(QUIESCENCE_WINDOW_MS);
 
       // Verify the second UI Render span was created and ended correctly
-      expect(mockTracer.startSpan.callCount).to.equal(3); // 1 root span + 2 UI Render spans
       expect(
         mockTracer.startSpan.calledWith(
           'UI Render',
@@ -642,8 +641,9 @@ describe('RootSpanContextManager', () => {
         )
       ).to.be.true;
       expect(secondUiSpan).to.not.equal(firstUiSpan);
-      expect(secondUiSpan.end.calledWith(110 + UI_RENDER_QUIESCENCE_WINDOW_MS + 5))
-        .to.be.true;
+      expect(
+        secondUiSpan.end.calledWith(110 + UI_RENDER_QUIESCENCE_WINDOW_MS + 5)
+      ).to.be.true;
     });
 
     it('should create one ui render span if two raf cycles are not separated by the quiescence period', () => {

--- a/packages/crashlytics/src/tracing/root-span-context-manager.test.ts
+++ b/packages/crashlytics/src/tracing/root-span-context-manager.test.ts
@@ -243,10 +243,10 @@ describe('RootSpanContextManager', () => {
       mutationObserverCallback();
 
       clock.tick(5);
-      requestAnimationFrameCallbacks(); // Frame 1: prePaintAtMs = 105
+      requestAnimationFrameCallbacks(); // Frame 1: activeUiRenderSpan started at 105
 
       clock.tick(5);
-      requestAnimationFrameCallbacks(); // Frame 2: postPaintAtMs = 110
+      requestAnimationFrameCallbacks(); // Frame 2: lastUiActivityMs = 110
 
       clock.tick(QUIESCENCE_WINDOW_MS - 1);
       expect((rootSpan.span as any).end.called).to.be.false;
@@ -294,7 +294,7 @@ describe('RootSpanContextManager', () => {
       requestAnimationFrameCallbacks(); // Frame 1
 
       clock.tick(5);
-      requestAnimationFrameCallbacks(); // Frame 2: postPaintAtMs = QUIESCENCE_WINDOW_MS + 15
+      requestAnimationFrameCallbacks(); // Frame 2: lastUiActivityMs = QUIESCENCE_WINDOW_MS + 15
 
       clock.tick(QUIESCENCE_WINDOW_MS); // let quiescence complete
 
@@ -464,7 +464,7 @@ describe('RootSpanContextManager', () => {
 
       // Run Frame 1 at T = 105
       clock.tick(5);
-      requestAnimationFrameCallbacks(); // Frame 1: prePaintAtMs = 105
+      requestAnimationFrameCallbacks(); // Frame 1: activeUiRenderSpan started at 105
 
       // Interrupt at T = 108
       clock.tick(3);
@@ -490,11 +490,11 @@ describe('RootSpanContextManager', () => {
 
       // Run Frame 1 at T = 105
       clock.tick(5);
-      requestAnimationFrameCallbacks(); // Frame 1: prePaintAtMs = 105
+      requestAnimationFrameCallbacks(); // Frame 1: activeUiRenderSpan started at 105
 
       // Run Frame 2 at T = 110
       clock.tick(5);
-      requestAnimationFrameCallbacks(); // Frame 2: postPaintAtMs = 110
+      requestAnimationFrameCallbacks(); // Frame 2: lastUiActivityMs = 110
 
       // Interrupt at T = 115 before quiescence completes
       clock.tick(5);
@@ -518,11 +518,11 @@ describe('RootSpanContextManager', () => {
 
       // Run Frame 1 at T = 105
       clock.tick(5);
-      requestAnimationFrameCallbacks(); // Frame 1: prePaintAtMs = 105
+      requestAnimationFrameCallbacks(); // Frame 1: activeUiRenderSpan started at 105
 
       // Run Frame 2 at T = 110
       clock.tick(5);
-      requestAnimationFrameCallbacks(); // Frame 2: postPaintAtMs = 110
+      requestAnimationFrameCallbacks(); // Frame 2: lastUiActivityMs = 110
 
       // Let quiescence complete
       clock.tick(QUIESCENCE_WINDOW_MS); // Both timers will fire.
@@ -544,19 +544,20 @@ describe('RootSpanContextManager', () => {
 
       // Run Frame 1 at T = 105
       clock.tick(5);
-      requestAnimationFrameCallbacks(); // Frame 1: prePaintAtMs = 105
+      requestAnimationFrameCallbacks(); // Frame 1: activeUiRenderSpan started at 105
+
+      const firstUiSpan = mockSpan; // first UI render span has started
 
       // Run Frame 2 at T = 110
       clock.tick(5);
-      requestAnimationFrameCallbacks(); // Frame 2: postPaintAtMs = 110
+      requestAnimationFrameCallbacks(); // Frame 2: lastUiActivityMs = 110
 
       // Let UI render quiescence complete
       clock.tick(UI_RENDER_QUIESCENCE_WINDOW_MS);
 
       // Verify first UI Render span was created
       expect(mockTracer.startSpan.calledWith('UI Render')).to.be.true;
-      expect(mockSpan.end.calledWith(110)).to.be.true;
-      const firstUiSpan = mockSpan;
+      expect(firstUiSpan.end.calledWith(110)).to.be.true;
 
       // Second mutation
       clock.tick(10);
@@ -566,16 +567,18 @@ describe('RootSpanContextManager', () => {
       clock.tick(5);
       requestAnimationFrameCallbacks(); // Frame 1
 
+      const secondUiSpan = mockSpan; // second UI render span has started
+
       // Run Frame 2
       clock.tick(5);
-      requestAnimationFrameCallbacks(); // Frame 2: postPaintAtMs = 130 + UI_RENDER_QUIESCENCE_WINDOW_MS
+      requestAnimationFrameCallbacks(); // Frame 2: lastUiActivityMs = 130 + UI_RENDER_QUIESCENCE_WINDOW_MS
 
       // Let everything quiesce
       clock.tick(QUIESCENCE_WINDOW_MS);
 
       // Second UI Render span ended backdated to 130 + UI_RENDER_QUIESCENCE_WINDOW_MS
-      expect(mockSpan).to.not.equal(firstUiSpan);
-      expect(mockSpan.end.calledWith(130 + UI_RENDER_QUIESCENCE_WINDOW_MS)).to
+      expect(secondUiSpan).to.not.equal(firstUiSpan);
+      expect(secondUiSpan.end.calledWith(130 + UI_RENDER_QUIESCENCE_WINDOW_MS)).to
         .be.true;
     });
 
@@ -595,11 +598,13 @@ describe('RootSpanContextManager', () => {
 
       // Run Frame 1 for mutation 1 at T = 105
       clock.tick(5);
-      requestAnimationFrameCallbacks(); // Frame 1: prePaintAtMs = 105
+      requestAnimationFrameCallbacks(); // Frame 1: activeUiRenderSpan started at 105
+
+      const firstUiSpan = mockSpan; // first UI render span has started
 
       // Run Frame 2 for mutation 1 at T = 110
       clock.tick(5);
-      requestAnimationFrameCallbacks(); // Frame 2: postPaintAtMs = 110
+      requestAnimationFrameCallbacks(); // Frame 2: lastUiActivityMs = 110
 
       // Advance clock without running the quiescence timer
       clock.setSystemTime(110 + UI_RENDER_QUIESCENCE_WINDOW_MS);
@@ -608,7 +613,9 @@ describe('RootSpanContextManager', () => {
       mutationObserverCallback();
 
       // Run Frame 1 for mutation 2
-      requestAnimationFrameCallbacks(); // Frame 1: prePaintAtMs = 127 (ends first UI render span backdated to 110)
+      requestAnimationFrameCallbacks(); // Frame 1: activeUiRenderSpan started at 127 (ends first UI render span backdated to 110)
+
+      const secondUiSpan = mockSpan; // second UI render span has started
 
       // Verify first UI Render span was created (startTime: 105, endTime: 110)
       expect(
@@ -617,28 +624,25 @@ describe('RootSpanContextManager', () => {
           sinon.match({ startTime: 105 })
         )
       ).to.be.true;
-      expect(mockSpan.end.calledWith(110)).to.be.true;
-      const firstUiSpan = mockSpan;
+      expect(firstUiSpan.end.calledWith(110)).to.be.true;
 
       // Run Frame 2 for mutation 2
       clock.tick(5);
-      requestAnimationFrameCallbacks(); // Frame 2: postPaintAtMs = 110 + UI_RENDER_QUIESCENCE_WINDOW_MS + 5
+      requestAnimationFrameCallbacks(); // Frame 2: lastUiActivityMs = 110 + UI_RENDER_QUIESCENCE_WINDOW_MS + 5
 
       // Let everything quiesce
       clock.tick(QUIESCENCE_WINDOW_MS);
 
-      // Verify the second UI Render span was created
-      const uiRenderSpanCalls = mockTracer.startSpan
-        .getCalls()
-        .filter((c: any) => c.args[0] === 'UI Render');
-      expect(uiRenderSpanCalls.length).to.equal(2);
-
-      expect(uiRenderSpanCalls[0].args[1]).to.deep.include({ startTime: 105 });
-      expect(uiRenderSpanCalls[1].args[1]).to.deep.include({
-        startTime: 110 + UI_RENDER_QUIESCENCE_WINDOW_MS
-      });
-      expect(mockSpan).to.not.equal(firstUiSpan);
-      expect(mockSpan.end.calledWith(110 + UI_RENDER_QUIESCENCE_WINDOW_MS + 5))
+      // Verify the second UI Render span was created and ended correctly
+      expect(mockTracer.startSpan.callCount).to.equal(3); // 1 root span + 2 UI Render spans
+      expect(
+        mockTracer.startSpan.calledWith(
+          'UI Render',
+          sinon.match({ startTime: 110 + UI_RENDER_QUIESCENCE_WINDOW_MS })
+        )
+      ).to.be.true;
+      expect(secondUiSpan).to.not.equal(firstUiSpan);
+      expect(secondUiSpan.end.calledWith(110 + UI_RENDER_QUIESCENCE_WINDOW_MS + 5))
         .to.be.true;
     });
 
@@ -654,11 +658,11 @@ describe('RootSpanContextManager', () => {
 
       // Run Frame 1 for mutation 1 at T = 105
       clock.tick(5);
-      requestAnimationFrameCallbacks(); // Frame 1: prePaintAtMs = 105
+      requestAnimationFrameCallbacks(); // Frame 1: activeUiRenderSpan started at 105
 
       // Run Frame 2 for mutation 1 at T = 110
       clock.tick(5);
-      requestAnimationFrameCallbacks(); // Frame 2: postPaintAtMs = 110
+      requestAnimationFrameCallbacks(); // Frame 2: lastUiActivityMs = 110
 
       // Second mutation at T = 112 (within quiescence window of 110)
       clock.tick(2);
@@ -666,11 +670,11 @@ describe('RootSpanContextManager', () => {
 
       // Run Frame 1 for mutation 2 at T = 115
       clock.tick(3);
-      requestAnimationFrameCallbacks(); // Frame 1: prePaintAtMs remains 105, postPaintAtMs reset to undefined
+      requestAnimationFrameCallbacks(); // Frame 1: activeUiRenderSpan created, lastUiActivityMs reset to undefined
 
       // Run Frame 2 for mutation 2 at T = 120
       clock.tick(5);
-      requestAnimationFrameCallbacks(); // Frame 2: postPaintAtMs = 120
+      requestAnimationFrameCallbacks(); // Frame 2: lastUiActivityMs = 120
 
       // Let everything quiesce
       clock.tick(QUIESCENCE_WINDOW_MS);
@@ -731,7 +735,7 @@ describe('RootSpanContextManager', () => {
 
       // Run Frame 1 at T = 105
       clock.tick(5);
-      requestAnimationFrameCallbacks(); // Frame 1: prePaintAtMs = 105
+      requestAnimationFrameCallbacks(); // Frame 1: activeUiRenderSpan started at 105
 
       // Interrupt at T = 108 before Frame 2 runs
       clock.tick(3);
@@ -763,11 +767,11 @@ describe('RootSpanContextManager', () => {
 
       // Run Frame 1 at T = 105
       clock.tick(5);
-      requestAnimationFrameCallbacks(); // Frame 1: prePaintAtMs = 105
+      requestAnimationFrameCallbacks(); // Frame 1: activeUiRenderSpan started at 105
 
       // Run Frame 2 at T = 110
       clock.tick(5);
-      requestAnimationFrameCallbacks(); // Frame 2: postPaintAtMs = 110
+      requestAnimationFrameCallbacks(); // Frame 2: lastUiActivityMs = 110
 
       // Interrupt at T = 115 during quiescence
       clock.tick(5);

--- a/packages/crashlytics/src/tracing/root-span-context-manager.ts
+++ b/packages/crashlytics/src/tracing/root-span-context-manager.ts
@@ -288,17 +288,15 @@ export class RootSpan {
   }
 
   /**
-   * Starts and immediately ends a 'UI Render' span to capture the duration
-   * of the measured UI rendering work.
+   * Ends a 'UI Render' child span parented to this root span.
    */
   private endUIRenderSpan(): void {
     if (this.activeUiRenderSpan) {
-      this.lastUiActivityMs = this.lastUiActivityMs ?? this.interruptedAtMs;
-      if (this.lastUiActivityMs !== undefined) {
-        this.activeUiRenderSpan.end(this.lastUiActivityMs);
-        this.activeUiRenderSpan = undefined;
-        this.clearRenderQuiesce();
-      }
+      this.lastUiActivityMs =
+        this.lastUiActivityMs ?? this.interruptedAtMs ?? Date.now();
+      this.activeUiRenderSpan.end(this.lastUiActivityMs);
+      this.activeUiRenderSpan = undefined;
+      this.clearRenderQuiesce();
     }
   }
 

--- a/packages/crashlytics/src/tracing/root-span-context-manager.ts
+++ b/packages/crashlytics/src/tracing/root-span-context-manager.ts
@@ -43,11 +43,11 @@ export const UI_RENDER_QUIESCENCE_WINDOW_MS = 17;
  */
 export class RootSpan {
   span: Span;
+  private activeUiRenderSpan: Span | undefined;
   private rootSpanStartAtMs: number;
   private activeNetworkRequests: number;
   private lastBackgroundActivityMs?: number;
-  private prePaintAtMs: number | undefined;
-  private postPaintAtMs: number | undefined;
+  private lastUiActivityMs: number | undefined;
   private interruptedAtMs: number | undefined;
   private quiescenceTimerId: ReturnType<typeof setTimeout> | null;
   private quiescenceRenderTimerId: ReturnType<typeof setTimeout> | null;
@@ -80,8 +80,7 @@ export class RootSpan {
       : Date.now();
 
     this.lastBackgroundActivityMs = undefined;
-    this.prePaintAtMs = undefined;
-    this.postPaintAtMs = undefined;
+    this.lastUiActivityMs = undefined;
     this.interruptedAtMs = undefined;
     this.quiescenceTimerId = null;
     this.quiescenceRenderTimerId = null;
@@ -142,7 +141,7 @@ export class RootSpan {
 
     this.clearMutationObserver();
 
-    this.endUIRenderSpan(this.postPaintAtMs ?? this.interruptedAtMs);
+    this.endUIRenderSpan();
 
     this.endRootSpanOrWait();
   }
@@ -175,19 +174,17 @@ export class RootSpan {
       ) {
         window.requestAnimationFrame(() => {
           // capture UI activity start in frame 1
-          const currTimestamp = Date.now();
-
-          if (this.prePaintAtMs === undefined) {
-            this.prePaintAtMs = currTimestamp;
-          } else if (this.postPaintAtMs !== undefined) {
-            const timeSinceRenderEnd = currTimestamp - this.postPaintAtMs;
+          if (!this.activeUiRenderSpan) {
+            this.startUIRenderSpan();
+          } else if (this.lastUiActivityMs !== undefined) {
+            const timeSinceRenderEnd = Date.now() - this.lastUiActivityMs;
             if (timeSinceRenderEnd >= UI_RENDER_QUIESCENCE_WINDOW_MS) {
               this.endUIRenderSpan();
-              this.prePaintAtMs = currTimestamp;
+              this.startUIRenderSpan();
             }
           }
 
-          this.postPaintAtMs = undefined;
+          this.lastUiActivityMs = undefined;
           /**
            * Quiescence does not exist during a pending post rAF callback because it is guaranteed
            * to happen eventually and no waiting period should prevent it (besides an interrupt)
@@ -197,7 +194,7 @@ export class RootSpan {
           // any queued timeout callback for a completed quiescence period becomes invalid here
           window.requestAnimationFrame(() => {
             // capture UI activity end in frame 2
-            this.postPaintAtMs = Date.now();
+            this.lastUiActivityMs = Date.now();
 
             this.renderQuiesce();
             this.quiesce();
@@ -228,14 +225,8 @@ export class RootSpan {
     if (this.lastBackgroundActivityMs !== undefined) {
       activityTimes.push(this.lastBackgroundActivityMs);
     }
-    if (this.postPaintAtMs !== undefined) {
-      activityTimes.push(this.postPaintAtMs);
-    } else if (
-      this.interruptedAtMs !== undefined &&
-      (this.prePaintAtMs !== undefined ||
-        this.lastBackgroundActivityMs === undefined)
-    ) {
-      activityTimes.push(this.interruptedAtMs);
+    if (this.lastUiActivityMs !== undefined) {
+      activityTimes.push(this.lastUiActivityMs);
     }
     return Math.max(...activityTimes);
   }
@@ -283,29 +274,32 @@ export class RootSpan {
   }
 
   /**
+   * Starts a 'UI Render' child span parented to this root span.
+   * @param startTimeMs The start timestamp of the UI rendering work.
+   */
+  private startUIRenderSpan(startTimeMs: number = Date.now()): void {
+    const parentContext = trace.setSpan(context.active(), this.span);
+    this.activeUiRenderSpan = this.tracer.startSpan(
+      'UI Render',
+      {
+        startTime: startTimeMs
+      },
+      parentContext
+    );
+  }
+
+  /**
    * Starts and immediately ends a 'UI Render' span to capture the duration
    * of the measured UI rendering work.
-   * @param endTimeMs Optional end timestamp. Defaults to the last paint completion time.
    */
-  private endUIRenderSpan(
-    endTimeMs: number | undefined = this.postPaintAtMs
-  ): void {
-    if (this.prePaintAtMs !== undefined && endTimeMs !== undefined) {
-      const parentContext = trace.setSpan(context.active(), this.span);
-
-      const uiSpan = this.tracer.startSpan(
-        'UI Render',
-        {
-          startTime: this.prePaintAtMs
-        },
-        parentContext
-      );
-
-      uiSpan.end(endTimeMs);
-
-      this.prePaintAtMs = undefined;
-
-      this.clearRenderQuiesce();
+  private endUIRenderSpan(): void {
+    if (this.activeUiRenderSpan) {
+      this.lastUiActivityMs = this.lastUiActivityMs ?? this.interruptedAtMs;
+      if (this.lastUiActivityMs !== undefined) {
+        this.activeUiRenderSpan.end(this.lastUiActivityMs);
+        this.activeUiRenderSpan = undefined;
+        this.clearRenderQuiesce();
+      }
     }
   }
 

--- a/packages/crashlytics/src/tracing/root-span-context-manager.ts
+++ b/packages/crashlytics/src/tracing/root-span-context-manager.ts
@@ -221,13 +221,12 @@ export class RootSpan {
   }
 
   private getLastActivityMs(): number {
-    const activityTimes: number[] = [this.rootSpanStartAtMs];
-    if (this.lastBackgroundActivityMs !== undefined) {
-      activityTimes.push(this.lastBackgroundActivityMs);
-    }
-    if (this.lastUiActivityMs !== undefined) {
-      activityTimes.push(this.lastUiActivityMs);
-    }
+    const activityTimes = [
+      this.rootSpanStartAtMs,
+      this.lastBackgroundActivityMs,
+      this.lastUiActivityMs
+    ].filter((t): t is number => t !== undefined);
+
     return Math.max(...activityTimes);
   }
 


### PR DESCRIPTION
- Starts UI Render span immediately when it should start and persists the active span object
- Solves complexity issue of interruption truncation in getLastActivityMs by assigning interruption time directly to lastUiActivityMs in ui render end prior to root span end
