### PR TITLE
adding navigation log support for angular

### DIFF
--- a/common/api-review/crashlytics-angular.api.md
+++ b/common/api-review/crashlytics-angular.api.md
@@ -4,8 +4,10 @@
 
 ```ts
 
+import { DestroyRef } from '@angular/core';
 import { ErrorHandler } from '@angular/core';
 import { FirebaseApp } from '@firebase/app';
+import { Router } from '@angular/router';
 
 // @public
 export interface Crashlytics {
@@ -26,6 +28,15 @@ export class FirebaseErrorHandler implements ErrorHandler {
     // (undocumented)
     handleError(error: unknown): void;
     }
+
+// @public
+export function getRawPath(url: string): string;
+
+// @public
+export function getSafeRoutePath(router: Router): string;
+
+// @public
+export function setupNavigationTracking(app: FirebaseApp, router: Router, destroyRef: DestroyRef, crashlyticsOptions?: CrashlyticsOptions): void;
 
 
 // (No @packageDocumentation comment for this package)

--- a/common/api-review/crashlytics-angular.api.md
+++ b/common/api-review/crashlytics-angular.api.md
@@ -30,12 +30,6 @@ export class FirebaseErrorHandler implements ErrorHandler {
     }
 
 // @public
-export function getRawPath(url: string): string;
-
-// @public
-export function getSafeRoutePath(router: Router): string;
-
-// @public
 export function setupNavigationTracking(app: FirebaseApp, router: Router, destroyRef: DestroyRef, crashlyticsOptions?: CrashlyticsOptions): void;
 
 

--- a/common/api-review/crashlytics-next-navigation.api.md
+++ b/common/api-review/crashlytics-next-navigation.api.md
@@ -25,9 +25,6 @@ export interface CrashlyticsOptions {
     tracingUrl?: string;
 }
 
-// @public
-export function getParameterizedRoute(pathname: string | null, params: Record<string, string | string[] | undefined> | null): string;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/docs-devsite/crashlytics_angular.md
+++ b/docs-devsite/crashlytics_angular.md
@@ -11,6 +11,17 @@ https://github.com/firebase/firebase-js-sdk
 
 # @firebase/crashlytics/angular
 
+## Functions
+
+|  Function | Description |
+|  --- | --- |
+|  <b>function(app, ...)</b> |
+|  [setupNavigationTracking(app, router, destroyRef, crashlyticsOptions)](./crashlytics_angular.md#setupnavigationtracking_93fc190) | Configures automatic Angular router navigation tracking for Firebase Crashlytics.<!-- -->This function subscribes to router navigation events, keeps the Crashlytics route path attribute updated, and logs view boundary telemetry automatically. |
+|  <b>function(router, ...)</b> |
+|  [getSafeRoutePath(router)](./crashlytics_angular.md#getsaferoutepath_0db96c6) | Constructs the safe, templated route path from the router state. Example output: '/users/:id/posts' |
+|  <b>function(url, ...)</b> |
+|  [getRawPath(url)](./crashlytics_angular.md#getrawpath_205fad7) | Extracts the raw path portion from a full URL by stripping query parameters and hashes. |
+
 ## Classes
 
 |  Class | Description |
@@ -23,4 +34,102 @@ https://github.com/firebase/firebase-js-sdk
 |  --- | --- |
 |  [Crashlytics](./crashlytics_angular.crashlytics.md#crashlytics_interface) | An instance of the Firebase Crashlytics SDK.<!-- -->Do not create this instance directly. Instead, use [getCrashlytics()](./crashlytics_.md#getcrashlytics_a9d22a1)<!-- -->. |
 |  [CrashlyticsOptions](./crashlytics_angular.crashlyticsoptions.md#crashlyticsoptions_interface) | Options for initializing the Crashlytics service using [getCrashlytics()](./crashlytics_.md#getcrashlytics_a9d22a1)<!-- -->. |
+
+## function(app, ...)
+
+### setupNavigationTracking(app, router, destroyRef, crashlyticsOptions) {:#setupnavigationtracking_93fc190}
+
+Configures automatic Angular router navigation tracking for Firebase Crashlytics.
+
+This function subscribes to router navigation events, keeps the Crashlytics route path attribute updated, and logs view boundary telemetry automatically.
+
+<b>Signature:</b>
+
+```typescript
+export declare function setupNavigationTracking(app: FirebaseApp, router: Router, destroyRef: DestroyRef, crashlyticsOptions?: CrashlyticsOptions): void;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  app | [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface) | The [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface) instance to use. |
+|  router | Router | The Angular  instance to subscribe to. |
+|  destroyRef | DestroyRef | The  instance to bind teardown logic to. |
+|  crashlyticsOptions | [CrashlyticsOptions](./crashlytics_.crashlyticsoptions.md#crashlyticsoptions_interface) | Optional. [CrashlyticsOptions](./crashlytics_.crashlyticsoptions.md#crashlyticsoptions_interface) that configure the Crashlytics instance. |
+
+<b>Returns:</b>
+
+void
+
+### Example
+
+
+```typescript
+import { ApplicationConfig, ErrorHandler, inject, DestroyRef } from '@angular/core';
+import { Router } from '@angular/router';
+import { FirebaseErrorHandler, setupNavigationTracking } from '@firebase/crashlytics/angular';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    {
+      provide: ErrorHandler,
+      useFactory: () => new FirebaseErrorHandler(firebaseApp)
+    },
+    provideEnvironmentInitializer(() => {
+      inject(ErrorHandler);
+      setupNavigationTracking(
+        firebaseApp,
+        inject(Router),
+        inject(DestroyRef)
+      );
+    })
+  ]
+};
+
+```
+
+## function(router, ...)
+
+### getSafeRoutePath(router) {:#getsaferoutepath_0db96c6}
+
+Constructs the safe, templated route path from the router state. Example output: '/users/:id/posts'
+
+<b>Signature:</b>
+
+```typescript
+export declare function getSafeRoutePath(router: Router): string;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  router | Router |  |
+
+<b>Returns:</b>
+
+string
+
+## function(url, ...)
+
+### getRawPath(url) {:#getrawpath_205fad7}
+
+Extracts the raw path portion from a full URL by stripping query parameters and hashes.
+
+<b>Signature:</b>
+
+```typescript
+export declare function getRawPath(url: string): string;
+```
+
+#### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  url | string |  |
+
+<b>Returns:</b>
+
+string
 

--- a/docs-devsite/crashlytics_angular.md
+++ b/docs-devsite/crashlytics_angular.md
@@ -15,12 +15,7 @@ https://github.com/firebase/firebase-js-sdk
 
 |  Function | Description |
 |  --- | --- |
-|  <b>function(app, ...)</b> |
 |  [setupNavigationTracking(app, router, destroyRef, crashlyticsOptions)](./crashlytics_angular.md#setupnavigationtracking_93fc190) | Configures automatic Angular router navigation tracking for Firebase Crashlytics.<!-- -->This function subscribes to router navigation events, keeps the Crashlytics route path attribute updated, and logs view boundary telemetry automatically. |
-|  <b>function(router, ...)</b> |
-|  [getSafeRoutePath(router)](./crashlytics_angular.md#getsaferoutepath_0db96c6) | Constructs the safe, templated route path from the router state. Example output: '/users/:id/posts' |
-|  <b>function(url, ...)</b> |
-|  [getRawPath(url)](./crashlytics_angular.md#getrawpath_205fad7) | Extracts the raw path portion from a full URL by stripping query parameters and hashes. |
 
 ## Classes
 
@@ -88,48 +83,4 @@ export const appConfig: ApplicationConfig = {
 };
 
 ```
-
-## function(router, ...)
-
-### getSafeRoutePath(router) {:#getsaferoutepath_0db96c6}
-
-Constructs the safe, templated route path from the router state. Example output: '/users/:id/posts'
-
-<b>Signature:</b>
-
-```typescript
-export declare function getSafeRoutePath(router: Router): string;
-```
-
-#### Parameters
-
-|  Parameter | Type | Description |
-|  --- | --- | --- |
-|  router | Router |  |
-
-<b>Returns:</b>
-
-string
-
-## function(url, ...)
-
-### getRawPath(url) {:#getrawpath_205fad7}
-
-Extracts the raw path portion from a full URL by stripping query parameters and hashes.
-
-<b>Signature:</b>
-
-```typescript
-export declare function getRawPath(url: string): string;
-```
-
-#### Parameters
-
-|  Parameter | Type | Description |
-|  --- | --- | --- |
-|  url | string |  |
-
-<b>Returns:</b>
-
-string
 

--- a/docs-devsite/crashlytics_next-navigation.md
+++ b/docs-devsite/crashlytics_next-navigation.md
@@ -15,10 +15,7 @@ https://github.com/firebase/firebase-js-sdk
 
 |  Function | Description |
 |  --- | --- |
-|  <b>function({ firebaseApp, crashlyticsOptions }, ...)</b> |
 |  [CrashlyticsNavigationTracker({ firebaseApp, crashlyticsOptions })](./crashlytics_next-navigation.md#crashlyticsnavigationtracker_c141224) | A client-side routing component for Next.js App Router that automatically captures navigation events and updates route attributes.<!-- -->This component should be mounted inside a root Client Component layout. |
-|  <b>function(pathname, ...)</b> |
-|  [getParameterizedRoute(pathname, params)](./crashlytics_next-navigation.md#getparameterizedroute_3fcbe19) | Constructs a parameterized route template for Next.js App Router by replacing dynamic parameter values in the pathname with parameter placeholders. |
 
 ## Interfaces
 
@@ -73,31 +70,4 @@ export default function RootLayout({ children }) {
 }
 
 ```
-
-## function(pathname, ...)
-
-### getParameterizedRoute(pathname, params) {:#getparameterizedroute_3fcbe19}
-
-Constructs a parameterized route template for Next.js App Router by replacing dynamic parameter values in the pathname with parameter placeholders.
-
-<b>Signature:</b>
-
-```typescript
-export declare function getParameterizedRoute(pathname: string | null, params: Record<string, string | string[] | undefined> | null): string;
-```
-
-#### Parameters
-
-|  Parameter | Type | Description |
-|  --- | --- | --- |
-|  pathname | string \| null |  |
-|  params | Record&lt;string, string \| string\[\] \| undefined&gt; \| null |  |
-
-<b>Returns:</b>
-
-string
-
-### Example
-
-// pathname = "/users/123/details", params = { id: "123" } // returns "/users/:id/details"
 

--- a/packages/crashlytics/src/angular/index.test.ts
+++ b/packages/crashlytics/src/angular/index.test.ts
@@ -96,7 +96,7 @@ describe('FirebaseErrorHandler', () => {
     await deleteApp(app);
   });
 
-  it('should register routePath provider in attributesStore', () => {
+  it('should register routePath provider in attributesStore and return correct route path', async () => {
     const setRoutePathProviderSpy = sinon.spy(
       attributesStore,
       'setRoutePathProvider'
@@ -104,6 +104,12 @@ describe('FirebaseErrorHandler', () => {
     const testInjector = TestBed.inject(Injector);
     runInInjectionContext(testInjector, () => new FirebaseErrorHandler(app));
     expect(setRoutePathProviderSpy).to.have.been.calledWith(sinon.match.func);
+
+    const provider = setRoutePathProviderSpy.getCall(0).args[0];
+    const router = TestBed.inject(Router);
+    await router.navigate(['/static-route']);
+    expect(provider).to.not.be.undefined;
+    expect(provider!()).to.equal('/static-route');
   });
 
   it('should log the error to the console', async () => {

--- a/packages/crashlytics/src/angular/index.test.ts
+++ b/packages/crashlytics/src/angular/index.test.ts
@@ -105,7 +105,7 @@ describe('FirebaseErrorHandler', () => {
     runInInjectionContext(testInjector, () => new FirebaseErrorHandler(app));
     expect(setRoutePathProviderSpy).to.have.been.calledWith(sinon.match.func);
 
-    const provider = setRoutePathProviderSpy.getCall(0).args[0];
+    const provider = setRoutePathProviderSpy.firstCall.args[0];
     const router = TestBed.inject(Router);
     await router.navigate(['/static-route']);
     expect(provider).to.not.be.undefined;

--- a/packages/crashlytics/src/angular/index.test.ts
+++ b/packages/crashlytics/src/angular/index.test.ts
@@ -121,8 +121,8 @@ describe('getSafeRoutePath', () => {
     TestBed.configureTestingModule({
       imports: [
         RouterModule.forRoot([
-          { path: 'static-route', component: DummyComponent },
-          { path: 'dynamic/:id/route', component: DummyComponent }
+          { path: 'static-route', component: MockComponent },
+          { path: 'dynamic/:id/route', component: MockComponent }
         ])
       ],
       providers: [provideZoneChangeDetection()]
@@ -187,10 +187,10 @@ describe('setupNavigationTracking', () => {
     TestBed.configureTestingModule({
       imports: [
         RouterModule.forRoot([
-          { path: 'home', component: DummyComponent },
-          { path: 'about', component: DummyComponent },
-          { path: 'dashboard', component: DummyComponent },
-          { path: 'users/:id', component: DummyComponent }
+          { path: 'home', component: MockComponent },
+          { path: 'about', component: MockComponent },
+          { path: 'dashboard', component: MockComponent },
+          { path: 'users/:id', component: MockComponent }
         ])
       ],
       providers: [provideZoneChangeDetection()]
@@ -220,11 +220,26 @@ describe('setupNavigationTracking', () => {
     expect(routePathAfterUnmount).to.be.undefined;
   });
 
-  it('should invoke logViewBoundary on initialization', async () => {
+  it('should invoke logViewBoundary on initialization if the router is set up', async () => {
     await router.navigate(['/home']);
     const logViewBoundaryStub = stub(crashlytics, 'logViewBoundary');
 
     setupNavigationTracking(app, router, destroyRef);
+
+    expect(logViewBoundaryStub).to.have.been.calledWith(
+      fakeCrashlytics,
+      '/home'
+    );
+  });
+
+  it('should not invoke logViewBoundary on initialization if the router is not set up yet', async () => {
+    const logViewBoundaryStub = stub(crashlytics, 'logViewBoundary');
+
+    setupNavigationTracking(app, router, destroyRef);
+
+    expect(logViewBoundaryStub).to.not.have.been.called;
+
+    await router.navigate(['/home']);
 
     expect(logViewBoundaryStub).to.have.been.calledWith(
       fakeCrashlytics,

--- a/packages/crashlytics/src/angular/index.test.ts
+++ b/packages/crashlytics/src/angular/index.test.ts
@@ -156,9 +156,24 @@ describe('getRawPath', () => {
     expect(getRawPath('/home#section1')).to.equal('/home');
   });
 
+  it('strips matrix parameters', () => {
+    expect(getRawPath('/users;id=123;role=admin/profile')).to.equal(
+      '/users/profile'
+    );
+    expect(
+      getRawPath('/users;id=123/profile;tab=posts/details;view=detailed')
+    ).to.equal('/users/profile/details');
+  });
+
   it('strips both query parameters and hash fragment', () => {
     expect(getRawPath('/home?foo=bar#section1')).to.equal('/home');
     expect(getRawPath('/home#section1?foo=bar')).to.equal('/home');
+  });
+
+  it('strips query parameters, hash fragments, and matrix parameters combined', () => {
+    expect(
+      getRawPath('/users;id=123/profile;tab=posts?foo=bar#section1')
+    ).to.equal('/users/profile');
   });
 });
 

--- a/packages/crashlytics/src/angular/index.test.ts
+++ b/packages/crashlytics/src/angular/index.test.ts
@@ -43,7 +43,7 @@ import {
   BrowserTestingModule,
   platformBrowserTesting
 } from '@angular/platform-browser/testing';
-import { AttributesStore } from '../attributes-store';
+import { LOG_ATTR_KEY, AttributesStore } from '../attributes-store';
 
 use(sinonChai);
 use(chaiAsPromised);
@@ -51,7 +51,7 @@ use(chaiAsPromised);
 TestBed.initTestEnvironment(BrowserTestingModule, platformBrowserTesting());
 
 @Component({ template: '' })
-class MockComponent { }
+class MockComponent {}
 
 describe('FirebaseErrorHandler', () => {
   let errorHandler: FirebaseErrorHandler;
@@ -197,7 +197,7 @@ describe('setupNavigationTracking', () => {
       attributesStore,
       loggerProvider: {
         getLogger: () => ({
-          emit: () => { }
+          emit: () => {}
         })
       }
     } as unknown as Crashlytics;

--- a/packages/crashlytics/src/angular/index.test.ts
+++ b/packages/crashlytics/src/angular/index.test.ts
@@ -25,12 +25,18 @@ import { FirebaseApp, deleteApp, initializeApp } from '@firebase/app';
 import * as crashlytics from '../api';
 import {
   Component,
+  DestroyRef,
   Injector,
   provideZoneChangeDetection,
   runInInjectionContext
 } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { FirebaseErrorHandler, getSafeRoutePath } from '.';
+import {
+  FirebaseErrorHandler,
+  setupNavigationTracking,
+  getSafeRoutePath,
+  getRawPath
+} from '.';
 import { Crashlytics } from '../public-types';
 import { Router, RouterModule } from '@angular/router';
 import {
@@ -45,7 +51,7 @@ use(chaiAsPromised);
 TestBed.initTestEnvironment(BrowserTestingModule, platformBrowserTesting());
 
 @Component({ template: '' })
-class MockComponent {}
+class MockComponent { }
 
 describe('FirebaseErrorHandler', () => {
   let errorHandler: FirebaseErrorHandler;
@@ -90,7 +96,7 @@ describe('FirebaseErrorHandler', () => {
     await deleteApp(app);
   });
 
-  it('should register routePath provider in attributesStore and return correct route path', async () => {
+  it('should register routePath provider in attributesStore', () => {
     const setRoutePathProviderSpy = sinon.spy(
       attributesStore,
       'setRoutePathProvider'
@@ -98,12 +104,6 @@ describe('FirebaseErrorHandler', () => {
     const testInjector = TestBed.inject(Injector);
     runInInjectionContext(testInjector, () => new FirebaseErrorHandler(app));
     expect(setRoutePathProviderSpy).to.have.been.calledWith(sinon.match.func);
-
-    const provider = setRoutePathProviderSpy.firstCall.args[0];
-    const router = TestBed.inject(Router);
-    await router.navigate(['/static-route']);
-    expect(provider).to.not.be.undefined;
-    expect(provider!()).to.equal('/static-route');
   });
 
   it('should log the error to the console', async () => {
@@ -121,8 +121,8 @@ describe('getSafeRoutePath', () => {
     TestBed.configureTestingModule({
       imports: [
         RouterModule.forRoot([
-          { path: 'static-route', component: MockComponent },
-          { path: 'dynamic/:id/route', component: MockComponent }
+          { path: 'static-route', component: DummyComponent },
+          { path: 'dynamic/:id/route', component: DummyComponent }
         ])
       ],
       providers: [provideZoneChangeDetection()]
@@ -138,5 +138,132 @@ describe('getSafeRoutePath', () => {
   it('should return the parameterized route pattern', async () => {
     await router.navigate(['/dynamic/my-name/route']);
     expect(getSafeRoutePath(router)).to.equal('/dynamic/:id/route');
+  });
+});
+
+describe('getRawPath', () => {
+  it('returns the same path if there are no query parameters or hashes', () => {
+    expect(getRawPath('/home')).to.equal('/home');
+    expect(getRawPath('/users/123/profile')).to.equal('/users/123/profile');
+  });
+
+  it('strips query parameters', () => {
+    expect(getRawPath('/home?foo=bar')).to.equal('/home');
+    expect(getRawPath('/home?foo=bar&baz=qux')).to.equal('/home');
+  });
+
+  it('strips hash fragment', () => {
+    expect(getRawPath('/home#section1')).to.equal('/home');
+  });
+
+  it('strips both query parameters and hash fragment', () => {
+    expect(getRawPath('/home?foo=bar#section1')).to.equal('/home');
+    expect(getRawPath('/home#section1?foo=bar')).to.equal('/home');
+  });
+});
+
+describe('setupNavigationTracking', () => {
+  let app: FirebaseApp;
+  let fakeCrashlytics: Crashlytics;
+  let attributesStore: AttributesStore;
+  let router: Router;
+  let destroyRef: DestroyRef;
+
+  beforeEach(() => {
+    app = initializeApp({ projectId: 'p', appId: 'fakeapp' });
+    attributesStore = new AttributesStore(app.options);
+    fakeCrashlytics = {
+      attributesStore,
+      loggerProvider: {
+        getLogger: () => ({
+          emit: () => { }
+        })
+      }
+    } as unknown as Crashlytics;
+
+    stub(crashlytics, 'getCrashlytics').returns(fakeCrashlytics);
+
+    // Set up a real Angular testing module with routes
+    TestBed.configureTestingModule({
+      imports: [
+        RouterModule.forRoot([
+          { path: 'home', component: DummyComponent },
+          { path: 'about', component: DummyComponent },
+          { path: 'dashboard', component: DummyComponent },
+          { path: 'users/:id', component: DummyComponent }
+        ])
+      ],
+      providers: [provideZoneChangeDetection()]
+    });
+
+    router = TestBed.inject(Router);
+    destroyRef = TestBed.inject(DestroyRef);
+  });
+
+  afterEach(async () => {
+    restore();
+    await deleteApp(app);
+  });
+
+  it('should register routePath in attributesStore on initialization and clear registration on destruction', async () => {
+    await router.navigate(['/home']);
+    setupNavigationTracking(app, router, destroyRef);
+
+    const routePath =
+      attributesStore.getLogAttributes()[LOG_ATTR_KEY.ROUTE_PATH];
+    expect(routePath).to.equal('/home');
+
+    TestBed.resetTestingModule();
+
+    const routePathAfterUnmount =
+      attributesStore.getLogAttributes()[LOG_ATTR_KEY.ROUTE_PATH];
+    expect(routePathAfterUnmount).to.be.undefined;
+  });
+
+  it('should invoke logViewBoundary on initialization', async () => {
+    await router.navigate(['/home']);
+    const logViewBoundaryStub = stub(crashlytics, 'logViewBoundary');
+
+    setupNavigationTracking(app, router, destroyRef);
+
+    expect(logViewBoundaryStub).to.have.been.calledWith(
+      fakeCrashlytics,
+      '/home'
+    );
+  });
+
+  it('should invoke logViewBoundary with new route pattern if raw path changes', async () => {
+    await router.navigate(['/users/123']);
+    setupNavigationTracking(app, router, destroyRef);
+
+    const logViewBoundaryStub = stub(crashlytics, 'logViewBoundary');
+
+    await router.navigate(['/users/456']);
+    expect(logViewBoundaryStub).to.have.been.calledWith(
+      fakeCrashlytics,
+      '/users/:id'
+    );
+  });
+
+  it('should not invoke logViewBoundary if raw path remains the same', async () => {
+    await router.navigate(['/home']);
+    setupNavigationTracking(app, router, destroyRef);
+
+    const logViewBoundaryStub = stub(crashlytics, 'logViewBoundary');
+
+    await router.navigate(['/home']);
+
+    expect(logViewBoundaryStub).to.not.have.been.called;
+  });
+
+  it('should set routePath in attributesStore with new route pattern if raw path changes', async () => {
+    await router.navigate(['/home']);
+    setupNavigationTracking(app, router, destroyRef);
+
+    await router.navigate(['/about']);
+
+    const routePath =
+      attributesStore.getLogAttributes()[LOG_ATTR_KEY.ROUTE_PATH];
+    expect(routePath).to.equal('/about');
   });
 });

--- a/packages/crashlytics/src/angular/index.ts
+++ b/packages/crashlytics/src/angular/index.ts
@@ -16,7 +16,13 @@
  */
 
 import { ErrorHandler, inject, DestroyRef } from '@angular/core';
-import { ActivatedRouteSnapshot, NavigationEnd, Router } from '@angular/router';
+import {
+  ActivatedRouteSnapshot,
+  NavigationEnd,
+  Router,
+  DefaultUrlSerializer,
+  UrlSegmentGroup
+} from '@angular/router';
 import { registerCrashlytics } from '../register';
 import { recordError, getCrashlytics, logViewBoundary } from '../api';
 import { Crashlytics, CrashlyticsOptions } from '../public-types';
@@ -51,12 +57,30 @@ export function getSafeRoutePath(router: Router): string {
 }
 
 /**
- * Extracts the raw path portion from a full URL by stripping query parameters and hashes.
+ * Recursively traverses the parsed URL segment group tree and clears the parameter map
+ * of each segment to strip out all Angular matrix parameters (e.g. `;id=123`).
+ */
+function stripMatrixParams(group: UrlSegmentGroup): void {
+  for (const segment of group.segments) {
+    segment.parameters = {};
+  }
+  for (const child of Object.values(group.children)) {
+    stripMatrixParams(child);
+  }
+}
+
+/**
+ * Extracts the raw path portion from a full URL by stripping query parameters, hashes, and matrix parameters.
  *
  * @internal
  */
 export function getRawPath(url: string): string {
-  return url.split('?')[0].split('#')[0];
+  const serializer = new DefaultUrlSerializer();
+  const urlTree = serializer.parse(url);
+  urlTree.queryParams = {};
+  urlTree.fragment = null;
+  stripMatrixParams(urlTree.root);
+  return serializer.serialize(urlTree);
 }
 
 /**

--- a/packages/crashlytics/src/angular/index.ts
+++ b/packages/crashlytics/src/angular/index.ts
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-import { ErrorHandler, inject } from '@angular/core';
-import { ActivatedRouteSnapshot, Router } from '@angular/router';
+import { ErrorHandler, inject, DestroyRef } from '@angular/core';
+import { ActivatedRouteSnapshot, NavigationEnd, Router } from '@angular/router';
 import { registerCrashlytics } from '../register';
-import { recordError, getCrashlytics } from '../api';
+import { recordError, getCrashlytics, logViewBoundary } from '../api';
 import { Crashlytics, CrashlyticsOptions } from '../public-types';
 import { FirebaseApp } from '@firebase/app';
 import { CrashlyticsInternal } from '../types';
@@ -30,8 +30,6 @@ export * from '../public-types';
 /**
  * Constructs the safe, templated route path from the router state.
  * Example output: '/users/:id/posts'
- *
- * @internal
  */
 export function getSafeRoutePath(router: Router): string {
   let currentRoute: ActivatedRouteSnapshot | null =
@@ -42,13 +40,20 @@ export function getSafeRoutePath(router: Router): string {
     currentRoute = currentRoute.firstChild;
   }
 
-  // Traverse down from the root to the deepest child, collecting configured paths
+  // Traverse up from the deepest child to the root, collecting configured paths
   const pathFromRoot = currentRoute.pathFromRoot
     .map(route => route.routeConfig?.path)
     .filter(path => path !== undefined && path !== '') // Filter out empty or undefined paths
     .join('/');
 
   return `/${pathFromRoot}`;
+}
+
+/**
+ * Extracts the raw path portion from a full URL by stripping query parameters and hashes.
+ */
+export function getRawPath(url: string): string {
+  return url.split('?')[0].split('#')[0];
 }
 
 /**
@@ -110,4 +115,73 @@ export class FirebaseErrorHandler implements ErrorHandler {
   handleError(error: unknown): void {
     recordError(this.crashlytics, error);
   }
+}
+
+/**
+ * Configures automatic Angular router navigation tracking for Firebase Crashlytics.
+ *
+ * This function subscribes to router navigation events, keeps the Crashlytics route path attribute
+ * updated, and logs view boundary telemetry automatically.
+ *
+ * @example
+ * ```typescript
+ * import { ApplicationConfig, ErrorHandler, inject, DestroyRef } from '@angular/core';
+ * import { Router } from '@angular/router';
+ * import { FirebaseErrorHandler, setupNavigationTracking } from '@firebase/crashlytics/angular';
+ *
+ * export const appConfig: ApplicationConfig = {
+ *   providers: [
+ *     {
+ *       provide: ErrorHandler,
+ *       useFactory: () => new FirebaseErrorHandler(firebaseApp)
+ *     },
+ *     provideEnvironmentInitializer(() => {
+ *       inject(ErrorHandler);
+ *       setupNavigationTracking(
+ *         firebaseApp,
+ *         inject(Router),
+ *         inject(DestroyRef)
+ *       );
+ *     })
+ *   ]
+ * };
+ * ```
+ *
+ * @param app - The {@link @firebase/app#FirebaseApp} instance to use.
+ * @param router - The Angular {@link @angular/router#Router} instance to subscribe to.
+ * @param destroyRef - The {@link @angular/core#DestroyRef} instance to bind teardown logic to.
+ * @param crashlyticsOptions - Optional. {@link CrashlyticsOptions} that configure the Crashlytics instance.
+ *
+ * @public
+ */
+export function setupNavigationTracking(
+  app: FirebaseApp,
+  router: Router,
+  destroyRef: DestroyRef,
+  crashlyticsOptions?: CrashlyticsOptions
+): void {
+  const crashlytics = getCrashlytics(app, crashlyticsOptions);
+  const attributesStore = (crashlytics as CrashlyticsInternal).attributesStore;
+
+  attributesStore.setRoutePathProvider(() => getSafeRoutePath(router));
+
+  const initialPattern = getSafeRoutePath(router);
+  let lastRawPath = getRawPath(router.url);
+  logViewBoundary(crashlytics, initialPattern);
+
+  const subscription = router.events.subscribe(event => {
+    if (event instanceof NavigationEnd) {
+      const currentRawPath = getRawPath(router.url);
+      if (currentRawPath !== lastRawPath) {
+        lastRawPath = currentRawPath;
+        const pattern = getSafeRoutePath(router);
+        logViewBoundary(crashlytics, pattern);
+      }
+    }
+  });
+
+  destroyRef.onDestroy(() => {
+    attributesStore.setRoutePathProvider(undefined);
+    subscription.unsubscribe();
+  });
 }

--- a/packages/crashlytics/src/angular/index.ts
+++ b/packages/crashlytics/src/angular/index.ts
@@ -32,8 +32,7 @@ export * from '../public-types';
  * Example output: '/users/:id/posts'
  */
 export function getSafeRoutePath(router: Router): string {
-  let currentRoute: ActivatedRouteSnapshot | null =
-    router.routerState.snapshot.root;
+  let currentRoute: ActivatedRouteSnapshot = router.routerState.snapshot.root;
 
   // Find the deepest activated child route
   while (currentRoute.firstChild) {
@@ -165,13 +164,16 @@ export function setupNavigationTracking(
 
   attributesStore.setRoutePathProvider(() => getSafeRoutePath(router));
 
-  const initialPattern = getSafeRoutePath(router);
-  let lastRawPath = getRawPath(router.url);
-  logViewBoundary(crashlytics, initialPattern);
+  let lastRawPath: string | undefined = undefined;
+  if (router.navigated) {
+    const initialPattern = getSafeRoutePath(router);
+    lastRawPath = getRawPath(router.url);
+    logViewBoundary(crashlytics, initialPattern);
+  }
 
   const subscription = router.events.subscribe(event => {
     if (event instanceof NavigationEnd) {
-      const currentRawPath = getRawPath(router.url);
+      const currentRawPath = getRawPath(event.urlAfterRedirects);
       if (currentRawPath !== lastRawPath) {
         lastRawPath = currentRawPath;
         const pattern = getSafeRoutePath(router);

--- a/packages/crashlytics/src/angular/index.ts
+++ b/packages/crashlytics/src/angular/index.ts
@@ -47,7 +47,7 @@ export function getSafeRoutePath(router: Router): string {
     currentRoute = currentRoute.firstChild;
   }
 
-  // Traverse up from the deepest child to the root, collecting configured paths
+  // Traverse down from the root to the deepest child, collecting configured paths
   const pathFromRoot = currentRoute.pathFromRoot
     .map(route => route.routeConfig?.path)
     .filter(path => path !== undefined && path !== '') // Filter out empty or undefined paths

--- a/packages/crashlytics/src/angular/index.ts
+++ b/packages/crashlytics/src/angular/index.ts
@@ -30,6 +30,8 @@ export * from '../public-types';
 /**
  * Constructs the safe, templated route path from the router state.
  * Example output: '/users/:id/posts'
+ *
+ * @internal
  */
 export function getSafeRoutePath(router: Router): string {
   let currentRoute: ActivatedRouteSnapshot = router.routerState.snapshot.root;
@@ -50,6 +52,8 @@ export function getSafeRoutePath(router: Router): string {
 
 /**
  * Extracts the raw path portion from a full URL by stripping query parameters and hashes.
+ *
+ * @internal
  */
 export function getRawPath(url: string): string {
   return url.split('?')[0].split('#')[0];

--- a/packages/crashlytics/src/api.test.ts
+++ b/packages/crashlytics/src/api.test.ts
@@ -601,7 +601,7 @@ function getFakeApp(): FirebaseApp {
         ({
           getId: async () => 'iid',
           getToken: async () => 'authToken'
-        } as _FirebaseInstallationsInternal),
+        }) as _FirebaseInstallationsInternal,
       ComponentType.PUBLIC
     )
   );

--- a/packages/crashlytics/src/attributes-store.ts
+++ b/packages/crashlytics/src/attributes-store.ts
@@ -92,8 +92,8 @@ export class AttributesStore {
     const appVersion = options?.appVersion
       ? options.appVersion
       : AUTO_CONSTANTS?.appVersion
-      ? AUTO_CONSTANTS.appVersion
-      : 'unset';
+        ? AUTO_CONSTANTS.appVersion
+        : 'unset';
     this._appVersion = appVersion;
   }
 
@@ -145,9 +145,8 @@ export class AttributesStore {
       activeSpanContext?.spanId &&
       this._projectId
     ) {
-      attributes[
-        LOG_ATTR_KEY.TRACE
-      ] = `projects/${this._projectId}/traces/${activeSpanContext.traceId}`;
+      attributes[LOG_ATTR_KEY.TRACE] =
+        `projects/${this._projectId}/traces/${activeSpanContext.traceId}`;
       attributes[LOG_ATTR_KEY.SPAN_ID] = activeSpanContext.spanId;
     }
 
@@ -173,9 +172,8 @@ export class AttributesStore {
   getSpanAttributes(): Attributes {
     const attributes: Attributes = {};
     if (this._projectId) {
-      attributes[
-        SPAN_ATTR_KEY.GCP_RESOURCE_NAME
-      ] = `//firebasetelemetry.googleapis.com/projects/${this._projectId}/locations/${this._region}/`;
+      attributes[SPAN_ATTR_KEY.GCP_RESOURCE_NAME] =
+        `//firebasetelemetry.googleapis.com/projects/${this._projectId}/locations/${this._region}/`;
     }
 
     if (this._appVersion) {

--- a/packages/crashlytics/src/next-navigation/index.ts
+++ b/packages/crashlytics/src/next-navigation/index.ts
@@ -34,6 +34,8 @@ export * from '../public-types';
  * @example
  * // pathname = "/users/123/details", params = { id: "123" }
  * // returns "/users/:id/details"
+ *
+ * @internal
  */
 export function getParameterizedRoute(
   pathname: string | null,


### PR DESCRIPTION
Adding a function to call on the client side to set up a navigation listener to create navigation logs.

Also refactored getSafeRoutePath to be a shared function between error logging and navigation tracking.