### PR TITLE
Prefactor `AttributesStore` to more cleanly support span attributes

### DIFF
--- a/packages/crashlytics/src/angular/index.test.ts
+++ b/packages/crashlytics/src/angular/index.test.ts
@@ -37,7 +37,7 @@ import {
   BrowserTestingModule,
   platformBrowserTesting
 } from '@angular/platform-browser/testing';
-import { ATTR_KEY_ROUTE_PATH, AttributesStore } from '../attributes-store';
+import { LOG_ATTR_KEY, AttributesStore } from '../attributes-store';
 
 use(sinonChai);
 use(chaiAsPromised);
@@ -103,17 +103,17 @@ describe('FirebaseErrorHandler', () => {
     it('should set the routePath attribute', async () => {
       await router.navigate(['/static-route']);
 
-      expect(attributesStore.getLogAttributes()[ATTR_KEY_ROUTE_PATH]).to.equal(
-        '/static-route'
-      );
+      expect(
+        attributesStore.getLogAttributes()[LOG_ATTR_KEY.ROUTE_PATH]
+      ).to.equal('/static-route');
     });
 
     it('should remove dynamic content from route', async () => {
       await router.navigate(['/dynamic/my-name/route']);
 
-      expect(attributesStore.getLogAttributes()[ATTR_KEY_ROUTE_PATH]).to.equal(
-        '/dynamic/:id/route'
-      );
+      expect(
+        attributesStore.getLogAttributes()[LOG_ATTR_KEY.ROUTE_PATH]
+      ).to.equal('/dynamic/:id/route');
     });
   });
 });

--- a/packages/crashlytics/src/api.test.ts
+++ b/packages/crashlytics/src/api.test.ts
@@ -40,7 +40,7 @@ import { AUTO_CONSTANTS } from './auto-constants';
 import { CrashlyticsInternal } from './types';
 import {
   AttributesStore,
-  COMMON_ATTR_KEY,
+  LOG_ATTR_KEY,
   SESSION_STORAGE_SESSION_ID_KEY
 } from './attributes-store';
 
@@ -233,8 +233,8 @@ describe('Top level API', () => {
         'exception.type': 'TestError',
         'exception.stacktrace': '...stack trace...',
         'exception.message': 'This is a test error',
-        [COMMON_ATTR_KEY.APP_VERSION]: 'unset',
-        [COMMON_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID
+        [LOG_ATTR_KEY.APP_VERSION]: 'unset',
+        [LOG_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -252,8 +252,8 @@ describe('Top level API', () => {
         'exception.type': 'Error',
         'exception.stacktrace': 'No stack trace available',
         'exception.message': 'error with no stack',
-        [COMMON_ATTR_KEY.APP_VERSION]: 'unset',
-        [COMMON_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID
+        [LOG_ATTR_KEY.APP_VERSION]: 'unset',
+        [LOG_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -265,8 +265,8 @@ describe('Top level API', () => {
       expect(log.severityNumber).to.equal(SeverityNumber.ERROR);
       expect(log.body).to.equal('a string error');
       expect(log.attributes).to.deep.equal({
-        [COMMON_ATTR_KEY.APP_VERSION]: 'unset',
-        [COMMON_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID
+        [LOG_ATTR_KEY.APP_VERSION]: 'unset',
+        [LOG_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -278,8 +278,8 @@ describe('Top level API', () => {
       expect(log.severityNumber).to.equal(SeverityNumber.ERROR);
       expect(log.body).to.equal('Unknown error type: number');
       expect(log.attributes).to.deep.equal({
-        [COMMON_ATTR_KEY.APP_VERSION]: 'unset',
-        [COMMON_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID
+        [LOG_ATTR_KEY.APP_VERSION]: 'unset',
+        [LOG_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -307,10 +307,10 @@ describe('Top level API', () => {
         'exception.type': 'TestError',
         'exception.stacktrace': '...stack trace...',
         'exception.message': 'This is a test error',
-        [COMMON_ATTR_KEY.APP_VERSION]: 'unset',
+        [LOG_ATTR_KEY.APP_VERSION]: 'unset',
         'logging.googleapis.com/trace': `projects/${PROJECT_ID}/traces/my-trace`,
         'logging.googleapis.com/spanId': `my-span`,
-        [COMMON_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID
+        [LOG_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -334,14 +334,14 @@ describe('Top level API', () => {
         'exception.type': 'TestError',
         'exception.stacktrace': '...stack trace...',
         'exception.message': 'This is a test error',
-        [COMMON_ATTR_KEY.APP_VERSION]: 'unset',
+        [LOG_ATTR_KEY.APP_VERSION]: 'unset',
         strAttr: 'string attribute',
         mapAttr: {
           boolAttr: true,
           numAttr: 2
         },
         arrAttr: [1, 2, 3],
-        [COMMON_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID
+        [LOG_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -361,8 +361,8 @@ describe('Top level API', () => {
       expect(emittedLogs.length).to.equal(1);
       const log = emittedLogs[0];
       expect(log.attributes).to.deep.equal({
-        [COMMON_ATTR_KEY.APP_VERSION]: '1.0.0',
-        [COMMON_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID
+        [LOG_ATTR_KEY.APP_VERSION]: '1.0.0',
+        [LOG_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -376,8 +376,8 @@ describe('Top level API', () => {
       expect(emittedLogs.length).to.equal(1);
       const log = emittedLogs[0];
       expect(log.attributes).to.deep.equal({
-        [COMMON_ATTR_KEY.APP_VERSION]: '1.2.3',
-        [COMMON_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID
+        [LOG_ATTR_KEY.APP_VERSION]: '1.2.3',
+        [LOG_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -396,9 +396,9 @@ describe('Top level API', () => {
         'exception.type': 'TestError',
         'exception.stacktrace': '...stack trace...',
         'exception.message': 'This is a test error',
-        [COMMON_ATTR_KEY.APP_VERSION]: 'unset',
+        [LOG_ATTR_KEY.APP_VERSION]: 'unset',
         'route_path': '/my-route',
-        [COMMON_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID
+        [LOG_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID
       });
     });
 
@@ -412,7 +412,7 @@ describe('Top level API', () => {
 
         expect(emittedLogs.length).to.equal(1);
         const log = emittedLogs[0];
-        expect(log.attributes![COMMON_ATTR_KEY.SESSION_ID]).to.equal(
+        expect(log.attributes![LOG_ATTR_KEY.SESSION_ID]).to.equal(
           'existing-session-id'
         );
       });
@@ -437,7 +437,7 @@ describe('Top level API', () => {
 
         expect(emittedLogs.length).to.equal(1);
         const log = emittedLogs[0];
-        expect(log.attributes![COMMON_ATTR_KEY.SESSION_ID]).to.be.undefined;
+        expect(log.attributes![LOG_ATTR_KEY.SESSION_ID]).to.be.undefined;
       });
 
       it('should handle errors when sessionStorage.setItem throws', () => {
@@ -460,7 +460,7 @@ describe('Top level API', () => {
 
         expect(emittedLogs.length).to.equal(1);
         const log = emittedLogs[0];
-        expect(log.attributes![COMMON_ATTR_KEY.SESSION_ID]).to.be.undefined;
+        expect(log.attributes![LOG_ATTR_KEY.SESSION_ID]).to.be.undefined;
       });
     });
   });

--- a/packages/crashlytics/src/attributes-store.ts
+++ b/packages/crashlytics/src/attributes-store.ts
@@ -16,7 +16,7 @@
  */
 
 import { Provider } from '@firebase/component';
-import { Attributes, AttributeValue, trace } from '@opentelemetry/api';
+import { AttributeValue, trace } from '@opentelemetry/api';
 import { AnyValueMap } from '@opentelemetry/api-logs';
 import { _FirebaseInstallationsInternal } from '@firebase/installations';
 import { CrashlyticsOptions } from './public-types';
@@ -24,28 +24,28 @@ import { AUTO_CONSTANTS } from './auto-constants';
 import { FirebaseOptions } from '@firebase/app-types';
 
 export const ATTR_KEY_INSTALLATION_ID = 'app.installation.id';
-export const ATTR_KEY_ROUTE_PATH = 'route_path';
 export const SESSION_STORAGE_SESSION_ID_KEY = 'firebasecrashlytics.sessionid';
 
-export const COMMON_ATTR_KEY = {
+export const LOG_ATTR_KEY = {
   APP_VERSION: 'app.build_id',
-  SESSION_ID: 'session.id'
+  SESSION_ID: 'session.id',
+  ROUTE_PATH: 'route_path',
+  TRACE: 'logging.googleapis.com/trace',
+  SPAN_ID: 'logging.googleapis.com/spanId'
 };
 
 type Attribute = Record<string, AttributeValue>;
-type CommonAttributeKey =
-  (typeof COMMON_ATTR_KEY)[keyof typeof COMMON_ATTR_KEY];
-type CommonAttribute = Record<CommonAttributeKey, AttributeValue>;
 
 /**
  * A store for Crashlytics specific attributes for telemetry data.
  */
 export class AttributesStore {
-  private commonAttributes: Partial<CommonAttribute> = {};
-  private _routePathProvider?: () => string;
-  private installations: _FirebaseInstallationsInternal | null;
   private _projectId: string | undefined;
+  private _appVersion: string | undefined;
+  private _sessionId: string | undefined;
+  private _installations: _FirebaseInstallationsInternal | null;
   private _iid: string | undefined;
+  private _routePathProvider?: () => string;
 
   constructor(
     firebaseOptions: FirebaseOptions,
@@ -58,18 +58,18 @@ export class AttributesStore {
     // Get session id from storage, if available
     const existingSessionId = this.getSessionIdFromStorage();
     if (existingSessionId) {
-      this.commonAttributes[COMMON_ATTR_KEY.SESSION_ID] = existingSessionId;
+      this._sessionId = existingSessionId;
     }
 
     // Installations provider
-    this.installations =
+    this._installations =
       installationsProvider?.getImmediate({
         optional: true
       }) ?? null;
-    if (!this.installations) {
+    if (!this._installations) {
       void installationsProvider
         ?.get()
-        .then(installations => (this.installations = installations))
+        .then(installations => (this._installations = installations))
         .catch(() => {});
     }
   }
@@ -83,23 +83,21 @@ export class AttributesStore {
       : AUTO_CONSTANTS?.appVersion
       ? AUTO_CONSTANTS.appVersion
       : 'unset';
-    this.commonAttributes[COMMON_ATTR_KEY.APP_VERSION] = appVersion;
+    this._appVersion = appVersion;
   }
 
   /**
    * Get the active session id.
    */
   get sessionId(): string | undefined {
-    return this.commonAttributes[COMMON_ATTR_KEY.SESSION_ID] as
-      | string
-      | undefined;
+    return this._sessionId;
   }
 
   /**
    * Set and persist the session id.
    */
   setSessionId(id: string): void {
-    this.commonAttributes[COMMON_ATTR_KEY.SESSION_ID] = id;
+    this._sessionId = id;
     if (typeof sessionStorage !== 'undefined') {
       try {
         sessionStorage.setItem(SESSION_STORAGE_SESSION_ID_KEY, id);
@@ -118,26 +116,36 @@ export class AttributesStore {
   }
 
   /**
-   * Get the log attributes, including the trace context.
+   * Get the log attributes.
    * @returns The log attributes.
    */
   getLogAttributes(): AnyValueMap {
-    // Trace context is dynamic, so we retrieve it at the time of logging
-    const traceContextAttributes: Attributes = {};
-    const activeSpanContext = trace.getActiveSpan()?.spanContext();
-    if (activeSpanContext?.traceId && activeSpanContext?.spanId) {
-      traceContextAttributes[
-        'logging.googleapis.com/trace'
-      ] = `projects/${this._projectId}/traces/${activeSpanContext.traceId}`;
-      traceContextAttributes['logging.googleapis.com/spanId'] =
-        activeSpanContext.spanId;
+    const attributes: AnyValueMap = {};
+    if (this._appVersion) {
+      attributes[LOG_ATTR_KEY.APP_VERSION] = this._appVersion;
+    }
+    if (this._sessionId) {
+      attributes[LOG_ATTR_KEY.SESSION_ID] = this._sessionId;
     }
 
-    return {
-      ...this.commonAttributes,
-      ...this.getRoutePathAttribute(),
-      ...traceContextAttributes
-    } as AnyValueMap;
+    const activeSpanContext = trace.getActiveSpan()?.spanContext();
+    if (
+      activeSpanContext?.traceId &&
+      activeSpanContext?.spanId &&
+      this._projectId
+    ) {
+      attributes[
+        LOG_ATTR_KEY.TRACE
+      ] = `projects/${this._projectId}/traces/${activeSpanContext.traceId}`;
+      attributes[LOG_ATTR_KEY.SPAN_ID] = activeSpanContext.spanId;
+    }
+
+    const path = this._routePathProvider?.();
+    if (path) {
+      attributes[LOG_ATTR_KEY.ROUTE_PATH] = path;
+    }
+
+    return attributes;
   }
 
   /**
@@ -146,7 +154,7 @@ export class AttributesStore {
    * @returns an attribute object with installation id, or null if installation id is not available
    */
   async getInstallationIdAttribute(): Promise<Attribute | null> {
-    if (!this.installations) {
+    if (!this._installations) {
       return null;
     }
     if (this._iid) {
@@ -155,7 +163,7 @@ export class AttributesStore {
       };
     }
 
-    const iid = await this.installations.getId();
+    const iid = await this._installations.getId();
     if (!iid) {
       return null;
     }
@@ -164,15 +172,6 @@ export class AttributesStore {
     return {
       [ATTR_KEY_INSTALLATION_ID]: iid
     };
-  }
-
-  private getRoutePathAttribute(): Attribute {
-    const path = this._routePathProvider?.();
-    if (!path) {
-      return {};
-    }
-
-    return { [ATTR_KEY_ROUTE_PATH]: path };
   }
 
   private getSessionIdFromStorage(): string | undefined {

--- a/packages/crashlytics/src/constants.ts
+++ b/packages/crashlytics/src/constants.ts
@@ -25,9 +25,6 @@ export const DEFAULT_TELEMETRY_ENDPOINT =
 /** Default region for telemetry data. */
 export const DEFAULT_TELEMETRY_REGION = 'global';
 
-/** Key for storing the session ID in sessionStorage. */
-export const CRASHLYTICS_SESSION_ID_KEY = 'firebasecrashlytics.sessionid';
-
 /** Symbol for the internal flag indicating an error has already been logged. */
 export const ALREADY_LOGGED_FLAG = Symbol('firebase_crashlytics_logged');
 

--- a/packages/crashlytics/src/helpers.test.ts
+++ b/packages/crashlytics/src/helpers.test.ts
@@ -20,11 +20,14 @@ import { LoggerProvider } from '@opentelemetry/sdk-logs';
 import { Logger, LogRecord } from '@opentelemetry/api-logs';
 import { isNode } from '@firebase/util';
 import { registerListeners, startNewSession } from './helpers';
-import { CRASHLYTICS_SESSION_ID_KEY } from './constants';
 import { AUTO_CONSTANTS } from './auto-constants';
 import { CrashlyticsService } from './service';
 import { CrashlyticsInternal } from './types';
-import { AttributesStore, COMMON_ATTR_KEY } from './attributes-store';
+import {
+  AttributesStore,
+  LOG_ATTR_KEY,
+  SESSION_STORAGE_SESSION_ID_KEY
+} from './attributes-store';
 
 const MOCK_SESSION_ID = '00000000-0000-0000-0000-000000000000';
 
@@ -118,11 +121,11 @@ describe('helpers', () => {
     it('should create a new session and log it with app version (unset)', () => {
       startNewSession(fakeCrashlytics);
 
-      expect(storage[CRASHLYTICS_SESSION_ID_KEY]).to.equal(MOCK_SESSION_ID);
+      expect(storage[SESSION_STORAGE_SESSION_ID_KEY]).to.equal(MOCK_SESSION_ID);
       expect(emittedLogs.length).to.equal(1);
       expect(emittedLogs[0].attributes).to.deep.equal({
-        [COMMON_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID,
-        [COMMON_ATTR_KEY.APP_VERSION]: 'unset'
+        [LOG_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID,
+        [LOG_ATTR_KEY.APP_VERSION]: 'unset'
       });
     });
 
@@ -133,8 +136,8 @@ describe('helpers', () => {
       startNewSession(fakeCrashlytics);
 
       expect(emittedLogs[0].attributes).to.deep.equal({
-        [COMMON_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID,
-        [COMMON_ATTR_KEY.APP_VERSION]: '1.2.3'
+        [LOG_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID,
+        [LOG_ATTR_KEY.APP_VERSION]: '1.2.3'
       });
     });
 
@@ -149,8 +152,8 @@ describe('helpers', () => {
       startNewSession(telemetryWithVersion);
 
       expect(emittedLogs[0].attributes).to.deep.equal({
-        [COMMON_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID,
-        [COMMON_ATTR_KEY.APP_VERSION]: '9.9.9'
+        [LOG_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID,
+        [LOG_ATTR_KEY.APP_VERSION]: '9.9.9'
       });
     });
   });

--- a/packages/crashlytics/src/next.ts
+++ b/packages/crashlytics/src/next.ts
@@ -21,7 +21,7 @@ import { recordError, getCrashlytics } from './api';
 import { Instrumentation } from 'next';
 import { CrashlyticsOptions } from './public-types';
 import { NEXTJS_REQUEST_ATTRIBUTE_KEYS } from './constants';
-import { ATTR_KEY_ROUTE_PATH } from './attributes-store';
+import { LOG_ATTR_KEY } from './attributes-store';
 
 export { Instrumentation };
 
@@ -47,7 +47,7 @@ export function nextOnRequestError(
     const crashlytics = getCrashlytics(getApp(), crashlyticsOptions);
 
     const attributes = {
-      [ATTR_KEY_ROUTE_PATH]: errorContext.routePath,
+      [LOG_ATTR_KEY.ROUTE_PATH]: errorContext.routePath,
       [NEXTJS_REQUEST_ATTRIBUTE_KEYS.PATH]: errorRequest.path,
       [NEXTJS_REQUEST_ATTRIBUTE_KEYS.METHOD]: errorRequest.method,
       [NEXTJS_REQUEST_ATTRIBUTE_KEYS.ROUTER_KIND]: errorContext.routerKind,

--- a/packages/crashlytics/src/react-router/index.test.tsx
+++ b/packages/crashlytics/src/react-router/index.test.tsx
@@ -26,7 +26,7 @@ import { CrashlyticsRoutes } from '.';
 import React from 'react';
 import { render } from '@testing-library/react';
 import { MemoryRouter, Route } from 'react-router-dom';
-import { ATTR_KEY_ROUTE_PATH, AttributesStore } from '../attributes-store';
+import { LOG_ATTR_KEY, AttributesStore } from '../attributes-store';
 
 use(sinonChai);
 use(chaiAsPromised);
@@ -178,9 +178,9 @@ describe('CrashlyticsRoutes', () => {
       </MemoryRouter>
     );
 
-    expect(fakeAttributesStore.getLogAttributes()[ATTR_KEY_ROUTE_PATH]).to.equal('/users/:id');
+    expect(fakeAttributesStore.getLogAttributes()[LOG_ATTR_KEY.ROUTE_PATH]).to.equal('/users/:id');
 
     unmount();
-    expect(fakeAttributesStore.getLogAttributes()[ATTR_KEY_ROUTE_PATH]).to.be.undefined;
+    expect(fakeAttributesStore.getLogAttributes()[LOG_ATTR_KEY.ROUTE_PATH]).to.be.undefined;
   });
 });


### PR DESCRIPTION
Prefactor for https://github.com/firebase/firebase-js-sdk/pull/10077, to keep `crashlytics2` and `crashlytics-traces2` consistent.