### PR TITLE
feat(firestore): support atomic option in PipelineExecuteOptions (b/520421910)

### DIFF
--- a/common/api-review/firestore-pipelines.api.md
+++ b/common/api-review/firestore-pipelines.api.md
@@ -1313,6 +1313,7 @@ export class Pipeline {
 
 // @public
 export interface PipelineExecuteOptions {
+    atomic?: boolean;
     indexMode?: 'recommended';
     pipeline: Pipeline;
     rawOptions?: {

--- a/packages/firestore/src/api/pipeline_impl.ts
+++ b/packages/firestore/src/api/pipeline_impl.ts
@@ -171,34 +171,32 @@ export function execute(
 
   return firestoreClientExecutePipeline(client, structuredPipeline, {
     atomic
-  }).then(
-    result => {
-      // Get the execution time from the first result.
-      // firestoreClientExecutePipeline returns at least one PipelineStreamElement
-      // even if the returned document set is empty.
-      const executionTime =
-        result.length > 0 ? result[0].executionTime?.toTimestamp() : undefined;
+  }).then(result => {
+    // Get the execution time from the first result.
+    // firestoreClientExecutePipeline returns at least one PipelineStreamElement
+    // even if the returned document set is empty.
+    const executionTime =
+      result.length > 0 ? result[0].executionTime?.toTimestamp() : undefined;
 
-      const docs = result
-        // Currently ignore any response from ExecutePipeline that does
-        // not contain any document data in the `fields` property.
-        .filter(element => !!element.fields)
-        .map(
-          element =>
-            new PipelineResult(
-              userDataWriter,
-              element.fields!,
-              element.key?.path
-                ? new DocumentReference(firestore, null, element.key)
-                : undefined,
-              element.createTime?.toTimestamp(),
-              element.updateTime?.toTimestamp()
-            )
-        );
+    const docs = result
+      // Currently ignore any response from ExecutePipeline that does
+      // not contain any document data in the `fields` property.
+      .filter(element => !!element.fields)
+      .map(
+        element =>
+          new PipelineResult(
+            userDataWriter,
+            element.fields!,
+            element.key?.path
+              ? new DocumentReference(firestore, null, element.key)
+              : undefined,
+            element.createTime?.toTimestamp(),
+            element.updateTime?.toTimestamp()
+          )
+      );
 
-      return new PipelineSnapshot(pipeline, docs, executionTime);
-    }
-  );
+    return new PipelineSnapshot(pipeline, docs, executionTime);
+  });
 }
 
 /**

--- a/packages/firestore/src/api/pipeline_impl.ts
+++ b/packages/firestore/src/api/pipeline_impl.ts
@@ -135,7 +135,7 @@ export function execute(
         pipeline: pipelineOrOptions
       };
 
-  const { pipeline, rawOptions, ...rest } = options;
+  const { pipeline, rawOptions, atomic, ...rest } = options;
 
   if (!pipeline._db) {
     return Promise.reject(
@@ -169,7 +169,9 @@ export function execute(
     structuredPipelineOptions
   );
 
-  return firestoreClientExecutePipeline(client, structuredPipeline).then(
+  return firestoreClientExecutePipeline(client, structuredPipeline, {
+    atomic
+  }).then(
     result => {
       // Get the execution time from the first result.
       // firestoreClientExecutePipeline returns at least one PipelineStreamElement

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -563,14 +563,15 @@ export function firestoreClientRunAggregateQuery(
 
 export function firestoreClientExecutePipeline(
   client: FirestoreClient,
-  pipeline: StructuredPipeline
+  pipeline: StructuredPipeline,
+  options?: { atomic?: boolean }
 ): Promise<PipelineStreamElement[]> {
   const deferred = new Deferred<PipelineStreamElement[]>();
 
   client.asyncQueue.enqueueAndForget(async () => {
     try {
       const datastore = await getDatastore(client);
-      deferred.resolve(invokeExecutePipeline(datastore, pipeline));
+      deferred.resolve(invokeExecutePipeline(datastore, pipeline, options));
     } catch (e) {
       deferred.reject(e as Error);
     }

--- a/packages/firestore/src/lite-api/pipeline_impl.ts
+++ b/packages/firestore/src/lite-api/pipeline_impl.ts
@@ -110,31 +110,32 @@ export function execute(
 
   return invokeExecutePipeline(datastore, structuredPipeline, { atomic }).then(
     result => {
-    // Get the execution time from the first result.
-    // firestoreClientExecutePipeline returns at least one PipelineStreamElement
-    // even if the returned document set is empty.
-    const executionTime =
-      result.length > 0 ? result[0].executionTime?.toTimestamp() : undefined;
+      // Get the execution time from the first result.
+      // firestoreClientExecutePipeline returns at least one PipelineStreamElement
+      // even if the returned document set is empty.
+      const executionTime =
+        result.length > 0 ? result[0].executionTime?.toTimestamp() : undefined;
 
-    const docs = result
-      // Currently ignore any response from ExecutePipeline that does
-      // not contain any document data in the `fields` property.
-      .filter(element => !!element.fields)
-      .map(
-        element =>
-          new PipelineResult(
-            userDataWriter,
-            element.fields!,
-            element.key?.path
-              ? new DocumentReference(firestore, null, element.key)
-              : undefined,
-            element.createTime?.toTimestamp(),
-            element.updateTime?.toTimestamp()
-          )
-      );
+      const docs = result
+        // Currently ignore any response from ExecutePipeline that does
+        // not contain any document data in the `fields` property.
+        .filter(element => !!element.fields)
+        .map(
+          element =>
+            new PipelineResult(
+              userDataWriter,
+              element.fields!,
+              element.key?.path
+                ? new DocumentReference(firestore, null, element.key)
+                : undefined,
+              element.createTime?.toTimestamp(),
+              element.updateTime?.toTimestamp()
+            )
+        );
 
-    return new PipelineSnapshot(pipeline, docs, executionTime);
-  });
+      return new PipelineSnapshot(pipeline, docs, executionTime);
+    }
+  );
 }
 
 /**

--- a/packages/firestore/src/lite-api/pipeline_impl.ts
+++ b/packages/firestore/src/lite-api/pipeline_impl.ts
@@ -28,6 +28,7 @@ import { Firestore } from './database';
 import { Pipeline } from './pipeline';
 import { PipelineResult, PipelineSnapshot } from './pipeline-result';
 import { PipelineSource } from './pipeline-source';
+import { PipelineExecuteOptions } from './pipeline_options';
 import { DocumentReference } from './reference';
 import { LiteUserDataWriter } from './reference_impl';
 import { Stage } from './stage';
@@ -50,37 +51,32 @@ declare module './database' {
 /**
  * Executes this pipeline and returns a Promise to represent the asynchronous operation.
  *
- * The returned Promise can be used to track the progress of the pipeline execution
- * and retrieve the results (or handle any errors) asynchronously.
- *
- * The pipeline results are returned as a {@link @firebase/firestore/pipelines#PipelineSnapshot} that contains
- * a list of {@link @firebase/firestore/pipelines#PipelineResult} objects. Each {@link @firebase/firestore/pipelines#PipelineResult} typically
- * represents a single key/value map that has passed through all the
- * stages of the pipeline, however this might differ depending on the stages involved in the
- * pipeline. For example:
- *
- * <ul>
- *   <li>If there are no stages or only transformation stages, each {@link @firebase/firestore/pipelines#PipelineResult}
- *       represents a single document.</li>
- *   <li>If there is an aggregation, only a single {@link @firebase/firestore/pipelines#PipelineResult} is returned,
- *       representing the aggregated results over the entire dataset .</li>
- *   <li>If there is an aggregation stage with grouping, each {@link @firebase/firestore/pipelines#PipelineResult} represents a
- *       distinct group and its associated aggregated values.</li>
- * </ul>
- *
- * @example
- * ```typescript
- * const snapshot: PipelineSnapshot = await execute(firestore.pipeline().collection("books")
- *     .where(gt(field("rating"), 4.5))
- *     .select("title", "author", "rating"));
- *
- * const results: PipelineResults = snapshot.results;
- * ```
- *
  * @param pipeline - The pipeline to execute.
  * @returns A Promise representing the asynchronous pipeline execution.
  */
-export function execute(pipeline: Pipeline): Promise<PipelineSnapshot> {
+export function execute(pipeline: Pipeline): Promise<PipelineSnapshot>;
+/**
+ * Executes a pipeline with options and returns a Promise to represent the asynchronous operation.
+ *
+ * @param options - Specifies the pipeline to execute and options.
+ * @returns A Promise representing the asynchronous pipeline execution.
+ */
+export function execute(
+  options: PipelineExecuteOptions
+): Promise<PipelineSnapshot>;
+export function execute(
+  pipelineOrOptions: Pipeline | PipelineExecuteOptions
+): Promise<PipelineSnapshot> {
+  const options: PipelineExecuteOptions = !(
+    pipelineOrOptions instanceof Pipeline
+  )
+    ? pipelineOrOptions
+    : {
+        pipeline: pipelineOrOptions
+      };
+
+  const { pipeline, rawOptions, atomic, ...rest } = options;
+
   if (!pipeline._db) {
     return Promise.reject(
       new FirestoreError(
@@ -101,7 +97,10 @@ export function execute(pipeline: Pipeline): Promise<PipelineSnapshot> {
   pipeline._readUserData(context);
   const userDataWriter = new LiteUserDataWriter(firestore);
 
-  const structuredPipelineOptions = new StructuredPipelineOptions({}, {});
+  const structuredPipelineOptions = new StructuredPipelineOptions(
+    rest,
+    rawOptions
+  );
   structuredPipelineOptions._readUserData(context);
 
   const structuredPipeline: StructuredPipeline = new StructuredPipeline(
@@ -109,7 +108,8 @@ export function execute(pipeline: Pipeline): Promise<PipelineSnapshot> {
     structuredPipelineOptions
   );
 
-  return invokeExecutePipeline(datastore, structuredPipeline).then(result => {
+  return invokeExecutePipeline(datastore, structuredPipeline, { atomic }).then(
+    result => {
     // Get the execution time from the first result.
     // firestoreClientExecutePipeline returns at least one PipelineStreamElement
     // even if the returned document set is empty.

--- a/packages/firestore/src/lite-api/pipeline_options.ts
+++ b/packages/firestore/src/lite-api/pipeline_options.ts
@@ -27,6 +27,12 @@ export interface PipelineExecuteOptions {
   pipeline: Pipeline;
 
   /**
+   * Indicates that the pipeline will be executed atomically in a single RPC
+   * transaction on the server.
+   */
+  atomic?: boolean;
+
+  /**
    * Specify the index mode.
    */
   indexMode?: 'recommended';

--- a/packages/firestore/src/protos/firestore_proto_api.ts
+++ b/packages/firestore/src/protos/firestore_proto_api.ts
@@ -250,6 +250,7 @@ export declare namespace firestoreV1ApiClientInterfaces {
     transaction?: string;
     newTransaction?: TransactionOptions;
     readTime?: string;
+    autoCommitTransaction?: boolean;
   }
   interface ExecutePipelineResponse {
     transaction?: string;

--- a/packages/firestore/src/remote/datastore.ts
+++ b/packages/firestore/src/remote/datastore.ts
@@ -244,12 +244,18 @@ export async function invokeBatchGetDocumentsRpc(
 
 export async function invokeExecutePipeline(
   datastore: Datastore,
-  structuredPipeline: StructuredPipeline
+  structuredPipeline: StructuredPipeline,
+  options?: { atomic?: boolean }
 ): Promise<PipelineStreamElement[]> {
   const datastoreImpl = debugCast(datastore, DatastoreImpl);
   const executePipelineRequest: ProtoExecutePipelineRequest = {
     database: getEncodedDatabaseId(datastoreImpl.serializer),
-    structuredPipeline: structuredPipeline._toProto(datastoreImpl.serializer)
+    structuredPipeline: structuredPipeline._toProto(datastoreImpl.serializer),
+    ...(options?.atomic
+      ? {
+          autoCommitTransaction: true
+        }
+      : {})
   };
 
   const response = await datastoreImpl.invokeStreamingRPC<

--- a/packages/firestore/test/integration/api/pipeline.test.ts
+++ b/packages/firestore/test/integration/api/pipeline.test.ts
@@ -2438,6 +2438,36 @@ apiDescribe.skipClassic('Pipelines', persistence => {
         );
         expectResults(res, { documents_modified: 0 });
       });
+
+      it('can execute update stage atomically', async () => {
+        const res = await execute({
+          pipeline: firestore
+            .pipeline()
+            .collection(randomCol.path)
+            .where(equal(field('__name__').documentId(), 'book1'))
+            .update([constant('AtomicUpdate').as('status')]),
+          atomic: true
+        });
+        expectResults(res, { documents_modified: 1 });
+
+        const docSnap = await getDoc(doc(randomCol, 'book1'));
+        expect(docSnap.get('status')).to.equal('AtomicUpdate');
+      });
+
+      it('can execute delete stage with atomic explicitly set to false', async () => {
+        const deleteRes = await execute({
+          pipeline: firestore
+            .pipeline()
+            .collection(randomCol.path)
+            .where(equal(field('__name__').documentId(), 'book2'))
+            .delete(),
+          atomic: false
+        });
+        expectResults(deleteRes, { documents_modified: 1 });
+
+        const docSnap = await getDoc(doc(randomCol, 'book2'));
+        expect(docSnap.exists()).to.be.false;
+      });
     });
   });
 

--- a/packages/firestore/test/integration/api/pipeline.test.ts
+++ b/packages/firestore/test/integration/api/pipeline.test.ts
@@ -46,11 +46,9 @@ import {
   deleteDoc,
   FirestoreError,
   getDocs,
-  getDoc,
-  setLogLevel
+  getDoc
 } from '../util/firebase_export';
 import { apiDescribe, withTestCollection, withTestDbs } from '../util/helpers';
-
 import {
   array,
   mod,

--- a/packages/firestore/test/unit/api/pipeline_impl.test.ts
+++ b/packages/firestore/test/unit/api/pipeline_impl.test.ts
@@ -306,5 +306,45 @@ describe('stage serialization', () => {
         executePipelineRequest
       );
     });
+
+    it('defaults to atomic=false when atomic option is omitted or false', async () => {
+      const firestore = newTestFirestore();
+      const spy = fakePipelineResponse(firestore);
+
+      // Execute without atomic option
+      await execute({
+        pipeline: firestore.pipeline().collection('foo')
+      });
+
+      const reqDefault = spy.args[0][EXECUTE_PIPELINE_REQUEST] as ProtoExecutePipelineRequest;
+      expect(reqDefault.newTransaction).to.be.undefined;
+      expect(reqDefault.autoCommitTransaction).to.be.undefined;
+
+      // Execute with atomic: false
+      const firestore2 = newTestFirestore();
+      const spy2 = fakePipelineResponse(firestore2);
+      await execute({
+        pipeline: firestore2.pipeline().collection('foo'),
+        atomic: false
+      });
+
+      const reqFalse = spy2.args[0][EXECUTE_PIPELINE_REQUEST] as ProtoExecutePipelineRequest;
+      expect(reqFalse.newTransaction).to.be.undefined;
+      expect(reqFalse.autoCommitTransaction).to.be.undefined;
+    });
+
+    it('serializes autoCommitTransaction on ProtoExecutePipelineRequest when atomic is true', async () => {
+      const firestore = newTestFirestore();
+      const spy = fakePipelineResponse(firestore);
+
+      await execute({
+        pipeline: firestore.pipeline().collection('foo'),
+        atomic: true
+      });
+
+      const req = spy.args[0][EXECUTE_PIPELINE_REQUEST] as ProtoExecutePipelineRequest;
+      expect(req.autoCommitTransaction).to.be.true;
+      expect(req.newTransaction).to.be.undefined;
+    });
   });
 });

--- a/packages/firestore/test/unit/api/pipeline_impl.test.ts
+++ b/packages/firestore/test/unit/api/pipeline_impl.test.ts
@@ -316,7 +316,9 @@ describe('stage serialization', () => {
         pipeline: firestore.pipeline().collection('foo')
       });
 
-      const reqDefault = spy.args[0][EXECUTE_PIPELINE_REQUEST] as ProtoExecutePipelineRequest;
+      const reqDefault = spy.args[0][
+        EXECUTE_PIPELINE_REQUEST
+      ] as ProtoExecutePipelineRequest;
       expect(reqDefault.newTransaction).to.be.undefined;
       expect(reqDefault.autoCommitTransaction).to.be.undefined;
 
@@ -328,7 +330,9 @@ describe('stage serialization', () => {
         atomic: false
       });
 
-      const reqFalse = spy2.args[0][EXECUTE_PIPELINE_REQUEST] as ProtoExecutePipelineRequest;
+      const reqFalse = spy2.args[0][
+        EXECUTE_PIPELINE_REQUEST
+      ] as ProtoExecutePipelineRequest;
       expect(reqFalse.newTransaction).to.be.undefined;
       expect(reqFalse.autoCommitTransaction).to.be.undefined;
     });
@@ -342,7 +346,9 @@ describe('stage serialization', () => {
         atomic: true
       });
 
-      const req = spy.args[0][EXECUTE_PIPELINE_REQUEST] as ProtoExecutePipelineRequest;
+      const req = spy.args[0][
+        EXECUTE_PIPELINE_REQUEST
+      ] as ProtoExecutePipelineRequest;
       expect(req.autoCommitTransaction).to.be.true;
       expect(req.newTransaction).to.be.undefined;
     });


### PR DESCRIPTION
Adds atomic option to PipelineExecuteOptions per b/520421910.