### PR TITLE
docs: update Node.js version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Please see [Environment Support](https://firebase.google.com/support/guides/envi
 #### Node.js
 
 Before you can start working on the Firebase JS SDK, you need to have Node.js
-installed on your machine. As of April 19th, 2024 the team has been testing with Node.js version 
-`20.12.2`, but the required version of Node.js may change as we update our dependencies.
+installed on your machine. As of July 17th, 2026 the team has been testing with Node.js version 
+`20.19.0`, but the required version of Node.js may change as we update our dependencies.
 
 To download Node.js visit https://nodejs.org/en/download/.
 
@@ -66,7 +66,7 @@ $ yarn -v
 $ java -version
 ```
 
-Your `node` version should be `20.12.2`, your `yarn` version should
+Your `node` version should be `20.19.0` or greater, your `yarn` version should
 be between `1.0.0` and `1.22.11`, and your `java` version should be `11.0` or greater.
 
 _NOTE: We will update the documentation as new versions are required, however


### PR DESCRIPTION
**Issue:** The README.md recommended Node.js 20.12.2. However, running yarn with Node 20.12.2 fails because the monorepo management dependency lerna (@9.0.6) requires Node.js ^20.19.0 || ^22.12.0 || >=24.0.0.

**Fix:** Updated Node.js recommendations to 20.19.0 or greater (matching the lerna range constraints

Verified clean yarn install and yarn build on Node 20.19.0