### PR TITLE
chore(data-connect): refactor streaming tests and change idle timeout back to 15s

### DIFF
--- a/.changeset/wild-mugs-exercise.md
+++ b/.changeset/wild-mugs-exercise.md
@@ -1,0 +1,6 @@
+---
+'@firebase/data-connect': minor
+'firebase': minor
+---
+
+Refactor data connect streaming tests and revert to 15 second idle timeout for streaming connections (doesn't need a public release note)

--- a/.changeset/wild-mugs-exercise.md
+++ b/.changeset/wild-mugs-exercise.md
@@ -1,6 +1,5 @@
 ---
-'@firebase/data-connect': minor
-'firebase': minor
+'@firebase/data-connect': patch
 ---
 
 Refactor data connect streaming tests and revert to 15 second idle timeout for streaming connections (doesn't need a public release note)

--- a/packages/data-connect/src/network/stream/streamTransport.ts
+++ b/packages/data-connect/src/network/stream/streamTransport.ts
@@ -49,14 +49,14 @@ import {
 const FIRST_REQUEST_ID = 1;
 
 /** Time to wait before closing an idle connection (no active subscriptions). */
-const IDLE_CONNECTION_TIMEOUT_MS = 0; // immediate close
+const IDLE_CONNECTION_TIMEOUT_MS = 15 * 1000; // 15 seconds
 
 /** Initial reconnect delay in ms */
-const INITIAL_RECONNECT_DELAY_MS = 1000;
+const INITIAL_RECONNECT_DELAY_MS = 1000; // 1 second
 /** Max reconnect delay in ms */
-const MAX_RECONNECT_DELAY_MS = 30000;
+const MAX_RECONNECT_DELAY_MS = 30 * 1000; // 30 seconds
 /** Max random jitter to add to reconnect delay in ms */
-const MAX_RECONNECT_JITTER_MS = 500;
+const MAX_RECONNECT_JITTER_MS = 0.5 * 1000; // 0.5 seconds
 /** Factor to multiply delay by on failure */
 const RECONNECT_BACKOFF_FACTOR = 1.3;
 /** Max number of reconnection attempts before giving up */

--- a/packages/data-connect/test/unit/streamTransport.test.ts
+++ b/packages/data-connect/test/unit/streamTransport.test.ts
@@ -49,6 +49,15 @@ chai.use(chaiAsPromised);
 
 class TestStreamTransport extends AbstractDataConnectStreamTransport {
   private isTestConnected = true;
+  private closeTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  async cleanupAndTerminate(code?: Code, reason?: string): Promise<void> {
+    if (this.closeTimeout) {
+      clearTimeout(this.closeTimeout);
+      this.closeTimeout = null;
+    }
+    return super.cleanupAndTerminate(code, reason);
+  }
 
   get streamIsReady(): boolean {
     return this.isTestConnected;
@@ -67,7 +76,8 @@ class TestStreamTransport extends AbstractDataConnectStreamTransport {
       return Promise.resolve();
     }
     this.isTestConnected = false;
-    setTimeout(() => {
+    this.closeTimeout = setTimeout(() => {
+      this.closeTimeout = null;
       this.onStreamClose(1000, 'Closed');
     }, 0);
     return Promise.resolve();

--- a/packages/data-connect/test/unit/streamTransport.test.ts
+++ b/packages/data-connect/test/unit/streamTransport.test.ts
@@ -42,14 +42,16 @@ import {
   SubscribeStreamRequest
 } from '../../src/network/stream/wire';
 
-import { expectIsNotSettled, sleep } from './testUtils';
+import { expectIsNotSettled, flushMicrotasks, sleep } from './testUtils';
 
 chai.use(sinonChai);
 chai.use(chaiAsPromised);
 
 class TestStreamTransport extends AbstractDataConnectStreamTransport {
+  private isTestConnected = true;
+
   get streamIsReady(): boolean {
-    return true;
+    return this.isTestConnected;
   }
 
   get endpointUrl(): string {
@@ -57,12 +59,21 @@ class TestStreamTransport extends AbstractDataConnectStreamTransport {
   }
 
   protected openConnection(): Promise<void> {
+    this.isTestConnected = true;
     return Promise.resolve();
   }
   protected closeConnection(): Promise<void> {
+    if (!this.isTestConnected) {
+      return Promise.resolve();
+    }
+    this.isTestConnected = false;
+    setTimeout(() => {
+      this.onStreamClose(1000, 'Closed');
+    }, 0);
     return Promise.resolve();
   }
   protected ensureConnection(): Promise<void> {
+    this.isTestConnected = true;
     return Promise.resolve();
   }
   protected sendMessage<Variables>(
@@ -182,6 +193,8 @@ interface TransportWithInternals {
   attemptReconnect(): void;
   onOnlineEventListener(): void;
   onVisibilityChangeEventListener(): void;
+  onConnectionReady(): void;
+  isTestConnected: boolean;
 }
 
 describe('AbstractDataConnectStreamTransport', () => {
@@ -1496,8 +1509,8 @@ describe('AbstractDataConnectStreamTransport', () => {
         });
 
         it('should clean map correctly when handleResponse rejects', async () => {
-          transport.invokeMutation(mutationName1, variables1).catch(() => {});
-          transport.invokeMutation(mutationName2, variables2).catch(() => {});
+          transport.invokeMutation(mutationName1, variables1).catch(() => { });
+          transport.invokeMutation(mutationName2, variables2).catch(() => { });
           const expectedKey1 = transport.getMapKey(mutationName1, variables1);
           const expectedKey2 = transport.getMapKey(mutationName2, variables2);
           const activeRequests1 =
@@ -1633,118 +1646,122 @@ describe('AbstractDataConnectStreamTransport', () => {
       clock.restore();
     });
 
-    it('should close connection immediately when idle (no active subscriptions)', async () => {
-      const closeSpy = sinon.spy(transport, 'closeConnection');
-      sinon.stub(transport, 'sendMessage').resolves();
-      const observer = {
-        onData: sinon.spy(),
-        onDisconnect: sinon.spy(),
-        onError: sinon.spy()
-      };
+    describe('Idle Timeout', () => {
+      const IDLE_CONNECTION_TIMEOUT_MS = 15 * 1000; // 15 seconds, copied from real implementation
 
-      await transport.invokeSubscribe(observer, queryName1, variables1);
-      await transport.invokeUnsubscribe(queryName1, variables1);
+      it('should close connection after grace period when idle (no active subscriptions)', async () => {
+        const closeSpy = sinon.spy(transport, 'closeConnection');
+        sinon.stub(transport, 'sendMessage').resolves();
+        const observer = {
+          onData: sinon.spy(),
+          onDisconnect: sinon.spy(),
+          onError: sinon.spy()
+        };
 
-      expect(closeSpy).to.not.have.been.called;
+        await transport.invokeSubscribe(observer, queryName1, variables1);
+        await transport.invokeUnsubscribe(queryName1, variables1);
 
-      await clock.tickAsync(0);
-      expect(closeSpy).to.have.been.calledOnce;
-    });
+        expect(closeSpy).to.not.have.been.called;
 
-    it('should cancel close if a new subscription arrives during timeout', async () => {
-      const closeSpy = sinon.spy(transport, 'closeConnection');
-      sinon.stub(transport, 'sendMessage').resolves();
-      const observer = {
-        onData: sinon.spy(),
-        onDisconnect: sinon.spy(),
-        onError: sinon.spy()
-      };
+        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS);
+        expect(closeSpy).to.have.been.calledOnce;
+      });
 
-      await transport.invokeSubscribe(observer, queryName1, variables1);
-      await transport.invokeUnsubscribe(queryName1, variables1);
+      it('should cancel close if a new subscription arrives during timeout', async () => {
+        const closeSpy = sinon.spy(transport, 'closeConnection');
+        sinon.stub(transport, 'sendMessage').resolves();
+        const observer = {
+          onData: sinon.spy(),
+          onDisconnect: sinon.spy(),
+          onError: sinon.spy()
+        };
 
-      expect(closeSpy).to.not.have.been.called;
+        await transport.invokeSubscribe(observer, queryName1, variables1);
+        await transport.invokeUnsubscribe(queryName1, variables1);
 
-      await transport.invokeSubscribe(observer, queryName2, variables2);
+        expect(closeSpy).to.not.have.been.called;
 
-      await clock.tickAsync(0);
-      expect(closeSpy).to.not.have.been.called;
-    });
+        await transport.invokeSubscribe(observer, queryName2, variables2);
 
-    it('should restart close timeout if subscribe fails and leaves no active subscriptions', async () => {
-      const closeSpy = sinon.spy(transport, 'closeConnection');
-      const sendMessageStub = sinon.stub(transport, 'sendMessage');
-      sendMessageStub.resolves();
-      const observer = {
-        onData: sinon.spy(),
-        onDisconnect: sinon.spy(),
-        onError: sinon.spy()
-      };
+        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS);
+        expect(closeSpy).to.not.have.been.called;
+      });
 
-      await transport.invokeSubscribe(observer, queryName1, variables1);
-      await transport.invokeUnsubscribe(queryName1, variables1);
+      it('should restart close timeout if subscribe fails and leaves no active subscriptions', async () => {
+        const closeSpy = sinon.spy(transport, 'closeConnection');
+        const sendMessageStub = sinon.stub(transport, 'sendMessage');
+        sendMessageStub.resolves();
+        const observer = {
+          onData: sinon.spy(),
+          onDisconnect: sinon.spy(),
+          onError: sinon.spy()
+        };
 
-      sendMessageStub.rejects();
-      await transport.invokeSubscribe(observer, queryName2, variables2);
+        await transport.invokeSubscribe(observer, queryName1, variables1);
+        await transport.invokeUnsubscribe(queryName1, variables1);
 
-      await Promise.resolve(); // let microtasks run
-      expect(closeSpy).to.not.have.been.called;
+        sendMessageStub.rejects();
+        await transport.invokeSubscribe(observer, queryName2, variables2);
 
-      await clock.tickAsync(0);
-      expect(closeSpy).to.have.been.calledOnce;
-    });
+        await flushMicrotasks(1);
+        expect(closeSpy).to.not.have.been.called;
 
-    it('should not close connection if there are active execute requests', async () => {
-      const closeSpy = sinon.spy(transport, 'closeConnection');
-      sinon.stub(transport, 'sendMessage').resolves();
-      const observer = {
-        onData: sinon.spy(),
-        onDisconnect: sinon.spy(),
-        onError: sinon.spy()
-      };
+        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS);
+        expect(closeSpy).to.have.been.calledOnce;
+      });
 
-      await transport.invokeSubscribe(observer, queryName1, variables1);
-      await transport.invokeUnsubscribe(queryName1, variables1);
+      it('should not close connection if there are active execute requests', async () => {
+        const closeSpy = sinon.spy(transport, 'closeConnection');
+        sinon.stub(transport, 'sendMessage').resolves();
+        const observer = {
+          onData: sinon.spy(),
+          onDisconnect: sinon.spy(),
+          onError: sinon.spy()
+        };
 
-      void transport.invokeQuery(queryName2, variables2);
+        await transport.invokeSubscribe(observer, queryName1, variables1);
+        await transport.invokeUnsubscribe(queryName1, variables1);
 
-      await clock.tickAsync(0);
-      expect(closeSpy).to.not.have.been.called;
-    });
+        void transport.invokeQuery(queryName2, variables2);
 
-    it('should close connection when last execute request finishes after idle timeout', async () => {
-      const closeSpy = sinon.spy(transport, 'closeConnection');
-      sinon.stub(transport, 'sendMessage').resolves();
-      const observer = {
-        onData: sinon.spy(),
-        onDisconnect: sinon.spy(),
-        onError: sinon.spy()
-      };
+        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS);
+        expect(closeSpy).to.not.have.been.called;
+      });
 
-      await transport.invokeSubscribe(observer, queryName1, variables1);
-      await transport.invokeUnsubscribe(queryName1, variables1);
+      it('should close connection when last execute request finishes after idle timeout', async () => {
+        const closeSpy = sinon.spy(transport, 'closeConnection');
+        sinon.stub(transport, 'sendMessage').resolves();
+        const observer = {
+          onData: sinon.spy(),
+          onDisconnect: sinon.spy(),
+          onError: sinon.spy()
+        };
 
-      const queryPromise = transport.invokeQuery(queryName2, variables2);
+        await transport.invokeSubscribe(observer, queryName1, variables1);
+        await transport.invokeUnsubscribe(queryName1, variables1);
 
-      await clock.tickAsync(0);
-      expect(closeSpy).to.not.have.been.called;
+        const queryPromise = transport.invokeQuery(queryName2, variables2);
 
-      const expectedKey = transport.getMapKey(queryName2, variables2);
-      const request = transport.activeInvokeQueryRequests.get(expectedKey);
-      const requestId = request!.requestId;
+        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS);
+        expect(closeSpy).to.not.have.been.called;
 
-      const dummyResponse = {
-        data: { result: 'result' },
-        errors: [],
-        extensions: {}
-      };
-      await transport.invokeHandleResponse(requestId, dummyResponse);
-      await queryPromise;
+        const expectedKey = transport.getMapKey(queryName2, variables2);
+        const request = transport.activeInvokeQueryRequests.get(expectedKey);
+        const requestId = request!.requestId;
 
-      // fast forward time again because the new idle timeout started when the query completed
-      await clock.tickAsync(0);
+        const dummyResponse = {
+          data: { result: 'result' },
+          errors: [],
+          extensions: {}
+        };
+        await transport.invokeHandleResponse(requestId, dummyResponse);
+        await queryPromise;
 
-      expect(closeSpy).to.have.been.calledOnce;
+        // fast forward time again because the new idle timeout started when the query completed
+        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS);
+
+        expect(closeSpy).to.have.been.calledOnce;
+      });
     });
 
     describe('Auth Disconnects', () => {
@@ -1839,48 +1856,6 @@ describe('AbstractDataConnectStreamTransport', () => {
         expect(closeSpy).to.not.have.been.called;
       });
     });
-  });
-
-  describe('Reconnection', () => {
-    let clock: sinon.SinonFakeTimers;
-    let sendMessageStub: sinon.SinonStub;
-    let ensureConnectionStub: sinon.SinonStub;
-
-    beforeEach(() => {
-      clock = sinon.useFakeTimers();
-      sendMessageStub = sinon.stub(transport, 'sendMessage').resolves();
-      ensureConnectionStub = sinon
-        .stub(transport, 'ensureConnection')
-        .resolves();
-    });
-
-    afterEach(() => {
-      clock.restore();
-      sinon.restore();
-    });
-
-    it('should start backoff on unexpected disconnect', async () => {
-      const observer = {
-        onData: sinon.spy(),
-        onDisconnect: sinon.spy(),
-        onError: sinon.spy()
-      };
-      transport.invokeSubscribe(observer, queryName1, variables1);
-
-      // Trigger unexpected disconnect (code 1006)
-      transport.onStreamClose(1006, 'Abnormal Closure');
-
-      // Should have started timer
-      expect(transport.reconnectTimer).to.not.be.null;
-    });
-
-    it('should NOT start backoff on graceful close with no subscriptions', async () => {
-      // No active subscriptions
-      transport.onStreamClose(1000, 'Normal Closure');
-
-      // Should NOT have started timer
-      expect(transport.reconnectTimer).to.be.null;
-    });
 
     it('should fail all pending mutations on unexpected disconnect', async () => {
       const observer = {
@@ -1903,80 +1878,128 @@ describe('AbstractDataConnectStreamTransport', () => {
       expect(transport.activeInvokeMutationRequests.size).to.equal(0);
     });
 
-    it('should re-request active subscriptions and queries on successful reconnect', async () => {
-      const attemptReconnectSpy = sinon.spy(transport, 'attemptReconnect');
-      const observer = {
-        onData: sinon.spy(),
-        onDisconnect: sinon.spy(),
-        onError: sinon.spy()
-      };
-      transport.invokeSubscribe(observer, queryName1, variables1);
+  });
 
-      // Stagger an execute request
-      void transport.invokeQuery(queryName1, variables1);
+  describe('Reconnects', () => {
+    let clock: sinon.SinonFakeTimers;
+    let sendMessageStub: sinon.SinonStub;
+    let ensureConnectionStub: sinon.SinonStub;
 
-      sendMessageStub.resetHistory();
-
-      // Trigger unexpected disconnect
-      transport.onStreamClose(1006, 'Abnormal Closure');
-
-      // Fast forward time to trigger reconnect
-      await clock.tickAsync(2000); // Default is 1000 + jitter
-      expect(attemptReconnectSpy).to.have.been.calledOnce;
-      expect(ensureConnectionStub).to.have.been.calledOnce;
-
-      // Should re-send subscribe and then query
-      expect(sendMessageStub).to.have.been.calledTwice;
-      const firstSent = sendMessageStub.firstCall.args[0];
-      const secondSent = sendMessageStub.secondCall.args[0];
-
-      expect(firstSent.subscribe).to.not.be.undefined;
-      expect(secondSent.resume).to.not.be.undefined;
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+      sendMessageStub = sinon.stub(transport, 'sendMessage').resolves();
+      ensureConnectionStub = sinon
+        .stub(transport, 'ensureConnection')
+        .callsFake(() => {
+          transport.isTestConnected = true;
+          return Promise.resolve();
+        });
     });
 
-    it('onOnline should trigger immediate reconnect if waiting', async () => {
-      const observer = {
-        onData: sinon.spy(),
-        onDisconnect: sinon.spy(),
-        onError: sinon.spy()
-      };
-      transport.invokeSubscribe(observer, queryName1, variables1);
-      transport.onStreamClose(1006, 'Abnormal Closure');
-
-      expect(transport.reconnectTimer).to.not.be.null;
-
-      transport.onOnlineEventListener();
-
-      expect(ensureConnectionStub).to.have.been.calledOnce;
-      expect(transport.reconnectTimer).to.be.null;
+    afterEach(() => {
+      clock.restore();
+      sinon.restore();
     });
 
-    it('onVisibilityChange should trigger immediate reconnect if waiting', async () => {
-      const isBrowser = typeof window !== 'undefined';
-      if (!isBrowser) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (global as any).document = { visibilityState: 'visible' };
-      }
+    describe('Automatic and Intelligent Reconnection', () => {
+      it('should start backoff on unexpected disconnect', async () => {
+        const observer = {
+          onData: sinon.spy(),
+          onDisconnect: sinon.spy(),
+          onError: sinon.spy()
+        };
+        transport.invokeSubscribe(observer, queryName1, variables1);
 
-      const observer = {
-        onData: sinon.spy(),
-        onDisconnect: sinon.spy(),
-        onError: sinon.spy()
-      };
-      transport.invokeSubscribe(observer, queryName1, variables1);
-      transport.onStreamClose(1006, 'Abnormal Closure');
+        // Trigger unexpected disconnect (code 1006)
+        transport.onStreamClose(1006, 'Abnormal Closure');
 
-      expect(transport.reconnectTimer).to.not.be.null;
+        // Should have started timer
+        expect(transport.reconnectTimer).to.not.be.null;
+      });
 
-      transport.onVisibilityChangeEventListener();
+      it('should NOT start backoff on graceful close with no subscriptions', async () => {
+        // No active subscriptions
+        transport.onStreamClose(1000, 'Normal Closure');
 
-      expect(ensureConnectionStub).to.have.been.calledOnce;
-      expect(transport.reconnectTimer).to.be.null;
+        // Should NOT have started timer
+        expect(transport.reconnectTimer).to.be.null;
+      });
 
-      if (!isBrowser) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        delete (global as any).document;
-      }
+      it('onOnline should trigger immediate reconnect if waiting', async () => {
+        const observer = {
+          onData: sinon.spy(),
+          onDisconnect: sinon.spy(),
+          onError: sinon.spy()
+        };
+        transport.invokeSubscribe(observer, queryName1, variables1);
+        transport.onStreamClose(1006, 'Abnormal Closure');
+
+        expect(transport.reconnectTimer).to.not.be.null;
+
+        transport.onOnlineEventListener();
+
+        expect(ensureConnectionStub).to.have.been.calledOnce;
+        expect(transport.reconnectTimer).to.be.null;
+      });
+
+      it('onVisibilityChange should trigger immediate reconnect if waiting', async () => {
+        const isBrowser = typeof window !== 'undefined';
+        if (!isBrowser) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (global as any).document = { visibilityState: 'visible' };
+        }
+
+        const observer = {
+          onData: sinon.spy(),
+          onDisconnect: sinon.spy(),
+          onError: sinon.spy()
+        };
+        transport.invokeSubscribe(observer, queryName1, variables1);
+        transport.onStreamClose(1006, 'Abnormal Closure');
+
+        expect(transport.reconnectTimer).to.not.be.null;
+
+        transport.onVisibilityChangeEventListener();
+
+        expect(ensureConnectionStub).to.have.been.calledOnce;
+        expect(transport.reconnectTimer).to.be.null;
+
+        if (!isBrowser) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          delete (global as any).document;
+        }
+      });
+
+      it('should re-request active subscriptions and queries on successful reconnect', async () => {
+        const attemptReconnectSpy = sinon.spy(transport, 'attemptReconnect');
+        const observer = {
+          onData: sinon.spy(),
+          onDisconnect: sinon.spy(),
+          onError: sinon.spy()
+        };
+        transport.invokeSubscribe(observer, queryName1, variables1);
+
+        // Stagger an execute request
+        void transport.invokeQuery(queryName1, variables1);
+
+        sendMessageStub.resetHistory();
+
+        // Trigger unexpected disconnect
+        transport.onStreamClose(1006, 'Abnormal Closure');
+
+        // Fast forward time to trigger reconnect
+        await clock.tickAsync(2000); // Default is 1000 + jitter
+        expect(attemptReconnectSpy).to.have.been.calledOnce;
+        expect(ensureConnectionStub).to.have.been.calledOnce;
+
+        // Should re-send subscribe and then query
+        expect(sendMessageStub).to.have.been.calledTwice;
+        const firstSent = sendMessageStub.firstCall.args[0];
+        const secondSent = sendMessageStub.secondCall.args[0];
+
+        expect(firstSent.subscribe).to.not.be.undefined;
+        expect(secondSent.resume).to.not.be.undefined;
+      });
     });
   });
 
@@ -2013,10 +2036,10 @@ describe('AbstractDataConnectStreamTransport', () => {
         hadRemoveEventListener = 'removeEventListener' in anyGlobalThis;
 
         if (!hadAddEventListener) {
-          anyGlobalThis.addEventListener = () => {};
+          anyGlobalThis.addEventListener = () => { };
         }
         if (!hadRemoveEventListener) {
-          anyGlobalThis.removeEventListener = () => {};
+          anyGlobalThis.removeEventListener = () => { };
         }
 
         removeEventListenerSpy = sinon.spy(

--- a/packages/data-connect/test/unit/streamTransport.test.ts
+++ b/packages/data-connect/test/unit/streamTransport.test.ts
@@ -1857,7 +1857,7 @@ describe('AbstractDataConnectStreamTransport', () => {
       });
     });
 
-    it('should fail all pending mutations on unexpected disconnect', async () => {
+    it('should fail all active mutations on unexpected disconnect', async () => {
       const observer = {
         onData: sinon.spy(),
         onDisconnect: sinon.spy(),
@@ -1877,7 +1877,6 @@ describe('AbstractDataConnectStreamTransport', () => {
       );
       expect(transport.activeInvokeMutationRequests.size).to.equal(0);
     });
-
   });
 
   describe('Reconnects', () => {
@@ -1925,6 +1924,37 @@ describe('AbstractDataConnectStreamTransport', () => {
         expect(transport.reconnectTimer).to.be.null;
       });
 
+      it('should re-request active subscriptions and queries on successful reconnect', async () => {
+        const attemptReconnectSpy = sinon.spy(transport, 'attemptReconnect');
+        const observer = {
+          onData: sinon.spy(),
+          onDisconnect: sinon.spy(),
+          onError: sinon.spy()
+        };
+        transport.invokeSubscribe(observer, queryName1, variables1);
+
+        // Stagger an execute request
+        void transport.invokeQuery(queryName1, variables1);
+
+        sendMessageStub.resetHistory();
+
+        // Trigger unexpected disconnect
+        transport.onStreamClose(1006, 'Abnormal Closure');
+
+        // Fast forward time to trigger reconnect
+        await clock.tickAsync(2000); // Default is 1000 + jitter
+        expect(attemptReconnectSpy).to.have.been.calledOnce;
+        expect(ensureConnectionStub).to.have.been.calledOnce;
+
+        // Should re-send subscribe and then query
+        expect(sendMessageStub).to.have.been.calledTwice;
+        const firstSent = sendMessageStub.firstCall.args[0];
+        const secondSent = sendMessageStub.secondCall.args[0];
+
+        expect(firstSent.subscribe).to.not.be.undefined;
+        expect(secondSent.resume).to.not.be.undefined;
+      });
+
       it('onOnline should trigger immediate reconnect if waiting', async () => {
         const observer = {
           onData: sinon.spy(),
@@ -1968,37 +1998,6 @@ describe('AbstractDataConnectStreamTransport', () => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           delete (global as any).document;
         }
-      });
-
-      it('should re-request active subscriptions and queries on successful reconnect', async () => {
-        const attemptReconnectSpy = sinon.spy(transport, 'attemptReconnect');
-        const observer = {
-          onData: sinon.spy(),
-          onDisconnect: sinon.spy(),
-          onError: sinon.spy()
-        };
-        transport.invokeSubscribe(observer, queryName1, variables1);
-
-        // Stagger an execute request
-        void transport.invokeQuery(queryName1, variables1);
-
-        sendMessageStub.resetHistory();
-
-        // Trigger unexpected disconnect
-        transport.onStreamClose(1006, 'Abnormal Closure');
-
-        // Fast forward time to trigger reconnect
-        await clock.tickAsync(2000); // Default is 1000 + jitter
-        expect(attemptReconnectSpy).to.have.been.calledOnce;
-        expect(ensureConnectionStub).to.have.been.calledOnce;
-
-        // Should re-send subscribe and then query
-        expect(sendMessageStub).to.have.been.calledTwice;
-        const firstSent = sendMessageStub.firstCall.args[0];
-        const secondSent = sendMessageStub.secondCall.args[0];
-
-        expect(firstSent.subscribe).to.not.be.undefined;
-        expect(secondSent.resume).to.not.be.undefined;
       });
     });
   });

--- a/packages/data-connect/test/unit/streamTransport.test.ts
+++ b/packages/data-connect/test/unit/streamTransport.test.ts
@@ -49,15 +49,6 @@ chai.use(chaiAsPromised);
 
 class TestStreamTransport extends AbstractDataConnectStreamTransport {
   private isTestConnected = true;
-  private closeTimeout: ReturnType<typeof setTimeout> | null = null;
-
-  async cleanupAndTerminate(code?: Code, reason?: string): Promise<void> {
-    if (this.closeTimeout) {
-      clearTimeout(this.closeTimeout);
-      this.closeTimeout = null;
-    }
-    return super.cleanupAndTerminate(code, reason);
-  }
 
   get streamIsReady(): boolean {
     return this.isTestConnected;
@@ -72,14 +63,7 @@ class TestStreamTransport extends AbstractDataConnectStreamTransport {
     return Promise.resolve();
   }
   protected closeConnection(): Promise<void> {
-    if (!this.isTestConnected) {
-      return Promise.resolve();
-    }
     this.isTestConnected = false;
-    this.closeTimeout = setTimeout(() => {
-      this.closeTimeout = null;
-      this.onStreamClose(1000, 'Closed');
-    }, 0);
     return Promise.resolve();
   }
   protected ensureConnection(): Promise<void> {

--- a/packages/data-connect/test/unit/streamTransport.test.ts
+++ b/packages/data-connect/test/unit/streamTransport.test.ts
@@ -1673,11 +1673,11 @@ describe('AbstractDataConnectStreamTransport', () => {
 
         expect(closeSpy).to.not.have.been.called;
 
-        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS);
+        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS + 100);
         expect(closeSpy).to.have.been.calledOnce;
       });
 
-      it('should cancel close if a new subscription arrives during timeout', async () => {
+      it('should not close connection if a new subscription arrives during timeout', async () => {
         const closeSpy = sinon.spy(transport, 'closeConnection');
         sinon.stub(transport, 'sendMessage').resolves();
         const observer = {
@@ -1693,7 +1693,7 @@ describe('AbstractDataConnectStreamTransport', () => {
 
         await transport.invokeSubscribe(observer, queryName2, variables2);
 
-        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS);
+        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS + 100);
         expect(closeSpy).to.not.have.been.called;
       });
 
@@ -1716,7 +1716,7 @@ describe('AbstractDataConnectStreamTransport', () => {
         await flushMicrotasks(1);
         expect(closeSpy).to.not.have.been.called;
 
-        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS);
+        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS + 100);
         expect(closeSpy).to.have.been.calledOnce;
       });
 
@@ -1734,7 +1734,7 @@ describe('AbstractDataConnectStreamTransport', () => {
 
         void transport.invokeQuery(queryName2, variables2);
 
-        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS);
+        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS + 100);
         expect(closeSpy).to.not.have.been.called;
       });
 
@@ -1752,7 +1752,7 @@ describe('AbstractDataConnectStreamTransport', () => {
 
         const queryPromise = transport.invokeQuery(queryName2, variables2);
 
-        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS);
+        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS + 100);
         expect(closeSpy).to.not.have.been.called;
 
         const expectedKey = transport.getMapKey(queryName2, variables2);
@@ -1768,7 +1768,7 @@ describe('AbstractDataConnectStreamTransport', () => {
         await queryPromise;
 
         // fast forward time again because the new idle timeout started when the query completed
-        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS);
+        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS + 100);
 
         expect(closeSpy).to.have.been.calledOnce;
       });

--- a/packages/data-connect/test/unit/streamTransport.test.ts
+++ b/packages/data-connect/test/unit/streamTransport.test.ts
@@ -1519,8 +1519,8 @@ describe('AbstractDataConnectStreamTransport', () => {
         });
 
         it('should clean map correctly when handleResponse rejects', async () => {
-          transport.invokeMutation(mutationName1, variables1).catch(() => { });
-          transport.invokeMutation(mutationName2, variables2).catch(() => { });
+          transport.invokeMutation(mutationName1, variables1).catch(() => {});
+          transport.invokeMutation(mutationName2, variables2).catch(() => {});
           const expectedKey1 = transport.getMapKey(mutationName1, variables1);
           const expectedKey2 = transport.getMapKey(mutationName2, variables2);
           const activeRequests1 =
@@ -2045,10 +2045,10 @@ describe('AbstractDataConnectStreamTransport', () => {
         hadRemoveEventListener = 'removeEventListener' in anyGlobalThis;
 
         if (!hadAddEventListener) {
-          anyGlobalThis.addEventListener = () => { };
+          anyGlobalThis.addEventListener = () => {};
         }
         if (!hadRemoveEventListener) {
-          anyGlobalThis.removeEventListener = () => { };
+          anyGlobalThis.removeEventListener = () => {};
         }
 
         removeEventListenerSpy = sinon.spy(

--- a/packages/data-connect/test/unit/testUtils.ts
+++ b/packages/data-connect/test/unit/testUtils.ts
@@ -63,6 +63,17 @@ export function sleep(ms: number): Promise<void> {
 }
 
 /**
+ * Flushes the microtask queue.
+ * @param ticks The number of times to flush the microtask queue.
+ * @internal
+ */
+export async function flushMicrotasks(ticks: number = 2): Promise<void> {
+  for (let i = 0; i < ticks; i++) {
+    await Promise.resolve();
+  }
+}
+
+/**
  * Mock WebSocket class for testing purposes.
  * @internal
  */

--- a/packages/data-connect/test/unit/transportManager.test.ts
+++ b/packages/data-connect/test/unit/transportManager.test.ts
@@ -524,6 +524,8 @@ describe('DataConnectTransportManager', () => {
       let streamTransport: WebSocketTransport;
       let restInvokeQuerySpy: sinon.SinonStub;
 
+      const IDLE_CONNECTION_TIMEOUT_MS = 15 * 1000; // 15 seconds, copied from real implementation
+
       beforeEach(() => {
         clock = sinon.useFakeTimers();
         streamTransport = manager.initStreamTransport() as WebSocketTransport;
@@ -543,7 +545,7 @@ describe('DataConnectTransportManager', () => {
         clock.restore();
       });
 
-      it('should route to REST during idle timeout and disconnect immediately', async () => {
+      it('should route to REST during idle timeout and disconnect after grace period', async () => {
         const observer: SubscribeObserver<TestData> = {
           onData: () => {},
           onDisconnect: () => {},
@@ -563,7 +565,7 @@ describe('DataConnectTransportManager', () => {
 
         expect(manager.streamTransport).to.exist;
 
-        await clock.tickAsync(0);
+        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS);
         expect(manager.streamTransport).to.be.undefined;
       });
 
@@ -577,7 +579,7 @@ describe('DataConnectTransportManager', () => {
         manager.invokeSubscribe(observer, queryName1, variables1);
         manager.invokeUnsubscribe(queryName1, variables1);
 
-        await clock.tickAsync(0);
+        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS);
         expect(manager.streamTransport).to.be.undefined;
 
         restInvokeQuerySpy.resetHistory();
@@ -595,7 +597,7 @@ describe('DataConnectTransportManager', () => {
         manager.invokeSubscribe(observer, queryName1, variables1);
         manager.invokeUnsubscribe(queryName1, variables1);
 
-        await clock.tickAsync(0);
+        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS);
         expect(manager.streamTransport).to.be.undefined;
 
         manager.invokeSubscribe(observer, queryName1, variables1);

--- a/packages/data-connect/test/unit/transportManager.test.ts
+++ b/packages/data-connect/test/unit/transportManager.test.ts
@@ -565,7 +565,7 @@ describe('DataConnectTransportManager', () => {
 
         expect(manager.streamTransport).to.exist;
 
-        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS);
+        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS + 100);
         expect(manager.streamTransport).to.be.undefined;
       });
 
@@ -579,7 +579,7 @@ describe('DataConnectTransportManager', () => {
         manager.invokeSubscribe(observer, queryName1, variables1);
         manager.invokeUnsubscribe(queryName1, variables1);
 
-        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS);
+        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS + 100);
         expect(manager.streamTransport).to.be.undefined;
 
         restInvokeQuerySpy.resetHistory();
@@ -597,7 +597,7 @@ describe('DataConnectTransportManager', () => {
         manager.invokeSubscribe(observer, queryName1, variables1);
         manager.invokeUnsubscribe(queryName1, variables1);
 
-        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS);
+        await clock.tickAsync(IDLE_CONNECTION_TIMEOUT_MS + 100);
         expect(manager.streamTransport).to.be.undefined;
 
         manager.invokeSubscribe(observer, queryName1, variables1);


### PR DESCRIPTION
## Description
✨ Reorganizes and hardens stream transport tests by grouping idle timeout and automatic reconnection suites, and using realistic connection states and timeouts instead of instantaneous mock states. Also changes idle timeout back to 15s

## Changes
- Returns stream idle timeout back to 15s, updates tests
- Grouped idle timeout tests into a dedicated `Idle Timeout` describe block.
- Updated `TestStreamTransport` mock to track connection state realistically and simulate asynchronous closure.
- Replaced instant idle connection timeouts (`0` ms) in tests with the actual `IDLE_CONNECTION_TIMEOUT_MS` (15s).
- Reorganized reconnection tests under an `Automatic and Intelligent Reconnection` suite.
- Replaced manual `Promise.resolve()` ticks with a new `flushMicrotasks` utility in `testUtils.ts`.
- Renamed "pending mutations" to "active mutations" in test description and reordered test cases.

## Testing
- Updated all existing unit tests in `streamTransport.test.ts` to support the real 15s idle timeout.
- Added a `flushMicrotasks` utility in `testUtils.ts` to flush the microtask queue.
- **All other changes are just whitespace / re-organizing changes.**