### PR TITLE
feat(ai): add global MediaResolution setting to GenerationConfig

### DIFF
--- a/common/api-review/ai.api.md
+++ b/common/api-review/ai.api.md
@@ -563,6 +563,7 @@ export interface GenerationConfig {
     // (undocumented)
     frequencyPenalty?: number;
     imageConfig?: ImageConfig;
+    inputMediaResolution?: MediaResolution;
     // (undocumented)
     maxOutputTokens?: number;
     // (undocumented)
@@ -1077,6 +1078,7 @@ export interface LiveGenerationConfig {
     contextWindowCompression?: ContextWindowCompressionConfig;
     frequencyPenalty?: number;
     inputAudioTranscription?: AudioTranscriptionConfig;
+    inputMediaResolution?: MediaResolution;
     maxOutputTokens?: number;
     outputAudioTranscription?: AudioTranscriptionConfig;
     presencePenalty?: number;
@@ -1194,6 +1196,17 @@ export interface LiveSessionResumptionUpdate {
     // (undocumented)
     type: 'sessionResumptionUpdate';
 }
+
+// @public
+export const MediaResolution: {
+    readonly LOW: "MEDIA_RESOLUTION_LOW";
+    readonly MEDIUM: "MEDIA_RESOLUTION_MEDIUM";
+    readonly HIGH: "MEDIA_RESOLUTION_HIGH";
+    readonly ULTRA_HIGH: "MEDIA_RESOLUTION_ULTRA_HIGH";
+};
+
+// @public
+export type MediaResolution = (typeof MediaResolution)[keyof typeof MediaResolution];
 
 // @public
 export const Modality: {

--- a/packages/ai/src/models/generative-model.test.ts
+++ b/packages/ai/src/models/generative-model.test.ts
@@ -24,7 +24,8 @@ import {
   ChromeAdapter,
   ThinkingLevel,
   ImageConfigAspectRatio,
-  ImageConfigImageSize
+  ImageConfigImageSize,
+  MediaResolution
 } from '../public-types';
 import * as request from '../requests/request';
 import { SinonStub, match, restore, stub } from 'sinon';
@@ -340,6 +341,18 @@ describe('GenerativeModel', () => {
       aspectRatio: '1:1',
       imageSize: '512'
     });
+  });
+  it('passes inputMediaResolution through in generationConfig', () => {
+    const genModel = new GenerativeModel(fakeAI, {
+      model: 'gemini-2.5-flash',
+      generationConfig: {
+        inputMediaResolution: MediaResolution.LOW
+      }
+    });
+    const chatSession = genModel.startChat();
+    expect(chatSession.params?.generationConfig?.inputMediaResolution).to.equal(
+      'MEDIA_RESOLUTION_LOW'
+    );
   });
   it('overrides base model params with startChatParams', () => {
     const genModel = new GenerativeModel(fakeAI, {

--- a/packages/ai/src/types/enums.ts
+++ b/packages/ai/src/types/enums.ts
@@ -543,3 +543,24 @@ export const ThinkingLevel = {
  * @public
  */
 export type ThinkingLevel = (typeof ThinkingLevel)[keyof typeof ThinkingLevel];
+
+/**
+ * Media resolution levels for image and video inputs.
+ *
+ * @public
+ */
+export const MediaResolution = {
+  LOW: 'MEDIA_RESOLUTION_LOW',
+  MEDIUM: 'MEDIA_RESOLUTION_MEDIUM',
+  HIGH: 'MEDIA_RESOLUTION_HIGH',
+  // ULTRA_HIGH is currently internal only, but will be added later
+  ULTRA_HIGH: 'MEDIA_RESOLUTION_ULTRA_HIGH'
+} as const;
+
+/**
+ * Media resolution levels for image and video inputs.
+ *
+ * @public
+ */
+export type MediaResolution = (typeof MediaResolution)[keyof typeof MediaResolution];
+

--- a/packages/ai/src/types/requests.ts
+++ b/packages/ai/src/types/requests.ts
@@ -30,7 +30,8 @@ import {
   ImageConfigImageSize,
   InferenceMode,
   ResponseModality,
-  ThinkingLevel
+  ThinkingLevel,
+  MediaResolution
 } from './enums';
 import { ObjectSchemaRequest, SchemaRequest } from './schema';
 
@@ -185,6 +186,10 @@ export interface GenerationConfig {
    * @public
    */
   imageConfig?: ImageConfig;
+  /**
+   * The media resolution setting for image and video inputs.
+   */
+  inputMediaResolution?: MediaResolution;
 }
 
 /**
@@ -260,6 +265,10 @@ export interface LiveGenerationConfig {
    * @beta
    */
   contextWindowCompression?: ContextWindowCompressionConfig;
+  /**
+   * The media resolution setting for image and video inputs.
+   */
+  inputMediaResolution?: MediaResolution;
 }
 
 /**


### PR DESCRIPTION
Implements the initial global configuration setting for **Input Media Resolution** across `@firebase/ai` (per `go/alf-media-resolution`).
## Changes
* **New exported enum:** Added `MediaResolution` (`LOW`, `MEDIUM`, `HIGH`, `ULTRA_HIGH`) to [enums.ts](file:///Users/chholland/repos/fb-JETSKI/packages/ai/src/types/enums.ts).
* **Updated config interfaces:** Added optional `inputMediaResolution?: MediaResolution` property to `GenerationConfig` (`@public`) and `LiveGenerationConfig` (`@beta`) in [requests.ts](file:///Users/chholland/repos/fb-JETSKI/packages/ai/src/types/requests.ts).
* **Tests & API Declarations:** Updated `common/api-review/ai.api.md` and added unit test coverage for `inputMediaResolution` passthrough in [generative-model.test.ts](file:///Users/chholland/repos/fb-JETSKI/packages/ai/src/models/generative-model.test.ts).