### PR TITLE
fix(firestore): correct misleading cross-database reference log

### DIFF
--- a/.changeset/quiet-moons-report.md
+++ b/.changeset/quiet-moons-report.md
@@ -1,0 +1,5 @@
+---
+'@firebase/firestore': patch
+---
+
+Fix the cross-database document reference log naming the referenced document rather than the document that contains the reference.

--- a/packages/firestore/src/lite-api/user_data_writer.ts
+++ b/packages/firestore/src/lite-api/user_data_writer.ts
@@ -185,9 +185,8 @@ export abstract class AbstractUserDataWriter {
     if (!databaseId.isEqual(expectedDatabaseId)) {
       // TODO(b/64130202): Somehow support foreign references.
       logError(
-        `Document ${key} contains a document ` +
-          `reference within a different database (` +
-          `${databaseId.projectId}/${databaseId.database}) which is not ` +
+        `A document reference to ${key} refers to a different database (` +
+          `${databaseId.projectId}/${databaseId.database}), which is not ` +
           `supported. It will be treated as a reference in the current ` +
           `database (${expectedDatabaseId.projectId}/${expectedDatabaseId.database}) ` +
           `instead.`


### PR DESCRIPTION
Fixes the log in `AbstractUserDataWriter.convertDocumentKey` so it stops naming the reference's target as though that document contained the reference.

Filed first as #10249, which has the details and a repro.

Before:

```
Document targets/the-target contains a document reference within a different database (demo-project-b/(default)) which is not supported. ...
```

After:

```
A document reference to targets/the-target refers to a different database (demo-project-b/(default)), which is not supported. ...
```

`targets/the-target` is what the reference points *at*. The document that actually holds it (`containers/the-container` in the repro) was never named, because both the database id and the document key are parsed from the reference value itself.

### Testing

Nothing asserts this string anywhere in the repo, and only log copy changes, so no behaviour is affected.

I haven't added a test. Asserting on log wording would make any future rewording brittle, and the assertion actually worth having (that the log names the containing document) isn't satisfied by this change. Happy to add one if you'd prefer.

### API changes

None. `AbstractUserDataWriter` is `@internal` and doesn't appear in `common/api-review/firestore.api.md`. No signatures change, and `firestore-compat` picks this up automatically since it calls `convertDocumentKey` rather than reimplementing it.

Naming the containing document would be the better fix, but it looks disproportionate for a diagnostic string: the key would have to be threaded through `convertValue` → `convertObject` → `convertObjectMap`/`convertArray` → `convertReference` (protected abstract, so every subclass changes) → `convertDocumentKey`, across both `firestore` and `firestore-compat`. It would also have to be optional, since `aggregate_types.ts` and `pipeline-result.ts` hold a writer for results that aren't document fields. Glad to attempt that instead if you'd rather.

Changeset included, patch bump on `@firebase/firestore`.
