### PR TITLE
keep-alive: true logic to allow for flush() to succeed on tab close

### DIFF
--- a/packages/crashlytics/src/constants.ts
+++ b/packages/crashlytics/src/constants.ts
@@ -54,3 +54,12 @@ export const NEXTJS_REQUEST_ATTRIBUTE_KEYS = {
   ROUTER_KIND: `${NEXTJS_ATTRIBUTE_NAMESPACE}.router_kind`,
   ROUTE_TYPE: `${NEXTJS_ATTRIBUTE_NAMESPACE}.route_type`
 };
+
+/**
+ * Maximum safe payload size (in bytes) to use with keepalive: true.
+ * Browsers limit total keepalive data to 64KB, which includes both the request body
+ * and all HTTP request headers. We use 60,000 bytes as a safe limit to leave a buffer
+ * of ~5KB for headers (such as large App Check tokens, API keys, and content-type).
+ */
+export const KEEPALIVE_MAX_PAYLOAD_SIZE = 60000;
+

--- a/packages/crashlytics/src/constants.ts
+++ b/packages/crashlytics/src/constants.ts
@@ -62,4 +62,3 @@ export const NEXTJS_REQUEST_ATTRIBUTE_KEYS = {
  * of ~5KB for headers (such as large App Check tokens, API keys, and content-type).
  */
 export const KEEPALIVE_MAX_PAYLOAD_SIZE = 60000;
-

--- a/packages/crashlytics/src/fetch-transport.test.ts
+++ b/packages/crashlytics/src/fetch-transport.test.ts
@@ -22,6 +22,7 @@ import * as sinon from 'sinon';
 import * as assert from 'assert';
 import { DynamicHeaderProvider } from './types';
 import { FetchTransport } from './fetch-transport';
+import { KEEPALIVE_MAX_PAYLOAD_SIZE } from './constants';
 import {
   ExportResponseRetryable,
   ExportResponseFailure,
@@ -285,5 +286,58 @@ describe('FetchTransport', () => {
         }
       }, done /* catch any rejections */);
     });
+
+    it('sets keepalive: true when payload is within the safe limit', done => {
+      // arrange
+      const fetchStub = sinon
+        .stub(globalThis, 'fetch')
+        .resolves(new Response('test response', { status: 200 }));
+      const transport = new FetchTransport(testTransportParameters);
+      const smallPayload = new Uint8Array(KEEPALIVE_MAX_PAYLOAD_SIZE - 100);
+
+      //act
+      transport.send(smallPayload, requestTimeout).then(() => {
+        // assert
+        try {
+          sinon.assert.calledOnceWithMatch(
+            fetchStub,
+            testTransportParameters.url,
+            {
+              keepalive: true
+            }
+          );
+          done();
+        } catch (e) {
+          done(e);
+        }
+      }, done);
+    });
+
+    it('sets keepalive: false when payload is over the safe limit', done => {
+      // arrange
+      const fetchStub = sinon
+        .stub(globalThis, 'fetch')
+        .resolves(new Response('test response', { status: 200 }));
+      const transport = new FetchTransport(testTransportParameters);
+      const largePayload = new Uint8Array(KEEPALIVE_MAX_PAYLOAD_SIZE + 100);
+
+      //act
+      transport.send(largePayload, requestTimeout).then(() => {
+        // assert
+        try {
+          sinon.assert.calledOnceWithMatch(
+            fetchStub,
+            testTransportParameters.url,
+            {
+              keepalive: false
+            }
+          );
+          done();
+        } catch (e) {
+          done(e);
+        }
+      }, done);
+    });
   });
 });
+

--- a/packages/crashlytics/src/fetch-transport.test.ts
+++ b/packages/crashlytics/src/fetch-transport.test.ts
@@ -340,4 +340,3 @@ describe('FetchTransport', () => {
     });
   });
 });
-

--- a/packages/crashlytics/src/fetch-transport.ts
+++ b/packages/crashlytics/src/fetch-transport.ts
@@ -24,6 +24,7 @@ import {
 } from '@opentelemetry/otlp-exporter-base';
 import { diag } from '@opentelemetry/api';
 import { DynamicHeaderProvider } from './types';
+import { KEEPALIVE_MAX_PAYLOAD_SIZE } from './constants';
 
 function isExportRetryable(statusCode: number): boolean {
   const retryCodes = [429, 502, 503, 504];
@@ -89,11 +90,16 @@ export class FetchTransport implements IExporterTransport {
         }
       }
 
+      // Browsers limit the total keepalive budget (payload + headers) to 64KB.
+      // If the limit is exceeded, fetch throws a TypeError. We only use keepalive
+      // if the payload is within a safe limit.
+      const keepalive = data.byteLength < KEEPALIVE_MAX_PAYLOAD_SIZE;
+
       const body = {
         method: 'POST',
         headers,
         signal: abortController.signal,
-        keepalive: false,
+        keepalive,
         mode: 'cors',
         body: data
       } as RequestInit;


### PR DESCRIPTION
Allows in-flight log requests to succeed upon termination of the page.