### PR TITLE
chore(deps): Upgrade versions of official workflow actions to the latest versions

### DIFF
--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -33,13 +33,13 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
       with:
         # This makes Actions fetch all Git history so check_changeset script can diff properly.
         fetch-depth: 0
         persist-credentials: false
     - name: Set up Node (22)
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
       with:
         node-version: 22.12.0
     - name: Yarn install

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -26,13 +26,13 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
         with:
           # get all history for the diff
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Node (22)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
         with:
           node-version: 22.12.0
       - name: Yarn install

--- a/.github/workflows/check-pkg-paths.yml
+++ b/.github/workflows/check-pkg-paths.yml
@@ -26,13 +26,13 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
       with:
         # This makes Actions fetch all Git history so run-changed script can diff properly.
         fetch-depth: 0
         persist-credentials: false
     - name: Set up Node (22)
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
       with:
         node-version: 22.12.0
     - name: Yarn install

--- a/.github/workflows/check-vertexai-responses.yml
+++ b/.github/workflows/check-vertexai-responses.yml
@@ -27,7 +27,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
         with:
           persist-credentials: false
       - name: Clone mock responses

--- a/.github/workflows/deploy-config.yml
+++ b/.github/workflows/deploy-config.yml
@@ -34,13 +34,13 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
       with:
         # This makes Actions fetch all Git history so run-changed script can diff properly.
         fetch-depth: 0
         persist-credentials: false
     - name: Set up node (22)
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
       with:
         node-version: 22.12.0
     # firebase-tools has a minimum java version requirement

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
         with:
           persist-credentials: false
       - name: Set up Node (22)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
         with:
           node-version: 22.12.0
       - name: install Chrome stable

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -30,13 +30,13 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
       with:
         # get all history for the diff
         fetch-depth: 0
         persist-credentials: false
     - name: Set up node (22)
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
       with:
         node-version: 22.12.0
     - name: Yarn install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,11 +25,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
       with:
         persist-credentials: false
     - name: Set up node (22)
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
       with:
         node-version: 22.12.0
     - name: yarn install

--- a/.github/workflows/prerelease-manual-deploy.yml
+++ b/.github/workflows/prerelease-manual-deploy.yml
@@ -34,13 +34,13 @@ jobs:
     
         steps:
         - name: Checkout Repo
-          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+          uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
           with:
             # Canary release script requires git history and tags.
             fetch-depth: 0
             persist-credentials: false
         - name: Set up node (22)
-          uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+          uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
           with:
             node-version: 22.12.0
         - name: Yarn install

--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -29,12 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Setup Node.js 20.x
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
         with:
           node-version: 22.12.0
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -31,14 +31,14 @@ jobs:
     if: ${{ !startsWith(github.event.head_commit.message, 'Version Packages (#') }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Node.js 20.x
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
         with:
           node-version: 22.12.0
 

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -34,11 +34,11 @@ jobs:
 
     steps:
     - name: Set up node (22)
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
       with:
         node-version: 22.12.0
     - name: Checkout release branch (with history)
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
       with:
         # Release script requires git history and tags.
         fetch-depth: 0

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -52,7 +52,7 @@ jobs:
     if: github.event.inputs.release-branch == 'release' || endsWith(github.event.inputs.release-branch, '-releasebranch')
     steps:
     - name: Set up node (22)
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
       with:
         node-version: 22.12.0
     - name: Merge main into release
@@ -71,7 +71,7 @@ jobs:
         RELEASE_BRANCH: ${{ github.event.inputs.release-branch }}
         SOURCE_BRANCH: ${{ github.event.inputs.source-branch }}
     - name: Checkout current branch (with history)
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
       with:
         # Release script requires git history and tags.
         fetch-depth: 0

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -46,11 +46,11 @@ jobs:
     - name: install Chrome stable
       run: |
         npx @puppeteer/browsers install chrome@stable
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
       with:
         persist-credentials: false
     - name: Set up Node (22)
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
       with:
         node-version: 22.12.0
     - name: Test setup and yarn install
@@ -66,7 +66,7 @@ jobs:
         gzip build.tar
     - name: Upload build archive
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
       with:
           name: build.tar.gz
           path: build.tar.gz
@@ -82,17 +82,17 @@ jobs:
     - name: install Chrome stable
       run: |
         npx @puppeteer/browsers install chrome@stable
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
       with:
         persist-credentials: false
     - name: Download build archive
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
       with:
         name: build.tar.gz
     - name: Unzip build artifact
       run: tar xf build.tar.gz
     - name: Set up Node (22)
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
       with:
         node-version: 22.12.0
     # firebase-tools has a minimum java version requirement and is called by
@@ -155,17 +155,17 @@ jobs:
         echo "::warning ::${CHROME_VERSION_MISMATCH_MESSAGE}"
         echo "::warning ::Previously validated version: ${CHROME_VALIDATED_VERSION} vs. Installed version: $chromeVersionString"
         fi
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
       with:
         persist-credentials: false
     - name: Download build archive
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
       with:
         name: build.tar.gz
     - name: Unzip build artifact
       run: tar xf build.tar.gz
     - name: Set up Node (22)
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
       with:
         node-version: 22.12.0
     - name: Test setup and yarn install
@@ -207,17 +207,17 @@ jobs:
     - name: install Chrome stable
       run: |
         npx @puppeteer/browsers install chrome@stable
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
       with:
         persist-credentials: false
     - name: Download build archive
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
       with:
         name: build.tar.gz
     - name: Unzip build artifact
       run: tar xf build.tar.gz
     - name: Set up Node (22)
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
       with:
         node-version: 22.12.0
     - name: Test setup and yarn install
@@ -262,17 +262,17 @@ jobs:
     - name: install Chrome stable
       run: |
         npx @puppeteer/browsers install chrome@stable
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
       with:
         persist-credentials: false
     - name: Download build archive
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
       with:
         name: build.tar.gz
     - name: Unzip build artifact
       run: tar xf build.tar.gz
     - name: Set up Node (22)
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
       with:
         node-version: 22.12.0
     - run: cp config/ci.config.json config/project.json

--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -55,13 +55,13 @@ jobs:
         run: |
          echo $CHROME_VERSION_NOTES=$CHROME_VERSION_MISMATCH_MESSAGE
       - name: Checkout Repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
         with:
           # This makes Actions fetch all Git history so run-changed script can diff properly.
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Node (22)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
         with:
           node-version: 22.12.0
       # firebase-tools has a minimum java version requirement
@@ -87,13 +87,13 @@ jobs:
       - name: install Firefox stable
         run: npx @puppeteer/browsers install firefox@stable
       - name: Checkout Repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
         with:
           # This makes Actions fetch all Git history so run-changed script can diff properly.
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Node (22)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
         with:
           node-version: 22.12.0
       - name: Test setup and yarn install
@@ -115,12 +115,12 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Node (22)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
         with:
           node-version: 22.12.0
       - name: Test setup and yarn install

--- a/.github/workflows/test-changed-fcm-integration.yml
+++ b/.github/workflows/test-changed-fcm-integration.yml
@@ -37,13 +37,13 @@ jobs:
         sudo apt-get update
         sudo apt-get install google-chrome-stable
     - name: Checkout Repo
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
       with:
         # This makes Actions fetch all Git history so run-changed script can diff properly.
         fetch-depth: 0
         persist-credentials: false
     - name: Set up Node (22)
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
       with:
         node-version: 22.12.0
     - name: Test setup and yarn install

--- a/.github/workflows/test-changed-firestore-integration.yml
+++ b/.github/workflows/test-changed-firestore-integration.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
       with:
         # This makes Actions fetch all Git history so run-changed script can diff properly.
         fetch-depth: 0
@@ -75,7 +75,7 @@ jobs:
       continue-on-error: true
 
     - name: Set up Node (22)
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
       with:
         node-version: 22.12.0
     - name: install Chrome stable

--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -36,13 +36,13 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
         with:
           # This makes Actions fetch all Git history so run-changed script can diff properly.
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Node (22)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
         with:
           node-version: 22.12.0
       - name: install Chrome stable
@@ -76,7 +76,7 @@ jobs:
           gzip build.tar
       - name: Upload build archive
         if: ${{ !cancelled() && steps.build.outcome == 'success' && steps.check-changed.outcome != 'success' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
         with:
           name: build.tar.gz
           path: build.tar.gz
@@ -89,7 +89,7 @@ jobs:
     if: ${{ needs.build.outputs.changed == 'true'}}
     steps:
       - name: Set up Node (22)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
         with:
           node-version: 22.12.0
       - name: install Chrome stable
@@ -97,7 +97,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install google-chrome-stable
       - name: Download build archive
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
         with:
           name: build.tar.gz
       - name: Unzip build artifact
@@ -117,7 +117,7 @@ jobs:
     if: ${{ needs.build.outputs.changed == 'true'}}
     steps:
       - name: Set up Node (22)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
         with:
           node-version: 22.12.0
       - name: install Chrome stable
@@ -125,7 +125,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install google-chrome-stable
       - name: Download build archive
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
         with:
           name: build.tar.gz
       - name: Unzip build artifact
@@ -147,7 +147,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     steps:
       - name: Set up Node (22)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
         with:
           node-version: 22.12.0
       - name: install Chrome stable
@@ -155,7 +155,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install google-chrome-stable
       - name: Download build archive
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
         with:
           name: build.tar.gz
       - name: Unzip build artifact
@@ -180,11 +180,11 @@ jobs:
       - name: install Firefox stable
         run: npx @puppeteer/browsers install firefox@stable
       - name: Set up Node (22)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
         with:
           node-version: 22.12.0
       - name: Download build archive
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
         with:
           name: build.tar.gz
       - name: Unzip build artifact
@@ -208,13 +208,13 @@ jobs:
       - name: install Firefox stable
         run: npx @puppeteer/browsers install firefox@stable
       - name: Download build archive
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
         with:
           name: build.tar.gz
       - name: Unzip build artifact
         run: tar xf build.tar.gz
       - name: Set up Node (22)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
         with:
           node-version: 22.12.0
       - name: Test setup and yarn install
@@ -232,11 +232,11 @@ jobs:
     if: ${{ needs.build.outputs.changed == 'true'}}
     steps:
       - name: Set up Node (22)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
         with:
           node-version: 22.12.0
       - name: Download build archive
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
         with:
           name: build.tar.gz
       - name: Unzip build artifact
@@ -263,13 +263,13 @@ jobs:
     if: ${{ needs.build.outputs.changed == 'true'}}
     steps:
       - name: Download build archive
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
         with:
           name: build.tar.gz
       - name: Unzip build artifact
         run: tar xf build.tar.gz
       - name: Set up Node (22)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
         with:
           node-version: 22.12.0
       - name: Test setup

--- a/.github/workflows/test-changed-misc.yml
+++ b/.github/workflows/test-changed-misc.yml
@@ -30,13 +30,13 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
       with:
         # This makes Actions fetch all Git history so run-changed script can diff properly.
         fetch-depth: 0
         persist-credentials: false
     - name: Set up Node (22)
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
       with:
         node-version: 22.12.0
     # firebase-tools has a minimum java version requirement and is called by

--- a/.github/workflows/test-changed.yml
+++ b/.github/workflows/test-changed.yml
@@ -30,13 +30,13 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
         with:
           # This makes Actions fetch all Git history so run-changed script can diff properly.
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Node (22)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
         with:
           node-version: 22.12.0
       # firebase-tools has a minimum java version requirement
@@ -64,12 +64,12 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Node (22)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
         with:
           node-version: 22.12.0
       - name: install Firefox stable
@@ -94,12 +94,12 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Node (22)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
         with:
           node-version: 22.12.0
       - name: Test setup and yarn install


### PR DESCRIPTION
Upgrade workflow actions versions of official actions to the latest versions

The following actions were upgraded, pinned to the corresponding commits:
* actions/checkout@v7
* actions/download-artifact@v8
* actions/setup-node@v7
* actions/upload-artifact@v7

The immediate rationale for this change is to fix the "Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24" warnings posted during github actions runs.

Some other actions also need upgrading, but these are the lowest risk. The other actions can be upgraded in separate PRs.