### PR TITLE
chore(firestore): resolve duplicate assertion ID and resolve duplicate assertion ID

### DIFF
--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -111,7 +111,7 @@ jobs:
     name: Test Firestore
     strategy:
       matrix:
-        test-name: ["test:browser", "test:node:emulator", "test:lite:browser", "test:browser:prod:enterprise", "test:lite:browser:enterprise"]
+        test-name: ["assertion-id:check", "test:browser", "test:node:emulator", "test:lite:browser", "test:browser:prod:enterprise", "test:lite:browser:enterprise"]
     runs-on: ubuntu-latest
     needs: build
     if: ${{ needs.build.outputs.changed == 'true'}}

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -30,7 +30,7 @@
     "test:lite:browser:debug": "karma start --browsers=Chrome --lite --auto-watch",
     "test": "run-s --npm-path npm lint assertion-id:check test:all",
     "test:ci": "node ../../scripts/run_tests_in_ci.js -s test:all:ci",
-    "test:all:ci": "run-s --npm-path npm test:browser test:node:emulator test:lite:browser test:browser:prod:enterprise test:lite:browser:enterprise",
+    "test:all:ci": "run-s --npm-path npm assertion-id:check test:browser test:node:emulator test:lite:browser test:browser:prod:enterprise test:lite:browser:enterprise",
     "test:all": "run-p --npm-path npm test:browser test:lite:browser test:node:emulator test:minified test:browser:prod:enterprise test:lite:browser:enterprise",
     "test:browser": "karma start",
     "test:browser:emulator:debug": "karma start --browsers=Chrome --targetBackend=emulator",

--- a/packages/firestore/src/core/expressions.ts
+++ b/packages/firestore/src/core/expressions.ts
@@ -1752,7 +1752,7 @@ export class CoreArrayContainsAny implements EvaluableExpr {
             break;
           }
           default:
-            fail(0xae40, { value, search });
+            fail(0xebf3, { value, search });
             break;
         }
       }


### PR DESCRIPTION
Because the assertion-id is in code supporting offline pipeline evaluation, which is not public, I'm only marking this as a chore and will not include a changeset.