### PR TITLE
[Firestore] Fix querySnapshotFromJSON to preserve query sort order

### DIFF
--- a/packages/firestore/src/api/snapshot.ts
+++ b/packages/firestore/src/api/snapshot.ts
@@ -950,10 +950,13 @@ export function querySnapshotFromJSON<
 
     // Create an internal Query object from the named query in the bundle.
     const query = fromBundledQuery(bundleLoader.queries[0].bundledQuery!);
+    const comparator = isPipeline(query)
+      ? newPipelineComparator(query)
+      : newQueryComparator(query);
 
     // Construct the arrays of document data for the query.
     const bundledDocuments = bundleLoader.documents;
-    let documentSet = new DocumentSet();
+    let documentSet = new DocumentSet(comparator);
     bundledDocuments.map(bundledDocument => {
       const document = fromDocument(serializer, bundledDocument.document!);
       documentSet = documentSet.add(document);

--- a/packages/firestore/test/unit/api/database.test.ts
+++ b/packages/firestore/test/unit/api/database.test.ts
@@ -39,9 +39,10 @@ import {
   firestore,
   newTestFirestore,
   query,
-  querySnapshot
+  querySnapshot,
+  querySnapshotWithQuery
 } from '../../util/api_helpers';
-import { keys } from '../../util/helpers';
+import { keys, query as internalQuery, orderBy } from '../../util/helpers';
 
 describe('Bundle', () => {
   it('loadBundle does not throw with an empty bundle string)', async () => {
@@ -727,6 +728,22 @@ describe('QuerySnapshot', () => {
           }
         }
       }
+    }
+  });
+
+  it('fromJSON respects query sort order', () => {
+    if (isNode()) {
+      const q = internalQuery('foo', orderBy('title', 'asc'));
+      const snapshot = querySnapshotWithQuery(q, {
+        docA: { title: 'C' },
+        docB: { title: 'B' },
+        docC: { title: 'A' }
+      });
+      const db = firestore();
+      const querySnap = querySnapshotFromJSON(db, snapshot.toJSON());
+      expect(querySnap).to.exist;
+      const titles = querySnap.docs.map(d => d.data()['title']);
+      expect(titles).to.deep.equal(['A', 'B', 'C']);
     }
   });
 

--- a/packages/firestore/test/util/api_helpers.ts
+++ b/packages/firestore/test/util/api_helpers.ts
@@ -34,13 +34,17 @@ import {
 } from '../../src/api/credentials';
 import { ExpUserDataWriter } from '../../src/api/user_data_writer';
 import { DatabaseId } from '../../src/core/database_info';
-import { newQueryForPath, Query as InternalQuery } from '../../src/core/query';
+import {
+  newQueryForPath,
+  newQueryComparator,
+  Query as InternalQuery
+} from '../../src/core/query';
 import {
   ChangeType,
   DocumentViewChange,
   ViewSnapshot
 } from '../../src/core/view_snapshot';
-import { DocumentKeySet } from '../../src/model/collections';
+import { documentKeySet, DocumentKeySet } from '../../src/model/collections';
 import { DocumentSet } from '../../src/model/document_set';
 import { JsonObject } from '../../src/model/object_value';
 import { TEST_PROJECT } from '../unit/local/persistence_test_helpers';
@@ -160,6 +164,42 @@ export function querySnapshot(
     syncStateChanged,
     false,
     hasCachedResults ?? false
+  );
+  const db = firestore();
+  return new QuerySnapshot(
+    db,
+    new ExpUserDataWriter(db),
+    new Query(db, /* converter= */ null, query),
+    viewSnapshot
+  );
+}
+
+export function querySnapshotWithQuery(
+  query: InternalQuery,
+  docsToAdd: { [key: string]: JsonObject<unknown> }
+): QuerySnapshot {
+  const comparator = newQueryComparator(query);
+  let newDocuments: DocumentSet = new DocumentSet(comparator);
+  const documentChanges: DocumentViewChange[] = [];
+  Object.keys(docsToAdd).forEach(key => {
+    const docToAdd = doc(
+      query.path.canonicalString() + '/' + key,
+      1,
+      docsToAdd[key]
+    );
+    newDocuments = newDocuments.add(docToAdd);
+    documentChanges.push({ type: ChangeType.Added, doc: docToAdd });
+  });
+  const viewSnapshot: ViewSnapshot = new ViewSnapshot(
+    query,
+    newDocuments,
+    new DocumentSet(comparator),
+    documentChanges,
+    documentKeySet(),
+    false,
+    true,
+    false,
+    false
   );
   const db = firestore();
   return new QuerySnapshot(


### PR DESCRIPTION
### Detailed Problem Description
Fixes #10107.

When a `QuerySnapshot` is deserialized with `querySnapshotFromJSON`, `DocumentSet` was being instantiated without the query comparator (`new DocumentSet()`). As a result, `DocumentSet` defaulted to sorting documents by document key rather than preserving the query's sort order.

### Solution
Pass the query comparator (`newQueryComparator(query)` or `newPipelineComparator(query)`) to `new DocumentSet(comparator)` in `querySnapshotFromJSON`.

### Testing
Added unit test `fromJSON respects query sort order` in `database.test.ts` verifying that documents ordered by non-key fields maintain their sort order after `.toJSON()` and `querySnapshotFromJSON()`. Verified failure without the fix and pass with the fix.