### PR TITLE
fix(messaging): resolve getToken() when observed service worker becomes redundant

### DIFF
--- a/.changeset/quick-plums-report.md
+++ b/.changeset/quick-plums-report.md
@@ -1,5 +1,6 @@
 ---
 '@firebase/messaging': patch
+'firebase': patch
 ---
 
 Fix `getToken()` intermittently failing with "Service worker not registered after 10000 ms". `waitForRegistrationActive` now resolves once the registration has an active worker and follows replacement workers, instead of only watching the worker observed at registration time (which can become redundant and never fire `activated`).

--- a/.changeset/quick-plums-report.md
+++ b/.changeset/quick-plums-report.md
@@ -1,0 +1,5 @@
+---
+'@firebase/messaging': patch
+---
+
+Fix `getToken()` intermittently failing with "Service worker not registered after 10000 ms". `waitForRegistrationActive` now resolves once the registration has an active worker and follows replacement workers, instead of only watching the worker observed at registration time (which can become redundant and never fire `activated`).

--- a/packages/messaging/src/helpers/registerDefaultSw.test.ts
+++ b/packages/messaging/src/helpers/registerDefaultSw.test.ts
@@ -1,0 +1,160 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '../testing/setup';
+
+import { expect } from 'chai';
+import { stub, useFakeTimers } from 'sinon';
+
+import type { MessagingService } from '../messaging-service';
+import { getFakeMessagingService } from '../testing/fakes/messaging-service';
+import {
+  DEFAULT_REGISTRATION_TIMEOUT,
+  DEFAULT_SW_SCOPE
+} from '../util/constants';
+import { registerDefaultSw } from './registerDefaultSw';
+
+/** Minimal ServiceWorker whose state transitions can be driven by the test. */
+class ControllableServiceWorker extends EventTarget {
+  constructor(public state: ServiceWorkerState = 'installing') {
+    super();
+  }
+
+  transitionTo(state: ServiceWorkerState): void {
+    this.state = state;
+    this.dispatchEvent(new Event('statechange'));
+  }
+}
+
+/** Minimal ServiceWorkerRegistration with controllable worker slots. */
+class ControllableRegistration extends EventTarget {
+  active: ServiceWorker | null = null;
+  installing: ServiceWorker | null = null;
+  waiting: ServiceWorker | null = null;
+  scope = DEFAULT_SW_SCOPE;
+
+  async update(): Promise<void> {}
+
+  async unregister(): Promise<boolean> {
+    return true;
+  }
+}
+
+function asWorker(sw: ControllableServiceWorker): ServiceWorker {
+  return sw as unknown as ServiceWorker;
+}
+
+function asRegistration(
+  reg: ControllableRegistration
+): ServiceWorkerRegistration {
+  return reg as unknown as ServiceWorkerRegistration;
+}
+
+// Lets the awaited navigator.serviceWorker.register() settle so that
+// waitForRegistrationActive has attached its listeners before the test drives
+// service worker state transitions.
+function flushMicrotasks(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+describe('registerDefaultSw', () => {
+  let messaging: MessagingService;
+
+  beforeEach(() => {
+    messaging = getFakeMessagingService();
+  });
+
+  it('resolves when the registration already has an active worker', async () => {
+    const registration = new ControllableRegistration();
+    registration.active = asWorker(new ControllableServiceWorker('activated'));
+    stub(navigator.serviceWorker, 'register').resolves(
+      asRegistration(registration)
+    );
+
+    await expect(registerDefaultSw(messaging)).to.eventually.be.fulfilled;
+    expect(messaging.swRegistration).to.equal(asRegistration(registration));
+  });
+
+  it('resolves when a replacement worker activates after the observed worker becomes redundant', async () => {
+    const registration = new ControllableRegistration();
+    const firstWorker = new ControllableServiceWorker('installing');
+    registration.installing = asWorker(firstWorker);
+    stub(navigator.serviceWorker, 'register').resolves(
+      asRegistration(registration)
+    );
+
+    const pending = registerDefaultSw(messaging);
+    await flushMicrotasks();
+
+    // A replacement worker appears and the originally observed worker becomes
+    // redundant. The redundant worker never fires 'activated', which is the
+    // exact case the SDK used to hang on until the timeout.
+    const secondWorker = new ControllableServiceWorker('installing');
+    registration.installing = asWorker(secondWorker);
+    firstWorker.transitionTo('redundant');
+
+    // The replacement worker activates.
+    registration.active = asWorker(secondWorker);
+    registration.installing = null;
+    secondWorker.transitionTo('activated');
+
+    await expect(pending).to.eventually.be.fulfilled;
+  });
+
+  it('resolves for a worker that only appears via updatefound', async () => {
+    const registration = new ControllableRegistration();
+    // No active/installing/waiting worker at registration time.
+    stub(navigator.serviceWorker, 'register').resolves(
+      asRegistration(registration)
+    );
+
+    const pending = registerDefaultSw(messaging);
+    await flushMicrotasks();
+
+    const worker = new ControllableServiceWorker('installing');
+    registration.installing = asWorker(worker);
+    registration.dispatchEvent(new Event('updatefound'));
+
+    registration.active = asWorker(worker);
+    registration.installing = null;
+    worker.transitionTo('activated');
+
+    await expect(pending).to.eventually.be.fulfilled;
+  });
+
+  it('rejects if no worker becomes active before the timeout', async () => {
+    const clock = useFakeTimers();
+    try {
+      const registration = new ControllableRegistration();
+      registration.installing = asWorker(
+        new ControllableServiceWorker('installing')
+      );
+      stub(navigator.serviceWorker, 'register').resolves(
+        asRegistration(registration)
+      );
+
+      const pending = registerDefaultSw(messaging);
+      await clock.tickAsync(DEFAULT_REGISTRATION_TIMEOUT);
+
+      await expect(pending).to.eventually.be.rejectedWith(
+        /Service worker not registered after/
+      );
+    } finally {
+      clock.restore();
+    }
+  });
+});

--- a/packages/messaging/src/helpers/registerDefaultSw.ts
+++ b/packages/messaging/src/helpers/registerDefaultSw.ts
@@ -22,7 +22,7 @@ import {
 } from '../util/constants';
 import { ERROR_FACTORY, ErrorCode } from '../util/errors';
 
-import { MessagingService } from '../messaging-service';
+import type { MessagingService } from '../messaging-service';
 
 export async function registerDefaultSw(
   messaging: MessagingService
@@ -59,6 +59,17 @@ export async function registerDefaultSw(
  * swRegistration.pushManager.subscribe() too soon after register(). The only
  * solution seems to be waiting for the service worker registration `state`
  * to become "active".
+ *
+ * The worker that is installing/waiting when this is first called can be
+ * replaced before it activates. For example registerDefaultSw() calls
+ * update() right after register(), which may install a new worker and drive
+ * the originally observed worker to the "redundant" state, where it never
+ * fires "activated". Watching only that first worker's statechange therefore
+ * hangs until the timeout even though a replacement worker activates
+ * successfully. To handle this we (1) resolve as soon as the registration has
+ * any active worker, (2) follow replacement workers via "updatefound", and
+ * (3) re-attach to the next incoming worker when the one we were watching
+ * becomes redundant.
  */
 async function waitForRegistrationActive(
   registration: ServiceWorkerRegistration
@@ -73,21 +84,54 @@ async function waitForRegistrationActive(
         ),
       DEFAULT_REGISTRATION_TIMEOUT
     );
-    const incomingSw = registration.installing || registration.waiting;
-    if (registration.active) {
+
+    let watchedSw: ServiceWorker | null = null;
+
+    const cleanup = (): void => {
       clearTimeout(rejectTimeout);
-      resolve();
-    } else if (incomingSw) {
-      incomingSw.onstatechange = ev => {
-        if ((ev.target as ServiceWorker)?.state === 'activated') {
-          incomingSw.onstatechange = null;
-          clearTimeout(rejectTimeout);
-          resolve();
-        }
-      };
-    } else {
-      clearTimeout(rejectTimeout);
-      reject(new Error('No incoming service worker found.'));
+      registration.removeEventListener('updatefound', onUpdateFound);
+      watchedSw?.removeEventListener('statechange', onStateChange);
+    };
+
+    // Resolve as soon as the registration has an active worker, regardless of
+    // which specific worker reached the "activated" state.
+    const resolveIfActive = (): boolean => {
+      if (registration.active) {
+        cleanup();
+        resolve();
+        return true;
+      }
+      return false;
+    };
+
+    // Watch a single incoming worker for state transitions.
+    const watch = (sw: ServiceWorker | null): void => {
+      watchedSw?.removeEventListener('statechange', onStateChange);
+      watchedSw = sw;
+      watchedSw?.addEventListener('statechange', onStateChange);
+    };
+
+    const onStateChange = (): void => {
+      if (resolveIfActive()) {
+        return;
+      }
+      // The worker we were watching was replaced and will never activate;
+      // follow the next incoming worker instead.
+      if (watchedSw?.state === 'redundant') {
+        watch(registration.installing || registration.waiting);
+      }
+    };
+
+    function onUpdateFound(): void {
+      watch(registration.installing);
+      resolveIfActive();
     }
+
+    if (resolveIfActive()) {
+      return;
+    }
+
+    registration.addEventListener('updatefound', onUpdateFound);
+    watch(registration.installing || registration.waiting);
   });
 }


### PR DESCRIPTION

### Discussion

Fixes #10197.

`getToken()` intermittently fails with:

> Messaging: We are unable to register the default service worker. Service worker not registered after 10000 ms (messaging/failed-service-worker-registration).

even though the service worker registers and activates successfully.


### Root cause

`waitForRegistrationActive` (added in #8661) captures a single worker
(`registration.installing || registration.waiting`) at call time and resolves
only when *that specific worker* fires `statechange` → `'activated'`.

`registerDefaultSw` calls `registration.update()` immediately before awaiting
`waitForRegistrationActive`. When that update installs a replacement worker —
common right after a redeploy, when the SW script or one of its
`importScripts` dependencies changed — the originally observed worker
transitions to `'redundant'` and never fires `'activated'`. The promise then
hangs until the 10s timeout, even though the replacement worker activates
successfully in the meantime. The `'redundant'` transition is never handled,
so the call can neither recover nor fail fast.


### Fix

`waitForRegistrationActive` now:

1. resolves as soon as `registration.active` is set, regardless of which
   specific worker reached the `'activated'` state;
2. follows replacement workers via the registration's `updatefound` event; and
3. re-attaches to the next incoming worker when the one it was watching
   becomes `'redundant'`.

All listeners and the timeout are cleaned up once the promise settles.

This also removes the previous immediate `'No incoming service worker found.'`
rejection: a worker can still arrive via `updatefound` after `register()`
resolves, so the wait now relies on the existing timeout for the genuine
"nothing ever activates" case.

No public API changes.


### Testing

* All existing `@firebase/messaging` tests pass.
* Added `packages/messaging/src/helpers/registerDefaultSw.test.ts` covering:
  * resolves when the registration already has an active worker;
  * resolves when a replacement worker activates after the originally observed
    worker becomes redundant (the regression, which previously timed out);
  * resolves for a worker that only appears via `updatefound`;
  * rejects when no worker becomes active before the timeout.

### API Changes

None
