### PR TITLE
Support API key referrer restrictions by changing the Auth SDK referrer policy

### DIFF
--- a/.changeset/tame-yaks-yawn.md
+++ b/.changeset/tame-yaks-yawn.md
@@ -1,0 +1,6 @@
+---
+'@firebase/auth': patch
+'@firebase/auth-compat': patch
+---
+
+Update referrer policy for auth API requests from no-referrer to strict-origin-when-cross-origin to support HTTP Referrer-restricted API keys in browser environments.

--- a/packages/auth/src/api/index.test.ts
+++ b/packages/auth/src/api/index.test.ts
@@ -337,11 +337,11 @@ describe('api/_performApiRequest', () => {
     afterEach(mockFetch.tearDown);
 
     it('should have referrerPolicy set', async () => {
-      let referrerPolicySet: boolean = false;
+      let referrerPolicy: string | undefined = undefined;
       mockFetch.setUpWithOverride(
         (input: RequestInfo | URL, request?: RequestInit) => {
-          if (request !== undefined && request.referrerPolicy !== undefined) {
-            referrerPolicySet = true;
+          if (request !== undefined) {
+            referrerPolicy = request.referrerPolicy;
           }
           return Promise.resolve(new Response(JSON.stringify(serverResponse)));
         }
@@ -353,7 +353,7 @@ describe('api/_performApiRequest', () => {
         request
       );
       await expect(promise).to.be.fulfilled;
-      expect(referrerPolicySet).to.be.true;
+      expect(referrerPolicy).to.eq('strict-origin-when-cross-origin');
     });
 
     it('should not have referrerPolicy set on Cloudflare workers', async () => {

--- a/packages/auth/src/api/index.ts
+++ b/packages/auth/src/api/index.ts
@@ -179,7 +179,7 @@ export async function _performApiRequest<T, V>(
        'RequestInitializerDict' is not implemented."
        https://github.com/cloudflare/next-on-pages/issues/487 */
     if (!isCloudflareWorker()) {
-      fetchArgs.referrerPolicy = 'no-referrer';
+      fetchArgs.referrerPolicy = 'strict-origin-when-cross-origin';
     }
 
     if (auth.emulatorConfig && isCloudWorkstation(auth.emulatorConfig.host)) {


### PR DESCRIPTION
Update the Firebase web Auth SDK from setting `no-referrer` to `strict-origin-when-cross-origin` so that API key restrictions can be used in addition to the existing AppCheck support.

See go/firebase-web-auth-referrer for additional details
