### PR TITLE
chore(format): optimize code formatting speed repo-wide

### DIFF
--- a/integration/firestore/package.json
+++ b/integration/firestore/package.json
@@ -8,7 +8,7 @@
     "build:persistence": "yarn typings:public && INCLUDE_FIRESTORE_PERSISTENCE=true gulp compile-tests",
     "build:memory": "yarn typings:public && INCLUDE_FIRESTORE_PERSISTENCE=false gulp compile-tests",
     "karma:singlerun": "karma start",
-    "prettier": "prettier --write '*.js' '*.ts'",
+    "prettier": "prettier --cache --write '*.js' '*.ts'",
     "test:persistence": " yarn build:persistence; karma start",
     "test:persistence:debug": "yarn build:persistence; karma start --auto-watch --browsers Chrome",
     "test:memory": "yarn build:memory; karma start",

--- a/packages/data-connect/package.json
+++ b/packages/data-connect/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore' --fix",
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts'  --ignore-path '../../.gitignore'",
     "build": "rollup -c rollup.config.js && yarn api-report",
-    "prettier": "prettier --write '*.js' '*.ts' '@(src|test)/**/*.ts'",
+    "prettier": "prettier --cache --write '*.js' '*.ts' '@(src|test)/**/*.ts'",
     "build:deps": "lerna run --scope @firebase/'{app,data-connect}' --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm lint test:emulator",

--- a/packages/database-compat/package.json
+++ b/packages/database-compat/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "lint": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts'  --ignore-path '../../.gitignore'",
-    "prettier": "prettier --write '*.js' '*.ts' '@(src|test)/**/*.ts'",
+    "prettier": "prettier --cache --write '*.js' '*.ts' '@(src|test)/**/*.ts'",
     "build": "rollup -c rollup.config.js",
     "build:release": "yarn build && yarn add-compat-overloads",
     "build:deps": "lerna run --scope @firebase/database-compat --include-dependencies build",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "lint": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts'  --ignore-path '../../.gitignore'",
-    "prettier": "prettier --write '*.js' '*.ts' '@(src|test)/**/*.ts'",
+    "prettier": "prettier --cache --write '*.js' '*.ts' '@(src|test)/**/*.ts'",
     "build": "rollup -c rollup.config.js && yarn api-report",
     "build:deps": "lerna run --scope @firebase/'{app,database}' --include-dependencies build",
     "dev": "rollup -c -w",

--- a/packages/firestore-compat/package.json
+++ b/packages/firestore-compat/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "lint": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
-    "prettier": "prettier --write '*.js' '@(src|test)/**/*.ts'",
+    "prettier": "prettier --cache --write '*.js' '@(src|test)/**/*.ts'",
     "build": "rollup -c ./rollup.config.js",
     "build:console": "node tools/console.build.js",
     "build:deps": "lerna run --scope @firebase/firestore-compat --include-dependencies build",

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -21,7 +21,7 @@
     "dev": "rollup -c -w",
     "lint": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
-    "prettier": "prettier --write '*.js' '@(lite|src|test|scripts)/**/*.ts' 'test/unit/remote/bloom_filter_golden_test_data/*.json'",
+    "prettier": "prettier --cache --write '*.js' '@(lite|src|test|scripts)/**/*.ts' 'test/unit/remote/bloom_filter_golden_test_data/*.json'",
     "test:lite": "ts-node ./scripts/run-tests.ts --emulator --platform node_lite --main=lite/index.ts 'test/lite/**/*.test.ts'",
     "test:lite:prod": "ts-node ./scripts/run-tests.ts --platform node_lite --main=lite/index.ts 'test/lite/**/*.test.ts'",
     "test:lite:prod:enterprise": "ts-node ./scripts/run-tests.ts --platform node_lite --databaseId=enterprise --main=lite/index.ts  --firestoreEdition=enterprise 'test/lite/**/*.test.ts'",

--- a/packages/performance-compat/package.json
+++ b/packages/performance-compat/package.json
@@ -30,7 +30,7 @@
     "test:browser": "karma start",
     "test:browser:debug": "karma start --browsers Chrome --auto-watch",
     "trusted-type-check": "tsec -p tsconfig.json --noEmit",
-    "prettier": "prettier --write '{src,test}/**/*.{js,ts}'",
+    "prettier": "prettier --cache --write '{src,test}/**/*.{js,ts}'",
     "add-compat-overloads": "ts-node-script ../../scripts/build/create-overloads.ts -i ../performance/dist/src/index.d.ts -o dist/src/index.d.ts -a -r FirebasePerformance:FirebasePerformanceCompat -r FirebaseApp:FirebaseAppCompat --moduleToEnhance @firebase/performance"
   },
   "license": "Apache-2.0",

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -29,7 +29,7 @@
     "test:browser": "karma start",
     "test:debug": "karma start --browsers=Chrome --auto-watch",
     "trusted-type-check": "tsec -p tsconfig.json --noEmit",
-    "prettier": "prettier --write '{src,test}/**/*.{js,ts}'",
+    "prettier": "prettier --cache --write '{src,test}/**/*.{js,ts}'",
     "api-report": "api-extractor run --local --verbose",
     "doc": "api-documenter markdown --input temp --output docs",
     "build:doc": "yarn build && yarn doc"

--- a/packages/remote-config/package.json
+++ b/packages/remote-config/package.json
@@ -29,7 +29,7 @@
     "test:browser": "karma start",
     "test:debug": "karma start --browsers=Chrome --auto-watch",
     "trusted-type-check": "tsec -p tsconfig.json --noEmit",
-    "prettier": "prettier --write '{src,test}/**/*.{js,ts}'",
+    "prettier": "prettier --cache --write '{src,test}/**/*.{js,ts}'",
     "api-report": "api-extractor run --local --verbose",
     "doc": "api-documenter markdown --input temp --output docs",
     "build:doc": "yarn build && yarn doc",

--- a/packages/storage-compat/package.json
+++ b/packages/storage-compat/package.json
@@ -30,7 +30,7 @@
     "test:node": "TS_NODE_FILES=true TS_NODE_CACHE=NO TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --file src/index.ts --config ../../config/mocharc.node.js",
     "test:debug": "karma start --browser=Chrome",
     "trusted-type-check": "tsec -p tsconfig.json --noEmit",
-    "prettier": "prettier --write 'src/**/*.ts' 'test/**/*.ts'",
+    "prettier": "prettier --cache --write 'src/**/*.ts' 'test/**/*.ts'",
     "add-compat-overloads": "ts-node-script ../../scripts/build/create-overloads.ts -i ../storage/dist/storage-public.d.ts -o dist/src/index.d.ts -a -r FirebaseStorage:types.FirebaseStorage -r StorageReference:types.Reference -r FirebaseApp:FirebaseAppCompat --moduleToEnhance @firebase/storage"
   },
   "peerDependencies": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -40,7 +40,7 @@
     "test:node": "TS_NODE_FILES=true TS_NODE_CACHE=NO TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --file src/index.node.ts --config ../../config/mocharc.node.js",
     "test:debug": "karma start --browser=Chrome",
     "trusted-type-check": "tsec -p tsconfig.json --noEmit",
-    "prettier": "prettier --write 'src/**/*.ts' 'test/**/*.ts'",
+    "prettier": "prettier --cache --write 'src/**/*.ts' 'test/**/*.ts'",
     "api-report": "api-extractor run --local --verbose && ts-node-script ../../repo-scripts/prune-dts/prune-dts.ts --input dist/storage-public.d.ts --output dist/storage-public.d.ts",
     "typings:public": "node ../../scripts/build/use_typings.js ./dist/storage-public.d.ts"
   },

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -31,7 +31,7 @@
     "build": "rollup -c && yarn api-report",
     "build:deps": "lerna run --scope @firebase/util --include-dependencies build",
     "dev": "rollup -c -w",
-    "prettier": "prettier --write 'src/**/*.ts' 'test/**/*.ts'",
+    "prettier": "prettier --cache --write 'src/**/*.ts' 'test/**/*.ts'",
     "test": "run-p --npm-path npm lint test:all",
     "test:ci": "node ../../scripts/run_tests_in_ci.js -s test:all",
     "test:all": "run-p --npm-path npm test:browser test:node",

--- a/repo-scripts/prune-dts/package.json
+++ b/repo-scripts/prune-dts/package.json
@@ -8,7 +8,7 @@
   "description": "A script to prune non-exported types from a d.ts.",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "scripts": {
-    "prettier": "prettier --write '**/*.ts'",
+    "prettier": "prettier --cache --write '**/*.ts'",
     "test": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha --require ts-node/register --timeout 5000 *.test.ts"
   },
   "license": "Apache-2.0",

--- a/scripts/format/license.ts
+++ b/scripts/format/license.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import fs from 'mz/fs';
+import { open, readFile, writeFile } from 'fs/promises';
 import chalk from 'chalk';
 import glob from 'glob';
 
@@ -41,12 +41,25 @@ const licenseHeader = `/**
 const copyrightPattern = /Copyright \d{4} Google (Inc\.|LLC)/;
 const oldCopyrightPattern = /(\s*\*\s*Copyright \d{4}) Google Inc\./;
 
-async function readFiles(paths: string[]) {
-  const fileContents = await Promise.all(paths.map(path => fs.readFile(path)));
-  return fileContents.map((buffer, idx) => ({
-    contents: String(buffer),
-    path: paths[idx]
-  }));
+/**
+ * Reads only the first N bytes of a file to optimize execution speed.
+ */
+async function readHead(path: string, bytesToRead = 1000): Promise<string> {
+  let handle;
+  try {
+    handle = await open(path, 'r');
+    const { buffer, bytesRead } = await handle.read(
+      Buffer.alloc(bytesToRead),
+      0,
+      bytesToRead,
+      0
+    );
+    return buffer.toString('utf8', 0, bytesRead);
+  } finally {
+    if (handle) {
+      await handle.close();
+    }
+  }
 }
 
 function addLicenseTag(contents: string) {
@@ -97,38 +110,57 @@ export async function doLicense(changedFiles?: string[]) {
   console.log(
     chalk`{green Validating license headers in ${filesToChange.length} files.}`
   );
-  const files = await readFiles(filesToChange);
 
-  await Promise.all(
-    files.map(({ contents, path }) => {
-      let result = contents;
+  // Batch processing in chunks of 100 to prevent EMFILE (too many open files) errors.
+  const limit = 100;
+  for (let i = 0; i < filesToChange.length; i += limit) {
+    const chunk = filesToChange.slice(i, i + limit);
+    await Promise.all(
+      chunk.map(async path => {
+        try {
+          // Read only the head chunk to fast-path validation on files that already have valid headers.
+          const head = await readHead(path);
 
-      // Files with no license block at all.
-      if (result.match(copyrightPattern) == null) {
-        result = licenseHeader + result;
-        console.log(`Adding license to ${path}.`);
-      }
+          const needsLicenseBlock = head.match(copyrightPattern) == null;
+          const needsLicenseTag = head.match(/@license/) == null;
+          const hasOldCopyright = head.match(oldCopyrightPattern) != null;
 
-      // Files with no @license tag.
-      if (result.match(/@license/) == null) {
-        result = addLicenseTag(result);
-        console.log(`Adding @license tag to ${path}.`);
-      }
+          if (needsLicenseBlock || needsLicenseTag || hasOldCopyright) {
+            const contents = await readFile(path, 'utf8');
+            let result = contents;
 
-      // Files with the old form of copyright notice.
-      if (result.match(oldCopyrightPattern) != null) {
-        result = rewriteCopyrightLine(result);
-        console.log(`Updating old copyright notice found in ${path}.`);
-      }
+            // Files with no license block at all.
+            // Double-check the copyright pattern on the full file content to avoid duplicate
+            // headers if the copyright notice is located past the first 1000 bytes.
+            if (needsLicenseBlock && result.match(copyrightPattern) == null) {
+              result = licenseHeader + result;
+              console.log(`Adding license to ${path}.`);
+            }
 
-      if (contents !== result) {
-        count++;
-        return fs.writeFile(path, result, 'utf8');
-      } else {
-        return Promise.resolve();
-      }
-    })
-  );
+            // Files with no @license tag.
+            if (needsLicenseTag && result.match(/@license/) == null) {
+              result = addLicenseTag(result);
+              console.log(`Adding @license tag to ${path}.`);
+            }
+
+            // Files with the old form of copyright notice.
+            if (hasOldCopyright && result.match(oldCopyrightPattern) != null) {
+              result = rewriteCopyrightLine(result);
+              console.log(`Updating old copyright notice found in ${path}.`);
+            }
+
+            if (contents !== result) {
+              count++;
+              await writeFile(path, result, 'utf8');
+            }
+          }
+        } catch (err) {
+          console.error(chalk`{red Error processing ${path}:}`, err);
+        }
+      })
+    );
+  }
+
   if (count === 0) {
     console.log(chalk`{green No files needed license changes.}`);
   } else {

--- a/scripts/format/prettier.ts
+++ b/scripts/format/prettier.ts
@@ -64,6 +64,7 @@ export async function doPrettier(changedFiles?: string[]) {
     'prettier',
     '--config',
     `${resolve(root, '.prettierrc')}`,
+    '--cache',
     '--write'
   ];
 


### PR DESCRIPTION
Enable prettier caching (`--cache`) across all package prettier scripts and the main format script, and optimize the custom license header checker to read only the first 1000 bytes of each file.

Performance Data:
- Repo-wide formatting (`yarn format --all`):
  - Before caching: ~35-40s (uncached formatting + full license check)
  - After caching: ~5.8s (cached formatting + header-only license check)
  - Speedup: ~6x speedup

**AI Disclaimer**: These changes were generated by AI. I validated the changes manually by introducing format errors into files, and remove licensed headers to validate that the scripts still report errors / add license headers back.