### PR TITLE
chore: add merge-to-main workflow and fix git tag

### DIFF
--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -12,14 +12,14 @@ jobs:
       # 1. Fetch short-lived token from the GitHub App
       - name: Generate Temporary Token
         id: generate-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.FIREBASE_RELEASE_APP_ID }}
+          client-id: ${{ secrets.FIREBASE_RELEASE_APP_ID }}
           private-key: ${{ secrets.FIREBASE_RELEASE_APP_PRIVATE_KEY }}
 
       # 2. Checkout code using the dynamic token
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
         with:
           token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0

--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Merge Release Branch To Main
 
 on:

--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -33,11 +33,11 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
 
-      # 3. Configure Git user metadata using the App's profile
+      # 3. Configure Git user metadata using OSS bot profile
       - name: Configure Git
         run: |
-          git config --global user.name "firebase-release-app[bot]"
-          git config --global user.email "firebase-release-app[bot]@users.noreply.github.com"
+          git config --global user.name "google-oss-bot"
+          git config --global user.email "firebase-oss-bot@google.com"
 
       # 4. Merge release branch
       - name: Merge release branch

--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -12,9 +12,9 @@ jobs:
   merge-to-main:
     runs-on: ubuntu-latest
     environment: release
-    # Allow GITHUB_TOKEN to have write permissions
+    # Merge permissions are granted by the temporary token, not this one
     permissions:
-      contents: write
+      contents: read
     name: Merge Release Branch To Main
     steps:
       # 1. Fetch short-lived token from the GitHub App

--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -2,6 +2,11 @@ name: Merge Release Branch To Main
 
 on:
   workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Version to release (e.g., 12.7.0)'
+        required: true
+
 
 jobs:
   merge-to-main:
@@ -37,5 +42,5 @@ jobs:
           git pull origin release
           git checkout main
           git pull origin main
-          git merge release
+          git merge release --no-ff -m "(chore): Merge release into main for release $VERSION"
           git push origin master

--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           client-id: ${{ secrets.FIREBASE_RELEASE_APP_ID }}
           private-key: ${{ secrets.FIREBASE_RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
 
       # 2. Checkout code using the dynamic token
       - name: Checkout Repository

--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -41,6 +41,8 @@ jobs:
 
       # 4. Merge release branch
       - name: Merge release branch
+        env:
+          VERSION: ${{ inputs.release_version }}
         run: |
           git checkout release
           git pull origin release

--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -12,6 +12,9 @@ jobs:
   merge-to-main:
     runs-on: ubuntu-latest
     environment: release
+    # Allow GITHUB_TOKEN to have write permissions
+    permissions:
+      contents: write
     name: Merge Release Branch To Main
     steps:
       # 1. Fetch short-lived token from the GitHub App

--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -1,0 +1,41 @@
+name: Merge Release Branch To Main
+
+on:
+  workflow_dispatch:
+
+jobs:
+  merge-to-main:
+    runs-on: ubuntu-latest
+    environment: release
+    name: Merge Release Branch To Main
+    steps:
+      # 1. Fetch short-lived token from the GitHub App
+      - name: Generate Temporary Token
+        id: generate-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.FIREBASE_RELEASE_APP_ID }}
+          private-key: ${{ secrets.FIREBASE_RELEASE_APP_PRIVATE_KEY }}
+
+      # 2. Checkout code using the dynamic token
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          fetch-depth: 0
+
+      # 3. Configure Git user metadata using the App's profile
+      - name: Configure Git
+        run: |
+          git config --global user.name "firebase-release-app[bot]"
+          git config --global user.email "firebase-release-app[bot]@users.noreply.github.com"
+
+      # 4. Merge release branch
+      - name: Merge release branch
+        run: |
+          git checkout release
+          git pull origin release
+          git checkout main
+          git pull origin main
+          git merge release
+          git push origin master

--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -47,4 +47,4 @@ jobs:
           git checkout main
           git pull origin main
           git merge release --no-ff -m "(chore): Merge release into main for release $VERSION"
-          git push origin master
+          git push origin main

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -26,8 +26,7 @@ jobs:
     name: Create Release PR
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
-      contents: write
+      contents: read
     if: ${{ !startsWith(github.event.head_commit.message, 'Version Packages (#') }}
     steps:
       - name: Checkout Repo
@@ -52,6 +51,16 @@ jobs:
         run: |
           git pull -f --no-rebase origin main:main
           yarn ts-node-script scripts/ci/add_changeset.ts
+
+      # Fetch short-lived token from the GitHub App for creating PR
+      - name: Generate Temporary Token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.FIREBASE_RELEASE_APP_ID }}
+          private-key: ${{ secrets.FIREBASE_RELEASE_APP_PRIVATE_KEY }}
+          permission-pull-requests: write
+          permission-contents: write
       
       # Configures git user as "google-oss-bot" for the next step
       - name: Configure Git User
@@ -69,4 +78,4 @@ jobs:
           # This token affects who the opening of the PR is credited to
           # while the git user (above) determines the commit author.
           # We want to set them both to match github-oss-bot.
-          GITHUB_TOKEN: ${{ secrets.OSS_BOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -126,7 +126,15 @@ jobs:
         -d "{\"version\":\"$BASE_VERSION\",\"date\":\"$DATE\"}" \
         $RELEASE_TRACKER_URL/logProduction
       env:
-        STEPS_GET_VERSION_OUTPUTS_BASE_VERSION: ${{ steps.get-version.outputs.BASE_VERSION }}    
+        STEPS_GET_VERSION_OUTPUTS_BASE_VERSION: ${{ steps.get-version.outputs.BASE_VERSION }}
+    # Fetch short-lived token from the GitHub App
+    - name: Generate Temporary Token
+      id: generate-token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v3
+      with:
+        client-id: ${{ secrets.FIREBASE_RELEASE_APP_ID }}
+        private-key: ${{ secrets.FIREBASE_RELEASE_APP_PRIVATE_KEY }}
+        permission-contents: write
     # Configures git user as "google-oss-bot" for the next step
     - name: Configure Git User
       run: |
@@ -137,10 +145,9 @@ jobs:
       # of the workflow. But should fail workflow so we notice it. So putting
       # near the end.
       run: yarn ts-node scripts/release/publish-git-tags.ts
-      # The script injects this token into the git push command
-      # Use OSS_BOT for a consistent username and token that is CLA approved
+      # The script injects this token (generated above) into the git push command
       env:
-        GITHUB_TOKEN: ${{ secrets.OSS_BOT_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
     - name: Create GitHub release
       # Depends on generated tag above.
       env:

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -126,15 +126,21 @@ jobs:
         -d "{\"version\":\"$BASE_VERSION\",\"date\":\"$DATE\"}" \
         $RELEASE_TRACKER_URL/logProduction
       env:
-        STEPS_GET_VERSION_OUTPUTS_BASE_VERSION: ${{ steps.get-version.outputs.BASE_VERSION }}
+        STEPS_GET_VERSION_OUTPUTS_BASE_VERSION: ${{ steps.get-version.outputs.BASE_VERSION }}    
+    # Configures git user as "google-oss-bot" for the next step
+    - name: Configure Git User
+      run: |
+        git config --global user.name "google-oss-bot"
+        git config --global user.email "firebase-oss-bot@google.com"
     - name: Publish git tags
       # This commonly runs into permissions errors. Should not block the rest
       # of the workflow. But should fail workflow so we notice it. So putting
       # near the end.
       run: yarn ts-node scripts/release/publish-git-tags.ts
       # The script injects this token into the git push command
+      # Use OSS_BOT for a consistent username and token that is CLA approved
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.OSS_BOT_GITHUB_TOKEN }}
     - name: Create GitHub release
       # Depends on generated tag above.
       env:

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -127,7 +127,7 @@ jobs:
         $RELEASE_TRACKER_URL/logProduction
       env:
         STEPS_GET_VERSION_OUTPUTS_BASE_VERSION: ${{ steps.get-version.outputs.BASE_VERSION }}
-    # Fetch short-lived token from the GitHub App
+    # Fetch short-lived token from the GitHub App for publishing git tags
     - name: Generate Temporary Token
       id: generate-token
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v3

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     # Allow GITHUB_TOKEN to have write permissions
     permissions:
-      contents: write
+      contents: read
 
     steps:
     - name: Set up node (22)
@@ -151,7 +151,7 @@ jobs:
     - name: Create GitHub release
       # Depends on generated tag above.
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       run: |
         # Get the newest release tag for the firebase package (e.g. firebase@10.12.0)
         NEWEST_TAG=$(git describe --tags --match "firebase@[0-9]*.[0-9]*.[0-9]*" --abbrev=0)

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -28,7 +28,6 @@ jobs:
     environment: release
     name: Production Release
     runs-on: ubuntu-latest
-    # Allow GITHUB_TOKEN to have write permissions
     permissions:
       contents: read
 
@@ -127,7 +126,9 @@ jobs:
         $RELEASE_TRACKER_URL/logProduction
       env:
         STEPS_GET_VERSION_OUTPUTS_BASE_VERSION: ${{ steps.get-version.outputs.BASE_VERSION }}
-    # Fetch short-lived token from the GitHub App for publishing git tags
+    # Fetch short-lived token from the GitHub App for 
+    # publishing git tags (contents: write)
+    # publishing Github release (contents: write, pull-requests: read)
     - name: Generate Temporary Token
       id: generate-token
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v3
@@ -135,6 +136,7 @@ jobs:
         client-id: ${{ secrets.FIREBASE_RELEASE_APP_ID }}
         private-key: ${{ secrets.FIREBASE_RELEASE_APP_PRIVATE_KEY }}
         permission-contents: write
+        permission-pull-requests: read
     # Configures git user as "google-oss-bot" for the next step
     - name: Configure Git User
       run: |

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -51,6 +51,17 @@ jobs:
     # Block this workflow if run on a non-release branch.
     if: github.event.inputs.release-branch == 'release' || endsWith(github.event.inputs.release-branch, '-releasebranch')
     steps:
+
+    # Fetch short-lived token from the GitHub App for
+    # - merging main into release (contents: write)
+    # - triggering E2E test workflow (contents: write)
+    - name: Generate Temporary Token
+      id: generate-token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v3
+      with:
+        client-id: ${{ secrets.FIREBASE_RELEASE_APP_ID }}
+        private-key: ${{ secrets.FIREBASE_RELEASE_APP_PRIVATE_KEY }}
+        permission-contents: write
     - name: Set up node (22)
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
       with:
@@ -58,7 +69,7 @@ jobs:
     - name: Merge main into release
       uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
       with:
-        github-token: ${{ secrets.OSS_BOT_GITHUB_TOKEN }}
+        github-token: ${{ steps.generate-token.outputs.token }}
         script: |
           const result = await github.rest.repos.merge({
             owner: context.repo.owner,
@@ -159,12 +170,12 @@ jobs:
     - name: Launch E2E tests workflow
       # Trigger e2e-test.yml
       run: |
-        OSS_BOT_GITHUB_TOKEN=${{ secrets.OSS_BOT_GITHUB_TOKEN }}
+        TEMPORARY_GITHUB_TOKEN=${{ steps.generate-token.outputs.token }}
         VERSION_OR_TAG=${STEPS_GET_VERSION_OUTPUTS_STAGING_VERSION}
         curl -X POST \
         -H "Content-Type:application/json" \
         -H "Accept:application/vnd.github.v3+json" \
-        -H "Authorization:Bearer $OSS_BOT_GITHUB_TOKEN" \
+        -H "Authorization:Bearer $TEMPORARY_GITHUB_TOKEN" \
         -d "{\"event_type\":\"staging-tests\", \"client_payload\":{\"versionOrTag\":\"$VERSION_OR_TAG\"}}" \
         https://api.github.com/repos/firebase/firebase-js-sdk/dispatches
       env:

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -170,7 +170,6 @@ jobs:
     - name: Launch E2E tests workflow
       # Trigger e2e-test.yml
       run: |
-        TEMPORARY_GITHUB_TOKEN=${{ steps.generate-token.outputs.token }}
         VERSION_OR_TAG=${STEPS_GET_VERSION_OUTPUTS_STAGING_VERSION}
         curl -X POST \
         -H "Content-Type:application/json" \
@@ -179,6 +178,7 @@ jobs:
         -d "{\"event_type\":\"staging-tests\", \"client_payload\":{\"versionOrTag\":\"$VERSION_OR_TAG\"}}" \
         https://api.github.com/repos/firebase/firebase-js-sdk/dispatches
       env:
+        TEMPORARY_GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         STEPS_GET_VERSION_OUTPUTS_STAGING_VERSION: ${{ steps.get-version.outputs.STAGING_VERSION }}
     - name: Check for changes requiring a reference doc publish
       id: docs-check


### PR DESCRIPTION
- Add merge-to-main.yml which adds a manually triggerable workflow that merges the release branch into main, to be done after a release has successfully completed. This workflow uses a Github app ("firebase-release-app") to generate a temporary token allowing this git action. The action accepts a version string as an input, which it will add to the commit message.

- Configure a git user before trying to push git tags in the prod release workflow. 

- Remove all instances of OSS_BOT_GITHUB_TOKEN and replace with the short-lived token generated by the app