### PR TITLE
Compare scheme and host case-insensitively in isCloudWorkstation

### DIFF
--- a/.changeset/brave-rivers-wonder.md
+++ b/.changeset/brave-rivers-wonder.md
@@ -1,0 +1,5 @@
+---
+'@firebase/util': patch
+---
+
+Fixed `isCloudWorkstation()` comparing the URL scheme and host name case-sensitively. A mixed-case host such as `ABC.CloudWorkstations.dev` was not recognised, and an upper-case scheme caused the whole URL to be matched as if it were a host name.

--- a/packages/util/src/url.ts
+++ b/packages/util/src/url.ts
@@ -30,8 +30,8 @@ export function isCloudWorkstation(url: string): boolean {
     const host =
       lowerCaseUrl.startsWith('http://') || lowerCaseUrl.startsWith('https://')
         ? new URL(url).hostname
-        : url;
-    return host.toLowerCase().endsWith('.cloudworkstations.dev');
+        : lowerCaseUrl;
+    return host.endsWith('.cloudworkstations.dev');
   } catch {
     return false;
   }

--- a/packages/util/src/url.ts
+++ b/packages/util/src/url.ts
@@ -24,12 +24,14 @@ export function isCloudWorkstation(url: string): boolean {
   // In HTTP request builders, it's called with the protocol.
   // If called with protocol prefix, it's a valid URL, so we extract the hostname
   // If called without, we assume the string is the hostname.
+  // URL schemes and host names are both case-insensitive, so compare in lower case.
   try {
+    const lowerCaseUrl = url.toLowerCase();
     const host =
-      url.startsWith('http://') || url.startsWith('https://')
+      lowerCaseUrl.startsWith('http://') || lowerCaseUrl.startsWith('https://')
         ? new URL(url).hostname
         : url;
-    return host.endsWith('.cloudworkstations.dev');
+    return host.toLowerCase().endsWith('.cloudworkstations.dev');
   } catch {
     return false;
   }

--- a/packages/util/test/url.test.ts
+++ b/packages/util/test/url.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { assert } from 'chai';
+import { isCloudWorkstation } from '../src/url';
+
+describe('isCloudWorkstation', () => {
+  it('accepts a bare cloud workstation hostname', () => {
+    assert.isTrue(isCloudWorkstation('abc.cloudworkstations.dev'));
+  });
+
+  it('accepts a cloud workstation url with a protocol', () => {
+    assert.isTrue(isCloudWorkstation('https://abc.cloudworkstations.dev'));
+    assert.isTrue(isCloudWorkstation('http://abc.cloudworkstations.dev'));
+  });
+
+  it('ignores case in the hostname and the scheme', () => {
+    // Host names and URL schemes are both case-insensitive.
+    assert.isTrue(isCloudWorkstation('ABC.CloudWorkstations.dev'));
+    assert.isTrue(isCloudWorkstation('https://ABC.CloudWorkstations.dev'));
+    assert.isTrue(isCloudWorkstation('HTTPS://abc.cloudworkstations.dev'));
+  });
+
+  it('rejects hosts that merely contain the suffix', () => {
+    assert.isFalse(isCloudWorkstation('evil-cloudworkstations.dev'));
+    assert.isFalse(isCloudWorkstation('abc.cloudworkstations.dev.example.com'));
+  });
+
+  it('rejects a url whose path ends with the suffix', () => {
+    assert.isFalse(
+      isCloudWorkstation('https://example.com/abc.cloudworkstations.dev')
+    );
+    // The scheme is compared case-insensitively, so this is matched on the
+    // hostname too rather than falling through to the raw string.
+    assert.isFalse(
+      isCloudWorkstation('HTTPS://example.com/abc.cloudworkstations.dev')
+    );
+  });
+
+  it('returns false for an empty string', () => {
+    assert.isFalse(isCloudWorkstation(''));
+  });
+});


### PR DESCRIPTION
## Problem

`isCloudWorkstation()` compares both the scheme prefix and the host suffix case-sensitively, but URL schemes and host names are both case-insensitive ([RFC 3986 §3.1](https://www.rfc-editor.org/rfc/rfc3986#section-3.1), [RFC 4343](https://www.rfc-editor.org/rfc/rfc4343)). That produces two wrong answers:

```ts
isCloudWorkstation('ABC.CloudWorkstations.dev')
// false — but 'abc.cloudworkstations.dev' is true, and DNS does not distinguish them

isCloudWorkstation('HTTPS://example.com/abc.cloudworkstations.dev')
// true — 'HTTPS://' does not match the lower-case prefixes, so the whole URL is
// treated as a host name and the *path* satisfies the suffix check.
// The same URL with a lower-case scheme correctly returns false.
```

The second one is the direction that matters more: it makes a non-cloud-workstation URL look like a cloud workstation host, and callers use that answer to decide cloud-workstation-specific behaviour (`packages/util/src/url.ts` also exposes `pingServer`, which sends `credentials: 'include'`).

Note the mixed-case *host* only fails in the bare-hostname branch — `new URL(url).hostname` already lower-cases, so `https://ABC.CloudWorkstations.dev` happens to work while `ABC.CloudWorkstations.dev` does not. So the two documented call styles disagree with each other today.

## Fix

Lower-case the value before both comparisons.

Negative cases are unaffected — the suffix check keeps its leading dot and stays anchored to the end, so these still return `false`:

* `evil-cloudworkstations.dev`
* `abc.cloudworkstations.dev.example.com`
* `https://example.com/abc.cloudworkstations.dev`

Full matrix I verified, before vs after:

| input | before | after |
| --- | --- | --- |
| `abc.cloudworkstations.dev` | true | true |
| `ABC.CloudWorkstations.dev` | **false** | true |
| `https://abc.cloudworkstations.dev` | true | true |
| `https://ABC.CloudWorkstations.dev` | true | true |
| `HTTPS://abc.cloudworkstations.dev` | true | true |
| `HTTPS://example.com/abc.cloudworkstations.dev` | **true** | false |
| `https://example.com/abc.cloudworkstations.dev` | false | false |
| `evil-cloudworkstations.dev` | false | false |
| `abc.cloudworkstations.dev.example.com` | false | false |
| `''` | false | false |

## Tests

`packages/util/src/url.ts` had no test file, so this adds `packages/util/test/url.test.ts` covering the accepted forms, the case-insensitivity of both scheme and host, and the negative cases above.

```console
$ cd packages/util
$ mocha "test/**/*.test.ts" --config ../../config/mocharc.node.js
64 passing
```

Baseline on an unmodified checkout is `58 passing`, so all 6 additions are new coverage. Reverting only `src/url.ts` fails exactly the two bug cases:

```
✖ ignores case in the hostname and the scheme
✖ rejects a url whose path ends with the suffix
```

`prettier --check` passes on both files, and `tsc --noEmit` reports nothing for either — the only diagnostic in my environment comes from a newer `@types/node` than TypeScript 5.5.4 expects, in `url.d.ts`.

I did not touch `pingServer` or any caller, and no existing test referenced `isCloudWorkstation`.
