### PR TITLE
chore(deps): Remove "request" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,6 @@
     "postinstall-postinstall": "2.1.0",
     "prettier": "3.9.4",
     "protobufjs-cli": "^1.1.3",
-    "request": "2.88.2",
     "rollup": "4.62.2",
     "rollup-plugin-license": "3.7.1",
     "semver": "7.7.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "@types/mocha": "9.1.1",
     "@types/mz": "2.7.8",
     "@types/node": "18.19.83",
-    "@types/request": "2.48.12",
     "@types/sinon": "9.0.11",
     "@types/sinon-chai": "3.2.12",
     "@types/tmp": "0.2.6",

--- a/scripts/emulator-testing/emulators/database-emulator.ts
+++ b/scripts/emulator-testing/emulators/database-emulator.ts
@@ -38,22 +38,22 @@ export class DatabaseEmulator extends Emulator {
     this.namespace = namespace;
   }
 
-  setPublicRules(): Promise<number> {
+  async setPublicRules(): Promise<number> {
     const jsonRules = JSON.stringify(rulesJSON);
     console.log(`Setting rule ${jsonRules} to emulator ...`);
-    return new Promise<number>((resolve, reject) => {
-      request.put(
-        {
-          uri: `http://localhost:${this.port}/.settings/rules.json?ns=${this.namespace}`,
-          headers: { Authorization: 'Bearer owner' },
-          body: jsonRules
+    const response = await fetch(
+      `http://localhost:${this.port}/.settings/rules.json?ns=${this.namespace}`,
+      {
+        method: 'PUT',
+        headers: {
+          'Authorization': 'Bearer owner',
+          'Content-Type': 'application/json'
         },
-        (error, response, body) => {
-          if (error) reject(error);
-          console.log(`Done setting public rule to emulator: ${body}.`);
-          resolve(response.statusCode);
-        }
-      );
-    });
+        body: jsonRules
+      }
+    );
+    const body = await response.text();
+    console.log(`Done setting public rule to emulator: ${body}.`);
+    return response.status;
   }
 }

--- a/scripts/emulator-testing/emulators/database-emulator.ts
+++ b/scripts/emulator-testing/emulators/database-emulator.ts
@@ -49,7 +49,8 @@ export class DatabaseEmulator extends Emulator {
           'Authorization': 'Bearer owner',
           'Content-Type': 'application/json'
         },
-        body: jsonRules
+        body: jsonRules,
+        signal: AbortSignal.timeout(10000)
       }
     );
     const body = await response.text();

--- a/yarn.lock
+++ b/yarn.lock
@@ -8249,17 +8249,7 @@ form-data@4.0.5, form-data@^4.0.5:
     hasown "^2.0.2"
     mime-types "^2.1.12"
 
-form-data@^2.5.0:
-  version "2.5.2"
-  resolved "https://registry.npmjs.org/form-data/-/form-data-2.5.2.tgz#dc653743d1de2fcc340ceea38079daf6e9069fd2"
-  integrity sha512-GgwY0PS7DbXqajuGf4OYlsrIu3zgxD6Vvql43IBhm6MahqA5SK/7mwhtNj2AdH2z35YR34ujJ7BN+3fFC3jP5Q==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.6"
-    mime-types "^2.1.12"
-    safe-buffer "^5.2.1"
-
-form-data@^2.5.5:
+form-data@^2.5.0, form-data@^2.5.5:
   version "2.5.6"
   resolved "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz#ef39b3d99e2fc9f25420c0db7962fe36cafcd244"
   integrity sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==
@@ -14645,7 +14635,7 @@ replacestream@^4.0.3:
     object-assign "^4.0.1"
     readable-stream "^2.0.2"
 
-request@2.88.2, request@^2.88.0, request@^2.88.2:
+request@^2.88.0, request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.npmjs.org/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3731,16 +3731,6 @@
   resolved "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
-"@types/request@2.48.12":
-  version "2.48.12"
-  resolved "https://registry.npmjs.org/@types/request/-/request-2.48.12.tgz#0f590f615a10f87da18e9790ac94c29ec4c5ef30"
-  integrity sha512-G3sY+NpsA9jnwm0ixhAFQSJ3Q9JkpLZpJbI3GMv0mIAT0y3mRabYeINzal5WOChIiaTEGQYlHOKgkaM9EisWHw==
-  dependencies:
-    "@types/caseless" "*"
-    "@types/node" "*"
-    "@types/tough-cookie" "*"
-    form-data "^2.5.0"
-
 "@types/request@^2.48.8":
   version "2.48.13"
   resolved "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz#abdf4256524e801ea8fdda54320f083edb5a6b80"
@@ -8249,7 +8239,7 @@ form-data@4.0.5, form-data@^4.0.5:
     hasown "^2.0.2"
     mime-types "^2.1.12"
 
-form-data@^2.5.0, form-data@^2.5.5:
+form-data@^2.5.5:
   version "2.5.6"
   resolved "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz#ef39b3d99e2fc9f25420c0db7962fe36cafcd244"
   integrity sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==


### PR DESCRIPTION
Removing the `request` dependency which has not been updated in 6 years and has a transitive dependency (`form-data` version 2.3.3) that is listed as a critical security vulnerability. It is only used in one place, in `database-emulator.ts` which is part of a test pipeline to start up rtdb emulator tests. I replaced that code with a native fetch call. (`request` is from before `fetch` was available in Node and offered a user-friendly way to make http requests, it is now obsolete).

Also removed `@types/request`.

Unfortunately this doesn't really fix the `form-data` issue as `request` is still a transitive dependency of `coveralls` and `selenium-assistant` which were both last published a year ago and have not been updated.