### PR TITLE
Fix extractQuerystring treating a missing '?' as index 0

### DIFF
--- a/.changeset/lucky-moons-listen.md
+++ b/.changeset/lucky-moons-listen.md
@@ -1,0 +1,5 @@
+---
+'@firebase/util': patch
+---
+
+Fixed `extractQuerystring()` treating `indexOf('?') === -1` as a match, which made it return the whole URL when there was no query string, and return an empty string when the input started with `?`.

--- a/packages/util/src/query.ts
+++ b/packages/util/src/query.ts
@@ -60,7 +60,7 @@ export function querystringDecode(querystring: string): Record<string, string> {
  */
 export function extractQuerystring(url: string): string {
   const queryStart = url.indexOf('?');
-  if (!queryStart) {
+  if (queryStart < 0) {
     return '';
   }
   const fragmentStart = url.indexOf('#', queryStart);

--- a/packages/util/test/query.test.ts
+++ b/packages/util/test/query.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { assert } from 'chai';
+import {
+  querystring,
+  querystringDecode,
+  extractQuerystring
+} from '../src/query';
+
+describe('querystring', () => {
+  it('returns an empty string for no params', () => {
+    assert.strictEqual(querystring({}), '');
+  });
+
+  it('joins params with a leading ampersand', () => {
+    assert.strictEqual(querystring({ a: 'b' }), '&a=b');
+    assert.strictEqual(querystring({ a: 1, b: 'x' }), '&a=1&b=x');
+  });
+
+  it('encodes keys and values', () => {
+    assert.strictEqual(querystring({ 'a b': 'c&d' }), '&a%20b=c%26d');
+  });
+});
+
+describe('querystringDecode', () => {
+  it('decodes params with and without a leading question mark', () => {
+    assert.deepEqual(querystringDecode('?a=1&b=2'), { a: '1', b: '2' });
+    assert.deepEqual(querystringDecode('a=1'), { a: '1' });
+  });
+
+  it('returns an empty object for an empty string', () => {
+    assert.deepEqual(querystringDecode(''), {});
+  });
+
+  it('decodes percent-encoded keys and values', () => {
+    assert.deepEqual(querystringDecode('?a%20b=c%26d'), { 'a b': 'c&d' });
+  });
+});
+
+describe('extractQuerystring', () => {
+  it('returns the query string including the leading question mark', () => {
+    assert.strictEqual(
+      extractQuerystring('https://example.com/path?a=1&b=2'),
+      '?a=1&b=2'
+    );
+  });
+
+  it('stops at the fragment', () => {
+    assert.strictEqual(
+      extractQuerystring('https://example.com/path?a=1#frag'),
+      '?a=1'
+    );
+  });
+
+  it('returns an empty string when the url has no query', () => {
+    assert.strictEqual(extractQuerystring('https://example.com/path'), '');
+  });
+
+  it('returns an empty string when the url only has a fragment', () => {
+    assert.strictEqual(extractQuerystring('https://example.com/path#frag'), '');
+  });
+
+  it('handles a query string at the start of the input', () => {
+    assert.strictEqual(extractQuerystring('?a=1&b=2'), '?a=1&b=2');
+    assert.strictEqual(extractQuerystring('?a=1#frag'), '?a=1');
+  });
+});


### PR DESCRIPTION
## Problem

`extractQuerystring()` in `packages/util/src/query.ts` guards with `if (!queryStart)`:

```ts
export function extractQuerystring(url: string): string {
  const queryStart = url.indexOf('?');
  if (!queryStart) {
    return '';
  }
  const fragmentStart = url.indexOf('#', queryStart);
  return url.substring(queryStart, fragmentStart > 0 ? fragmentStart : undefined);
}
```

`indexOf` returns `-1` when the character is absent, and `!(-1)` is `false`, so the early return never fires for a URL without a query string. Execution falls through to `url.substring(-1, …)`, which JavaScript clamps to `substring(0, …)` — returning the **entire URL**. And `!0` is `true`, so an input that legitimately *starts* with `?` returns `''` and loses its query string.

Three of five cases violate the documented contract ("Extract the query string part of a URL, including the leading question mark (if present)"):

| input | before | expected |
| --- | --- | --- |
| `https://example.com/path` | `'https://example.com/path'` | `''` |
| `https://example.com/path#frag` | `'https://example.com/path'` | `''` |
| `?a=1&b=2` | `''` | `'?a=1&b=2'` |
| `https://example.com/p?a=1` | `'?a=1'` | `'?a=1'` ✅ |
| `https://example.com/p?a=1#frag` | `'?a=1'` | `'?a=1'` ✅ |

## Fix

Compare against `queryStart < 0`.

## Blast radius

The only consumer in this repo is `packages/auth/src/core/action_code_url.ts`, which uses it to parse email action links:

```ts
const link = querystringDecode(extractQuerystring(url))['link'];
```

I traced both changed paths there and neither alters current auth behaviour:

* **No-query URL** — before, the whole URL was fed to `querystringDecode`, which split it into a single junk key (`{'https://x/y': 'undefined'}`), so `['link']` was `undefined`. After, it decodes `''` → `{}`, so `['link']` is still `undefined`. Same result, less nonsense in between.
* **Input starting with `?`** — before, the query was dropped and lookups failed; after, a nested `deep_link_id` / `link` in such a value is found, which is what the function is documented to do.

So the fix is strictly more correct and does not loosen anything. Flagging it explicitly because the caller sits in `auth`.

## Tests

`packages/util/src/query.ts` had no test file, so this adds `packages/util/test/query.test.ts` covering `querystring`, `querystringDecode` and `extractQuerystring`, including the three cases above.

```console
$ cd packages/util && mocha "test/**/*.test.ts" --config ../../config/mocharc.node.js
69 passing
```

That is `58 passing` on an unmodified checkout, so the 11 additions are all new coverage. Reverting only `src/query.ts` fails exactly the three regression cases:

```
AssertionError: expected 'https://example.com/path' to equal ''
AssertionError: expected 'https://example.com/path' to equal ''
AssertionError: expected '' to equal '?a=1&b=2'
```

`prettier --check` (3.9.4, the pinned version) passes on both files, and `tsc --noEmit` reports nothing for either — the only diagnostics in my environment come from a newer `@types/node` than TypeScript 5.5.4 expects, in `fs.d.ts`/`stream.d.ts`. I could not run `eslint` locally because the version `npx` resolved wants flat config while the repo uses `.eslintrc`; CI will cover it.

## Not included

`querystringDecode('?a')` returns `{ a: 'undefined' }` — the literal string, because `decodeURIComponent(undefined)` stringifies — where `URLSearchParams` would give `''`. That is a separate function and changing it could affect callers, so I left it alone and only noted it here. Happy to follow up if you'd like it fixed.
