### PR TITLE
chore: add generated files to `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,9 @@
 *.md       text eol=lf
 
 *.json  linguist-language=JSON-with-Comments
+
+# Generated and snapshot files (collapsed by default in GitHub PRs)
+# =================================================================
+common/api-review/*.api.md linguist-generated=true
+repo-scripts/prune-dts/tests/**/*.d.ts linguist-generated=true
+yarn.lock linguist-generated=true


### PR DESCRIPTION
Adds paths to generated files to gitattributes. This will eliminate noise from generated files in PR diffs.

_"Use the linguist-generated attribute to mark or unmark paths that you would like to be ignored for the repository's language statistics and hidden by default in diffs."_ https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github