### PR TITLE
docs(firestore): fix API Extractor forgotten export errors for pipelines

### DIFF
--- a/packages/firestore/pipelines/pipelines.ts
+++ b/packages/firestore/pipelines/pipelines.ts
@@ -27,7 +27,7 @@
 // types need to be exported here to ensure that api-extractor behaves
 // correctly. If a type from api.ts is missing from this export, then
 // api-extractor may rename it with a suffix `_#`, e.g. `YourType_2`.
-export type {
+export {
   Timestamp,
   DocumentReference,
   VectorValue,

--- a/repo-scripts/prune-dts/extract-public-api.ts
+++ b/repo-scripts/prune-dts/extract-public-api.ts
@@ -103,7 +103,10 @@ function loadApiExtractorConfig(
           'logLevel': 'none'
         },
         'ae-forgotten-export': {
-          'logLevel': apiReportEnabled ? 'error' : 'none',
+          'logLevel':
+            apiReportEnabled && !excludeForgottenExportWarning
+              ? 'error'
+              : 'none',
           'addToApiReportFile': !excludeForgottenExportWarning
         }
       },


### PR DESCRIPTION
API extractor reported `ae-forgotten-export` errors during the firestore pipelines api report generation because shared types exported with `export type` syntax and the prune-dts script did not apply the `excludeForgottenExportWarning` option to message log levels.

This updates `pipelines.ts` to export shared types as regular exports (matching lite/pipelines) and updates `extract-public-api.ts` to respect `excludeForgottenExportWarning` for `ae-forgotten-export` `logLevel`.