### PR TITLE
Fix fetch transport appending headers bug

### DIFF
--- a/packages/crashlytics/src/fetch-transport.test.ts
+++ b/packages/crashlytics/src/fetch-transport.test.ts
@@ -216,6 +216,40 @@ describe('FetchTransport', () => {
       }, done /* catch any rejections */);
     });
 
+    it('does not accumulate dynamic headers across multiple send calls', async () => {
+      // arrange
+      const fetchStub = sinon
+        .stub(globalThis, 'fetch')
+        .resolves(new Response('test response', { status: 200 }));
+
+      let counter = 1;
+      const dynamicProvider: DynamicHeaderProvider = {
+        getHeader: sinon
+          .stub()
+          .callsFake(() =>
+            Promise.resolve(['dynamic-header', `value-${counter++}`])
+          )
+      };
+
+      const transport = new FetchTransport({
+        ...testTransportParameters,
+        dynamicHeaderProviders: [dynamicProvider]
+      });
+
+      // act
+      await transport.send(testPayload, requestTimeout);
+      await transport.send(testPayload, requestTimeout);
+
+      // assert
+      sinon.assert.calledTwice(fetchStub);
+
+      const firstHeaders = fetchStub.firstCall.args[1]?.headers as Headers;
+      assert.strictEqual(firstHeaders?.get('dynamic-header'), 'value-1');
+
+      const secondHeaders = fetchStub.secondCall.args[1]?.headers as Headers;
+      assert.strictEqual(secondHeaders?.get('dynamic-header'), 'value-2');
+    });
+
     it('handles dynamic header providers that return null', done => {
       // arrange
       const fetchStub = sinon

--- a/packages/crashlytics/src/fetch-transport.ts
+++ b/packages/crashlytics/src/fetch-transport.ts
@@ -70,7 +70,7 @@ export class FetchTransport implements IExporterTransport {
     const timeout = setTimeout(() => abortController.abort(), timeoutMillis);
     try {
       const url = new URL(this.parameters.url);
-      const headers = this.parameters.headers;
+      const headers = new Headers(this.parameters.headers);
 
       if (
         this.parameters.dynamicHeaderProviders &&


### PR DESCRIPTION
There's a bug with the dynamic headers in fetch transport where the app check token get continuously appended on subsequent requests.