### PR TITLE
refactoring getSafeRoutePath placement

### DIFF
--- a/packages/crashlytics/src/angular/index.test.ts
+++ b/packages/crashlytics/src/angular/index.test.ts
@@ -99,7 +99,7 @@ describe('FirebaseErrorHandler', () => {
     runInInjectionContext(testInjector, () => new FirebaseErrorHandler(app));
     expect(setRoutePathProviderSpy).to.have.been.calledWith(sinon.match.func);
 
-    const provider = setRoutePathProviderSpy.firstCall.args[0];
+    const provider = setRoutePathProviderSpy.getCall(0).args[0];
     const router = TestBed.inject(Router);
     await router.navigate(['/static-route']);
     expect(provider).to.not.be.undefined;

--- a/packages/crashlytics/src/angular/index.test.ts
+++ b/packages/crashlytics/src/angular/index.test.ts
@@ -90,7 +90,7 @@ describe('FirebaseErrorHandler', () => {
     await deleteApp(app);
   });
 
-  it('should register routePath provider in attributesStore', () => {
+  it('should register routePath provider in attributesStore and return correct route path', async () => {
     const setRoutePathProviderSpy = sinon.spy(
       attributesStore,
       'setRoutePathProvider'
@@ -98,6 +98,12 @@ describe('FirebaseErrorHandler', () => {
     const testInjector = TestBed.inject(Injector);
     runInInjectionContext(testInjector, () => new FirebaseErrorHandler(app));
     expect(setRoutePathProviderSpy).to.have.been.calledWith(sinon.match.func);
+
+    const provider = setRoutePathProviderSpy.firstCall.args[0];
+    const router = TestBed.inject(Router);
+    await router.navigate(['/static-route']);
+    expect(provider).to.not.be.undefined;
+    expect(provider!()).to.equal('/static-route');
   });
 
   it('should log the error to the console', async () => {

--- a/packages/crashlytics/src/angular/index.test.ts
+++ b/packages/crashlytics/src/angular/index.test.ts
@@ -99,7 +99,7 @@ describe('FirebaseErrorHandler', () => {
     runInInjectionContext(testInjector, () => new FirebaseErrorHandler(app));
     expect(setRoutePathProviderSpy).to.have.been.calledWith(sinon.match.func);
 
-    const provider = setRoutePathProviderSpy.getCall(0).args[0];
+    const provider = setRoutePathProviderSpy.firstCall.args[0];
     const router = TestBed.inject(Router);
     await router.navigate(['/static-route']);
     expect(provider).to.not.be.undefined;

--- a/packages/crashlytics/src/angular/index.test.ts
+++ b/packages/crashlytics/src/angular/index.test.ts
@@ -20,7 +20,7 @@ import 'zone.js/testing';
 import { expect, use } from 'chai';
 import sinonChai from 'sinon-chai';
 import chaiAsPromised from 'chai-as-promised';
-import { restore, stub } from 'sinon';
+import sinon, { restore, stub } from 'sinon';
 import { FirebaseApp, deleteApp, initializeApp } from '@firebase/app';
 import * as crashlytics from '../api';
 import {
@@ -30,14 +30,14 @@ import {
   runInInjectionContext
 } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { FirebaseErrorHandler } from '.';
+import { FirebaseErrorHandler, getSafeRoutePath } from '.';
 import { Crashlytics } from '../public-types';
 import { Router, RouterModule } from '@angular/router';
 import {
   BrowserTestingModule,
   platformBrowserTesting
 } from '@angular/platform-browser/testing';
-import { LOG_ATTR_KEY, AttributesStore } from '../attributes-store';
+import { AttributesStore } from '../attributes-store';
 
 use(sinonChai);
 use(chaiAsPromised);
@@ -45,11 +45,10 @@ use(chaiAsPromised);
 TestBed.initTestEnvironment(BrowserTestingModule, platformBrowserTesting());
 
 @Component({ template: '' })
-class DummyComponent {}
+class MockComponent {}
 
 describe('FirebaseErrorHandler', () => {
   let errorHandler: FirebaseErrorHandler;
-  let router: Router;
   let app: FirebaseApp;
 
   let fakeCrashlytics: Crashlytics;
@@ -73,8 +72,8 @@ describe('FirebaseErrorHandler', () => {
     TestBed.configureTestingModule({
       imports: [
         RouterModule.forRoot([
-          { path: 'static-route', component: DummyComponent },
-          { path: 'dynamic/:id/route', component: DummyComponent }
+          { path: 'static-route', component: MockComponent },
+          { path: 'dynamic/:id/route', component: MockComponent }
         ])
       ],
       providers: [provideZoneChangeDetection()]
@@ -84,12 +83,21 @@ describe('FirebaseErrorHandler', () => {
       testInjector,
       () => new FirebaseErrorHandler(app)
     );
-    router = TestBed.inject(Router);
   });
 
   afterEach(async () => {
     restore();
     await deleteApp(app);
+  });
+
+  it('should register routePath provider in attributesStore', () => {
+    const setRoutePathProviderSpy = sinon.spy(
+      attributesStore,
+      'setRoutePathProvider'
+    );
+    const testInjector = TestBed.inject(Injector);
+    runInInjectionContext(testInjector, () => new FirebaseErrorHandler(app));
+    expect(setRoutePathProviderSpy).to.have.been.calledWith(sinon.match.func);
   });
 
   it('should log the error to the console', async () => {
@@ -98,22 +106,31 @@ describe('FirebaseErrorHandler', () => {
     expect(getCrashlyticsStub).to.have.been.called;
     expect(recordErrorStub).to.have.been.calledWith(fakeCrashlytics, testError);
   });
+});
 
-  describe('routePath integration', () => {
-    it('should set the routePath attribute', async () => {
-      await router.navigate(['/static-route']);
+describe('getSafeRoutePath', () => {
+  let router: Router;
 
-      expect(
-        attributesStore.getLogAttributes()[LOG_ATTR_KEY.ROUTE_PATH]
-      ).to.equal('/static-route');
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        RouterModule.forRoot([
+          { path: 'static-route', component: MockComponent },
+          { path: 'dynamic/:id/route', component: MockComponent }
+        ])
+      ],
+      providers: [provideZoneChangeDetection()]
     });
+    router = TestBed.inject(Router);
+  });
 
-    it('should remove dynamic content from route', async () => {
-      await router.navigate(['/dynamic/my-name/route']);
+  it('should return the static route path', async () => {
+    await router.navigate(['/static-route']);
+    expect(getSafeRoutePath(router)).to.equal('/static-route');
+  });
 
-      expect(
-        attributesStore.getLogAttributes()[LOG_ATTR_KEY.ROUTE_PATH]
-      ).to.equal('/dynamic/:id/route');
-    });
+  it('should return the parameterized route pattern', async () => {
+    await router.navigate(['/dynamic/my-name/route']);
+    expect(getSafeRoutePath(router)).to.equal('/dynamic/:id/route');
   });
 });

--- a/packages/crashlytics/src/angular/index.ts
+++ b/packages/crashlytics/src/angular/index.ts
@@ -30,6 +30,30 @@ registerCrashlytics();
 export * from '../public-types';
 
 /**
+ * Constructs the safe, templated route path from the router state.
+ * Example output: '/users/:id/posts'
+ *
+ * @internal
+ */
+export function getSafeRoutePath(router: Router): string {
+  let currentRoute: ActivatedRouteSnapshot | null =
+    router.routerState.snapshot.root;
+
+  // Find the deepest activated child route
+  while (currentRoute.firstChild) {
+    currentRoute = currentRoute.firstChild;
+  }
+
+  // Traverse up from the deepest child to the root, collecting configured paths
+  const pathFromRoot = currentRoute.pathFromRoot
+    .map(route => route.routeConfig?.path)
+    .filter(path => path !== undefined && path !== '') // Filter out empty or undefined paths
+    .join('/');
+
+  return `/${pathFromRoot}`;
+}
+
+/**
  * A custom ErrorHandler that captures uncaught errors and sends them to Firebase Crashlytics.
  *
  * This should be provided in your application's root module.
@@ -82,34 +106,10 @@ export class FirebaseErrorHandler implements ErrorHandler {
     this.crashlytics = getCrashlytics(app, crashlyticsOptions);
     const attributesStore = (this.crashlytics as CrashlyticsInternal)
       .attributesStore;
-    attributesStore.setRoutePathProvider(() =>
-      this.getSafeRoutePath(this.router)
-    );
+    attributesStore.setRoutePathProvider(() => getSafeRoutePath(this.router));
   }
 
   handleError(error: unknown): void {
     recordError(this.crashlytics, error);
-  }
-
-  /**
-   * Constructs the safe, templated route path from the router state.
-   * Example output: '/users/:id/posts'
-   */
-  private getSafeRoutePath(router: Router): string {
-    let currentRoute: ActivatedRouteSnapshot | null =
-      router.routerState.snapshot.root;
-
-    // Find the deepest activated child route
-    while (currentRoute.firstChild) {
-      currentRoute = currentRoute.firstChild;
-    }
-
-    // Traverse up from the deepest child to the root, collecting configured paths
-    const pathFromRoot = currentRoute.pathFromRoot
-      .map(route => route.routeConfig?.path)
-      .filter(path => path !== undefined && path !== '') // Filter out empty or undefined paths
-      .join('/');
-
-    return `/${pathFromRoot}`;
   }
 }

--- a/packages/crashlytics/src/angular/index.ts
+++ b/packages/crashlytics/src/angular/index.ts
@@ -44,7 +44,7 @@ export function getSafeRoutePath(router: Router): string {
     currentRoute = currentRoute.firstChild;
   }
 
-  // Traverse up from the deepest child to the root, collecting configured paths
+  // Traverse down from the root to the deepest child, collecting configured paths
   const pathFromRoot = currentRoute.pathFromRoot
     .map(route => route.routeConfig?.path)
     .filter(path => path !== undefined && path !== '') // Filter out empty or undefined paths


### PR DESCRIPTION
Refactoring location of getSafeRoutePath function due to refactor on crashlytics-traces2 branch. The intention is to make this function available for a navigation tracking listener here: #10147.


