### PR TITLE
chore: Change setup-node@master to v4

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
       - name: Set up Node (22)
-        uses: actions/setup-node@60c11408891ef62846c29c28c2374afe5c91fad5 # ratchet:actions/setup-node@master
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
         with:
           node-version: 22.10.0
       - name: install Chrome stable

--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
 
       - name: Setup Node.js 20.x
-        uses: actions/setup-node@60c11408891ef62846c29c28c2374afe5c91fad5 # ratchet:actions/setup-node@master
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
         with:
           node-version: 22.10.0
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js 20.x
-        uses: actions/setup-node@60c11408891ef62846c29c28c2374afe5c91fad5 # ratchet:actions/setup-node@master
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
         with:
           node-version: 22.10.0
 


### PR DESCRIPTION
#10064 locked actions to commits. A few of the workflows were using setup-node@master and the commit it was locked to doesn't seem to work. Changed these instances to lock to the commit version of setup-node@v4 that the other workflows are using, which is working.