### PR TITLE
adding otel user action and navigation timing logging support

### DIFF
--- a/packages/crashlytics/src/logging/logger-provider.ts
+++ b/packages/crashlytics/src/logging/logger-provider.ts
@@ -43,8 +43,6 @@ import {
 import { AttributesStore } from '../attributes-store';
 import { OnErrorLogRecordProcessor } from './on-error-log-record-processor';
 
-let unregisterInstrumentations: (() => void) | undefined;
-
 /**
  * Result returned by {@link createLoggerProvider}.
  *
@@ -128,11 +126,7 @@ export function createLoggerProvider(
       enabled: false
     });
 
-    if (unregisterInstrumentations) {
-      unregisterInstrumentations();
-    }
-
-    unregisterInstrumentations = registerInstrumentations({
+    registerInstrumentations({
       loggerProvider,
       instrumentations: [
         navigationTiming,

--- a/packages/crashlytics/src/logging/logger-provider.ts
+++ b/packages/crashlytics/src/logging/logger-provider.ts
@@ -43,6 +43,8 @@ import {
 import { AttributesStore } from '../attributes-store';
 import { OnErrorLogRecordProcessor } from './on-error-log-record-processor';
 
+let unregisterInstrumentations: (() => void) | undefined;
+
 /**
  * Result returned by {@link createLoggerProvider}.
  *
@@ -90,9 +92,17 @@ export function createLoggerProvider(
 
   const onErrorLogRecordProcessor = new OnErrorLogRecordProcessor(logExporter);
 
+  const customAttributesProcessor = {
+    onEmit: (logRecord: ReadableLogRecord) => {
+      Object.assign(logRecord.attributes, attributesStore.getLogAttributes());
+    },
+    forceFlush: () => Promise.resolve(),
+    shutdown: () => Promise.resolve()
+  };
+
   const loggerProvider = new LoggerProvider({
     resource,
-    processors: [onErrorLogRecordProcessor],
+    processors: [customAttributesProcessor, onErrorLogRecordProcessor],
     logRecordLimits: {}
   });
 
@@ -116,7 +126,11 @@ export function createLoggerProvider(
       enabled: false
     });
 
-    registerInstrumentations({
+    if (unregisterInstrumentations) {
+      unregisterInstrumentations();
+    }
+
+    unregisterInstrumentations = registerInstrumentations({
       loggerProvider,
       instrumentations: [
         navigationTiming,

--- a/packages/crashlytics/src/logging/logger-provider.ts
+++ b/packages/crashlytics/src/logging/logger-provider.ts
@@ -20,6 +20,9 @@ import {
   ReadableLogRecord,
   LogRecordExporter
 } from '@opentelemetry/sdk-logs';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { NavigationTimingInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/navigation-timing';
+import { UserActionInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/user-action';
 import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import { resourceFromAttributes } from '@opentelemetry/resources';
 import { JsonLogsSerializer } from '@opentelemetry/otlp-transformer';
@@ -92,6 +95,37 @@ export function createLoggerProvider(
     processors: [onErrorLogRecordProcessor],
     logRecordLimits: {}
   });
+
+  // TODO: Enable once @opentelemetry/browser-instrumentation supports applyCustomLogRecordData across its packages
+  // const applyCustomLogRecordData = (logRecord: LogRecord): void => {
+  //   logRecord.attributes = {
+  //     ...logRecord.attributes,
+  //     ...attributesStore.getLogAttributes()
+  //   };
+  // };
+
+  if (typeof window !== 'undefined') {
+    /*
+     * Initialize as disabled to prevent the instrumentation from auto-enabling during construction.
+     * In SSR frameworks (like Next.js), the page is already loaded when this script executes, so
+     * it will try to emit the navigation timing immediately. Deferring the enable state ensures
+     * the loggerProvider is fully bound by registerInstrumentations before the event is emitted.
+     * registerInstrumentations will automatically enable it once the provider is set.
+     */
+    const navigationTiming = new NavigationTimingInstrumentation({
+      enabled: false
+    });
+
+    registerInstrumentations({
+      loggerProvider,
+      instrumentations: [
+        navigationTiming,
+        new UserActionInstrumentation({
+          autoCapturedActions: ['click']
+        })
+      ]
+    });
+  }
 
   return { loggerProvider, onErrorLogRecordProcessor };
 }

--- a/packages/crashlytics/src/logging/logger-provider.ts
+++ b/packages/crashlytics/src/logging/logger-provider.ts
@@ -92,6 +92,8 @@ export function createLoggerProvider(
 
   const onErrorLogRecordProcessor = new OnErrorLogRecordProcessor(logExporter);
 
+  // TODO: Remove this custom processor and use applyCustomLogRecordData in the instrumentation config once
+  // @opentelemetry/browser-instrumentation supports it across all standard/experimental packages.
   const customAttributesProcessor = {
     onEmit: (logRecord: ReadableLogRecord) => {
       Object.assign(logRecord.attributes, attributesStore.getLogAttributes());

--- a/packages/crashlytics/src/tracing/tracing-provider.ts
+++ b/packages/crashlytics/src/tracing/tracing-provider.ts
@@ -50,8 +50,6 @@ import {
 } from '../constants';
 import { CrashlyticsOptions } from '../public-types';
 
-let unregisterInstrumentations: (() => void) | undefined;
-
 /**
  * Result returned by {@link createTracingProvider}.
  *
@@ -164,11 +162,7 @@ export function createTracingProvider(
     applyCustomAttributesOnSpan
   };
 
-  if (unregisterInstrumentations) {
-    unregisterInstrumentations();
-  }
-
-  unregisterInstrumentations = registerInstrumentations({
+  registerInstrumentations({
     instrumentations: [
       new FetchInstrumentation(networkInstrumentationConfig),
       new XMLHttpRequestInstrumentation(networkInstrumentationConfig),

--- a/packages/crashlytics/src/tracing/tracing-provider.ts
+++ b/packages/crashlytics/src/tracing/tracing-provider.ts
@@ -50,6 +50,8 @@ import {
 } from '../constants';
 import { CrashlyticsOptions } from '../public-types';
 
+let unregisterInstrumentations: (() => void) | undefined;
+
 /**
  * Result returned by {@link createTracingProvider}.
  *
@@ -162,7 +164,11 @@ export function createTracingProvider(
     applyCustomAttributesOnSpan
   };
 
-  registerInstrumentations({
+  if (unregisterInstrumentations) {
+    unregisterInstrumentations();
+  }
+
+  unregisterInstrumentations = registerInstrumentations({
     instrumentations: [
       new FetchInstrumentation(networkInstrumentationConfig),
       new XMLHttpRequestInstrumentation(networkInstrumentationConfig),

--- a/packages/crashlytics/tsconfig.json
+++ b/packages/crashlytics/tsconfig.json
@@ -8,6 +8,10 @@
       "@opentelemetry/browser-instrumentation/experimental/*": [
         "node_modules/@opentelemetry/browser-instrumentation/dist/*",
         "../../node_modules/@opentelemetry/browser-instrumentation/dist/*"
+      ],
+      "@opentelemetry/instrumentation": [
+        "node_modules/@opentelemetry/instrumentation",
+        "../../node_modules/@opentelemetry/instrumentation"
       ]
     }
   },


### PR DESCRIPTION
[Navigation timing](https://github.com/open-telemetry/opentelemetry-browser/tree/main/packages/instrumentation/src/navigation-timing)
Logs hard navigations with performance observer data (page loads, reloads)

[User action](https://github.com/open-telemetry/opentelemetry-browser/tree/main/packages/instrumentation/src/user-action)
Logs clicks (currently) of HTML elements on the web page.

Note: this change has a temporary sdk implementation for custom log attributes that will be replaced once the instrumentation libraries publish the feature for that