### PR TITLE
Add support for setting custom attributes in crashlytics options

### DIFF
--- a/common/api-review/crashlytics-angular.api.md
+++ b/common/api-review/crashlytics-angular.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { AnyValueMap } from '@opentelemetry/api-logs';
 import { ErrorHandler } from '@angular/core';
 import { FirebaseApp } from '@firebase/app';
 
@@ -15,6 +16,7 @@ export interface Crashlytics {
 // @public
 export interface CrashlyticsOptions {
     appVersion?: string;
+    customAttributes?: AnyValueMap;
     endpointUrl?: string;
     region?: string;
 }

--- a/common/api-review/crashlytics-react-router.api.md
+++ b/common/api-review/crashlytics-react-router.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { AnyValueMap } from '@opentelemetry/api-logs';
 import { default } from 'react';
 import { FirebaseApp } from '@firebase/app';
 import { RoutesProps } from 'react-router-dom';
@@ -16,6 +17,7 @@ export interface Crashlytics {
 // @public
 export interface CrashlyticsOptions {
     appVersion?: string;
+    customAttributes?: AnyValueMap;
     endpointUrl?: string;
     region?: string;
 }

--- a/common/api-review/crashlytics-react.api.md
+++ b/common/api-review/crashlytics-react.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { AnyValueMap } from '@opentelemetry/api-logs';
 import { FirebaseApp } from '@firebase/app';
 
 // @public
@@ -14,6 +15,7 @@ export interface Crashlytics {
 // @public
 export interface CrashlyticsOptions {
     appVersion?: string;
+    customAttributes?: AnyValueMap;
     endpointUrl?: string;
     region?: string;
 }

--- a/common/api-review/crashlytics.api.md
+++ b/common/api-review/crashlytics.api.md
@@ -16,6 +16,7 @@ export interface Crashlytics {
 // @public
 export interface CrashlyticsOptions {
     appVersion?: string;
+    customAttributes?: AnyValueMap;
     endpointUrl?: string;
     region?: string;
 }

--- a/docs-devsite/crashlytics_.crashlyticsoptions.md
+++ b/docs-devsite/crashlytics_.crashlyticsoptions.md
@@ -23,6 +23,7 @@ export interface CrashlyticsOptions
 |  Property | Type | Description |
 |  --- | --- | --- |
 |  [appVersion](./crashlytics_.crashlyticsoptions.md#crashlyticsoptionsappversion) | string | The version of the application. This should be a unique string that identifies the snapshot of code to be deployed, such as "1.0.2". If not specified, other default locations will be checked for an identifier. Setting a value here takes precedence over any other values. |
+|  [customAttributes](./crashlytics_.crashlyticsoptions.md#crashlyticsoptionscustomattributes) | AnyValueMap | Base set of custom attributes to send with automatic error collection. Key-value pairs defined here will be sent with all error logs. If custom attributes are also specified in <code>recordError()</code>, those values will take precedence over the base set defined here. |
 |  [endpointUrl](./crashlytics_.crashlyticsoptions.md#crashlyticsoptionsendpointurl) | string | The URL for the endpoint to which Crashlytics data should be sent, in the OpenTelemetry format. By default, data will be sent to Firebase. |
 |  [region](./crashlytics_.crashlyticsoptions.md#crashlyticsoptionsregion) | string | The Google Cloud region where the Crashlytics data should be sent.<!-- -->By default, data will be sent to the "global" region.<!-- -->Refer to https://cloud.google.com/logging/docs/regions for the list of available regions. |
 
@@ -34,6 +35,16 @@ The version of the application. This should be a unique string that identifies t
 
 ```typescript
 appVersion?: string;
+```
+
+## CrashlyticsOptions.customAttributes
+
+Base set of custom attributes to send with automatic error collection. Key-value pairs defined here will be sent with all error logs. If custom attributes are also specified in `recordError()`<!-- -->, those values will take precedence over the base set defined here.
+
+<b>Signature:</b>
+
+```typescript
+customAttributes?: AnyValueMap;
 ```
 
 ## CrashlyticsOptions.endpointUrl

--- a/docs-devsite/crashlytics_angular.crashlyticsoptions.md
+++ b/docs-devsite/crashlytics_angular.crashlyticsoptions.md
@@ -23,6 +23,7 @@ export interface CrashlyticsOptions
 |  Property | Type | Description |
 |  --- | --- | --- |
 |  [appVersion](./crashlytics_angular.crashlyticsoptions.md#crashlyticsoptionsappversion) | string | The version of the application. This should be a unique string that identifies the snapshot of code to be deployed, such as "1.0.2". If not specified, other default locations will be checked for an identifier. Setting a value here takes precedence over any other values. |
+|  [customAttributes](./crashlytics_angular.crashlyticsoptions.md#crashlyticsoptionscustomattributes) | AnyValueMap | Base set of custom attributes to send with automatic error collection. Key-value pairs defined here will be sent with all error logs. If custom attributes are also specified in <code>recordError()</code>, those values will take precedence over the base set defined here. |
 |  [endpointUrl](./crashlytics_angular.crashlyticsoptions.md#crashlyticsoptionsendpointurl) | string | The URL for the endpoint to which Crashlytics data should be sent, in the OpenTelemetry format. By default, data will be sent to Firebase. |
 |  [region](./crashlytics_angular.crashlyticsoptions.md#crashlyticsoptionsregion) | string | The Google Cloud region where the Crashlytics data should be sent.<!-- -->By default, data will be sent to the "global" region.<!-- -->Refer to https://cloud.google.com/logging/docs/regions for the list of available regions. |
 
@@ -34,6 +35,16 @@ The version of the application. This should be a unique string that identifies t
 
 ```typescript
 appVersion?: string;
+```
+
+## CrashlyticsOptions.customAttributes
+
+Base set of custom attributes to send with automatic error collection. Key-value pairs defined here will be sent with all error logs. If custom attributes are also specified in `recordError()`<!-- -->, those values will take precedence over the base set defined here.
+
+<b>Signature:</b>
+
+```typescript
+customAttributes?: AnyValueMap;
 ```
 
 ## CrashlyticsOptions.endpointUrl

--- a/docs-devsite/crashlytics_react-router.crashlyticsoptions.md
+++ b/docs-devsite/crashlytics_react-router.crashlyticsoptions.md
@@ -23,6 +23,7 @@ export interface CrashlyticsOptions
 |  Property | Type | Description |
 |  --- | --- | --- |
 |  [appVersion](./crashlytics_react-router.crashlyticsoptions.md#crashlyticsoptionsappversion) | string | The version of the application. This should be a unique string that identifies the snapshot of code to be deployed, such as "1.0.2". If not specified, other default locations will be checked for an identifier. Setting a value here takes precedence over any other values. |
+|  [customAttributes](./crashlytics_react-router.crashlyticsoptions.md#crashlyticsoptionscustomattributes) | AnyValueMap | Base set of custom attributes to send with automatic error collection. Key-value pairs defined here will be sent with all error logs. If custom attributes are also specified in <code>recordError()</code>, those values will take precedence over the base set defined here. |
 |  [endpointUrl](./crashlytics_react-router.crashlyticsoptions.md#crashlyticsoptionsendpointurl) | string | The URL for the endpoint to which Crashlytics data should be sent, in the OpenTelemetry format. By default, data will be sent to Firebase. |
 |  [region](./crashlytics_react-router.crashlyticsoptions.md#crashlyticsoptionsregion) | string | The Google Cloud region where the Crashlytics data should be sent.<!-- -->By default, data will be sent to the "global" region.<!-- -->Refer to https://cloud.google.com/logging/docs/regions for the list of available regions. |
 
@@ -34,6 +35,16 @@ The version of the application. This should be a unique string that identifies t
 
 ```typescript
 appVersion?: string;
+```
+
+## CrashlyticsOptions.customAttributes
+
+Base set of custom attributes to send with automatic error collection. Key-value pairs defined here will be sent with all error logs. If custom attributes are also specified in `recordError()`<!-- -->, those values will take precedence over the base set defined here.
+
+<b>Signature:</b>
+
+```typescript
+customAttributes?: AnyValueMap;
 ```
 
 ## CrashlyticsOptions.endpointUrl

--- a/docs-devsite/crashlytics_react.crashlyticsoptions.md
+++ b/docs-devsite/crashlytics_react.crashlyticsoptions.md
@@ -23,6 +23,7 @@ export interface CrashlyticsOptions
 |  Property | Type | Description |
 |  --- | --- | --- |
 |  [appVersion](./crashlytics_react.crashlyticsoptions.md#crashlyticsoptionsappversion) | string | The version of the application. This should be a unique string that identifies the snapshot of code to be deployed, such as "1.0.2". If not specified, other default locations will be checked for an identifier. Setting a value here takes precedence over any other values. |
+|  [customAttributes](./crashlytics_react.crashlyticsoptions.md#crashlyticsoptionscustomattributes) | AnyValueMap | Base set of custom attributes to send with automatic error collection. Key-value pairs defined here will be sent with all error logs. If custom attributes are also specified in <code>recordError()</code>, those values will take precedence over the base set defined here. |
 |  [endpointUrl](./crashlytics_react.crashlyticsoptions.md#crashlyticsoptionsendpointurl) | string | The URL for the endpoint to which Crashlytics data should be sent, in the OpenTelemetry format. By default, data will be sent to Firebase. |
 |  [region](./crashlytics_react.crashlyticsoptions.md#crashlyticsoptionsregion) | string | The Google Cloud region where the Crashlytics data should be sent.<!-- -->By default, data will be sent to the "global" region.<!-- -->Refer to https://cloud.google.com/logging/docs/regions for the list of available regions. |
 
@@ -34,6 +35,16 @@ The version of the application. This should be a unique string that identifies t
 
 ```typescript
 appVersion?: string;
+```
+
+## CrashlyticsOptions.customAttributes
+
+Base set of custom attributes to send with automatic error collection. Key-value pairs defined here will be sent with all error logs. If custom attributes are also specified in `recordError()`<!-- -->, those values will take precedence over the base set defined here.
+
+<b>Signature:</b>
+
+```typescript
+customAttributes?: AnyValueMap;
 ```
 
 ## CrashlyticsOptions.endpointUrl

--- a/packages/crashlytics/src/api.test.ts
+++ b/packages/crashlytics/src/api.test.ts
@@ -541,7 +541,7 @@ function getFakeApp(): FirebaseApp {
         ({
           getId: async () => 'iid',
           getToken: async () => 'authToken'
-        } as _FirebaseInstallationsInternal),
+        }) as _FirebaseInstallationsInternal,
       ComponentType.PUBLIC
     )
   );

--- a/packages/crashlytics/src/api.test.ts
+++ b/packages/crashlytics/src/api.test.ts
@@ -345,6 +345,52 @@ describe('Top level API', () => {
       });
     });
 
+    it('should propagate customAttributes from CrashlyticsOptions', () => {
+      const error = 'a string error';
+      fakeAttributesStore.updateOptions({
+        customAttributes: {
+          baseKey: 'baseValue',
+          commonKey: 'commonBaseValue'
+        }
+      });
+
+      recordError(fakeCrashlytics, error);
+
+      expect(emittedLogs.length).to.equal(1);
+      const log = emittedLogs[0];
+      expect(log.attributes).to.deep.equal({
+        [LOG_ATTR_KEY.APP_VERSION]: 'unset',
+        baseKey: 'baseValue',
+        commonKey: 'commonBaseValue',
+        [LOG_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID
+      });
+    });
+
+    it('recordError attributes should take precedence over customAttributes from CrashlyticsOptions', () => {
+      const error = 'a string error';
+      fakeAttributesStore.updateOptions({
+        customAttributes: {
+          baseKey: 'baseValue',
+          commonKey: 'commonBaseValue'
+        }
+      });
+
+      recordError(fakeCrashlytics, error, {
+        commonKey: 'commonOverrideValue',
+        newKey: 'newValue'
+      });
+
+      expect(emittedLogs.length).to.equal(1);
+      const log = emittedLogs[0];
+      expect(log.attributes).to.deep.equal({
+        [LOG_ATTR_KEY.APP_VERSION]: 'unset',
+        baseKey: 'baseValue',
+        commonKey: 'commonOverrideValue',
+        newKey: 'newValue',
+        [LOG_ATTR_KEY.SESSION_ID]: MOCK_SESSION_ID
+      });
+    });
+
     it('should use explicit app version when provided', () => {
       AUTO_CONSTANTS.appVersion = '1.2.3'; // Unused
       const crashlytics = new CrashlyticsService(

--- a/packages/crashlytics/src/attributes-store.test.ts
+++ b/packages/crashlytics/src/attributes-store.test.ts
@@ -246,7 +246,7 @@ describe('AttributesStore', () => {
     });
   });
 
-  describe('updateAppVersion', () => {
+  describe('updateOptions', () => {
     let originalAutoConstantsVersion: any;
 
     beforeEach(() => {
@@ -290,11 +290,39 @@ describe('AttributesStore', () => {
         '1.2.3'
       );
 
-      store.updateAppVersion({ appVersion: '3.4.5' });
+      store.updateOptions({ appVersion: '3.4.5' });
       expect(store.getLogAttributes()).to.have.property(
         'app.build_id',
         '3.4.5'
       );
+    });
+
+    it('should include customAttributes in log attributes if provided', () => {
+      const store = new AttributesStore({} as any, {
+        customAttributes: { key1: 'value1', key2: 'value2' }
+      });
+      expect(store.getLogAttributes()).to.include({
+        key1: 'value1',
+        key2: 'value2'
+      });
+    });
+
+    it('should update customAttributes when updateOptions is called', () => {
+      const store = new AttributesStore({} as any, {
+        customAttributes: { key1: 'value1' }
+      });
+      expect(store.getLogAttributes()).to.include({
+        key1: 'value1'
+      });
+
+      store.updateOptions({
+        customAttributes: { key1: 'value2', key3: 'value3' }
+      });
+      const logAttrs = store.getLogAttributes();
+      expect(logAttrs).to.include({
+        key1: 'value2',
+        key3: 'value3'
+      });
     });
   });
 

--- a/packages/crashlytics/src/attributes-store.ts
+++ b/packages/crashlytics/src/attributes-store.ts
@@ -42,7 +42,7 @@ type Attribute = Record<string, AttributeValue>;
 export class AttributesStore {
   private _projectId: string | undefined;
   private _appVersion: string | undefined;
-  private _customAttributes: Record<string, string> | undefined;
+  private _customAttributes: Record<string, unknown> | undefined;
   private _sessionId: string | undefined;
   private _installations: _FirebaseInstallationsInternal | null;
   private _iid: string | undefined;
@@ -85,7 +85,7 @@ export class AttributesStore {
       ? AUTO_CONSTANTS.appVersion
       : 'unset';
     this._appVersion = appVersion;
-    this._customAttributes = options?.customAttributes;
+    this._customAttributes = options?.customAttributes ? { ...options.customAttributes } : undefined;
   }
 
   /**

--- a/packages/crashlytics/src/attributes-store.ts
+++ b/packages/crashlytics/src/attributes-store.ts
@@ -82,10 +82,12 @@ export class AttributesStore {
     const appVersion = options?.appVersion
       ? options.appVersion
       : AUTO_CONSTANTS?.appVersion
-      ? AUTO_CONSTANTS.appVersion
-      : 'unset';
+        ? AUTO_CONSTANTS.appVersion
+        : 'unset';
     this._appVersion = appVersion;
-    this._customAttributes = options?.customAttributes ? { ...options.customAttributes } : undefined;
+    this._customAttributes = options?.customAttributes
+      ? { ...options.customAttributes }
+      : undefined;
   }
 
   /**
@@ -139,9 +141,8 @@ export class AttributesStore {
       activeSpanContext?.spanId &&
       this._projectId
     ) {
-      attributes[
-        LOG_ATTR_KEY.TRACE
-      ] = `projects/${this._projectId}/traces/${activeSpanContext.traceId}`;
+      attributes[LOG_ATTR_KEY.TRACE] =
+        `projects/${this._projectId}/traces/${activeSpanContext.traceId}`;
       attributes[LOG_ATTR_KEY.SPAN_ID] = activeSpanContext.spanId;
     }
 

--- a/packages/crashlytics/src/attributes-store.ts
+++ b/packages/crashlytics/src/attributes-store.ts
@@ -42,6 +42,7 @@ type Attribute = Record<string, AttributeValue>;
 export class AttributesStore {
   private _projectId: string | undefined;
   private _appVersion: string | undefined;
+  private _customAttributes: Record<string, string> | undefined;
   private _sessionId: string | undefined;
   private _installations: _FirebaseInstallationsInternal | null;
   private _iid: string | undefined;
@@ -53,7 +54,7 @@ export class AttributesStore {
     installationsProvider?: Provider<'installations-internal'>
   ) {
     this._projectId = firebaseOptions.projectId;
-    this.updateAppVersion(crashlyticsOptions);
+    this.updateOptions(crashlyticsOptions);
 
     // Get session id from storage, if available
     const existingSessionId = this.getSessionIdFromStorage();
@@ -75,15 +76,16 @@ export class AttributesStore {
   }
 
   /**
-   * Update the app version inside the store based on new Crashlytics options.
+   * Update the options inside the store based on new Crashlytics options.
    */
-  updateAppVersion(options?: CrashlyticsOptions): void {
+  updateOptions(options?: CrashlyticsOptions): void {
     const appVersion = options?.appVersion
       ? options.appVersion
       : AUTO_CONSTANTS?.appVersion
       ? AUTO_CONSTANTS.appVersion
       : 'unset';
     this._appVersion = appVersion;
+    this._customAttributes = options?.customAttributes;
   }
 
   /**
@@ -121,6 +123,9 @@ export class AttributesStore {
    */
   getLogAttributes(): AnyValueMap {
     const attributes: AnyValueMap = {};
+    if (this._customAttributes) {
+      Object.assign(attributes, this._customAttributes);
+    }
     if (this._appVersion) {
       attributes[LOG_ATTR_KEY.APP_VERSION] = this._appVersion;
     }

--- a/packages/crashlytics/src/auto-constants.ts
+++ b/packages/crashlytics/src/auto-constants.ts
@@ -22,4 +22,3 @@
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const AUTO_CONSTANTS: any = {};
-

--- a/packages/crashlytics/src/public-types.ts
+++ b/packages/crashlytics/src/public-types.ts
@@ -58,4 +58,12 @@ export interface CrashlyticsOptions {
    * for an identifier. Setting a value here takes precedence over any other values.
    */
   appVersion?: string;
+
+  /**
+   * Base set of custom attributes to send with automatic error collection.
+   * Key-value pairs defined here will be sent with all error logs.
+   * If custom attributes are also specified in `recordError()`, those values will
+   * take precedence over the base set defined here.
+   */
+  customAttributes?: Record<string, string>;
 }

--- a/packages/crashlytics/src/public-types.ts
+++ b/packages/crashlytics/src/public-types.ts
@@ -16,6 +16,7 @@
  */
 
 import { FirebaseApp } from '@firebase/app';
+import { AnyValueMap } from '@opentelemetry/api-logs';
 
 /**
  * An instance of the Firebase Crashlytics SDK.
@@ -65,5 +66,5 @@ export interface CrashlyticsOptions {
    * If custom attributes are also specified in `recordError()`, those values will
    * take precedence over the base set defined here.
    */
-  customAttributes?: Record<string, unknown>;
+  customAttributes?: AnyValueMap;
 }

--- a/packages/crashlytics/src/public-types.ts
+++ b/packages/crashlytics/src/public-types.ts
@@ -65,5 +65,5 @@ export interface CrashlyticsOptions {
    * If custom attributes are also specified in `recordError()`, those values will
    * take precedence over the base set defined here.
    */
-  customAttributes?: Record<string, string>;
+  customAttributes?: Record<string, unknown>;
 }

--- a/packages/crashlytics/src/service.ts
+++ b/packages/crashlytics/src/service.ts
@@ -35,7 +35,7 @@ export class CrashlyticsService implements Crashlytics, _FirebaseService {
 
   set options(optionsToSet: CrashlyticsOptions) {
     this._options = optionsToSet;
-    this.attributesStore.updateAppVersion(optionsToSet);
+    this.attributesStore.updateOptions(optionsToSet);
   }
 
   get options(): CrashlyticsOptions | undefined {


### PR DESCRIPTION
Adds the ability to provide a base set of custom attributes to send with every error log. Any attributes provided via programmatic error collection (e.g. `recordError`) take precedence if there are duplicate keys.
