### PR TITLE
fix(ci): Fix git tags workflow again

### DIFF
--- a/scripts/release/publish-git-tags.ts
+++ b/scripts/release/publish-git-tags.ts
@@ -42,7 +42,9 @@ async function pushReleaseTagsToGithub() {
   const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
 
   await exec(
-    'git -c http.extraHeader="Authorization: Basic ' + authHeader + '"' +
+    'git -c http.extraHeader="Authorization: Basic ' +
+      authHeader +
+      '"' +
       ` push origin ${currentBranch} ${tags.join(' ')} --no-verify`,
     {
       cwd: root

--- a/scripts/release/publish-git-tags.ts
+++ b/scripts/release/publish-git-tags.ts
@@ -40,14 +40,10 @@ async function pushReleaseTagsToGithub() {
   }
 
   const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
-  const repo = process.env.GITHUB_REPOSITORY;
-  const remote = repo
-    ? `https://x-access-token:${token}@github.com/${repo}.git`
-    : 'origin';
 
   await exec(
     `git -c http.extraHeader="Authorization: basic ${authHeader}"` +
-      ` push ${remote} ${currentBranch} ${tags.join(' ')} --no-verify`,
+      ` push origin ${currentBranch} ${tags.join(' ')} --no-verify`,
     {
       cwd: root
     }

--- a/scripts/release/publish-git-tags.ts
+++ b/scripts/release/publish-git-tags.ts
@@ -33,14 +33,21 @@ async function pushReleaseTagsToGithub() {
   let { stdout: currentBranch } = await exec(`git rev-parse --abbrev-ref HEAD`);
   currentBranch = currentBranch.trim();
 
-  if (!process.env.GITHUB_TOKEN) {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
     console.error('Unable to find GITHUB_TOKEN env variable.');
     process.exit(1);
   }
 
+  const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
+  const repo = process.env.GITHUB_REPOSITORY;
+  const remote = repo
+    ? `https://x-access-token:${token}@github.com/${repo}.git`
+    : 'origin';
+
   await exec(
-    `git -c http.extraHeader="Authorization: Bearer ${process.env.GITHUB_TOKEN}"` +
-      ` push origin ${currentBranch} ${tags.join(' ')} --no-verify`,
+    `git -c http.extraHeader="Authorization: basic ${authHeader}"` +
+      ` push ${remote} ${currentBranch} ${tags.join(' ')} --no-verify`,
     {
       cwd: root
     }

--- a/scripts/release/publish-git-tags.ts
+++ b/scripts/release/publish-git-tags.ts
@@ -42,7 +42,7 @@ async function pushReleaseTagsToGithub() {
   const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
 
   await exec(
-    `git -c http.extraHeader="Authorization: basic ${authHeader}"` +
+    'git -c http.extraHeader="Authorization: Basic ' + authHeader + '"' +
       ` push origin ${currentBranch} ${tags.join(' ')} --no-verify`,
     {
       cwd: root


### PR DESCRIPTION
Fix this script one last time? Encode auth header as "basic" and base64 instead of "Bearer" and plaintext, which is required over https.