### PR TITLE
build: add `skipLibCheck` to base tsconfig to resolve generic Buffer errors

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -4,6 +4,7 @@
     "declaration": true,
     "importHelpers": true,
     "strict": true,
+    "skipLibCheck": true,
     "lib": [
       "dom",
       "es2020",


### PR DESCRIPTION
The root `package.json` specifies `@types/node` 18.19.83 where Buffer is non-generic, but `@grpc/grpc-js` and `re2js` declare `Buffer<ArrayBuffer>` and `Int32Array<ArrayBuffer>` expecting Node 20+ / ES2024+ definitions.

Enabling `skipLibCheck` prevents TS from typechecking third-party declaration files in `node_modules` against older DOM/Node lib definitions. 

This resolves all TS2315 errors in the Firestore build.

Virtually every major TS monorepo uses `skipLibCheck: true`.
