### PR TITLE
adding background/foreground lifecycle logs

### DIFF
--- a/common/api-review/crashlytics.api.md
+++ b/common/api-review/crashlytics.api.md
@@ -33,6 +33,9 @@ export { Instrumentation }
 export function logViewBoundary(crashlytics: Crashlytics, urlTemplate: string, attributes?: AnyValueMap): void;
 
 // @public
+export function logVisibilityEvent(crashlytics: Crashlytics, visibilityState: 'visible' | 'hidden'): void;
+
+// @public
 export function nextOnRequestError(crashlyticsOptions?: CrashlyticsOptions): Instrumentation.onRequestError;
 
 // @public

--- a/docs-devsite/crashlytics_.md
+++ b/docs-devsite/crashlytics_.md
@@ -20,6 +20,7 @@ https://github.com/firebase/firebase-js-sdk
 |  <b>function(crashlytics, ...)</b> |
 |  [flush(crashlytics)](./crashlytics_.md#flush_16fdf66) | Flushes all enqueued Crashlytics data immediately, instead of waiting for default batching. |
 |  [logViewBoundary(crashlytics, urlTemplate, attributes)](./crashlytics_.md#logviewboundary_e310697) | Creates a log for view boundary on navigation event |
+|  [logVisibilityEvent(crashlytics, visibilityState)](./crashlytics_.md#logvisibilityevent_1d6b238) | Logs a page visibility transition event (foreground or background). |
 |  [recordError(crashlytics, error, attributes)](./crashlytics_.md#recorderror_6824e74) | Enqueues an error to be uploaded to the Firebase Crashlytics API. |
 |  [startUserInteractionTrace(crashlytics, rootSpanName)](./crashlytics_.md#startuserinteractiontrace_6ae1587) | Starts a new trace for a user interaction. If a root span is already active, it will be interrupted and a new root span will be started. |
 |  <b>function(crashlyticsOptions, ...)</b> |
@@ -112,6 +113,27 @@ export declare function logViewBoundary(crashlytics: Crashlytics, urlTemplate: s
 |  crashlytics | [Crashlytics](./crashlytics_.crashlytics.md#crashlytics_interface) | The [Crashlytics](./crashlytics_.crashlytics.md#crashlytics_interface) instance. |
 |  urlTemplate | string | The new URL pattern being navigated to. |
 |  attributes | AnyValueMap | Optional, arbitrary attributes to attach to the view boundary log |
+
+<b>Returns:</b>
+
+void
+
+### logVisibilityEvent(crashlytics, visibilityState) {:#logvisibilityevent_1d6b238}
+
+Logs a page visibility transition event (foreground or background).
+
+<b>Signature:</b>
+
+```typescript
+export declare function logVisibilityEvent(crashlytics: Crashlytics, visibilityState: 'visible' | 'hidden'): void;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  crashlytics | [Crashlytics](./crashlytics_.crashlytics.md#crashlytics_interface) | The [Crashlytics](./crashlytics_.crashlytics.md#crashlytics_interface) instance. |
+|  visibilityState | 'visible' \| 'hidden' | The current page visibility state ('visible' or 'hidden'). |
 
 <b>Returns:</b>
 

--- a/packages/crashlytics/src/api.test.ts
+++ b/packages/crashlytics/src/api.test.ts
@@ -562,28 +562,20 @@ describe('Top level API', () => {
   });
 
   describe('logVisibilityEvent', () => {
-    it('should emit a log record for a hidden visibility with correct body, severity number, and custom attributes', () => {
+    it("should emit a log record for a hidden visibility with body of 'Background lifecycle event'", () => {
       logVisibilityEvent(fakeCrashlytics, 'hidden');
 
       expect(emittedLogs).to.have.lengthOf(1);
       const log = emittedLogs[0];
       expect(log.body).to.equal('Background lifecycle event');
-      expect(log.severityNumber).to.equal(SeverityNumber.INFO);
-      expect(log.attributes).to.deep.equal(
-        fakeAttributesStore.getLogAttributes()
-      );
     });
 
-    it('should emit a log record for a visible visibility with correct body, severity number, and custom attributes', () => {
+    it("should emit a log record for a visible visibility with body of 'Foreground lifecycle event'", () => {
       logVisibilityEvent(fakeCrashlytics, 'visible');
 
       expect(emittedLogs).to.have.lengthOf(1);
       const log = emittedLogs[0];
       expect(log.body).to.equal('Foreground lifecycle event');
-      expect(log.severityNumber).to.equal(SeverityNumber.INFO);
-      expect(log.attributes).to.deep.equal(
-        fakeAttributesStore.getLogAttributes()
-      );
     });
   });
 });

--- a/packages/crashlytics/src/api.test.ts
+++ b/packages/crashlytics/src/api.test.ts
@@ -28,7 +28,13 @@ import {
 } from '@firebase/app';
 import { Component, ComponentType } from '@firebase/component';
 import { FirebaseAppCheckInternal } from '@firebase/app-check-interop-types';
-import { recordError, flush, getCrashlytics, logViewBoundary } from './api';
+import {
+  recordError,
+  flush,
+  getCrashlytics,
+  logViewBoundary,
+  logVisibilityEvent
+} from './api';
 import { CrashlyticsService } from './service';
 import { registerCrashlytics } from './register';
 import { _FirebaseInstallationsInternal } from '@firebase/installations';
@@ -552,6 +558,32 @@ describe('Top level API', () => {
       await flush(fakeCrashlytics);
 
       expect(emittedLogs.length).to.equal(0);
+    });
+  });
+
+  describe('logVisibilityEvent', () => {
+    it('should emit a log record for a hidden visibility with correct body, severity number, and custom attributes', () => {
+      logVisibilityEvent(fakeCrashlytics, 'hidden');
+
+      expect(emittedLogs).to.have.lengthOf(1);
+      const log = emittedLogs[0];
+      expect(log.body).to.equal('Background lifecycle event');
+      expect(log.severityNumber).to.equal(SeverityNumber.INFO);
+      expect(log.attributes).to.deep.equal(
+        fakeAttributesStore.getLogAttributes()
+      );
+    });
+
+    it('should emit a log record for a visible visibility with correct body, severity number, and custom attributes', () => {
+      logVisibilityEvent(fakeCrashlytics, 'visible');
+
+      expect(emittedLogs).to.have.lengthOf(1);
+      const log = emittedLogs[0];
+      expect(log.body).to.equal('Foreground lifecycle event');
+      expect(log.severityNumber).to.equal(SeverityNumber.INFO);
+      expect(log.attributes).to.deep.equal(
+        fakeAttributesStore.getLogAttributes()
+      );
     });
   });
 });

--- a/packages/crashlytics/src/api.ts
+++ b/packages/crashlytics/src/api.ts
@@ -25,7 +25,8 @@ import { CrashlyticsService } from './service';
 import {
   flush,
   generateClickSpanName,
-  startUserInteractionTrace
+  startUserInteractionTrace,
+  logVisibilityEvent
 } from './helpers';
 import { deepEqual } from '@firebase/util';
 import { SPAN_ATTR_KEY } from './attributes-store';
@@ -255,33 +256,4 @@ export function logViewBoundary(
   });
 }
 
-/**
- * Logs a page visibility transition event (foreground or background).
- *
- * @public
- *
- * @param crashlytics - The {@link Crashlytics} instance.
- * @param visibilityState - The current page visibility state ('visible' or 'hidden').
- */
-export function logVisibilityEvent(
-  crashlytics: Crashlytics,
-  visibilityState: 'visible' | 'hidden'
-): void {
-  const { loggerProvider, attributesStore } =
-    crashlytics as CrashlyticsInternal;
-  const logger = loggerProvider.getLogger('visibility-logger');
-  const customAttributes: AnyValueMap = attributesStore.getLogAttributes();
-
-  const body =
-    visibilityState === 'hidden'
-      ? 'Background lifecycle event'
-      : 'Foreground lifecycle event';
-
-  logger.emit({
-    severityNumber: SeverityNumber.INFO,
-    body,
-    attributes: customAttributes
-  });
-}
-
-export { flush, startUserInteractionTrace };
+export { flush, startUserInteractionTrace, logVisibilityEvent };

--- a/packages/crashlytics/src/api.ts
+++ b/packages/crashlytics/src/api.ts
@@ -255,4 +255,33 @@ export function logViewBoundary(
   });
 }
 
+/**
+ * Logs a page visibility transition event (foreground or background).
+ *
+ * @public
+ *
+ * @param crashlytics - The {@link Crashlytics} instance.
+ * @param visibilityState - The current page visibility state ('visible' or 'hidden').
+ */
+export function logVisibilityEvent(
+  crashlytics: Crashlytics,
+  visibilityState: 'visible' | 'hidden'
+): void {
+  const { loggerProvider, attributesStore } =
+    crashlytics as CrashlyticsInternal;
+  const logger = loggerProvider.getLogger('visibility-logger');
+  const customAttributes: AnyValueMap = attributesStore.getLogAttributes();
+
+  const body =
+    visibilityState === 'hidden'
+      ? 'Background lifecycle event'
+      : 'Foreground lifecycle event';
+
+  logger.emit({
+    severityNumber: SeverityNumber.INFO,
+    body,
+    attributes: customAttributes
+  });
+}
+
 export { flush, startUserInteractionTrace };

--- a/packages/crashlytics/src/fetch-transport.ts
+++ b/packages/crashlytics/src/fetch-transport.ts
@@ -93,7 +93,7 @@ export class FetchTransport implements IExporterTransport {
         method: 'POST',
         headers,
         signal: abortController.signal,
-        keepalive: true,
+        keepalive: false,
         mode: 'cors',
         body: data
       } as RequestInit;

--- a/packages/crashlytics/src/fetch-transport.ts
+++ b/packages/crashlytics/src/fetch-transport.ts
@@ -93,7 +93,7 @@ export class FetchTransport implements IExporterTransport {
         method: 'POST',
         headers,
         signal: abortController.signal,
-        keepalive: false,
+        keepalive: true,
         mode: 'cors',
         body: data
       } as RequestInit;

--- a/packages/crashlytics/src/helpers.test.ts
+++ b/packages/crashlytics/src/helpers.test.ts
@@ -214,10 +214,16 @@ describe('helpers', () => {
 
   describe('registerListeners', () => {
     let addEventListenerStub: sinon.SinonStub;
+    let listeners: Record<string, (...args: any[]) => any>;
 
     beforeEach(() => {
+      listeners = {};
       if (typeof window !== 'undefined') {
-        addEventListenerStub = sinon.stub(window, 'addEventListener');
+        addEventListenerStub = sinon
+          .stub(window, 'addEventListener')
+          .callsFake((event, callback) => {
+            listeners[event] = callback as (...args: any[]) => any;
+          });
       }
     });
 
@@ -237,18 +243,13 @@ describe('helpers', () => {
 
         expect(flushed).to.be.false;
         expect(emittedLogs).to.have.lengthOf(0);
-
-        const visibilityCall = addEventListenerStub
-          .getCalls()
-          .find(c => c.args[0] === 'visibilitychange');
-        expect(visibilityCall).to.be.ok;
-        const callback = visibilityCall!.args[1] as () => void | Promise<void>;
+        expect(listeners['visibilitychange']).to.be.ok;
 
         Object.defineProperty(document, 'visibilityState', {
           value: 'hidden',
           writable: true
         });
-        await callback();
+        await listeners['visibilitychange']();
 
         expect(flushed).to.be.true;
         expect(emittedLogs).to.have.lengthOf(1);
@@ -259,18 +260,13 @@ describe('helpers', () => {
 
         expect(flushed).to.be.false;
         expect(emittedLogs).to.have.lengthOf(0);
-
-        const visibilityCall = addEventListenerStub
-          .getCalls()
-          .find(c => c.args[0] === 'visibilitychange');
-        expect(visibilityCall).to.be.ok;
-        const callback = visibilityCall!.args[1] as () => void | Promise<void>;
+        expect(listeners['visibilitychange']).to.be.ok;
 
         Object.defineProperty(document, 'visibilityState', {
           value: 'visible',
           writable: true
         });
-        await callback();
+        await listeners['visibilitychange']();
 
         expect(flushed).to.be.false;
         expect(emittedLogs).to.have.lengthOf(1);
@@ -281,14 +277,9 @@ describe('helpers', () => {
         registerListeners(fakeCrashlytics);
 
         expect(flushed).to.be.false;
+        expect(listeners['pagehide']).to.be.ok;
 
-        const pagehideCall = addEventListenerStub
-          .getCalls()
-          .find(c => c.args[0] === 'pagehide');
-        expect(pagehideCall).to.be.ok;
-        const callback = pagehideCall!.args[1] as () => void | Promise<void>;
-
-        await callback();
+        await listeners['pagehide']();
 
         expect(flushed).to.be.true;
       });

--- a/packages/crashlytics/src/helpers.test.ts
+++ b/packages/crashlytics/src/helpers.test.ts
@@ -213,32 +213,82 @@ describe('helpers', () => {
   });
 
   describe('registerListeners', () => {
+    let addEventListenerStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      if (typeof window !== 'undefined') {
+        addEventListenerStub = sinon.stub(window, 'addEventListener');
+      }
+    });
+
+    afterEach(() => {
+      if (typeof window !== 'undefined') {
+        addEventListenerStub.restore();
+      }
+    });
+
     if (isNode()) {
       it('should do nothing in node', () => {
         registerListeners(fakeCrashlytics);
       });
     } else {
-      it('should flush logs when the visibility changes to hidden', () => {
+      it('should emit a log and flush when the visibility changes to hidden', async () => {
         registerListeners(fakeCrashlytics);
 
         expect(flushed).to.be.false;
+        expect(emittedLogs).to.have.lengthOf(0);
+
+        const visibilityCall = addEventListenerStub
+          .getCalls()
+          .find(c => c.args[0] === 'visibilitychange');
+        expect(visibilityCall).to.be.ok;
+        const callback = visibilityCall!.args[1] as () => void | Promise<void>;
 
         Object.defineProperty(document, 'visibilityState', {
           value: 'hidden',
           writable: true
         });
-        window.dispatchEvent(new Event('visibilitychange'));
+        await callback();
 
         expect(flushed).to.be.true;
+        expect(emittedLogs).to.have.lengthOf(1);
       });
 
-      it('should flush logs when the pagehide event fires', () => {
+      it('should emit a log but not flush when the visibility changes to visible', async () => {
+        registerListeners(fakeCrashlytics);
+
+        expect(flushed).to.be.false;
+        expect(emittedLogs).to.have.lengthOf(0);
+
+        const visibilityCall = addEventListenerStub
+          .getCalls()
+          .find(c => c.args[0] === 'visibilitychange');
+        expect(visibilityCall).to.be.ok;
+        const callback = visibilityCall!.args[1] as () => void | Promise<void>;
+
+        Object.defineProperty(document, 'visibilityState', {
+          value: 'visible',
+          writable: true
+        });
+        await callback();
+
+        expect(flushed).to.be.false;
+        expect(emittedLogs).to.have.lengthOf(1);
+      });
+
+      it('should flush logs when the pagehide event fires', async () => {
         startNewSession(fakeCrashlytics);
         registerListeners(fakeCrashlytics);
 
         expect(flushed).to.be.false;
 
-        window.dispatchEvent(new Event('pagehide'));
+        const pagehideCall = addEventListenerStub
+          .getCalls()
+          .find(c => c.args[0] === 'pagehide');
+        expect(pagehideCall).to.be.ok;
+        const callback = pagehideCall!.args[1] as () => void | Promise<void>;
+
+        await callback();
 
         expect(flushed).to.be.true;
       });

--- a/packages/crashlytics/src/helpers.ts
+++ b/packages/crashlytics/src/helpers.ts
@@ -15,11 +15,10 @@
  * limitations under the License.
  */
 
-import { SeverityNumber } from '@opentelemetry/api-logs';
+import { SeverityNumber, AnyValueMap } from '@opentelemetry/api-logs';
 import { CRASHLYTICS_TRACER_NAME } from './constants';
 import { Crashlytics } from './public-types';
 import { CrashlyticsInternal } from './types';
-import { logVisibilityEvent } from './api';
 import { type TimeInput } from '@opentelemetry/api';
 import { hrTimeToMilliseconds, timeInputToHrTime } from '@opentelemetry/core';
 
@@ -153,4 +152,33 @@ export function flush(crashlytics: Crashlytics): Promise<void> {
     .catch(err => {
       console.error('Error flushing logs from Firebase Crashlytics:', err);
     });
+}
+
+/**
+ * Logs a page visibility transition event (foreground or background).
+ *
+ * @public
+ *
+ * @param crashlytics - The {@link Crashlytics} instance.
+ * @param visibilityState - The current page visibility state ('visible' or 'hidden').
+ */
+export function logVisibilityEvent(
+  crashlytics: Crashlytics,
+  visibilityState: 'visible' | 'hidden'
+): void {
+  const { loggerProvider, attributesStore } =
+    crashlytics as CrashlyticsInternal;
+  const logger = loggerProvider.getLogger('visibility-logger');
+  const customAttributes: AnyValueMap = attributesStore.getLogAttributes();
+
+  const body =
+    visibilityState === 'hidden'
+      ? 'Background lifecycle event'
+      : 'Foreground lifecycle event';
+
+  logger.emit({
+    severityNumber: SeverityNumber.INFO,
+    body,
+    attributes: customAttributes
+  });
 }

--- a/packages/crashlytics/src/helpers.ts
+++ b/packages/crashlytics/src/helpers.ts
@@ -19,6 +19,7 @@ import { SeverityNumber } from '@opentelemetry/api-logs';
 import { CRASHLYTICS_TRACER_NAME } from './constants';
 import { Crashlytics } from './public-types';
 import { CrashlyticsInternal } from './types';
+import { logVisibilityEvent } from './api';
 import { type TimeInput } from '@opentelemetry/api';
 import { hrTimeToMilliseconds, timeInputToHrTime } from '@opentelemetry/core';
 
@@ -120,6 +121,13 @@ export function generateClickSpanName(element: Element): string {
 export function registerListeners(crashlytics: Crashlytics): void {
   if (typeof window !== 'undefined' && typeof document !== 'undefined') {
     window.addEventListener('visibilitychange', async () => {
+      if (
+        document.visibilityState === 'visible' ||
+        document.visibilityState === 'hidden'
+      ) {
+        logVisibilityEvent(crashlytics, document.visibilityState);
+      }
+
       if (document.visibilityState === 'hidden') {
         await flush(crashlytics);
       }


### PR DESCRIPTION
Implements foreground/background log events by using the visibilitychange event listener in registerListeners.

if the page changes to visible (user clicks back onto the tab or loads the tab for the first time), it is a foreground event.
If the page changes to hidden (user clicks off of the tab, minimizes tab), it is a background event.