### PR TITLE
Security Audit & Remediation: repo-scripts/api-documenter

### DIFF
--- a/repo-scripts/api-documenter/package.json
+++ b/repo-scripts/api-documenter/package.json
@@ -25,14 +25,11 @@
     "@microsoft/tsdoc": "0.12.24",
     "@rushstack/node-core-library": "5.19.1",
     "@rushstack/ts-command-line": "4.23.3",
-    "colors": "~1.4.0",
-    "resolve": "~1.22.0",
     "tslib": "^2.1.0",
     "js-yaml": "4.1.1"
   },
   "devDependencies": {
     "@types/js-yaml": "4.0.9",
-    "@types/resolve": "1.20.6",
     "jest-resolve": "29.7.0",
     "mocha-chai-jest-snapshot": "1.1.6"
   },

--- a/repo-scripts/api-documenter/src/cli/BaseAction.ts
+++ b/repo-scripts/api-documenter/src/cli/BaseAction.ts
@@ -20,7 +20,7 @@
 
 import * as path from 'path';
 import * as tsdoc from '@microsoft/tsdoc';
-import colors from 'colors';
+import { yellow } from '../utils/style';
 
 import {
   CommandLineAction,
@@ -143,7 +143,7 @@ export abstract class BaseAction extends CommandLineAction {
 
           if (result.errorMessage) {
             console.log(
-              colors.yellow(
+              yellow(
                 `Warning: Unresolved @inheritDoc tag for ${apiItem.displayName}: ` +
                   result.errorMessage
               )

--- a/repo-scripts/api-documenter/src/markdown/CustomMarkdownEmitter.ts
+++ b/repo-scripts/api-documenter/src/markdown/CustomMarkdownEmitter.ts
@@ -18,7 +18,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import { yellow } from '../utils/style';
 
 import { DocNode, DocLinkTag, StringBuilder } from '@microsoft/tsdoc';
 import {
@@ -217,12 +217,12 @@ export class CustomMarkdownEmitter extends MarkdownEmitter {
           context.writer.write(encodedLinkText);
           context.writer.write(`](${filename!})`);
         } else {
-          console.log(colors.yellow('WARNING: Unable to determine link text'));
+          console.log(yellow('WARNING: Unable to determine link text'));
         }
       }
     } else if (result.errorMessage) {
       console.log(
-        colors.yellow(
+        yellow(
           `WARNING: Unable to resolve reference "${docLinkTag.codeDestination!.emitAsTsdoc()}": ` +
             result.errorMessage
         )

--- a/repo-scripts/api-documenter/src/plugin/PluginLoader.ts
+++ b/repo-scripts/api-documenter/src/plugin/PluginLoader.ts
@@ -52,7 +52,7 @@ export class PluginLoader {
         const resolvedEntryPointPath: string = require.resolve(
           configPlugin.packageName,
           {
-            paths: [configFileFolder]
+            paths: [path.resolve(configFileFolder)]
           }
         );
 

--- a/repo-scripts/api-documenter/src/plugin/PluginLoader.ts
+++ b/repo-scripts/api-documenter/src/plugin/PluginLoader.ts
@@ -19,7 +19,6 @@
 // See LICENSE in the project root for license information.
 
 import * as path from 'path';
-import * as resolve from 'resolve';
 
 import {
   IApiDocumenterPluginManifest,
@@ -50,10 +49,10 @@ export class PluginLoader {
     for (const configPlugin of documenterConfig.configFile.plugins || []) {
       try {
         // Look for the package name in the same place as the config file
-        const resolvedEntryPointPath: string = resolve.sync(
+        const resolvedEntryPointPath: string = require.resolve(
           configPlugin.packageName,
           {
-            basedir: configFileFolder
+            paths: [configFileFolder]
           }
         );
 

--- a/repo-scripts/api-documenter/src/start.ts
+++ b/repo-scripts/api-documenter/src/start.ts
@@ -21,7 +21,7 @@
 // See LICENSE in the project root for license information.
 
 import * as os from 'os';
-import colors from 'colors';
+import { bold } from './utils/style';
 
 import { PackageJsonLookup } from '@rushstack/node-core-library';
 
@@ -31,7 +31,7 @@ const myPackageVersion: string =
   PackageJsonLookup.loadOwnPackageJson(__dirname).version;
 
 console.log(
-  os.EOL + colors.bold(`@firebase/api-documenter ${myPackageVersion} ` + os.EOL)
+  os.EOL + bold(`@firebase/api-documenter ${myPackageVersion} ` + os.EOL)
 );
 
 const parser: ApiDocumenterCommandLine = new ApiDocumenterCommandLine();

--- a/repo-scripts/api-documenter/src/utils/style.ts
+++ b/repo-scripts/api-documenter/src/utils/style.ts
@@ -15,10 +15,15 @@
  * limitations under the License.
  */
 
+const useColors: boolean =
+  typeof process !== 'undefined' &&
+  (process.env.FORCE_COLOR !== undefined ||
+    (!!process.stdout?.isTTY && !process.env.NO_COLOR));
+
 export function bold(text: string): string {
-  return `\x1b[1m${text}\x1b[22m`;
+  return useColors ? `\x1b[1m${text}\x1b[22m` : text;
 }
 
 export function yellow(text: string): string {
-  return `\x1b[33m${text}\x1b[39m`;
+  return useColors ? `\x1b[33m${text}\x1b[39m` : text;
 }

--- a/repo-scripts/api-documenter/src/utils/style.ts
+++ b/repo-scripts/api-documenter/src/utils/style.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function bold(text: string): string {
+  return `\x1b[1m${text}\x1b[22m`;
+}
+
+export function yellow(text: string): string {
+  return `\x1b[33m${text}\x1b[39m`;
+}

--- a/repo-scripts/api-documenter/tsconfig.json
+++ b/repo-scripts/api-documenter/tsconfig.json
@@ -6,7 +6,8 @@
     "module": "CommonJS",
     "target": "ES6",
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "typeRoots": ["../../node_modules/@types", "./node_modules/@types"]
   },
   "exclude": ["dist/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3592,11 +3592,6 @@
   resolved "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz#97d26e00cd4a0423b4af620abecf3e6f442b7975"
   integrity sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==
 
-"@types/resolve@1.20.6":
-  version "1.20.6"
-  resolved "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz#e6e60dad29c2c8c206c026e6dd8d6d1bdda850b8"
-  integrity sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==
-
 "@types/responselike@^1.0.0":
   version "1.0.3"
   resolved "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz#cc29706f0a397cfe6df89debfe4bf5cea159db50"
@@ -5905,7 +5900,7 @@ colors@1.0.3:
   resolved "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==
 
-colors@1.4.0, colors@~1.4.0:
+colors@1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
@@ -14657,7 +14652,7 @@ resolve.exports@^2.0.0:
   resolved "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz#41955e6f1b4013b7586f873749a635dea07ebe3f"
   integrity sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.20.0, resolve@^1.22.1, resolve@^1.22.4, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0, resolve@~1.22.0, resolve@~1.22.1:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.20.0, resolve@^1.22.1, resolve@^1.22.4, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0, resolve@~1.22.1:
   version "1.22.10"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz#b663e83ffb09bbf2386944736baae803029b8b39"
   integrity sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==


### PR DESCRIPTION
### Security Audit & Remediation: repo-scripts/api-documenter

#### A. Previous CVEs
- [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) - `js-yaml` (Severity: Moderate)
- [GHSA-c2qf-rxjj-qqgw](https://github.com/advisories/GHSA-c2qf-rxjj-qqgw) - `semver` (Severity: High)
- [GHSA-2g4f-4pwh-qvx6](https://github.com/advisories/GHSA-2g4f-4pwh-qvx6) - `ajv` (Severity: Moderate)
- [GHSA-qgmg-gppg-76g5](https://github.com/advisories/GHSA-qgmg-gppg-76g5) - `validator` (Severity: Moderate)
- [GHSA-9965-vmph-33xx](https://github.com/advisories/GHSA-9965-vmph-33xx) - `validator` (Severity: Moderate)
- [GHSA-vghf-hv5q-vc2g](https://github.com/advisories/GHSA-vghf-hv5q-vc2g) - `validator` (Severity: High)

#### B. Changes Made
- Removed unmaintained abandonware `colors@~1.4.0` and refactored call sites to use minimal native utility helper (`src/utils/style.ts`).
- Removed trivial utility wrapper `resolve@~1.22.0` (`@types/resolve@1.20.6`) and refactored call sites (`src/plugin/PluginLoader.ts`) to use native Node.js runtime stdlib `require.resolve`.

#### C. Remaining CVEs
- `semver@7.5.1` (Required by `@rushstack/node-core-library`): No non-breaking fix available upstream without major version bump of Rushstack core tools. Transitive tree: `@rushstack/node-core-library > semver`
- `ajv@8.17.1` (Required by `@rushstack/node-core-library`): No fix available upstream. Transitive tree: `@rushstack/node-core-library > ajv`
- `validator@13.15.20` (Required by `@rushstack/node-core-library > z-schema`): No fix available upstream. Transitive tree: `@rushstack/node-core-library > z-schema > validator`
- `js-yaml@4.1.1` (Required directly and via `@istanbuljs/load-nyc-config`): No fix available upstream. Transitive tree: `js-yaml` and `@istanbuljs/load-nyc-config > js-yaml`

#### D. Introduced CVEs
- None

#### E. Testing Strategy
- Ran existing unit test suite (`npm test`) - 100% passing (6 tests passing).
- Executed build verification (`npm run build`) - passing.