### PR TITLE
Fix primary lease arbitration treating all clients as zombied when LocalStorage is unavailable

### DIFF
--- a/.changeset/wild-camels-guard.md
+++ b/.changeset/wild-camels-guard.md
@@ -1,0 +1,6 @@
+---
+'firebase': patch
+'@firebase/firestore': patch
+---
+
+Fixed an issue where, on platforms without LocalStorage, every client was incorrectly considered "zombied" during primary lease arbitration, allowing a second persistence client to take over a live client's primary lease instead of failing with the exclusive-access error.

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -264,7 +264,6 @@ export class IndexedDbPersistence implements Persistence {
    */
   start(): Promise<void> {
     debugAssert(!this.started, 'IndexedDbPersistence double-started!');
-    debugAssert(this.window !== null, "Expected 'window' to be defined");
 
     // NOTE: This is expected to fail sometimes (in the case of another tab
     // already having the persistence lock), so it's the first thing we should
@@ -1029,11 +1028,16 @@ export class IndexedDbPersistence implements Persistence {
    * cleanup logic in `shutdown()`.
    */
   private isClientZombied(clientId: ClientId): boolean {
+    if (this.webStorage === null) {
+      // Without WebStorage (e.g. Node.js) there are no zombie markers, so no
+      // client can be identified as zombied. Stale clients are still aged out
+      // via their lease/metadata timestamps.
+      return false;
+    }
     try {
       const isZombied =
-        this.webStorage?.getItem(
-          this.zombiedClientLocalStorageKey(clientId)
-        ) !== null;
+        this.webStorage.getItem(this.zombiedClientLocalStorageKey(clientId)) !==
+        null;
       logDebug(
         LOG_TAG,
         `Client '${clientId}' ${

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -1547,6 +1547,39 @@ describe('IndexedDb: allowTabSynchronization', () => {
     });
   });
 
+  it('respects a foreign primary lease when WebStorage is unavailable', async () => {
+    // On platforms without LocalStorage (e.g. Node.js), no zombied-client
+    // markers exist. A second client must still respect the first client's
+    // primary lease rather than treating the leaseholder as zombied.
+    const serializer = new JsonProtoSerializer(
+      TEST_DATABASE_ID,
+      /* useProto3Json= */ true
+    );
+    const newWebStorageLessPersistence = (
+      clientId: ClientId
+    ): IndexedDbPersistence =>
+      new IndexedDbPersistence(
+        /* allowTabSynchronization= */ false,
+        TEST_PERSISTENCE_PREFIX,
+        clientId,
+        LruParams.DEFAULT,
+        newAsyncQueue(),
+        /* window= */ null,
+        /* document= */ null,
+        serializer,
+        MOCK_SEQUENCE_NUMBER_SYNCER,
+        /* forceOwningTab= */ false
+      );
+
+    const db1 = newWebStorageLessPersistence('clientA');
+    await db1.start();
+    const db2 = newWebStorageLessPersistence('clientB');
+    await expect(db2.start()).to.eventually.be.rejectedWith(
+      'Failed to obtain exclusive access to the persistence layer.'
+    );
+    await db1.shutdown();
+  });
+
   it('grants access when synchronization is enabled', async () => {
     return withMultiClientPersistence('clientA', async db1 => {
       await withMultiClientPersistence('clientB', async db2 => {});

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -1548,9 +1548,10 @@ describe('IndexedDb: allowTabSynchronization', () => {
   });
 
   it('respects a foreign primary lease when WebStorage is unavailable', async () => {
-    // On platforms without LocalStorage (e.g. Node.js), no zombied-client
-    // markers exist. A second client must still respect the first client's
-    // primary lease rather than treating the leaseholder as zombied.
+    // On platforms without LocalStorage (e.g. Web Workers, Node.js), no
+    // zombied-client markers exist. A second client must still respect the
+    // first client's primary lease rather than treating the leaseholder as
+    // zombied.
     const serializer = new JsonProtoSerializer(
       TEST_DATABASE_ID,
       /* useProto3Json= */ true
@@ -1572,12 +1573,16 @@ describe('IndexedDb: allowTabSynchronization', () => {
       );
 
     const db1 = newWebStorageLessPersistence('clientA');
-    await db1.start();
     const db2 = newWebStorageLessPersistence('clientB');
-    await expect(db2.start()).to.eventually.be.rejectedWith(
-      'Failed to obtain exclusive access to the persistence layer.'
-    );
-    await db1.shutdown();
+    try {
+      await db1.start();
+      await expect(db2.start()).to.eventually.be.rejectedWith(
+        'Failed to obtain exclusive access to the persistence layer.'
+      );
+    } finally {
+      await db2.shutdown();
+      await db1.shutdown();
+    }
   });
 
   it('grants access when synchronization is enabled', async () => {


### PR DESCRIPTION
isClientZombied() used `this.webStorage?.getItem(...) !== null`, which evaluates to true when webStorage is null (undefined !== null). On platforms without LocalStorage, every client was therefore considered zombied, so a second persistence client would ignore a live client's primary lease and take it over instead of failing with the exclusive-access error. Treat "no WebStorage" as "no zombie markers"; stale clients still age out via their lease/metadata timestamps.

Also removes the start() debug assertion that window is non-null: window is legitimately null on LocalStorage-less platforms and every use of it is already null-guarded.
