### PR TITLE
Fix querystring to always use apiKey even if a key is specified in the request

### DIFF
--- a/packages/auth/src/api/index.ts
+++ b/packages/auth/src/api/index.ts
@@ -157,7 +157,7 @@ export async function _performApiRequest<T, V>(
     }
 
     const query = querystring({
-      ...params
+      ...params,
       key: auth.config.apiKey,
     }).slice(1);
 

--- a/packages/auth/src/api/index.ts
+++ b/packages/auth/src/api/index.ts
@@ -157,8 +157,8 @@ export async function _performApiRequest<T, V>(
     }
 
     const query = querystring({
-      key: auth.config.apiKey,
       ...params
+      key: auth.config.apiKey,
     }).slice(1);
 
     const headers = await (auth as AuthInternal)._getAdditionalHeaders();

--- a/packages/auth/src/api/index.ts
+++ b/packages/auth/src/api/index.ts
@@ -158,7 +158,7 @@ export async function _performApiRequest<T, V>(
 
     const query = querystring({
       ...params,
-      key: auth.config.apiKey,
+      key: auth.config.apiKey
     }).slice(1);
 
     const headers = await (auth as AuthInternal)._getAdditionalHeaders();

--- a/packages/auth/test/helpers/api/helper.ts
+++ b/packages/auth/test/helpers/api/helper.ts
@@ -19,6 +19,8 @@ import { Endpoint } from '../../../src/api';
 import { TEST_HOST, TEST_KEY, TEST_SCHEME } from '../mock_auth';
 import { mock, Route } from '../mock_fetch';
 
+import { querystring } from '@firebase/util';
+
 export function endpointUrl(endpoint: Endpoint): string {
   return `${TEST_SCHEME}://${TEST_HOST}${endpoint}?key=${TEST_KEY}`;
 }
@@ -27,16 +29,11 @@ export function endpointUrlWithParams(
   endpoint: Endpoint,
   params: Record<string, any>
 ): string {
-  let url = `${TEST_SCHEME}://${TEST_HOST}${endpoint}?key=${TEST_KEY}`;
-  for (const key in params) {
-    if (Object.prototype.hasOwnProperty.call(params, key)) {
-      url += '&';
-      url += key;
-      url += '=';
-      url += encodeURIComponent(params[key]);
-    }
-  }
-  return url;
+  const query = querystring({
+    ...params,
+    key: TEST_KEY
+  }).slice(1);
+  return `${TEST_SCHEME}://${TEST_HOST}${endpoint}?${query}`;
 }
 
 export function mockEndpoint(


### PR DESCRIPTION
### Discussion

Details on underlying rationale for this change can be found in b/522371276

### Testing

Existing tests continue to pass

### API Changes

N/A