### PR TITLE
feat(app): add customIdentifier to FirebaseServerAppSettings 

### DIFF
--- a/.changeset/strong-dryers-hope.md
+++ b/.changeset/strong-dryers-hope.md
@@ -1,0 +1,6 @@
+---
+'@firebase/auth': minor
+'@firebase/app': minor
+---
+
+Added customIdentifier to FirebaseServerAppSettings. This allows developers to isolate FirebaseServerApp instances per request (e.g. in SSR/Next.js) or force a fresh instance to retry after transient failures instead of reusing a cached instance.

--- a/.changeset/strong-dryers-hope.md
+++ b/.changeset/strong-dryers-hope.md
@@ -1,6 +1,7 @@
 ---
 '@firebase/auth': minor
 '@firebase/app': minor
+'firebase': minor
 ---
 
 Added `customIdentifier` to `FirebaseServerAppSettings`. This allows developers to isolate `FirebaseServerApp` instances per request (e.g. in SSR/Next.js) or force a fresh instance to retry after transient failures instead of reusing a cached instance.

--- a/.changeset/strong-dryers-hope.md
+++ b/.changeset/strong-dryers-hope.md
@@ -3,4 +3,4 @@
 '@firebase/app': minor
 ---
 
-Added customIdentifier to FirebaseServerAppSettings. This allows developers to isolate FirebaseServerApp instances per request (e.g. in SSR/Next.js) or force a fresh instance to retry after transient failures instead of reusing a cached instance.
+Added `customIdentifier` to `FirebaseServerAppSettings`. This allows developers to isolate `FirebaseServerApp` instances per request (e.g. in SSR/Next.js) or force a fresh instance to retry after transient failures instead of reusing a cached instance.

--- a/common/api-review/app.api.md
+++ b/common/api-review/app.api.md
@@ -81,6 +81,7 @@ export interface FirebaseServerApp extends FirebaseApp {
 export interface FirebaseServerAppSettings extends Omit<FirebaseAppSettings, 'name'> {
     appCheckToken?: string;
     authIdToken?: string;
+    customIdentifier?: string;
     releaseOnDeref?: object;
 }
 
@@ -122,7 +123,7 @@ export function _isFirebaseApp(obj: FirebaseApp | FirebaseOptions | FirebaseAppS
 export function _isFirebaseServerApp(obj: FirebaseApp | FirebaseServerApp | null | undefined): obj is FirebaseServerApp;
 
 // @internal (undocumented)
-export function _isFirebaseServerAppSettings(obj: FirebaseApp | FirebaseOptions | FirebaseAppSettings): obj is FirebaseServerAppSettings;
+export function _isFirebaseServerAppSettings(obj: FirebaseApp | FirebaseOptions | FirebaseAppSettings | FirebaseServerAppSettings): obj is FirebaseServerAppSettings;
 
 // @public
 export function onLog(logCallback: LogCallback | null, options?: LogOptions): void;

--- a/docs-devsite/app.firebaseserverappsettings.md
+++ b/docs-devsite/app.firebaseserverappsettings.md
@@ -25,6 +25,7 @@ export interface FirebaseServerAppSettings extends Omit<FirebaseAppSettings, 'na
 |  --- | --- | --- |
 |  [appCheckToken](./app.firebaseserverappsettings.md#firebaseserverappsettingsappchecktoken) | string | An optional App Check token. If provided, the Firebase SDKs that use App Check will utilize this App Check token in place of requiring an instance of App Check to be initialized.<!-- -->If the token fails local verification due to expiration or parsing errors, then a console error is logged at the time of initialization of the <code>FirebaseServerApp</code> instance. |
 |  [authIdToken](./app.firebaseserverappsettings.md#firebaseserverappsettingsauthidtoken) | string | An optional Auth ID token used to resume a signed in user session from a client runtime environment.<!-- -->Invoking <code>getAuth</code> with a <code>FirebaseServerApp</code> configured with a validated <code>authIdToken</code> causes an automatic attempt to sign in the user that the <code>authIdToken</code> represents. The token needs to have been recently minted for this operation to succeed.<!-- -->If the token fails local verification due to expiration or parsing errors, then a console error is logged at the time of initialization of the <code>FirebaseServerApp</code> instance.<!-- -->If the Auth service has failed to validate the token when the Auth SDK is initialized, then an warning is logged to the console and the Auth SDK will not sign in a user on initialization.<!-- -->If a user is successfully signed in, then the Auth instance's <code>onAuthStateChanged</code> callback is invoked with the <code>User</code> object as per standard Auth flows. However, <code>User</code> objects created via an <code>authIdToken</code> do not have a refresh token. Attempted <code>refreshToken</code> operations fail. |
+|  [customIdentifier](./app.firebaseserverappsettings.md#firebaseserverappsettingscustomidentifier) | string | An optional custom identifier used to distinguish this <code>FirebaseServerApp</code> instance from others with identical options and tokens.<!-- -->By default, <code>initializeServerApp</code> caches and shares <code>FirebaseServerApp</code> instances based on a hash of the Firebase options, <code>authIdToken</code>, and <code>appCheckToken</code>. Providing a distinct <code>customIdentifier</code> (such as a request ID or UUID) isolates the instance to a specific execution context or enables clean retries after transient failures. |
 |  [releaseOnDeref](./app.firebaseserverappsettings.md#firebaseserverappsettingsreleaseonderef) | object | An optional object. If provided, the Firebase SDK uses a <code>FinalizationRegistry</code> object to monitor the garbage collection status of the provided object. The Firebase SDK releases its reference on the <code>FirebaseServerApp</code> instance when the provided <code>releaseOnDeref</code> object is garbage collected.<!-- -->You can use this field to reduce memory management overhead for your application. If provided, an app running in a SSR pass does not need to perform <code>FirebaseServerApp</code> cleanup, so long as the reference object is deleted (by falling out of SSR scope, for instance.)<!-- -->If an object is not provided then the application must clean up the <code>FirebaseServerApp</code> instance by invoking <code>deleteApp</code>.<!-- -->If the application provides an object in this parameter, but the application is executed in a JavaScript engine that predates the support of <code>FinalizationRegistry</code> (introduced in node v14.6.0, for instance), then an error is thrown at <code>FirebaseServerApp</code> initialization. |
 
 ## FirebaseServerAppSettings.appCheckToken
@@ -55,6 +56,18 @@ If a user is successfully signed in, then the Auth instance's `onAuthStateChange
 
 ```typescript
 authIdToken?: string;
+```
+
+## FirebaseServerAppSettings.customIdentifier
+
+An optional custom identifier used to distinguish this `FirebaseServerApp` instance from others with identical options and tokens.
+
+By default, `initializeServerApp` caches and shares `FirebaseServerApp` instances based on a hash of the Firebase options, `authIdToken`<!-- -->, and `appCheckToken`<!-- -->. Providing a distinct `customIdentifier` (such as a request ID or UUID) isolates the instance to a specific execution context or enables clean retries after transient failures.
+
+<b>Signature:</b>
+
+```typescript
+customIdentifier?: string;
 ```
 
 ## FirebaseServerAppSettings.releaseOnDeref

--- a/docs-devsite/app.md
+++ b/docs-devsite/app.md
@@ -134,7 +134,7 @@ export declare function initializeServerApp(config?: FirebaseServerAppSettings):
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  config | [FirebaseServerAppSettings](./app.firebaseserverappsettings.md#firebaseserverappsettings_interface) | Optional <code>FirebaseServerApp</code> settings, including tokens, releaseOnDeref, or customIdentifier. |
+|  config | [FirebaseServerAppSettings](./app.firebaseserverappsettings.md#firebaseserverappsettings_interface) | Optional <code>FirebaseServerApp</code> settings, including tokens, <code>releaseOnDeref</code>, or <code>customIdentifier</code>. |
 
 <b>Returns:</b>
 
@@ -379,7 +379,7 @@ export declare function initializeServerApp(options: FirebaseOptions | FirebaseA
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  options | [FirebaseOptions](./app.firebaseoptions.md#firebaseoptions_interface) \| [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface) | <code>Firebase.AppOptions</code> to configure the app's services, or a a <code>FirebaseApp</code> instance which contains the <code>AppOptions</code> within. |
-|  config | [FirebaseServerAppSettings](./app.firebaseserverappsettings.md#firebaseserverappsettings_interface) | Optional <code>FirebaseServerApp</code> settings, including tokens, releaseOnDeref, or customIdentifier. |
+|  config | [FirebaseServerAppSettings](./app.firebaseserverappsettings.md#firebaseserverappsettings_interface) | Optional <code>FirebaseServerApp</code> settings, including tokens, <code>releaseOnDeref</code>, or <code>customIdentifier</code>. |
 
 <b>Returns:</b>
 

--- a/docs-devsite/app.md
+++ b/docs-devsite/app.md
@@ -36,7 +36,7 @@ This package coordinates the communication between the different Firebase compon
 |  <b>function(options, ...)</b> |
 |  [initializeApp(options, name)](./app.md#initializeapp_cb2f5e1) | Creates and initializes a [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface) instance.<!-- -->See [Add Firebase to your app](https://firebase.google.com/docs/web/setup#add_firebase_to_your_app) and [Initialize multiple projects](https://firebase.google.com/docs/web/setup#multiple-projects) for detailed documentation. |
 |  [initializeApp(options, config)](./app.md#initializeapp_079e917) | Creates and initializes a FirebaseApp instance. |
-|  [initializeServerApp(options, config)](./app.md#initializeserverapp_30ab697) | Creates and initializes a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface) instance.<!-- -->The <code>FirebaseServerApp</code> is similar to <code>FirebaseApp</code>, but is intended for execution in server side rendering environments only. Initialization will fail if invoked from a browser environment.<!-- -->See [Add Firebase to your app](https://firebase.google.com/docs/web/setup#add_firebase_to_your_app) and [Initialize multiple projects](https://firebase.google.com/docs/web/setup#multiple-projects) for detailed documentation. |
+|  [initializeServerApp(options, config)](./app.md#initializeserverapp_30ab697) | Creates and initializes a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface) instance.<!-- -->The <code>FirebaseServerApp</code> is similar to <code>FirebaseApp</code>, but is intended for execution in server side rendering environments only. Initialization will fail if invoked from a browser environment.<!-- -->By default, instances are cached and deduplicated based on a hash of the provided options and settings. To isolate an instance or bypass cached state on retry, provide a unique [FirebaseServerAppSettings.customIdentifier](./app.firebaseserverappsettings.md#firebaseserverappsettingscustomidentifier)<!-- -->.<!-- -->See [Add Firebase to your app](https://firebase.google.com/docs/web/setup#add_firebase_to_your_app) and [Initialize multiple projects](https://firebase.google.com/docs/web/setup#multiple-projects) for detailed documentation. |
 
 ## Interfaces
 
@@ -134,7 +134,7 @@ export declare function initializeServerApp(config?: FirebaseServerAppSettings):
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  config | [FirebaseServerAppSettings](./app.firebaseserverappsettings.md#firebaseserverappsettings_interface) | Optional <code>FirebaseServerApp</code> settings. |
+|  config | [FirebaseServerAppSettings](./app.firebaseserverappsettings.md#firebaseserverappsettings_interface) | Optional <code>FirebaseServerApp</code> settings, including tokens, releaseOnDeref, or customIdentifier. |
 
 <b>Returns:</b>
 
@@ -364,6 +364,8 @@ Creates and initializes a [FirebaseServerApp](./app.firebaseserverapp.md#firebas
 
 The `FirebaseServerApp` is similar to `FirebaseApp`<!-- -->, but is intended for execution in server side rendering environments only. Initialization will fail if invoked from a browser environment.
 
+By default, instances are cached and deduplicated based on a hash of the provided options and settings. To isolate an instance or bypass cached state on retry, provide a unique [FirebaseServerAppSettings.customIdentifier](./app.firebaseserverappsettings.md#firebaseserverappsettingscustomidentifier)<!-- -->.
+
 See [Add Firebase to your app](https://firebase.google.com/docs/web/setup#add_firebase_to_your_app) and [Initialize multiple projects](https://firebase.google.com/docs/web/setup#multiple-projects) for detailed documentation.
 
 <b>Signature:</b>
@@ -377,7 +379,7 @@ export declare function initializeServerApp(options: FirebaseOptions | FirebaseA
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  options | [FirebaseOptions](./app.firebaseoptions.md#firebaseoptions_interface) \| [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface) | <code>Firebase.AppOptions</code> to configure the app's services, or a a <code>FirebaseApp</code> instance which contains the <code>AppOptions</code> within. |
-|  config | [FirebaseServerAppSettings](./app.firebaseserverappsettings.md#firebaseserverappsettings_interface) | Optional <code>FirebaseServerApp</code> settings. |
+|  config | [FirebaseServerAppSettings](./app.firebaseserverappsettings.md#firebaseserverappsettings_interface) | Optional <code>FirebaseServerApp</code> settings, including tokens, releaseOnDeref, or customIdentifier. |
 
 <b>Returns:</b>
 
@@ -407,7 +409,8 @@ initializeServerApp({
     messagingSenderId: "123456789"                  // Cloud Messaging
   },
   {
-   authIdToken: "Your Auth ID Token"
+   authIdToken: "Your Auth ID Token",
+   customIdentifier: "unique-request-id" // Optional: isolates instance or retries fresh
   });
 
 ```

--- a/packages/app/src/api.test.ts
+++ b/packages/app/src/api.test.ts
@@ -396,6 +396,59 @@ describe('API tests', () => {
     expect((appTwo as FirebaseServerAppImpl).isDeleted).to.be.true;
   });
 
+  it('creates distinct FirebaseServerApps when customIdentifier differs', async () => {
+    if (isBrowser()) {
+      return;
+    }
+
+    const options = { apiKey: 'APIKEY' };
+    const appOne = initializeServerApp(options, {
+      customIdentifier: 'scope-a'
+    });
+    const appTwo = initializeServerApp(options, {
+      customIdentifier: 'scope-b'
+    });
+
+    expect(appOne).to.not.equal(null);
+    expect(appTwo).to.not.equal(null);
+    expect(appOne).to.not.equal(appTwo);
+    expect(appOne.settings.customIdentifier).to.equal('scope-a');
+    expect(appTwo.settings.customIdentifier).to.equal('scope-b');
+
+    await deleteApp(appOne);
+    await deleteApp(appTwo);
+    expect((appOne as FirebaseServerAppImpl).isDeleted).to.be.true;
+    expect((appTwo as FirebaseServerAppImpl).isDeleted).to.be.true;
+  });
+
+  it('returns the same FirebaseServerApp when customIdentifier matches and tracks refCount', async () => {
+    if (isBrowser()) {
+      return;
+    }
+
+    const options = { apiKey: 'APIKEY' };
+    const appOne = initializeServerApp(options, {
+      customIdentifier: 'scope-a'
+    });
+    expect((appOne as FirebaseServerAppImpl).refCount).to.equal(1);
+
+    const appTwo = initializeServerApp(options, {
+      customIdentifier: 'scope-a'
+    });
+    expect(appTwo).to.equal(appOne);
+    expect((appOne as FirebaseServerAppImpl).refCount).to.equal(2);
+    expect((appTwo as FirebaseServerAppImpl).refCount).to.equal(2);
+
+    await deleteApp(appOne);
+    expect((appOne as FirebaseServerAppImpl).refCount).to.equal(1);
+    expect((appTwo as FirebaseServerAppImpl).refCount).to.equal(1);
+    expect((appOne as FirebaseServerAppImpl).isDeleted).to.be.false;
+
+    await deleteApp(appTwo);
+    expect((appOne as FirebaseServerAppImpl).refCount).to.equal(0);
+    expect((appOne as FirebaseServerAppImpl).isDeleted).to.be.true;
+  });
+
   describe('getApp', () => {
     it('retrieves DEFAULT App', () => {
       const app = initializeApp({});

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -242,7 +242,7 @@ export function initializeApp(
  *
  * @param options - `Firebase.AppOptions` to configure the app's services, or a
  *   a `FirebaseApp` instance which contains the `AppOptions` within.
- * @param config - Optional `FirebaseServerApp` settings, including tokens, releaseOnDeref, or customIdentifier.
+ * @param config - Optional `FirebaseServerApp` settings, including tokens, `releaseOnDeref`, or `customIdentifier`.
  *
  * @returns The initialized `FirebaseServerApp`.
  *
@@ -261,7 +261,7 @@ export function initializeServerApp(
 /**
  * Creates and initializes a {@link @firebase/app#FirebaseServerApp} instance.
  *
- * @param config - Optional `FirebaseServerApp` settings, including tokens, releaseOnDeref, or customIdentifier.
+ * @param config - Optional `FirebaseServerApp` settings, including tokens, `releaseOnDeref`, or `customIdentifier`.
  *
  * @returns The initialized `FirebaseServerApp`.
  *

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -209,6 +209,10 @@ export function initializeApp(
  * server side rendering environments only. Initialization will fail if invoked from a
  * browser environment.
  *
+ * By default, instances are cached and deduplicated based on a hash of the provided
+ * options and settings. To isolate an instance or bypass cached state on retry, provide
+ * a unique {@link FirebaseServerAppSettings.customIdentifier}.
+ *
  * See
  * {@link
  *   https://firebase.google.com/docs/web/setup#add_firebase_to_your_app
@@ -231,13 +235,14 @@ export function initializeApp(
  *     messagingSenderId: "123456789"                  // Cloud Messaging
  *   },
  *   {
- *    authIdToken: "Your Auth ID Token"
+ *    authIdToken: "Your Auth ID Token",
+ *    customIdentifier: "unique-request-id" // Optional: isolates instance or retries fresh
  *   });
  * ```
  *
  * @param options - `Firebase.AppOptions` to configure the app's services, or a
  *   a `FirebaseApp` instance which contains the `AppOptions` within.
- * @param config - Optional `FirebaseServerApp` settings.
+ * @param config - Optional `FirebaseServerApp` settings, including tokens, releaseOnDeref, or customIdentifier.
  *
  * @returns The initialized `FirebaseServerApp`.
  *
@@ -256,7 +261,7 @@ export function initializeServerApp(
 /**
  * Creates and initializes a {@link @firebase/app#FirebaseServerApp} instance.
  *
- * @param config - Optional `FirebaseServerApp` settings.
+ * @param config - Optional `FirebaseServerApp` settings, including tokens, releaseOnDeref, or customIdentifier.
  *
  * @returns The initialized `FirebaseServerApp`.
  *

--- a/packages/app/src/firebaseServerApp.test.ts
+++ b/packages/app/src/firebaseServerApp.test.ts
@@ -214,4 +214,20 @@ describe('FirebaseServerApp', () => {
     }
     expect(encounteredError).to.be.false;
   });
+
+  it('preserves customIdentifier in settings', () => {
+    const options = { apiKey: 'APIKEY' };
+    const serverAppSettings: FirebaseServerAppSettings = {
+      automaticDataCollectionEnabled: false,
+      releaseOnDeref: options,
+      customIdentifier: 'test-custom-id'
+    };
+    const app = new FirebaseServerAppImpl(
+      options,
+      serverAppSettings,
+      'testName',
+      new ComponentContainer('test')
+    );
+    expect(app.settings.customIdentifier).to.equal('test-custom-id');
+  });
 });

--- a/packages/app/src/internal.test.ts
+++ b/packages/app/src/internal.test.ts
@@ -29,7 +29,8 @@ import {
   _clearComponents,
   _getProvider,
   _removeServiceInstance,
-  _isFirebaseServerApp
+  _isFirebaseServerApp,
+  _isFirebaseServerAppSettings
 } from './internal';
 import { logger } from './logger';
 import { isBrowser } from '@firebase/util';
@@ -182,6 +183,31 @@ describe('Internal API tests', () => {
     it('undefined returns false', () => {
       let app: undefined;
       expect(_isFirebaseServerApp(app)).to.be.false;
+    });
+  });
+
+  describe('_isFirebaseServerAppSettings', () => {
+    it('returns true for object with customIdentifier', () => {
+      expect(_isFirebaseServerAppSettings({ customIdentifier: 'my-scope' })).to
+        .be.true;
+    });
+    it('returns true for object with other server app settings', () => {
+      expect(_isFirebaseServerAppSettings({ authIdToken: 'token' })).to.be.true;
+      expect(_isFirebaseServerAppSettings({ appCheckToken: 'token' })).to.be
+        .true;
+      expect(_isFirebaseServerAppSettings({ releaseOnDeref: {} })).to.be.true;
+      expect(
+        _isFirebaseServerAppSettings({
+          automaticDataCollectionEnabled: false
+        })
+      ).to.be.true;
+    });
+    it('returns false for standard FirebaseApp', () => {
+      const app = initializeApp({});
+      expect(_isFirebaseServerAppSettings(app)).to.be.false;
+    });
+    it('returns false for plain FirebaseOptions', () => {
+      expect(_isFirebaseServerAppSettings({ apiKey: 'KEY' })).to.be.false;
     });
   });
 });

--- a/packages/app/src/internal.test.ts
+++ b/packages/app/src/internal.test.ts
@@ -209,5 +209,14 @@ describe('Internal API tests', () => {
     it('returns false for plain FirebaseOptions', () => {
       expect(_isFirebaseServerAppSettings({ apiKey: 'KEY' })).to.be.false;
     });
+    it('returns false for null and undefined', () => {
+      expect(_isFirebaseServerAppSettings(null as any)).to.be.false;
+      expect(_isFirebaseServerAppSettings(undefined as any)).to.be.false;
+    });
+    it('returns false for primitive values', () => {
+      expect(_isFirebaseServerAppSettings('string' as any)).to.be.false;
+      expect(_isFirebaseServerAppSettings(123 as any)).to.be.false;
+      expect(_isFirebaseServerAppSettings(true as any)).to.be.false;
+    });
   });
 });

--- a/packages/app/src/internal.ts
+++ b/packages/app/src/internal.ts
@@ -170,7 +170,11 @@ export function _isFirebaseApp(
  * @internal
  */
 export function _isFirebaseServerAppSettings(
-  obj: FirebaseApp | FirebaseOptions | FirebaseAppSettings
+  obj:
+    | FirebaseApp
+    | FirebaseOptions
+    | FirebaseAppSettings
+    | FirebaseServerAppSettings
 ): obj is FirebaseServerAppSettings {
   if (_isFirebaseApp(obj)) {
     return false;
@@ -179,7 +183,8 @@ export function _isFirebaseServerAppSettings(
     'authIdToken' in obj ||
     'appCheckToken' in obj ||
     'releaseOnDeref' in obj ||
-    'automaticDataCollectionEnabled' in obj
+    'automaticDataCollectionEnabled' in obj ||
+    'customIdentifier' in obj
   );
 }
 

--- a/packages/app/src/internal.ts
+++ b/packages/app/src/internal.ts
@@ -176,6 +176,9 @@ export function _isFirebaseServerAppSettings(
     | FirebaseAppSettings
     | FirebaseServerAppSettings
 ): obj is FirebaseServerAppSettings {
+  if (typeof obj !== 'object' || obj === null) {
+    return false;
+  }
   if (_isFirebaseApp(obj)) {
     return false;
   }

--- a/packages/app/src/public-types.ts
+++ b/packages/app/src/public-types.ts
@@ -180,6 +180,17 @@ export interface FirebaseServerAppSettings extends Omit<
   'name'
 > {
   /**
+   * An optional custom identifier used to distinguish this `FirebaseServerApp`
+   * instance from others with identical options and tokens.
+   *
+   * By default, `initializeServerApp` caches and shares `FirebaseServerApp`
+   * instances based on a hash of the Firebase options, `authIdToken`, and `appCheckToken`.
+   * Providing a distinct `customIdentifier` (such as a request ID or UUID) isolates the
+   * instance to a specific execution context or enables clean retries after transient failures.
+   */
+  customIdentifier?: string;
+
+  /**
    * An optional Auth ID token used to resume a signed in user session from a client
    * runtime environment.
    *

--- a/packages/auth/test/integration/flows/firebaseserverapp.test.ts
+++ b/packages/auth/test/integration/flows/firebaseserverapp.test.ts
@@ -38,10 +38,11 @@ import {
   signOut,
   updateCurrentUser,
   updateEmail,
-  updateProfile
+  updateProfile,
+  User
 } from '@firebase/auth';
 import { isBrowser, FirebaseError } from '@firebase/util';
-import { initializeServerApp, deleteApp } from '@firebase/app';
+import { initializeServerApp, deleteApp, FirebaseServerApp } from '@firebase/app';
 import { FetchProvider } from '../../../src/core/util/fetch_provider';
 
 import {
@@ -496,6 +497,26 @@ describe('Integration test: Auth FirebaseServerApp tests', () => {
     await deleteApp(serverApp);
   });
 
+  function waitForUser(
+    authInstance: Auth,
+    timeoutMs: number
+  ): Promise<User | null> {
+    return new Promise(resolve => {
+      const timer = setTimeout(() => {
+        unsubscribe();
+        resolve(authInstance.currentUser);
+      }, timeoutMs);
+
+      const unsubscribe = onAuthStateChanged(authInstance, user => {
+        if (user) {
+          clearTimeout(timer);
+          unsubscribe();
+          resolve(user);
+        }
+      });
+    });
+  }
+
   it('recovers from transient auth failure using customIdentifier', async () => {
     if (isBrowser()) {
       return;
@@ -505,55 +526,84 @@ describe('Integration test: Auth FirebaseServerApp tests', () => {
     const authIdToken = await userCred.user.getIdToken();
     const config = getAppConfig();
 
-    // 1. Intercept fetch to simulate a transient network failure (e.g. AbortError) on getAccountInfo
     const realFetch = FetchProvider.fetch();
     let shouldFail = true;
-    FetchProvider.initialize(async (input, init) => {
-      if (
-        shouldFail &&
-        typeof input === 'string' &&
-        input.includes('getAccountInfo')
-      ) {
-        throw new Error('AbortError: The operation was aborted');
+    let failedApp: FirebaseServerApp | undefined;
+    let cachedApp: FirebaseServerApp | undefined;
+    let recoveredApp: FirebaseServerApp | undefined;
+
+    try {
+      FetchProvider.initialize(async (input, init) => {
+        const url =
+          typeof input === 'string'
+            ? input
+            : input instanceof URL
+            ? input.toString()
+            : typeof (input as Request)?.url === 'string'
+            ? (input as Request).url
+            : '';
+
+        if (shouldFail && url.includes('getAccountInfo')) {
+          throw new Error('AbortError: The operation was aborted');
+        }
+        return realFetch(input, init);
+      });
+
+      // Attempt 1: Fails due to simulated transient error; currentUser becomes null.
+      // This call always exhausts the timeout — there's no "sign-in failed" event to
+      // resolve early on, only the absence of a "sign-in succeeded" one.
+      failedApp = initializeServerApp(config, { authIdToken });
+      const failedAuth = getTestInstanceForServerApp(failedApp);
+      const failedUser = await waitForUser(failedAuth, signInWaitDuration);
+      expect(failedUser).to.be.null;
+
+      // Restore normal network conditions
+      shouldFail = false;
+
+      // Attempt 2: Re-requesting with identical settings returns the poisoned cached instance
+      cachedApp = initializeServerApp(config, { authIdToken });
+      expect(cachedApp).to.equal(failedApp);
+      const cachedAuth = getTestInstanceForServerApp(cachedApp);
+      expect(cachedAuth.currentUser).to.be.null;
+
+      // Note: customIdentifier provides failure-agnostic instance partitioning (the SDK performs
+      // no error classification or automatic retry). Supplying a new customIdentifier forces a genuinely
+      // fresh FirebaseServerApp instance, enabling callers to retry auth initialization explicitly.
+      recoveredApp = initializeServerApp(config, {
+        authIdToken,
+        customIdentifier: 'retry-request-1'
+      });
+      expect(recoveredApp).to.not.equal(failedApp);
+      const recoveredAuth = getTestInstanceForServerApp(recoveredApp);
+      const recoveredUser = await waitForUser(
+        recoveredAuth,
+        signInWaitDuration
+      );
+
+      expect(recoveredUser).to.not.be.null;
+      expect(recoveredUser?.uid).to.equal(userCred.user.uid);
+    } finally {
+      // Teardown: always restore the global FetchProvider and clean up initialized apps.
+      // Note: deleteApp is called once per initializeServerApp call to decrement refCounts
+      // back to 0 (cachedApp bumped refCount to 2 on the shared instance).
+      // Cleanup errors are collected to prevent masking original assertion failures.
+      FetchProvider.initialize(realFetch);
+      const cleanupErrors: unknown[] = [];
+      if (failedApp) {
+        await deleteApp(failedApp).catch(e => cleanupErrors.push(e));
       }
-      return realFetch(input, init);
-    });
-
-    // Attempt 1: Fails due to simulated transient error; currentUser becomes null
-    const failedApp = initializeServerApp(config, { authIdToken });
-    const failedAuth = getTestInstanceForServerApp(failedApp);
-    await new Promise(resolve => setTimeout(resolve, signInWaitDuration));
-    expect(failedAuth.currentUser).to.be.null;
-
-    // Restore normal network conditions
-    shouldFail = false;
-
-    // Attempt 2: Re-requesting with identical settings returns the poisoned cached instance
-    const cachedApp = initializeServerApp(config, { authIdToken });
-    expect(cachedApp).to.equal(failedApp);
-    const cachedAuth = getTestInstanceForServerApp(cachedApp);
-    expect(cachedAuth.currentUser).to.be.null;
-
-    // Note: customIdentifier just changes which cache bucket the instance falls into —
-    // it doesn't know or care whether the previous attempt failed, or why. The SDK never
-    // inspects the failure; it's up to the caller to decide when to retry. Passing a new
-    // customIdentifier forces a fresh FirebaseServerApp instance (and a fresh sign-in
-    // attempt) regardless of what went wrong before. This test simulates a transient
-    // AbortError, but the same mechanism works the same way for any failure.
-    const recoveredApp = initializeServerApp(config, {
-      authIdToken,
-      customIdentifier: 'retry-request-1'
-    });
-    expect(recoveredApp).to.not.equal(failedApp);
-    const recoveredAuth = getTestInstanceForServerApp(recoveredApp);
-    await new Promise(resolve => setTimeout(resolve, signInWaitDuration));
-    expect(recoveredAuth.currentUser).to.not.be.null;
-    expect(recoveredAuth.currentUser?.uid).to.equal(userCred.user.uid);
-
-    // Teardown
-    FetchProvider.initialize(realFetch);
-    await deleteApp(failedApp);
-    await deleteApp(cachedApp);
-    await deleteApp(recoveredApp);
+      if (cachedApp) {
+        await deleteApp(cachedApp).catch(e => cleanupErrors.push(e));
+      }
+      if (recoveredApp) {
+        await deleteApp(recoveredApp).catch(e => cleanupErrors.push(e));
+      }
+      if (cleanupErrors.length > 0) {
+        console.warn(
+          'Cleanup errors in firebaseserverapp test:',
+          cleanupErrors
+        );
+      }
+    }
   });
 });

--- a/packages/auth/test/integration/flows/firebaseserverapp.test.ts
+++ b/packages/auth/test/integration/flows/firebaseserverapp.test.ts
@@ -42,7 +42,11 @@ import {
   User
 } from '@firebase/auth';
 import { isBrowser, FirebaseError } from '@firebase/util';
-import { initializeServerApp, deleteApp, FirebaseServerApp } from '@firebase/app';
+import {
+  initializeServerApp,
+  deleteApp,
+  FirebaseServerApp
+} from '@firebase/app';
 import { FetchProvider } from '../../../src/core/util/fetch_provider';
 
 import {
@@ -538,10 +542,10 @@ describe('Integration test: Auth FirebaseServerApp tests', () => {
           typeof input === 'string'
             ? input
             : input instanceof URL
-            ? input.toString()
-            : typeof (input as Request)?.url === 'string'
-            ? (input as Request).url
-            : '';
+              ? input.toString()
+              : typeof (input as Request)?.url === 'string'
+                ? (input as Request).url
+                : '';
 
         if (shouldFail && url.includes('getAccountInfo')) {
           throw new Error('AbortError: The operation was aborted');

--- a/packages/auth/test/integration/flows/firebaseserverapp.test.ts
+++ b/packages/auth/test/integration/flows/firebaseserverapp.test.ts
@@ -42,6 +42,7 @@ import {
 } from '@firebase/auth';
 import { isBrowser, FirebaseError } from '@firebase/util';
 import { initializeServerApp, deleteApp } from '@firebase/app';
+import { FetchProvider } from '../../../src/core/util/fetch_provider';
 
 import {
   cleanUpTestInstance,
@@ -493,5 +494,66 @@ describe('Integration test: Auth FirebaseServerApp tests', () => {
     }
 
     await deleteApp(serverApp);
+  });
+
+  it('recovers from transient auth failure using customIdentifier', async () => {
+    if (isBrowser()) {
+      return;
+    }
+
+    const userCred = await signInAnonymously(auth);
+    const authIdToken = await userCred.user.getIdToken();
+    const config = getAppConfig();
+
+    // 1. Intercept fetch to simulate a transient network failure (e.g. AbortError) on getAccountInfo
+    const realFetch = FetchProvider.fetch();
+    let shouldFail = true;
+    FetchProvider.initialize(async (input, init) => {
+      if (
+        shouldFail &&
+        typeof input === 'string' &&
+        input.includes('getAccountInfo')
+      ) {
+        throw new Error('AbortError: The operation was aborted');
+      }
+      return realFetch(input, init);
+    });
+
+    // Attempt 1: Fails due to simulated transient error; currentUser becomes null
+    const failedApp = initializeServerApp(config, { authIdToken });
+    const failedAuth = getTestInstanceForServerApp(failedApp);
+    await new Promise(resolve => setTimeout(resolve, signInWaitDuration));
+    expect(failedAuth.currentUser).to.be.null;
+
+    // Restore normal network conditions
+    shouldFail = false;
+
+    // Attempt 2: Re-requesting with identical settings returns the poisoned cached instance
+    const cachedApp = initializeServerApp(config, { authIdToken });
+    expect(cachedApp).to.equal(failedApp);
+    const cachedAuth = getTestInstanceForServerApp(cachedApp);
+    expect(cachedAuth.currentUser).to.be.null;
+
+    // Note: customIdentifier just changes which cache bucket the instance falls into —
+    // it doesn't know or care whether the previous attempt failed, or why. The SDK never
+    // inspects the failure; it's up to the caller to decide when to retry. Passing a new
+    // customIdentifier forces a fresh FirebaseServerApp instance (and a fresh sign-in
+    // attempt) regardless of what went wrong before. This test simulates a transient
+    // AbortError, but the same mechanism works the same way for any failure.
+    const recoveredApp = initializeServerApp(config, {
+      authIdToken,
+      customIdentifier: 'retry-request-1'
+    });
+    expect(recoveredApp).to.not.equal(failedApp);
+    const recoveredAuth = getTestInstanceForServerApp(recoveredApp);
+    await new Promise(resolve => setTimeout(resolve, signInWaitDuration));
+    expect(recoveredAuth.currentUser).to.not.be.null;
+    expect(recoveredAuth.currentUser?.uid).to.equal(userCred.user.uid);
+
+    // Teardown
+    FetchProvider.initialize(realFetch);
+    await deleteApp(failedApp);
+    await deleteApp(cachedApp);
+    await deleteApp(recoveredApp);
   });
 });

--- a/packages/auth/test/integration/webdriver/persistence.test.ts
+++ b/packages/auth/test/integration/webdriver/persistence.test.ts
@@ -450,6 +450,10 @@ browserDescribe('WebDriver persistence test', (driver, browser) => {
       expect(await driver.getUserSnapshot()).to.be.null;
       await driver.selectMainWindow({ noWait: true });
       await driver.pause(700);
+      await driver.webDriver.wait(
+        async () => (await driver.getUserSnapshot()) === null,
+        5000
+      );
       expect(await driver.getUserSnapshot()).to.be.null;
 
       const cred2: UserCredential = await driver.call(
@@ -459,6 +463,10 @@ browserDescribe('WebDriver persistence test', (driver, browser) => {
 
       await driver.selectPopupWindow();
       await driver.pause(500);
+      await driver.webDriver.wait(
+        async () => (await driver.getUserSnapshot())?.uid === uid2,
+        5000
+      );
       expect(await driver.getUserSnapshot()).to.contain({ uid: uid2 });
     });
 
@@ -492,6 +500,10 @@ browserDescribe('WebDriver persistence test', (driver, browser) => {
       // And make sure it was updated in main window
       await driver.selectMainWindow({ noWait: true });
       await driver.pause(700);
+      await driver.webDriver.wait(
+        async () => (await driver.getUserSnapshot())?.uid === cred.user.uid,
+        5000
+      );
       expect((await driver.getUserSnapshot()).uid).to.eq(cred.user.uid);
     });
 
@@ -520,6 +532,10 @@ browserDescribe('WebDriver persistence test', (driver, browser) => {
       expect(await driver.getUserSnapshot()).to.be.null;
       await driver.selectMainWindow({ noWait: true });
       await driver.pause(500);
+      await driver.webDriver.wait(
+        async () => (await driver.getUserSnapshot()) === null,
+        5000
+      );
       expect(await driver.getUserSnapshot()).to.be.null;
 
       const cred2: UserCredential = await driver.call(
@@ -529,6 +545,10 @@ browserDescribe('WebDriver persistence test', (driver, browser) => {
 
       await driver.selectPopupWindow();
       await driver.pause(500);
+      await driver.webDriver.wait(
+        async () => (await driver.getUserSnapshot())?.uid === uid2,
+        5000
+      );
       expect(await driver.getUserSnapshot()).to.contain({ uid: uid2 });
     });
   });


### PR DESCRIPTION
### Description
In SSR environments an initial render pass can be discarded or aborted, causing the one-shot token sign-in (`getAccountInfo`) to fail transiently and set `currentUser = null`. Because the failed instance remains cached in memory under the token hash, all subsequent requests presenting the same token receive the poisoned instance with no recovery path until token rotation.
This PR introduces `customIdentifier?: string` to `FirebaseServerAppSettings`. Providing a distinct `customIdentifier` changes the computed instance hash, giving developers a clean "toolbox" mechanism to:
1. Isolate `FirebaseServerApp` instances per request (e.g., passing a request UUID in SSR).
2. Force a fresh server app instance to explicitly retry authentication after transient failures.

### Testing Plan
Added an integration test to verify that supplying `customIdentifier` successfully recovers from an initial transient auth failure. 

### API Changes
- Added optional property `customIdentifier?: string` to public interface `FirebaseServerAppSettings`.
- Backwards compatible (non-breaking change).

Fixes #10213 