### PR TITLE
fix(auth): handle NotAllowedError and null credential for iOS WebAuthn fallback

### DIFF
--- a/docs-devsite/auth.md
+++ b/docs-devsite/auth.md
@@ -960,7 +960,7 @@ export declare function signInWithPasskey(auth: Auth, name: string, manualSignUp
 |  --- | --- | --- |
 |  auth | [Auth](./auth.auth.md#auth_interface) | The Firebase Auth instance. |
 |  name | string | The user's name for passkey. |
-|  manualSignUp | boolean | When false, automatically creates an anonymous user if a passkey credential does not exist. Defaults to false. |
+|  manualSignUp | boolean | When false, automatically creates an anonymous user if a passkey credential does not exist. Due to browser limitations, this will also trigger if the user cancels the native passkey prompt. Defaults to false. |
 
 <b>Returns:</b>
 

--- a/packages/auth/src/core/strategies/passkey.test.ts
+++ b/packages/auth/src/core/strategies/passkey.test.ts
@@ -202,6 +202,92 @@ describe('passkey', async () => {
     }
   });
 
+  it('should fallback when passkey operation is cancelled (NotAllowedError)', async () => {
+    if (
+      typeof navigator === 'undefined' ||
+      typeof navigator.credentials === 'undefined'
+    ) {
+      return;
+    }
+    const notAllowedError = new Error('User cancelled');
+    notAllowedError.name = 'NotAllowedError';
+    sinon.stub(navigator.credentials, 'get').throws(notAllowedError);
+    sinon.stub(navigator.credentials, 'create').resolves(mockCredential);
+
+    const serverUser: APIUserInfo = { localId: 'local-id' };
+    mockEndpoint(Endpoint.SIGN_UP, {
+      idToken: 'id-token', refreshToken: 'refresh-token', expiresIn: '1234', localId: serverUser.localId!
+    });
+    mockEndpoint(Endpoint.GET_ACCOUNT_INFO, { users: [serverUser] });
+
+    mockEndpoint(Endpoint.START_PASSKEY_SIGNIN, {
+      credentialRequestOptions: { challenge: 'validbase64challenge', rpId: 'rp-id', userVerification: 'required' }
+    });
+
+    mockEndpoint(Endpoint.START_PASSKEY_ENROLLMENT, {
+      credentialCreationOptions: {
+        rp: { name: 'mock-rp' },
+        user: { id: 'mockuser', name: 'mock-user', displayName: 'Mock User' },
+        challenge: 'validbase64challenge',
+        pubKeyCredParams: [{ type: 'public-key', alg: -7 }, { type: 'public-key', alg: -257 }],
+        timeout: 60000,
+        excludeCredentials: [],
+        authenticatorSelection: { authenticatorAttachment: 'platform', requireResidentKey: false, userVerification: 'required' },
+        attestation: 'direct',
+        extensions: { example: true }
+      }
+    });
+
+    mockEndpoint(Endpoint.FINALIZE_PASSKEY_ENROLLMENT, {
+      idToken: 'id-token', refreshToken: 'refresh-token'
+    });
+
+    await signInWithPasskey(auth, 'name', false);
+    expect(auth.currentUser?.uid).to.eq('mock-uid');
+  });
+
+  it('should fallback when passkey credential is null', async () => {
+    if (
+      typeof navigator === 'undefined' ||
+      typeof navigator.credentials === 'undefined'
+    ) {
+      return;
+    }
+    sinon.stub(navigator.credentials, 'get').resolves(null);
+    sinon.stub(navigator.credentials, 'create').resolves(mockCredential);
+
+    const serverUser: APIUserInfo = { localId: 'local-id' };
+    mockEndpoint(Endpoint.SIGN_UP, {
+      idToken: 'id-token', refreshToken: 'refresh-token', expiresIn: '1234', localId: serverUser.localId!
+    });
+    mockEndpoint(Endpoint.GET_ACCOUNT_INFO, { users: [serverUser] });
+
+    mockEndpoint(Endpoint.START_PASSKEY_SIGNIN, {
+      credentialRequestOptions: { challenge: 'validbase64challenge', rpId: 'rp-id', userVerification: 'required' }
+    });
+
+    mockEndpoint(Endpoint.START_PASSKEY_ENROLLMENT, {
+      credentialCreationOptions: {
+        rp: { name: 'mock-rp' },
+        user: { id: 'mockuser', name: 'mock-user', displayName: 'Mock User' },
+        challenge: 'validbase64challenge',
+        pubKeyCredParams: [{ type: 'public-key', alg: -7 }, { type: 'public-key', alg: -257 }],
+        timeout: 60000,
+        excludeCredentials: [],
+        authenticatorSelection: { authenticatorAttachment: 'platform', requireResidentKey: false, userVerification: 'required' },
+        attestation: 'direct',
+        extensions: { example: true }
+      }
+    });
+
+    mockEndpoint(Endpoint.FINALIZE_PASSKEY_ENROLLMENT, {
+      idToken: 'id-token', refreshToken: 'refresh-token'
+    });
+
+    await signInWithPasskey(auth, 'name', false);
+    expect(auth.currentUser?.uid).to.eq('mock-uid');
+  });
+
   it('should enroll passkey', async () => {
     if (
       typeof navigator === 'undefined' ||
@@ -303,6 +389,37 @@ describe('passkey', async () => {
       expect((error as Error).message).to.equal(
         'The operation either timed out or was not allowed.'
       );
+    }
+  });
+
+  it('should throw NotAllowedError when passkey credential is null during enrollment', async () => {
+    if (
+      typeof navigator === 'undefined' ||
+      typeof navigator.credentials === 'undefined'
+    ) {
+      return;
+    }
+    sinon.stub(navigator.credentials, 'create').resolves(null);
+
+    mockEndpoint(Endpoint.START_PASSKEY_ENROLLMENT, {
+      credentialCreationOptions: {
+        rp: { name: 'mock-rp' },
+        user: { id: 'mockuser', name: 'mock-user', displayName: 'Mock User' },
+        challenge: 'validbase64challenge',
+        pubKeyCredParams: [{ type: 'public-key', alg: -7 }, { type: 'public-key', alg: -257 }],
+        timeout: 60000,
+        excludeCredentials: [],
+        authenticatorSelection: { authenticatorAttachment: 'platform', requireResidentKey: false, userVerification: 'required' },
+        attestation: 'direct',
+        extensions: { example: true }
+      }
+    });
+
+    try {
+      await enrollPasskey(user, 'name');
+      expect.fail('Expected function to throw an error');
+    } catch (error) {
+      expect((error as Error).name).to.equal('NotAllowedError');
     }
   });
 });

--- a/packages/auth/src/core/strategies/passkey.test.ts
+++ b/packages/auth/src/core/strategies/passkey.test.ts
@@ -216,12 +216,19 @@ describe('passkey', async () => {
 
     const serverUser: APIUserInfo = { localId: 'local-id' };
     mockEndpoint(Endpoint.SIGN_UP, {
-      idToken: 'id-token', refreshToken: 'refresh-token', expiresIn: '1234', localId: serverUser.localId!
+      idToken: 'id-token',
+      refreshToken: 'refresh-token',
+      expiresIn: '1234',
+      localId: serverUser.localId!
     });
     mockEndpoint(Endpoint.GET_ACCOUNT_INFO, { users: [serverUser] });
 
     mockEndpoint(Endpoint.START_PASSKEY_SIGNIN, {
-      credentialRequestOptions: { challenge: 'validbase64challenge', rpId: 'rp-id', userVerification: 'required' }
+      credentialRequestOptions: {
+        challenge: 'validbase64challenge',
+        rpId: 'rp-id',
+        userVerification: 'required'
+      }
     });
 
     mockEndpoint(Endpoint.START_PASSKEY_ENROLLMENT, {
@@ -229,17 +236,25 @@ describe('passkey', async () => {
         rp: { name: 'mock-rp' },
         user: { id: 'mockuser', name: 'mock-user', displayName: 'Mock User' },
         challenge: 'validbase64challenge',
-        pubKeyCredParams: [{ type: 'public-key', alg: -7 }, { type: 'public-key', alg: -257 }],
+        pubKeyCredParams: [
+          { type: 'public-key', alg: -7 },
+          { type: 'public-key', alg: -257 }
+        ],
         timeout: 60000,
         excludeCredentials: [],
-        authenticatorSelection: { authenticatorAttachment: 'platform', requireResidentKey: false, userVerification: 'required' },
+        authenticatorSelection: {
+          authenticatorAttachment: 'platform',
+          requireResidentKey: false,
+          userVerification: 'required'
+        },
         attestation: 'direct',
         extensions: { example: true }
       }
     });
 
     mockEndpoint(Endpoint.FINALIZE_PASSKEY_ENROLLMENT, {
-      idToken: 'id-token', refreshToken: 'refresh-token'
+      idToken: 'id-token',
+      refreshToken: 'refresh-token'
     });
 
     await signInWithPasskey(auth, 'name', false);
@@ -258,12 +273,19 @@ describe('passkey', async () => {
 
     const serverUser: APIUserInfo = { localId: 'local-id' };
     mockEndpoint(Endpoint.SIGN_UP, {
-      idToken: 'id-token', refreshToken: 'refresh-token', expiresIn: '1234', localId: serverUser.localId!
+      idToken: 'id-token',
+      refreshToken: 'refresh-token',
+      expiresIn: '1234',
+      localId: serverUser.localId!
     });
     mockEndpoint(Endpoint.GET_ACCOUNT_INFO, { users: [serverUser] });
 
     mockEndpoint(Endpoint.START_PASSKEY_SIGNIN, {
-      credentialRequestOptions: { challenge: 'validbase64challenge', rpId: 'rp-id', userVerification: 'required' }
+      credentialRequestOptions: {
+        challenge: 'validbase64challenge',
+        rpId: 'rp-id',
+        userVerification: 'required'
+      }
     });
 
     mockEndpoint(Endpoint.START_PASSKEY_ENROLLMENT, {
@@ -271,17 +293,25 @@ describe('passkey', async () => {
         rp: { name: 'mock-rp' },
         user: { id: 'mockuser', name: 'mock-user', displayName: 'Mock User' },
         challenge: 'validbase64challenge',
-        pubKeyCredParams: [{ type: 'public-key', alg: -7 }, { type: 'public-key', alg: -257 }],
+        pubKeyCredParams: [
+          { type: 'public-key', alg: -7 },
+          { type: 'public-key', alg: -257 }
+        ],
         timeout: 60000,
         excludeCredentials: [],
-        authenticatorSelection: { authenticatorAttachment: 'platform', requireResidentKey: false, userVerification: 'required' },
+        authenticatorSelection: {
+          authenticatorAttachment: 'platform',
+          requireResidentKey: false,
+          userVerification: 'required'
+        },
         attestation: 'direct',
         extensions: { example: true }
       }
     });
 
     mockEndpoint(Endpoint.FINALIZE_PASSKEY_ENROLLMENT, {
-      idToken: 'id-token', refreshToken: 'refresh-token'
+      idToken: 'id-token',
+      refreshToken: 'refresh-token'
     });
 
     await signInWithPasskey(auth, 'name', false);
@@ -406,10 +436,17 @@ describe('passkey', async () => {
         rp: { name: 'mock-rp' },
         user: { id: 'mockuser', name: 'mock-user', displayName: 'Mock User' },
         challenge: 'validbase64challenge',
-        pubKeyCredParams: [{ type: 'public-key', alg: -7 }, { type: 'public-key', alg: -257 }],
+        pubKeyCredParams: [
+          { type: 'public-key', alg: -7 },
+          { type: 'public-key', alg: -257 }
+        ],
         timeout: 60000,
         excludeCredentials: [],
-        authenticatorSelection: { authenticatorAttachment: 'platform', requireResidentKey: false, userVerification: 'required' },
+        authenticatorSelection: {
+          authenticatorAttachment: 'platform',
+          requireResidentKey: false,
+          userVerification: 'required'
+        },
         attestation: 'direct',
         extensions: { example: true }
       }

--- a/packages/auth/src/core/strategies/passkey.ts
+++ b/packages/auth/src/core/strategies/passkey.ts
@@ -49,7 +49,7 @@ const PASSKEY_LOOK_UP_ERROR_MESSAGE =
  * Signs in a user with a passkey. Use enrollPasskey to enroll a passkey credential for the current user.
  * @param auth - The Firebase Auth instance.
  * @param name - The user's name for passkey.
- * @param manualSignUp - When false, automatically creates an anonymous user if a passkey credential does not exist. Defaults to false.
+ * @param manualSignUp - When false, automatically creates an anonymous user if a passkey credential does not exist. Due to browser limitations, this will also trigger if the user cancels the native passkey prompt. Defaults to false.
  * @returns A promise that resolves with a `UserCredential` object.
  */
 export async function signInWithPasskey(

--- a/packages/auth/src/core/strategies/passkey.ts
+++ b/packages/auth/src/core/strategies/passkey.ts
@@ -100,8 +100,9 @@ export async function signInWithPasskey(
     return userCredential;
   } catch (error) {
     if (
-      ((error as Error).name === 'NotAllowedError' ||
-        (error as Error).message.includes(PASSKEY_LOOK_UP_ERROR_MESSAGE)) &&
+      error instanceof Error &&
+      (error.name === 'NotAllowedError' ||
+        error.message.includes(PASSKEY_LOOK_UP_ERROR_MESSAGE)) &&
       !manualSignUp
     ) {
       // If the user is not signed up, sign them up anonymously

--- a/packages/auth/src/core/strategies/passkey.ts
+++ b/packages/auth/src/core/strategies/passkey.ts
@@ -153,7 +153,9 @@ export async function enrollPasskey(
     })) as PublicKeyCredential;
 
     if (!credential) {
-      const err = new Error('The operation either timed out or was not allowed.');
+      const err = new Error(
+        'The operation either timed out or was not allowed.'
+      );
       err.name = 'NotAllowedError';
       throw err;
     }

--- a/packages/auth/src/core/strategies/passkey.ts
+++ b/packages/auth/src/core/strategies/passkey.ts
@@ -75,6 +75,12 @@ export async function signInWithPasskey(
       publicKey: options
     })) as PublicKeyCredential;
 
+    if (!credential) {
+      const err = new Error(PASSKEY_LOOK_UP_ERROR_MESSAGE);
+      err.name = 'NotAllowedError';
+      throw err;
+    }
+
     const finalizeSignInRequest: FinalizePasskeySignInRequest = {
       authenticatorAuthenticationResponse:
         publicKeyCredentialToJSON(credential),
@@ -94,7 +100,8 @@ export async function signInWithPasskey(
     return userCredential;
   } catch (error) {
     if (
-      (error as Error).message.includes(PASSKEY_LOOK_UP_ERROR_MESSAGE) &&
+      ((error as Error).name === 'NotAllowedError' ||
+        (error as Error).message.includes(PASSKEY_LOOK_UP_ERROR_MESSAGE)) &&
       !manualSignUp
     ) {
       // If the user is not signed up, sign them up anonymously
@@ -143,6 +150,13 @@ export async function enrollPasskey(
     const credential = (await navigator.credentials.create({
       publicKey: options
     })) as PublicKeyCredential;
+
+    if (!credential) {
+      const err = new Error('The operation either timed out or was not allowed.');
+      err.name = 'NotAllowedError';
+      throw err;
+    }
+
     const idToken = await userInternal.getIdToken();
     const finalizeEnrollmentRequest: FinalizePasskeyEnrollmentRequest = {
       idToken,


### PR DESCRIPTION
Correct issue causing the passkey signIn with manualSignUp = false on iOS devices to fail to trigger anonymous sign in followed by passkey creation/enrollment.

Previously on iOS, cancelling the system "Sign in" with passkey bottom sheet would not trigger the expected fallback handling of anonymous sign in as the call to .get() returned null instead of throwing. We are now catching the empty credential and treating it identical to the case of an error being thrown on cancellation/timeout.