### PR TITLE
fix(prune-dts): preserve license headers across pruned declaration files and align snapshots

### DIFF
--- a/repo-scripts/prune-dts/prune-dts.ts
+++ b/repo-scripts/prune-dts/prune-dts.ts
@@ -64,6 +64,24 @@ export function pruneDts(
   const transformedSourceFile: ts.SourceFile = result.transformed[0];
   let content = printer.printFile(transformedSourceFile);
 
+  // Preserve leading license comment if updateSourceFile dropped it from statement #0
+  const leadingComments = ts.getLeadingCommentRanges(
+    sourceFile.getFullText(),
+    0
+  );
+  if (leadingComments && leadingComments.length > 0) {
+    const firstComment = sourceFile
+      .getFullText()
+      .slice(leadingComments[0].pos, leadingComments[0].end);
+    if (
+      firstComment.includes('@license') &&
+      !content.trimStart().startsWith('/**\n * @license') &&
+      !content.trimStart().startsWith('/*\n * @license')
+    ) {
+      content = `${firstComment}\n` + content;
+    }
+  }
+
   fs.writeFileSync(outputLocation, content);
 }
 


### PR DESCRIPTION
Fixes 11 test failures currently in main caused by pruned license headers.

In https://github.com/firebase/firebase-js-sdk/commit/83e686478cea10c707909369dcf590cb09c59ef7, prune-dts.ts wrapped the transformer return value in `ts.factory.updateSourceFile`. When the first AST statement is pruned into a `NotEmittedStatement`, `updateSourceFile` causes the TypeScript Printer to drop the leading file header comment (`/** @license ... */`).

While this did not affect production SDK types (where imports/exports appear first and survive pruning), it caused unit tests (which start with unexported declarations) to lose their license headers.