### PR TITLE
fix(database-compat): fix regression in standalone bundle

### DIFF
--- a/.changeset/chilled-eels-dress.md
+++ b/.changeset/chilled-eels-dress.md
@@ -1,0 +1,5 @@
+---
+'@firebase/database-compat': patch
+---
+
+Fix regression causing peerDeps to be unbundled in standalone bundle.

--- a/packages/database-compat/rollup.config.js
+++ b/packages/database-compat/rollup.config.js
@@ -130,7 +130,9 @@ const cjsBuilds = [
       moduleSideEffects: false
     },
     external: id =>
-      deps
+      // for the standalone bundle, ignore peerDeps, so app and app-compat
+      // will be bundled
+      pkg.dependencies
         .filter(dep => dep !== '@firebase/database')
         .some(dep => id === dep || id.startsWith(`${dep}/`)),
     onwarn: onWarn

--- a/packages/database-compat/rollup.config.js
+++ b/packages/database-compat/rollup.config.js
@@ -25,7 +25,11 @@ import pkg from './package.json' with { type: 'json' };
 import standalonePkg from './standalone/package.json' with { type: 'json' };
 import { emitModulePackageFile } from '../../scripts/build/rollup_emit_module_package_file.js';
 
-const deps = Object.keys({ ...pkg.peerDependencies, ...pkg.dependencies });
+const depsAndPeerDeps = Object.keys({
+  ...pkg.peerDependencies,
+  ...pkg.dependencies
+});
+const depsOnly = Object.keys(pkg.dependencies);
 
 function onWarn(warning, defaultWarn) {
   if (warning.code === 'CIRCULAR_DEPENDENCY') {
@@ -59,7 +63,8 @@ const esmBuilds = [
     treeshake: {
       moduleSideEffects: false
     },
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`)),
+    external: id =>
+      depsAndPeerDeps.some(dep => id === dep || id.startsWith(`${dep}/`)),
     onwarn: onWarn
   },
   /**
@@ -78,7 +83,8 @@ const esmBuilds = [
     treeshake: {
       moduleSideEffects: false
     },
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`)),
+    external: id =>
+      depsAndPeerDeps.some(dep => id === dep || id.startsWith(`${dep}/`)),
     onwarn: onWarn
   }
 ];
@@ -101,7 +107,8 @@ const cjsBuilds = [
     treeshake: {
       moduleSideEffects: false
     },
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`)),
+    external: id =>
+      depsAndPeerDeps.some(dep => id === dep || id.startsWith(`${dep}/`)),
     onwarn: onWarn
   },
   /**
@@ -132,7 +139,7 @@ const cjsBuilds = [
     external: id =>
       // For the standalone bundle, exclude peerDependencies from externals,
       // so app and app-compat will be bundled.
-      Object.keys(pkg.dependencies)
+      depsOnly
         .filter(dep => dep !== '@firebase/database')
         .some(dep => id === dep || id.startsWith(`${dep}/`)),
     onwarn: onWarn

--- a/packages/database-compat/rollup.config.js
+++ b/packages/database-compat/rollup.config.js
@@ -130,8 +130,8 @@ const cjsBuilds = [
       moduleSideEffects: false
     },
     external: id =>
-      // for the standalone bundle, ignore peerDeps, so app and app-compat
-      // will be bundled
+      // For the standalone bundle, exclude peerDependencies from externals,
+      // so app and app-compat will be bundled.
       Object.keys(pkg.dependencies)
         .filter(dep => dep !== '@firebase/database')
         .some(dep => id === dep || id.startsWith(`${dep}/`)),

--- a/packages/database-compat/rollup.config.js
+++ b/packages/database-compat/rollup.config.js
@@ -132,7 +132,7 @@ const cjsBuilds = [
     external: id =>
       // for the standalone bundle, ignore peerDeps, so app and app-compat
       // will be bundled
-      pkg.dependencies
+      Object.keys(pkg.dependencies)
         .filter(dep => dep !== '@firebase/database')
         .some(dep => id === dep || id.startsWith(`${dep}/`)),
     onwarn: onWarn


### PR DESCRIPTION
In https://github.com/firebase/firebase-js-sdk/pull/10097, `@firebase/app` and `@firebase/app-compat` were added as peerDependencies to `@firebase/database-compat`. The rollup config was set to treat all `dependencies` and `peerDependencies` as externals, which is still correct for the main bundles, but incorrect for the standalone bundle, which is used by the admin SDK and needs to have app bundled into it.

Fixes #10242