### PR TITLE
replacing public tags with internal tags for tracing log functions

### DIFF
--- a/common/api-review/crashlytics.api.md
+++ b/common/api-review/crashlytics.api.md
@@ -30,12 +30,6 @@ export function getCrashlytics(app?: FirebaseApp, options?: CrashlyticsOptions):
 export { Instrumentation }
 
 // @public
-export function logViewBoundary(crashlytics: Crashlytics, urlTemplate: string, attributes?: AnyValueMap): void;
-
-// @public
-export function logVisibilityEvent(crashlytics: Crashlytics, visibilityState: 'visible' | 'hidden'): void;
-
-// @public
 export function nextOnRequestError(crashlyticsOptions?: CrashlyticsOptions): Instrumentation.onRequestError;
 
 // @public

--- a/docs-devsite/crashlytics_.md
+++ b/docs-devsite/crashlytics_.md
@@ -19,8 +19,6 @@ https://github.com/firebase/firebase-js-sdk
 |  [getCrashlytics(app, options)](./crashlytics_.md#getcrashlytics_a9d22a1) | Returns the default [Crashlytics](./crashlytics_.crashlytics.md#crashlytics_interface) instance that is associated with the provided [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface)<!-- -->. If no instance exists, initializes a new instance with the default settings. |
 |  <b>function(crashlytics, ...)</b> |
 |  [flush(crashlytics)](./crashlytics_.md#flush_16fdf66) | Flushes all enqueued Crashlytics data immediately, instead of waiting for default batching. |
-|  [logViewBoundary(crashlytics, urlTemplate, attributes)](./crashlytics_.md#logviewboundary_e310697) | Creates a log for view boundary on navigation event |
-|  [logVisibilityEvent(crashlytics, visibilityState)](./crashlytics_.md#logvisibilityevent_1d6b238) | Logs a page visibility transition event (foreground or background). |
 |  [recordError(crashlytics, error, attributes)](./crashlytics_.md#recorderror_6824e74) | Enqueues an error to be uploaded to the Firebase Crashlytics API. |
 |  <b>function(crashlyticsOptions, ...)</b> |
 |  [nextOnRequestError(crashlyticsOptions)](./crashlytics_.md#nextonrequesterror_3caf5de) | Automatically report uncaught errors from server routes to Firebase Crashlytics. |
@@ -94,49 +92,6 @@ export declare function flush(crashlytics: Crashlytics): Promise<void>;
 Promise&lt;void&gt;
 
 a promise which is resolved when all flushes are complete
-
-### logViewBoundary(crashlytics, urlTemplate, attributes) {:#logviewboundary_e310697}
-
-Creates a log for view boundary on navigation event
-
-<b>Signature:</b>
-
-```typescript
-export declare function logViewBoundary(crashlytics: Crashlytics, urlTemplate: string, attributes?: AnyValueMap): void;
-```
-
-#### Parameters
-
-|  Parameter | Type | Description |
-|  --- | --- | --- |
-|  crashlytics | [Crashlytics](./crashlytics_.crashlytics.md#crashlytics_interface) | The [Crashlytics](./crashlytics_.crashlytics.md#crashlytics_interface) instance. |
-|  urlTemplate | string | The new URL pattern being navigated to. |
-|  attributes | AnyValueMap | Optional, arbitrary attributes to attach to the view boundary log |
-
-<b>Returns:</b>
-
-void
-
-### logVisibilityEvent(crashlytics, visibilityState) {:#logvisibilityevent_1d6b238}
-
-Logs a page visibility transition event (foreground or background).
-
-<b>Signature:</b>
-
-```typescript
-export declare function logVisibilityEvent(crashlytics: Crashlytics, visibilityState: 'visible' | 'hidden'): void;
-```
-
-#### Parameters
-
-|  Parameter | Type | Description |
-|  --- | --- | --- |
-|  crashlytics | [Crashlytics](./crashlytics_.crashlytics.md#crashlytics_interface) | The [Crashlytics](./crashlytics_.crashlytics.md#crashlytics_interface) instance. |
-|  visibilityState | 'visible' \| 'hidden' | The current page visibility state ('visible' or 'hidden'). |
-
-<b>Returns:</b>
-
-void
 
 ### recordError(crashlytics, error, attributes) {:#recorderror_6824e74}
 

--- a/packages/crashlytics/src/api.test.ts
+++ b/packages/crashlytics/src/api.test.ts
@@ -34,13 +34,7 @@ import {
 } from '@firebase/app';
 import { Component, ComponentType } from '@firebase/component';
 import { FirebaseAppCheckInternal } from '@firebase/app-check-interop-types';
-import {
-  recordError,
-  flush,
-  getCrashlytics,
-  logViewBoundary,
-  logVisibilityEvent
-} from './api';
+import { recordError, flush, getCrashlytics, logViewBoundary } from './api';
 import { CrashlyticsService } from './service';
 import { registerCrashlytics } from './register';
 import { _FirebaseInstallationsInternal } from '@firebase/installations';
@@ -604,24 +598,6 @@ describe('Top level API', () => {
       await flush(fakeCrashlytics);
 
       expect(emittedLogs.length).to.equal(0);
-    });
-  });
-
-  describe('logVisibilityEvent', () => {
-    it("should emit a log record for a hidden visibility with body of 'Background lifecycle event'", () => {
-      logVisibilityEvent(fakeCrashlytics, 'hidden');
-
-      expect(emittedLogs).to.have.lengthOf(1);
-      const log = emittedLogs[0];
-      expect(log.body).to.equal('Background lifecycle event');
-    });
-
-    it("should emit a log record for a visible visibility with body of 'Foreground lifecycle event'", () => {
-      logVisibilityEvent(fakeCrashlytics, 'visible');
-
-      expect(emittedLogs).to.have.lengthOf(1);
-      const log = emittedLogs[0];
-      expect(log.body).to.equal('Foreground lifecycle event');
     });
   });
 });

--- a/packages/crashlytics/src/api.ts
+++ b/packages/crashlytics/src/api.ts
@@ -22,7 +22,7 @@ import { Crashlytics, CrashlyticsOptions } from './public-types';
 import { Provider } from '@firebase/component';
 import { AnyValueMap, SeverityNumber } from '@opentelemetry/api-logs';
 import { CrashlyticsService } from './service';
-import { flush, logVisibilityEvent } from './helpers';
+import { flush } from './helpers';
 import { deepEqual } from '@firebase/util';
 import { SPAN_ATTR_KEY } from './attributes-store';
 
@@ -199,6 +199,8 @@ export function registerGlobalErrorListeners(
 /**
  * Creates a log for view boundary on navigation event
  *
+ * @internal
+ *
  * @param crashlytics - The {@link Crashlytics} instance.
  * @param urlTemplate - The new URL pattern being navigated to.
  * @param attributes - Optional, arbitrary attributes to attach to the view boundary log
@@ -229,4 +231,4 @@ export function logViewBoundary(
   });
 }
 
-export { flush, logVisibilityEvent };
+export { flush };

--- a/packages/crashlytics/src/api.ts
+++ b/packages/crashlytics/src/api.ts
@@ -22,7 +22,6 @@ import { Crashlytics, CrashlyticsOptions } from './public-types';
 import { Provider } from '@firebase/component';
 import { AnyValueMap, SeverityNumber } from '@opentelemetry/api-logs';
 import { CrashlyticsService } from './service';
-import { flush } from './helpers';
 import { deepEqual } from '@firebase/util';
 import { SPAN_ATTR_KEY } from './attributes-store';
 
@@ -231,4 +230,4 @@ export function logViewBoundary(
   });
 }
 
-export { flush };
+export { flush } from './helpers';

--- a/packages/crashlytics/src/helpers.test.ts
+++ b/packages/crashlytics/src/helpers.test.ts
@@ -21,7 +21,11 @@ import { Logger, LogRecord } from '@opentelemetry/api-logs';
 import { trace, TracerProvider } from '@opentelemetry/api';
 import sinon from 'sinon';
 import { isNode } from '@firebase/util';
-import { registerListeners, startNewSession } from './helpers';
+import {
+  registerListeners,
+  startNewSession,
+  logVisibilityEvent
+} from './helpers';
 import { AUTO_CONSTANTS } from './auto-constants';
 import { CrashlyticsService } from './service';
 import { CrashlyticsInternal } from './types';
@@ -257,5 +261,23 @@ describe('helpers', () => {
         expect(flushed).to.be.true;
       });
     }
+  });
+
+  describe('logVisibilityEvent', () => {
+    it("should emit a log record for a hidden visibility with body of 'Background lifecycle event'", () => {
+      logVisibilityEvent(fakeCrashlytics, 'hidden');
+
+      expect(emittedLogs).to.have.lengthOf(1);
+      const log = emittedLogs[0];
+      expect(log.body).to.equal('Background lifecycle event');
+    });
+
+    it("should emit a log record for a visible visibility with body of 'Foreground lifecycle event'", () => {
+      logVisibilityEvent(fakeCrashlytics, 'visible');
+
+      expect(emittedLogs).to.have.lengthOf(1);
+      const log = emittedLogs[0];
+      expect(log.body).to.equal('Foreground lifecycle event');
+    });
   });
 });

--- a/packages/crashlytics/src/helpers.ts
+++ b/packages/crashlytics/src/helpers.ts
@@ -104,7 +104,7 @@ export function flush(crashlytics: Crashlytics): Promise<void> {
 /**
  * Logs a page visibility transition event (foreground or background).
  *
- * @public
+ * @internal
  *
  * @param crashlytics - The {@link Crashlytics} instance.
  * @param visibilityState - The current page visibility state ('visible' or 'hidden').


### PR DESCRIPTION
- Set @public tags for logViewBoundary and logVisibilityEvent to @internal. 

- Moved logVisibilityEvent tests to helpers.ts instead of api.ts as it is not used in framework specific code and does not need to be exported in api.ts (since its internal now)

- Updated documentation to reflect new visibility