### PR TITLE
Revert "chore(ci): make all firestore integration tests optional (#10028)"

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -214,7 +214,6 @@ jobs:
     - name: Run unit tests
       run: |
         yarn lerna run test:all:ci --scope '@firebase/firestore*' --stream --concurrency 1
-      continue-on-error: true
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}
         EXPERIMENTAL_MODE: true
@@ -265,7 +264,6 @@ jobs:
       working-directory: integration/firestore
     - run: xvfb-run yarn karma:singlerun
       working-directory: integration/firestore
-      continue-on-error: true
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}
 

--- a/.github/workflows/test-changed-firestore-integration.yml
+++ b/.github/workflows/test-changed-firestore-integration.yml
@@ -84,4 +84,3 @@ jobs:
       run: yarn build:changed firestore-integration
     - name: Run tests if firestore or its dependencies has changed
       run: yarn test:changed firestore-integration
-      continue-on-error: true

--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -102,7 +102,6 @@ jobs:
         run: cp config/ci.config.json config/project.json
       - name: Run compat tests
         run: cd packages/firestore-compat && yarn run test:ci
-        continue-on-error: true
 
   test-chrome:
     name: Test Firestore
@@ -131,7 +130,6 @@ jobs:
         run: cp config/ci.config.json config/project.json
       - name: Run tests
         run: cd packages/firestore && yarn run ${{ matrix.test-name }}
-        continue-on-error: ${{ matrix.test-name != 'test:node:emulator' }}
         env:
           EXPERIMENTAL_MODE: true
 
@@ -165,7 +163,6 @@ jobs:
           echo $INTEG_TESTS_GOOGLE_SERVICES > config/project.json
       - name: Run tests
         run: cd packages/firestore && yarn run ${{ matrix.test-name }}
-        continue-on-error: true
         env:
           EXPERIMENTAL_MODE: true
 
@@ -192,7 +189,6 @@ jobs:
         run: cp config/ci.config.json config/project.json
       - name: Run compat tests
         run: cd packages/firestore-compat && xvfb-run yarn run test:ci
-        continue-on-error: true
         env:
           BROWSERS: 'Firefox'
 
@@ -221,7 +217,6 @@ jobs:
         run: cp config/ci.config.json config/project.json
       - name: Run tests
         run: cd packages/firestore && xvfb-run yarn run ${{ matrix.test-name }}
-        continue-on-error: ${{ matrix.test-name != 'test:node:emulator' }}
         env:
           BROWSERS: 'Firefox'
           EXPERIMENTAL_MODE: true
@@ -248,7 +243,6 @@ jobs:
           npx playwright install webkit
       - name: Run compat tests
         run: cd packages/firestore-compat && yarn run test:ci
-        continue-on-error: true
         env:
           BROWSERS: 'WebkitHeadless'
 
@@ -280,7 +274,6 @@ jobs:
           npx playwright install webkit
       - name: Run tests
         run: cd packages/firestore && yarn run ${{ matrix.test-name }}
-        continue-on-error: true
         env:
           BROWSERS: 'WebkitHeadless'
           EXPERIMENTAL_MODE: true
@@ -290,8 +283,8 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     name: Check all required tests results
-    needs: [build]
+    needs: [build, test-chrome, compat-test-chrome]
     steps:
       - name: Check test matrix
-        if: needs.build.result == 'failure'
+        if: needs.build.result == 'failure' || needs.test-chrome.result == 'failure' || needs.compat-test-chrome.result == 'failure'
         run: exit 1

--- a/scripts/ci-test/tasks.ts
+++ b/scripts/ci-test/tasks.ts
@@ -78,7 +78,14 @@ const specialPaths = {
   'scripts/emulator-testing/firestore-test-runner.ts': ['@firebase/firestore'],
   'scripts/emulator-testing/database-test-runner.ts': ['@firebase/database'],
   'packages/firestore': ['firebase-firestore-integration-test'],
-  'packages/messaging': ['firebase-messaging-integration-test']
+  'packages/messaging': ['firebase-messaging-integration-test'],
+  '.github/workflows/test-changed-firestore.yml': [
+    '@firebase/firestore',
+    '@firebase/firestore-compat'
+  ],
+  '.github/workflows/test-changed-firestore-integration.yml': [
+    'firebase-firestore-integration-test'
+  ]
 };
 
 /**


### PR DESCRIPTION
Reverts the temporary change that made integration tests optional in Web SDK CI workflows