### PR TITLE
fix: add "@firebase/app" as a peerDep in compat packages

### DIFF
--- a/.changeset/mean-bats-learn.md
+++ b/.changeset/mean-bats-learn.md
@@ -1,0 +1,14 @@
+---
+'@firebase/installations-compat': patch
+'@firebase/remote-config-compat': patch
+'@firebase/performance-compat': patch
+'@firebase/analytics-compat': patch
+'@firebase/app-check-compat': patch
+'@firebase/firestore-compat': patch
+'@firebase/functions-compat': patch
+'@firebase/messaging-compat': patch
+'@firebase/storage-compat': patch
+'@firebase/auth-compat': patch
+---
+
+Added "@firebase/app" as a peerDependency of compat packages.

--- a/.changeset/mean-bats-learn.md
+++ b/.changeset/mean-bats-learn.md
@@ -7,6 +7,7 @@
 '@firebase/firestore-compat': patch
 '@firebase/functions-compat': patch
 '@firebase/messaging-compat': patch
+'@firebase/database-compat': patch
 '@firebase/storage-compat': patch
 '@firebase/auth-compat': patch
 ---

--- a/packages/analytics-compat/package.json
+++ b/packages/analytics-compat/package.json
@@ -19,6 +19,7 @@
   ],
   "license": "Apache-2.0",
   "peerDependencies": {
+    "@firebase/app": "0.x",
     "@firebase/app-compat": "0.x"
   },
   "devDependencies": {

--- a/packages/app-check-compat/package.json
+++ b/packages/app-check-compat/package.json
@@ -31,6 +31,7 @@
     "add-compat-overloads": "ts-node-script ../../scripts/build/create-overloads.ts -i ../app-check/dist/app-check-public.d.ts -o dist/src/index.d.ts -a -r AppCheck:FirebaseAppCheck -r FirebaseApp:FirebaseAppCompat --moduleToEnhance @firebase/app-check"
   },
   "peerDependencies": {
+    "@firebase/app": "0.x",
     "@firebase/app-compat": "0.x"
   },
   "dependencies": {

--- a/packages/auth-compat/package.json
+++ b/packages/auth-compat/package.json
@@ -46,6 +46,7 @@
     "add-compat-overloads": "ts-node-script ../../scripts/build/create-overloads.ts -i ../auth/dist/auth-public.d.ts -o dist/auth-compat/index.d.ts -a -r Auth:types.FirebaseAuth -r User:types.User -r FirebaseApp:FirebaseAppCompat --moduleToEnhance @firebase/auth"
   },
   "peerDependencies": {
+    "@firebase/app": "0.x",
     "@firebase/app-compat": "0.x"
   },
   "dependencies": {

--- a/packages/database-compat/package.json
+++ b/packages/database-compat/package.json
@@ -56,6 +56,18 @@
     "@firebase/component": "0.7.3",
     "tslib": "^2.1.0"
   },
+  "peerDependencies": {
+    "@firebase/app": "0.x",
+    "@firebase/app-compat": "0.x"
+  },
+  "peerDependenciesMeta": {
+    "@firebase/app": {
+      "optional": true
+    },
+    "@firebase/app-compat": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@firebase/app-compat": "0.5.15",
     "typescript": "5.5.4"

--- a/packages/firestore-compat/package.json
+++ b/packages/firestore-compat/package.json
@@ -43,6 +43,7 @@
     "add-compat-overloads": "ts-node-script ../../scripts/build/create-overloads.ts -i ../firestore/dist/index.d.ts -o dist/src/index.d.ts -a -r Firestore:types.FirebaseFirestore -r CollectionReference:types.CollectionReference -r DocumentReference:types.DocumentReference -r Query:types.Query -r FirebaseApp:FirebaseAppCompat --moduleToEnhance @firebase/firestore"
   },
   "peerDependencies": {
+    "@firebase/app": "0.x",
     "@firebase/app-compat": "0.x"
   },
   "dependencies": {

--- a/packages/functions-compat/package.json
+++ b/packages/functions-compat/package.json
@@ -26,6 +26,7 @@
   ],
   "license": "Apache-2.0",
   "peerDependencies": {
+    "@firebase/app": "0.x",
     "@firebase/app-compat": "0.x"
   },
   "devDependencies": {

--- a/packages/installations-compat/package.json
+++ b/packages/installations-compat/package.json
@@ -54,6 +54,7 @@
     "typescript": "5.5.4"
   },
   "peerDependencies": {
+    "@firebase/app": "0.x",
     "@firebase/app-compat": "0.x"
   },
   "dependencies": {

--- a/packages/messaging-compat/package.json
+++ b/packages/messaging-compat/package.json
@@ -35,6 +35,7 @@
     "add-compat-overloads": "ts-node-script ../../scripts/build/create-overloads.ts -i ../messaging/dist/index-public.d.ts -o dist/src/index.d.ts -a -r Messaging:MessagingCompat -r FirebaseApp:FirebaseAppCompat --moduleToEnhance @firebase/messaging"
   },
   "peerDependencies": {
+    "@firebase/app": "0.x",
     "@firebase/app-compat": "0.x"
   },
   "dependencies": {

--- a/packages/performance-compat/package.json
+++ b/packages/performance-compat/package.json
@@ -35,6 +35,7 @@
   },
   "license": "Apache-2.0",
   "peerDependencies": {
+    "@firebase/app": "0.x",
     "@firebase/app-compat": "0.x"
   },
   "dependencies": {

--- a/packages/remote-config-compat/package.json
+++ b/packages/remote-config-compat/package.json
@@ -34,6 +34,7 @@
   },
   "license": "Apache-2.0",
   "peerDependencies": {
+    "@firebase/app": "0.x",
     "@firebase/app-compat": "0.x"
   },
   "dependencies": {

--- a/packages/storage-compat/package.json
+++ b/packages/storage-compat/package.json
@@ -34,6 +34,7 @@
     "add-compat-overloads": "ts-node-script ../../scripts/build/create-overloads.ts -i ../storage/dist/storage-public.d.ts -o dist/src/index.d.ts -a -r FirebaseStorage:types.FirebaseStorage -r StorageReference:types.Reference -r FirebaseApp:FirebaseAppCompat --moduleToEnhance @firebase/storage"
   },
   "peerDependencies": {
+    "@firebase/app": "0.x",
     "@firebase/app-compat": "0.x"
   },
   "dependencies": {


### PR DESCRIPTION
This may fix the issue, or part of the issue, in https://github.com/firebase/firebase-js-sdk/issues/3707 where compat packages depend on their underlying modular package, which have a peer dependency on `@firebase/app` which isn't present in the compat package's package.json. This causes issues with some modern package managers like PNPM and Yarn PNP.