### PR TITLE
fix(remote-config): suppress stream errors when app is backgrounded

### DIFF
--- a/.changeset/fix-remote-config-background-stream-error.md
+++ b/.changeset/fix-remote-config-background-stream-error.md
@@ -1,0 +1,6 @@
+---
+'@firebase/remote-config': patch
+'firebase': patch
+---
+
+fix(remote-config): suppress stream errors when the app is backgrounded

--- a/packages/remote-config/src/client/realtime_handler.ts
+++ b/packages/remote-config/src/client/realtime_handler.ts
@@ -682,7 +682,7 @@ export class RealtimeHandler {
       // If responseCode is null then no connection was made to server and the SDK should still retry.
       if (connectionFailed || response?.ok) {
         await this.retryHttpConnectionWhenBackoffEnds();
-      } else {
+      } else if (!this.isInBackground) {
         const errorMessage = `Unable to connect to the server. HTTP status code: ${responseCode}`;
         const firebaseError = ERROR_FACTORY.create(
           ErrorCode.CONFIG_UPDATE_STREAM_ERROR,

--- a/packages/remote-config/test/client/realtime_handler.test.ts
+++ b/packages/remote-config/test/client/realtime_handler.test.ts
@@ -951,7 +951,7 @@ describe('RealtimeHandler', () => {
 
       await (realtime as any).prepareAndBeginRealtimeHttpStream();
 
-      expect(propagateErrorSpy).to.have.been.calledOnce;
+      expect(propagateErrorSpy).not.to.have.been.called;
     });
 
     it('should propagate CONFIG_UPDATE_STREAM_ERROR if retries are exhausted', async () => {


### PR DESCRIPTION
## Problem
`onConfigUpdated` error handlers receive `remoteconfig/stream-error` when the page is hidden (tab switch, minimize), even though background disconnects are expected. Reported in #9426.

## Root cause
`prepareAndBeginRealtimeHttpStream()` already skips retry/backoff updates when `isInBackground` is true, but the non-retryable `else` branch in the `finally` block still called `propagateError()`. When visibility closes the stream, `responseCode` can be `undefined`, which hit that branch and surfaced a fatal stream error to observers.

## Solution
Guard the non-retryable error path with `!this.isInBackground`, consistent with `makeRealtimeHttpConnection()`. Correct the inverted background regression test expectation.

## Tests run
- `corepack yarn install --frozen-lockfile --ignore-engines`
- `corepack yarn --cwd packages/remote-config build:deps`
- `../../node_modules/.bin/eslint -c .eslintrc.js src/client/realtime_handler.ts test/client/realtime_handler.test.ts --ignore-path ../../.gitignore` from `packages/remote-config`
- `./node_modules/.bin/prettier --check packages/remote-config/src/client/realtime_handler.ts packages/remote-config/test/client/realtime_handler.test.ts .changeset/fix-remote-config-background-stream-error.md`
- `corepack yarn --cwd packages/remote-config test:browser -- --browsers=ChromeHeadless --grep beginRealtimeHttpStream` (9 tests passed)
- `git diff --check`

Fixes #9426