### PR TITLE
App Start Ending Early Bug Fix

### DIFF
--- a/packages/crashlytics/src/tracing/root-span-context-manager.test.ts
+++ b/packages/crashlytics/src/tracing/root-span-context-manager.test.ts
@@ -286,16 +286,21 @@ describe('RootSpanContextManager', () => {
 
   describe('app-start root span', () => {
     it('should stay open for app-start root span until documentLoad span ends', () => {
-      const rootSpan = manager.startRootSpan(mockTracer as Tracer, 'span-1');
-      recordResourceFetchSpanStart(rootSpan, 'doc-load');
+      const rootSpan = manager.startRootSpan(mockTracer as Tracer, 'app-start');
       expect(manager.getActiveRootSpan()).to.equal(rootSpan);
 
-      clock.tick(QUIESCENCE_WINDOW_MS); // advance past quiescence window
-
+      // Check 1: Advance past quiescence prior to doc-load starting
+      clock.tick(QUIESCENCE_WINDOW_MS);
       expect(mockSpan.end.called).to.be.false;
 
-      recordResourceFetchSpanEnd(rootSpan, 'doc-load', 100);
-      clock.tick(QUIESCENCE_WINDOW_MS); // let quiescence complete
+      // Check 2: Start doc-load and advance past quiescence while in-flight
+      recordResourceFetchSpanStart(rootSpan, 'doc-load');
+      clock.tick(QUIESCENCE_WINDOW_MS);
+      expect(mockSpan.end.called).to.be.false;
+
+      // Check 3: End doc-load and verify root span closes after post-load quiescence
+      recordResourceFetchSpanEnd(rootSpan, 'doc-load', 300);
+      clock.tick(QUIESCENCE_WINDOW_MS);
 
       expect(mockSpan.end.called).to.be.true;
       expect(manager.getActiveRootSpan()).to.be.undefined;

--- a/packages/crashlytics/src/tracing/root-span-context-manager.test.ts
+++ b/packages/crashlytics/src/tracing/root-span-context-manager.test.ts
@@ -100,6 +100,7 @@ describe('RootSpanContextManager', () => {
     id: string = 'net-1'
   ): void => {
     rootSpan.onResourceFetchSpanStart({
+      name: id === 'doc-load' ? 'documentLoad' : id,
       spanContext: () => ({ spanId: id })
     } as any);
   };
@@ -110,6 +111,7 @@ describe('RootSpanContextManager', () => {
     endTimeMs: number = Date.now()
   ): void => {
     rootSpan.onResourceFetchSpanEnd({
+      name: id === 'doc-load' ? 'documentLoad' : id,
       spanContext: () => ({ spanId: id }),
       endTime: [Math.floor(endTimeMs / 1000), (endTimeMs % 1000) * 1000000]
     } as any);
@@ -283,7 +285,7 @@ describe('RootSpanContextManager', () => {
   });
 
   describe('app-start root span', () => {
-    it('should stay open for app-start root span until markDocumentLoaded is called', () => {
+    it('should stay open for app-start root span until documentLoad span ends', () => {
       const rootSpan = manager.startRootSpan(mockTracer as Tracer, 'span-1');
       recordResourceFetchSpanStart(rootSpan, 'doc-load');
       expect(manager.getActiveRootSpan()).to.equal(rootSpan);

--- a/packages/crashlytics/src/tracing/root-span-context-manager.ts
+++ b/packages/crashlytics/src/tracing/root-span-context-manager.ts
@@ -50,7 +50,6 @@ class UiRenderSpanManager {
   private isInterrupted = false;
 
   constructor(
-    private parentSpan: Span,
     private tracer: Tracer,
     private onRenderStart: () => void,
     private onRenderEnd: () => void
@@ -130,13 +129,12 @@ class UiRenderSpanManager {
   }
 
   private startUiRenderSpan(startTimeMs: number = Date.now()): void {
-    const parentContext = trace.setSpan(context.active(), this.parentSpan);
     this.activeRenderSpan = this.tracer.startSpan(
       'UI Render',
       {
         startTime: startTimeMs
       },
-      parentContext
+      context.active()
     );
   }
 
@@ -155,18 +153,29 @@ class UiRenderSpanManager {
 class ResourceFetchSpans {
   private activeSpanIds: Set<string>;
   private lastSpanCompletedAtMs?: number;
+  private isDocumentLoaded: boolean;
 
-  constructor() {
+  constructor(isAppStart: boolean = false) {
     this.activeSpanIds = new Set<string>();
     this.lastSpanCompletedAtMs = undefined;
+    this.isDocumentLoaded = !isAppStart;
   }
 
   hasActiveSpans(): boolean {
-    return this.activeSpanIds.size > 0;
+    return !this.isDocumentLoaded || this.activeSpanIds.size > 0;
   }
 
   getLastSpanCompletedAtMs(): number | undefined {
     return this.lastSpanCompletedAtMs;
+  }
+
+  setLastSpanCompletedAtMs(completedAtMs: number): void {
+    if (
+      this.lastSpanCompletedAtMs === undefined ||
+      completedAtMs > this.lastSpanCompletedAtMs
+    ) {
+      this.lastSpanCompletedAtMs = completedAtMs;
+    }
   }
 
   recordResourceFetchSpanStart(span: Span): void {
@@ -175,13 +184,11 @@ class ResourceFetchSpans {
 
   recordResourceFetchSpanEnd(span: ReadableSpan): void {
     if (this.activeSpanIds.delete(span.spanContext().spanId)) {
-      const completedAtMs = hrTimeToMilliseconds(span.endTime);
-      if (
-        this.lastSpanCompletedAtMs === undefined ||
-        completedAtMs > this.lastSpanCompletedAtMs
-      ) {
-        this.lastSpanCompletedAtMs = completedAtMs;
+      if (span.name === 'documentLoad') {
+        this.isDocumentLoaded = true;
       }
+      const completedAtMs = hrTimeToMilliseconds(span.endTime);
+      this.setLastSpanCompletedAtMs(completedAtMs);
     }
   }
 }
@@ -206,7 +213,6 @@ export class RootSpan {
    * and starting the root span quiescence tracking.
    * @param span The OpenTelemetry Span wrapped by this instance.
    * @param manager The context manager that manages active root spans.
-   * @param type The type of root span ('app-start' or 'user-interaction').
    * @param tracer The tracer used to start child spans (e.g. UI Render spans).
    */
   constructor(span: Span, manager: RootSpanContextManager, tracer: Tracer) {
@@ -219,9 +225,10 @@ export class RootSpan {
       ? hrTimeToMilliseconds(sdkSpan.startTime)
       : Date.now();
     this.quiescenceTimerId = null;
-    this.resourceFetchSpans = new ResourceFetchSpans();
+    this.resourceFetchSpans = new ResourceFetchSpans(
+      sdkSpan.name === 'app-start'
+    );
     this.uiRenderSpanManager = new UiRenderSpanManager(
-      this.span,
       this.tracer,
       () => this.clearQuiesce(),
       () => this.quiesce()

--- a/packages/crashlytics/src/tracing/root-span-context-manager.ts
+++ b/packages/crashlytics/src/tracing/root-span-context-manager.ts
@@ -153,12 +153,10 @@ class UiRenderSpanManager {
 class ResourceFetchSpans {
   private activeSpanIds: Set<string>;
   private lastSpanCompletedAtMs?: number;
-  private isDocumentLoaded: boolean;
 
-  constructor(isAppStart: boolean = false) {
+  constructor(private isDocumentLoaded: boolean) {
     this.activeSpanIds = new Set<string>();
     this.lastSpanCompletedAtMs = undefined;
-    this.isDocumentLoaded = !isAppStart;
   }
 
   hasActiveSpans(): boolean {
@@ -226,7 +224,7 @@ export class RootSpan {
       : Date.now();
     this.quiescenceTimerId = null;
     this.resourceFetchSpans = new ResourceFetchSpans(
-      sdkSpan.name === 'app-start'
+      sdkSpan.name !== 'app-start'
     );
     this.uiRenderSpanManager = new UiRenderSpanManager(
       this.tracer,

--- a/packages/crashlytics/src/tracing/root-span-context-manager.ts
+++ b/packages/crashlytics/src/tracing/root-span-context-manager.ts
@@ -167,7 +167,7 @@ class ResourceFetchSpans {
     return this.lastSpanCompletedAtMs;
   }
 
-  setLastSpanCompletedAtMs(completedAtMs: number): void {
+  private setLastSpanCompletedAtMs(completedAtMs: number): void {
     if (
       this.lastSpanCompletedAtMs === undefined ||
       completedAtMs > this.lastSpanCompletedAtMs


### PR DESCRIPTION
Fixes app start root span ending early bug by: 

- creating a check for a boolean isDocumentLoaded on root span end
- quiescing app start root span if isDocumentLoaded is not true
- setting context for UI render start to be the active context to avoid using stale root spans as context
- adding to existing test a check prior to the start of doc-load span to test early end edge case