### PR TITLE
feat(ai): support Chrome Extension Service Workers in ChromeAdapter via getGlobal()

### DIFF
--- a/.changeset/weak-berries-sparkle.md
+++ b/.changeset/weak-berries-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@firebase/ai': patch
+---
+
+Support Chrome Extension Manifest V3 Background Service Workers in ChromeAdapter by resolving global scope with getGlobal().

--- a/.changeset/weak-berries-sparkle.md
+++ b/.changeset/weak-berries-sparkle.md
@@ -2,4 +2,4 @@
 '@firebase/ai': patch
 ---
 
-Support Chrome Extension Manifest V3 Background Service Workers in ChromeAdapter by resolving global scope with getGlobal().
+Fixed incorrect detection of LanguageModel that prevented usage of on-device models in Chrome Extensions.

--- a/packages/ai/src/methods/chrome-adapter-browser.test.ts
+++ b/packages/ai/src/methods/chrome-adapter-browser.test.ts
@@ -870,7 +870,7 @@ describe('chromeAdapterFactory', () => {
     expect(adapter?.onDeviceParams.createOptions).to.exist;
   });
 
-  it('creates a ChromeAdapterImpl when globalThis.LanguageModel is defined without window', () => {
+  it('creates a ChromeAdapterImpl when LanguageModel is defined on the global object', () => {
     const fakeLanguageModel = {} as LanguageModel;
     const globalObj = getGlobal() as any;
     const originalLM = globalObj.LanguageModel;

--- a/packages/ai/src/methods/chrome-adapter-browser.test.ts
+++ b/packages/ai/src/methods/chrome-adapter-browser.test.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { getGlobal } from '@firebase/util';
 import { AIError } from '../errors';
 import { expect, use } from 'chai';
 import sinonChai from 'sinon-chai';
@@ -861,12 +862,28 @@ describe('chromeAdapterFactory', () => {
     const fakeLanguageModel = {} as LanguageModel;
     const adapter = chromeAdapterFactory(
       InferenceMode.PREFER_ON_DEVICE,
-      { LanguageModel: fakeLanguageModel } as Window,
+      { LanguageModel: fakeLanguageModel } as unknown as Window,
       { createOptions: {} }
     );
     expect(adapter?.languageModelProvider).to.equal(fakeLanguageModel);
     expect(adapter?.mode).to.equal(InferenceMode.PREFER_ON_DEVICE);
     expect(adapter?.onDeviceParams.createOptions).to.exist;
+  });
+
+  it('creates a ChromeAdapterImpl when globalThis.LanguageModel is defined without window', () => {
+    const fakeLanguageModel = {} as LanguageModel;
+    const globalObj = getGlobal() as any;
+    const originalLM = globalObj.LanguageModel;
+    try {
+      globalObj.LanguageModel = fakeLanguageModel;
+      const adapter = chromeAdapterFactory(
+        InferenceMode.PREFER_ON_DEVICE,
+        undefined
+      );
+      expect(adapter?.languageModelProvider).to.equal(fakeLanguageModel);
+    } finally {
+      globalObj.LanguageModel = originalLM;
+    }
   });
 });
 

--- a/packages/ai/src/methods/chrome-adapter.test.ts
+++ b/packages/ai/src/methods/chrome-adapter.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
+import { getGlobal, isNode } from '@firebase/util';
+import { chromeAdapterFactory, ChromeAdapterImpl } from './chrome-adapter';
+import { InferenceMode } from '../types';
+import { LanguageModel } from '../types/language-model';
+
+use(sinonChai);
+use(chaiAsPromised);
+
+describe('chromeAdapterFactory', () => {
+  it('returns undefined in native Node environment', function () {
+    if (!isNode()) {
+      this.skip();
+    }
+    const adapter = chromeAdapterFactory(
+      InferenceMode.PREFER_ON_DEVICE,
+      undefined
+    );
+    expect(adapter).to.be.undefined;
+  });
+
+  it('returns undefined when LanguageModel is not defined on global object', () => {
+    const globalObj = getGlobal() as Record<string, unknown>;
+    const originalLM = globalObj.LanguageModel;
+    try {
+      delete globalObj.LanguageModel;
+      const adapter = chromeAdapterFactory(
+        InferenceMode.PREFER_ON_DEVICE,
+        undefined
+      );
+      expect(adapter).to.be.undefined;
+    } finally {
+      if (originalLM !== undefined) {
+        globalObj.LanguageModel = originalLM;
+      }
+    }
+  });
+
+  it('instantiates ChromeAdapterImpl when LanguageModel is defined on any global object', () => {
+    const globalObj = getGlobal() as Record<string, unknown>;
+    const originalLM = globalObj.LanguageModel;
+    const fakeLanguageModel = {} as LanguageModel;
+    try {
+      globalObj.LanguageModel = fakeLanguageModel;
+      const adapter = chromeAdapterFactory(
+        InferenceMode.PREFER_ON_DEVICE,
+        undefined
+      );
+      expect(adapter).to.be.an.instanceOf(ChromeAdapterImpl);
+      expect(adapter?.languageModelProvider).to.equal(fakeLanguageModel);
+    } finally {
+      if (originalLM !== undefined) {
+        globalObj.LanguageModel = originalLM;
+      } else {
+        delete globalObj.LanguageModel;
+      }
+    }
+  });
+});

--- a/packages/ai/src/methods/chrome-adapter.ts
+++ b/packages/ai/src/methods/chrome-adapter.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { getGlobal } from '@firebase/util';
 import { AIError } from '../errors';
 import { logger } from '../logger';
 import {
@@ -445,12 +446,11 @@ export function chromeAdapterFactory(
   window?: Window,
   params?: OnDeviceParams
 ): ChromeAdapterImpl | undefined {
+  const globalObj = window || getGlobal();
+  const languageModel = (globalObj as Record<string, unknown>).LanguageModel as
+    LanguageModel | undefined;
   // Do not initialize a ChromeAdapter if we are not in hybrid mode.
-  if (typeof window !== 'undefined' && mode) {
-    return new ChromeAdapterImpl(
-      (window as Window).LanguageModel as LanguageModel,
-      mode,
-      params
-    );
+  if (languageModel && mode) {
+    return new ChromeAdapterImpl(languageModel, mode, params);
   }
 }


### PR DESCRIPTION
This PR enables `@firebase/ai` to natively support **Chrome Extension Background Service Workers (Manifest V3)** when using Hybrid Mode (`InferenceMode.PREFER_ON_DEVICE` or `InferenceMode.ONLY_ON_DEVICE`).

### Discussion
- **Problem**: In Chrome Extension Manifest V3 Background Service Workers, scripts run inside a `ServiceWorkerGlobalScope` where `window` is `undefined`, but `self` and `globalThis` are defined.
- When initializing an on-device model inside a Service Worker, `chromeAdapterFactory` received `undefined` for `window` and bypassed `ChromeAdapterImpl` initialization. This forced requests to fall back to Cloud REST endpoints even when Chrome's native Gemini Nano API (`globalThis.LanguageModel` / `self.LanguageModel`) was available.
- **Fix**: Updated `chromeAdapterFactory` in `chrome-adapter.ts` to automatically fall back to `getGlobal()` from `@firebase/util` whenever `window` is `undefined`. This allows `chromeAdapterFactory` to inspect `globalThis` / `self` and resolve Chrome's native `LanguageModel` API out-of-the-box in Service Worker environments.

### Testing
- Ran Node.js unit test suite (`368 passing`).
- Added Node.js unit tests in `chrome-adapter.test.ts` to verify `chromeAdapterFactory`:
  - Returns `undefined` when `LanguageModel` is not defined on the global object.
  - Instantiates `ChromeAdapterImpl` when `LanguageModel` is defined on `globalThis` without a `window` object.
- Verified end-to-end inside a live Manifest V3 Chrome Extension Service Worker (`response.inferenceSource === "ON_DEVICE"`, 0 network requests sent to Cloud REST endpoints).

### API Changes
- **No public API changes**: Does not alter public functions, types, or exported interfaces. All modifications are internal global scope resolution improvements inside `chromeAdapterFactory`.