### PR TITLE
chore(build): Add the GitHub token to `Publish to NPM` of `Production Release`

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -54,8 +54,15 @@ jobs:
       # --ignoreUnstaged Adding the @firebase/app changeset file means
       # there's unstaged changes. Ignore.
       # TODO: Make these flags defaults in the release script.
-      run: yarn release --releaseType Production --ci --skipTests --skipReinstall --ignoreUnstaged
+      run: |
+        # 1. Inject the credentials just-in-time
+        git remote set-url origin https://x-access-token:${OSS_BOT_GITHUB_TOKEN}@github.com/${{ github.repository }}.git
+        # 2. Run the release script
+        yarn release --releaseType Production --ci --skipTests --skipReinstall --ignoreUnstaged
+        # 3. Wipe the credentials so they don't stick around
+        git remote set-url origin https://github.com/${{ github.repository }}.git
       env:
+        OSS_BOT_GITHUB_TOKEN: ${{ secrets.OSS_BOT_GITHUB_TOKEN }}
         NPM_TOKEN_ANALYTICS: ${{secrets.NPM_TOKEN_ANALYTICS}}
         NPM_TOKEN_ANALYTICS_INTEROP_TYPES: ${{secrets.NPM_TOKEN_ANALYTICS_INTEROP_TYPES}}
         NPM_TOKEN_ANALYTICS_TYPES: ${{secrets.NPM_TOKEN_ANALYTICS_TYPES}}


### PR DESCRIPTION

### Discussion

A [previous security fix](https://github.com/firebase/firebase-js-sdk/commit/6d874fc3af568e48a9323c1f17a742cb42c79d5d#diff-ca8ddabd9f784f10990191f92cf0c33da82fe54eb4700ccf5458930a37c9a35b) restricted which steps the GitHub token would have access to. Previously the GitHub token was configured in the checked step of `.github/workflows/release-prod.yml` and the subsequent steps would inherit it. But now, with `persist-credentials: false`, the token's TTL is only that one step.

But we need the token for the `yarn release` script as well.

This explictly sets the token using `git` commands, then runs `yarn release` and then removes the token.

### Testing

CI

### API Changes

None.