### PR TITLE
fix(auth): allow longer reCAPTCHA language tags

### DIFF
--- a/.changeset/fix-auth-recaptcha-language-tags.md
+++ b/.changeset/fix-auth-recaptcha-language-tags.md
@@ -1,0 +1,7 @@
+---
+'@firebase/auth': patch
+'@firebase/auth-compat': patch
+'firebase': patch
+---
+
+Allow the reCAPTCHA V2 loader to accept longer browser language tags such as `en-GB-oxendict`.

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_loader.test.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_loader.test.ts
@@ -149,6 +149,18 @@ describe('platform_browser/recaptcha/recaptcha_loader', () => {
           'auth/argument-error'
         );
       });
+
+      it('accepts long browser language tags', async () => {
+        const promise = loader.load(auth, 'en-GB-oxendict');
+        expect(jsHelpers._loadJS).to.have.been.calledWithMatch(
+          /hl=en-GB-oxendict/
+        );
+        jsLoader.reject();
+        await expect(promise).to.be.rejectedWith(
+          FirebaseError,
+          'auth/internal-error'
+        );
+      });
     });
   });
 });

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_loader.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_loader.ts
@@ -125,7 +125,7 @@ export class ReCaptchaLoaderImpl implements ReCaptchaLoader {
 }
 
 function isHostLanguageValid(hl: string): boolean {
-  return hl.length <= 6 && /^\s*[a-zA-Z0-9\-]*\s*$/.test(hl);
+  return /^\s*[a-zA-Z0-9-]*\s*$/.test(hl);
 }
 
 export class MockReCaptchaLoaderImpl implements ReCaptchaLoader {


### PR DESCRIPTION
Fixes validation that rejected valid BCP-47 language tags longer than the previous limit.