### PR TITLE
fix(remote-config): suppress stream errors when app is backgrounded

### DIFF
--- a/.changeset/fix-remote-config-background-stream-error.md
+++ b/.changeset/fix-remote-config-background-stream-error.md
@@ -1,0 +1,6 @@
+---
+'@firebase/remote-config': patch
+'firebase': patch
+---
+
+fix(remote-config): suppress stream errors when the app is backgrounded

--- a/packages/remote-config/src/client/realtime_handler.ts
+++ b/packages/remote-config/src/client/realtime_handler.ts
@@ -682,7 +682,7 @@ export class RealtimeHandler {
       // If responseCode is null then no connection was made to server and the SDK should still retry.
       if (connectionFailed || response?.ok) {
         await this.retryHttpConnectionWhenBackoffEnds();
-      } else {
+      } else if (!this.isInBackground) {
         const errorMessage = `Unable to connect to the server. HTTP status code: ${responseCode}`;
         const firebaseError = ERROR_FACTORY.create(
           ErrorCode.CONFIG_UPDATE_STREAM_ERROR,

--- a/packages/remote-config/test/client/realtime_handler.test.ts
+++ b/packages/remote-config/test/client/realtime_handler.test.ts
@@ -951,7 +951,7 @@ describe('RealtimeHandler', () => {
 
       await (realtime as any).prepareAndBeginRealtimeHttpStream();
 
-      expect(propagateErrorSpy).to.have.been.calledOnce;
+      expect(propagateErrorSpy).not.to.have.been.called;
     });
 
     it('should propagate CONFIG_UPDATE_STREAM_ERROR if retries are exhausted', async () => {


### PR DESCRIPTION
When the page is hidden, closing the realtime HTTP stream can leave `responseCode` undefined. The \`finally\` block treated that as a fatal stream error and called \`propagateError\` even though \`isInBackground\` was already true.

Guard the non-retryable error path with \`!isInBackground\`, matching the existing retry-exhausted handling in \`makeRealtimeHttpConnection\`.

Fixes #9426