### PR TITLE
build: put include-dependencies flag back

### DIFF
--- a/integration/firestore/package.json
+++ b/integration/firestore/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "private": true,
   "scripts": {
-    "build:deps": "lerna run build --scope=\"@firebase/app\" --scope=\"@firebase/firestore\" && npm run typings:public",
+    "build:deps": "lerna run build --scope=\"@firebase/app\" --scope=\"@firebase/firestore\" --include-dependencies && npm run typings:public",
     "typings:public": "lerna run typings:public --scope=\"@firebase/app\" --scope=\"@firebase/firestore\"",
     "build:persistence": "yarn typings:public && INCLUDE_FIRESTORE_PERSISTENCE=true gulp compile-tests",
     "build:memory": "yarn typings:public && INCLUDE_FIRESTORE_PERSISTENCE=false gulp compile-tests",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c && yarn api-report",
-    "build:deps": "lerna run build --scope @firebase/ai",
+    "build:deps": "lerna run build --scope @firebase/ai --include-dependencies",
     "dev": "rollup -c -w",
     "update-responses": "../../scripts/update_vertexai_responses.sh",
     "testsetup": "yarn update-responses && yarn ts-node ./test-utils/convert-mocks.ts",

--- a/packages/analytics-compat/package.json
+++ b/packages/analytics-compat/package.json
@@ -40,7 +40,7 @@
     "lint": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c",
-    "build:deps": "lerna run build --scope @firebase/analytics-compat",
+    "build:deps": "lerna run build --scope @firebase/analytics-compat --include-dependencies",
     "build:release": "yarn build && yarn add-compat-overloads",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm lint test:browser",

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -22,7 +22,7 @@
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c && yarn api-report",
     "build:release": "yarn build && yarn typings:public",
-    "build:deps": "lerna run build --scope @firebase/analytics",
+    "build:deps": "lerna run build --scope @firebase/analytics --include-dependencies",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm lint test:all",
     "test:all": "run-p --npm-path npm test:browser test:integration",

--- a/packages/app-check-compat/package.json
+++ b/packages/app-check-compat/package.json
@@ -22,7 +22,7 @@
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c",
     "build:release": "yarn build && yarn add-compat-overloads",
-    "build:deps": "lerna run build --scope @firebase/app-check-compat",
+    "build:deps": "lerna run build --scope @firebase/app-check-compat --include-dependencies",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm lint test:browser",
     "test:ci": "node ../../scripts/run_tests_in_ci.js -s test:browser",

--- a/packages/app-check/package.json
+++ b/packages/app-check/package.json
@@ -22,7 +22,7 @@
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c && yarn api-report",
     "build:release": "yarn build && yarn api-report && yarn typings:public",
-    "build:deps": "lerna run build --scope @firebase/app-check",
+    "build:deps": "lerna run build --scope @firebase/app-check --include-dependencies",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm lint test:browser",
     "test:ci": "node ../../scripts/run_tests_in_ci.js -s test:browser",

--- a/packages/app-compat/package.json
+++ b/packages/app-compat/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts'  --ignore-path '../../.gitignore'",
     "build": "rollup -c && yarn api-report",
-    "build:deps": "lerna run build --scope @firebase/app-compat",
+    "build:deps": "lerna run build --scope @firebase/app-compat --include-dependencies",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm lint test:all",
     "test:all": "run-p --npm-path npm test:browser test:node",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -24,7 +24,7 @@
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c && yarn api-report",
     "build:release": "rollup -c rollup.config.release.js && yarn api-report && yarn typings:public",
-    "build:deps": "lerna run build --scope @firebase/app",
+    "build:deps": "lerna run build --scope @firebase/app --include-dependencies",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm lint test:all",
     "test:ci": "node ../../scripts/run_tests_in_ci.js -s test:all",

--- a/packages/auth-compat/package.json
+++ b/packages/auth-compat/package.json
@@ -29,7 +29,7 @@
     "lint": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c",
-    "build:deps": "lerna run build --scope @firebase/auth-compat",
+    "build:deps": "lerna run build --scope @firebase/auth-compat --include-dependencies",
     "build:release": "yarn build && yarn add-compat-overloads",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm lint test:all",

--- a/packages/auth/demo/package.json
+++ b/packages/auth/demo/package.json
@@ -13,7 +13,7 @@
     "demo": "rollup -c && firebase serve",
     "demo:emulator": "rollup -c && firebase emulators:start",
     "build": "rollup -c",
-    "build:deps": "yarn --cwd ../../../ lerna run build --scope=\"@firebase/app\" --scope=\"@firebase/auth\"",
+    "build:deps": "yarn --cwd ../../../ lerna run build --scope=\"@firebase/app\" --scope=\"@firebase/auth\" --include-dependencies",
     "dev": "rollup -c -w"
   },
   "dependencies": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -85,7 +85,7 @@
     "lint": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c && yarn api-report",
-    "build:deps": "lerna run build --scope @firebase/auth",
+    "build:deps": "lerna run build --scope @firebase/auth --include-dependencies",
     "build:release": "yarn build && yarn typings:public",
     "build:scripts": "tsc -moduleResolution node --module commonjs scripts/*.ts && ls scripts/*.js | xargs -I % sh -c 'terser %  -o %'",
     "dev": "rollup -c -w",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c",
-    "build:deps": "lerna run build --scope @firebase/component",
+    "build:deps": "lerna run build --scope @firebase/component --include-dependencies",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm lint test:all",
     "test:all": "run-p --npm-path npm test:browser test:node",

--- a/packages/data-connect/package.json
+++ b/packages/data-connect/package.json
@@ -29,7 +29,7 @@
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts'  --ignore-path '../../.gitignore'",
     "build": "rollup -c rollup.config.js && yarn api-report",
     "prettier": "prettier --cache --write '*.js' '*.ts' '@(src|test)/**/*.ts'",
-    "build:deps": "lerna run build --scope=\"@firebase/app\" --scope=\"@firebase/data-connect\" --include-dependencies",
+    "build:deps": "lerna run build --scope=\"@firebase/app\" --scope=\"@firebase/data-connect\" --include-dependencies --include-dependencies",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm lint test:emulator",
     "test:ci": "node ../../scripts/run_tests_in_ci.js -s test:all",

--- a/packages/data-connect/package.json
+++ b/packages/data-connect/package.json
@@ -29,7 +29,7 @@
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts'  --ignore-path '../../.gitignore'",
     "build": "rollup -c rollup.config.js && yarn api-report",
     "prettier": "prettier --cache --write '*.js' '*.ts' '@(src|test)/**/*.ts'",
-    "build:deps": "lerna run build --scope=\"@firebase/app\" --scope=\"@firebase/data-connect\" --include-dependencies --include-dependencies",
+    "build:deps": "lerna run build --scope=\"@firebase/app\" --scope=\"@firebase/data-connect\" --include-dependencies",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm lint test:emulator",
     "test:ci": "node ../../scripts/run_tests_in_ci.js -s test:all",

--- a/packages/database-compat/package.json
+++ b/packages/database-compat/package.json
@@ -39,7 +39,7 @@
     "prettier": "prettier --cache --write '*.js' '*.ts' '@(src|test)/**/*.ts'",
     "build": "rollup -c rollup.config.js",
     "build:release": "yarn build && yarn add-compat-overloads",
-    "build:deps": "lerna run build --scope @firebase/database-compat",
+    "build:deps": "lerna run build --scope @firebase/database-compat --include-dependencies",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm lint test:browser test:node",
     "test:ci": "node ../../scripts/run_tests_in_ci.js -s test",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -31,7 +31,7 @@
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts'  --ignore-path '../../.gitignore'",
     "prettier": "prettier --cache --write '*.js' '*.ts' '@(src|test)/**/*.ts'",
     "build": "rollup -c rollup.config.js && yarn api-report",
-    "build:deps": "lerna run build --scope=\"@firebase/app\" --scope=\"@firebase/database\"",
+    "build:deps": "lerna run build --scope=\"@firebase/app\" --scope=\"@firebase/database\" --include-dependencies",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm lint test:emulator",
     "test:ci": "node ../../scripts/run_tests_in_ci.js -s test:emulator",

--- a/packages/firestore-compat/package.json
+++ b/packages/firestore-compat/package.json
@@ -32,7 +32,7 @@
     "prettier": "prettier --cache --write '*.js' '@(src|test)/**/*.ts'",
     "build": "rollup -c ./rollup.config.js",
     "build:console": "node tools/console.build.js",
-    "build:deps": "lerna run build --scope @firebase/firestore-compat",
+    "build:deps": "lerna run build --scope @firebase/firestore-compat --include-dependencies",
     "build:release": "yarn build && yarn add-compat-overloads",
     "test": "run-s --npm-path npm lint test:all",
     "test:ci": "node ../../scripts/run_tests_in_ci.js -s test:all",

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -13,7 +13,7 @@
     "build": "run-p --npm-path npm build:lite build:main",
     "build:release": "yarn build && yarn typings:public",
     "build:scripts": "tsc -moduleResolution node --module commonjs scripts/*.ts && ls scripts/*.js | xargs -I % sh -c 'terser %  -o %'",
-    "build:deps": "lerna run build --scope @firebase/firestore",
+    "build:deps": "lerna run build --scope @firebase/firestore --include-dependencies",
     "build:main": "rollup -c rollup.config.js",
     "build:lite": "rollup -c rollup.config.lite.js",
     "build:debug": "rollup -c rollup.config.debug.js",

--- a/packages/functions-compat/package.json
+++ b/packages/functions-compat/package.json
@@ -47,7 +47,7 @@
     "lint": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c",
-    "build:deps": "lerna run build --scope @firebase/functions-compat",
+    "build:deps": "lerna run build --scope @firebase/functions-compat --include-dependencies",
     "build:release": "rollup -c rollup.config.release.js && yarn add-compat-overloads",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm lint test:all",

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c && yarn api-report",
-    "build:deps": "lerna run build --scope @firebase/functions",
+    "build:deps": "lerna run build --scope @firebase/functions --include-dependencies",
     "build:release": "rollup -c rollup.config.release.js && yarn api-report",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm lint test:all",

--- a/packages/installations-compat/package.json
+++ b/packages/installations-compat/package.json
@@ -22,7 +22,7 @@
     "lint": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c",
-    "build:deps": "lerna run build --scope @firebase/installations-compat",
+    "build:deps": "lerna run build --scope @firebase/installations-compat --include-dependencies",
     "build:release": "rollup -c rollup.config.release.js",
     "dev": "rollup -c -w",
     "test": "yarn type-check && yarn test:karma && yarn lint",

--- a/packages/installations/package.json
+++ b/packages/installations/package.json
@@ -22,7 +22,7 @@
     "lint": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c && yarn api-report",
-    "build:deps": "lerna run build --scope @firebase/installations",
+    "build:deps": "lerna run build --scope @firebase/installations --include-dependencies",
     "build:release": "yarn build && yarn typings:public",
     "dev": "rollup -c -w",
     "test": "yarn type-check && yarn test:karma && yarn lint",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -20,7 +20,7 @@
     "lint": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c",
-    "build:deps": "lerna run build --scope @firebase/logger",
+    "build:deps": "lerna run build --scope @firebase/logger --include-dependencies",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm lint test:all",
     "test:ci": "node ../../scripts/run_tests_in_ci.js -s test:all",

--- a/packages/messaging-compat/package.json
+++ b/packages/messaging-compat/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c",
-    "build:deps": "lerna run build --scope=\"@firebase/messaging-compat\"",
+    "build:deps": "lerna run build --scope=\"@firebase/messaging-compat\" --include-dependencies",
     "build:release": "yarn build && yarn add-compat-overloads",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm test:karma",

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c && yarn api-report",
-    "build:deps": "lerna run build --scope=\"@firebase/app\" --scope=\"@firebase/messaging\"",
+    "build:deps": "lerna run build --scope=\"@firebase/app\" --scope=\"@firebase/messaging\" --include-dependencies",
     "build:release": "yarn build && yarn typings:public",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm test:karma type-check lint ",

--- a/packages/performance-compat/package.json
+++ b/packages/performance-compat/package.json
@@ -22,7 +22,7 @@
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts'  --ignore-path '../../.gitignore'",
     "build": "rollup -c",
     "build:release": "rollup -c rollup.config.release.js && yarn add-compat-overloads",
-    "build:deps": "lerna run build --scope @firebase/performance-compat",
+    "build:deps": "lerna run build --scope @firebase/performance-compat --include-dependencies",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm lint test:all",
     "test:all": "run-p --npm-path npm test:browser",

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c && yarn api-report",
-    "build:deps": "lerna run build --scope @firebase/performance",
+    "build:deps": "lerna run build --scope @firebase/performance --include-dependencies",
     "build:release": "yarn build",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm lint test:browser",

--- a/packages/remote-config-compat/package.json
+++ b/packages/remote-config-compat/package.json
@@ -22,7 +22,7 @@
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts'  --ignore-path '../../.gitignore'",
     "build": "rollup -c",
     "build:release": "yarn build && yarn add-compat-overloads",
-    "build:deps": "lerna run build --scope @firebase/remote-config-compat",
+    "build:deps": "lerna run build --scope @firebase/remote-config-compat --include-dependencies",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm lint test:all",
     "test:all": "run-p --npm-path npm test:browser",

--- a/packages/remote-config/package.json
+++ b/packages/remote-config/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c && yarn api-report",
-    "build:deps": "lerna run build --scope @firebase/remote-config",
+    "build:deps": "lerna run build --scope @firebase/remote-config --include-dependencies",
     "build:release": "yarn build && yarn typings:public",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm lint test:browser",

--- a/packages/storage-compat/package.json
+++ b/packages/storage-compat/package.json
@@ -20,7 +20,7 @@
     "lint": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c rollup.config.js",
-    "build:deps": "lerna run build --scope @firebase/storage-compat",
+    "build:deps": "lerna run build --scope @firebase/storage-compat --include-dependencies",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm test:browser test:node lint",
     "test:ci": "node ../../scripts/run_tests_in_ci.js -s test:browser test:node",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -29,7 +29,7 @@
     "lint": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c rollup.config.js && yarn api-report",
-    "build:deps": "lerna run build --scope @firebase/storage",
+    "build:deps": "lerna run build --scope @firebase/storage --include-dependencies",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm test:browser test:node lint",
     "test:all": "run-p --npm-path npm test:browser test:node",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -29,7 +29,7 @@
     "lint": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c",
-    "build:deps": "lerna run build --scope @firebase/template",
+    "build:deps": "lerna run build --scope @firebase/template --include-dependencies",
     "dev": "rollup -c -w",
     "test": "run-p --npm-path npm lint test:all",
     "test:ci": "node ../../scripts/run_tests_in_ci.js -s test:all",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -29,7 +29,7 @@
     "lint": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --cache --cache-location '../../node_modules/.cache/eslint/' --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c && yarn api-report",
-    "build:deps": "lerna run build --scope @firebase/util",
+    "build:deps": "lerna run build --scope @firebase/util --include-dependencies",
     "dev": "rollup -c -w",
     "prettier": "prettier --cache --write 'src/**/*.ts' 'test/**/*.ts'",
     "test": "run-p --npm-path npm lint test:all",


### PR DESCRIPTION
I misunderstood the new lerna config when commenting on #10032. Adding `dependsOn: [^build]` makes it required that dependencies be built first but it doesn't actually build them, it just complains they aren't built. Restoring the `include-dependencies` flag that makes sure they get built.
