### PR TITLE
build(workflows): Remove Auth workflow annoation noting last tested Chrome version

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -30,8 +30,6 @@ env:
   # the behavior to use the new URLs.
   CHROMEDRIVER_CDNURL: https://googlechromelabs.github.io/
   CHROMEDRIVER_CDNBINARIESURL: https://storage.googleapis.com/chrome-for-testing-public
-  CHROME_VALIDATED_VERSION: linux-132.0.6834.110
-  CHROME_VERSION_MISMATCH_MESSAGE: "The Chrome version doesn't match the previously validated version. Consider updating CHROME_VALIDATED_VERSION in the GitHub workflow if tests pass, or rollback the installed Chrome version if tests fail."
   artifactRetentionDays: 14
   # Bump Node memory limit
   NODE_OPTIONS: "--max_old_space_size=4096"
@@ -146,15 +144,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # install Chrome first, so the correct version of webdriver can be installed by chromedriver
-      # when setting up the repo
+      # when setting up the repo.
     - name: install Chrome stable
       run: |
         npx @puppeteer/browsers install chrome@stable
-        chromeVersionString=$(ls chrome)
-        if [ "$CHROME_VALIDATED_VERSION" != "$chromeVersionString" ]; then
-        echo "::warning ::${CHROME_VERSION_MISMATCH_MESSAGE}"
-        echo "::warning ::Previously validated version: ${CHROME_VALIDATED_VERSION} vs. Installed version: $chromeVersionString"
-        fi
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
       with:
         persist-credentials: false

--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -26,7 +26,6 @@ env:
   # the behavior to use the new URLs.
   CHROMEDRIVER_CDNURL: https://googlechromelabs.github.io/
   CHROMEDRIVER_CDNBINARIESURL: https://storage.googleapis.com/chrome-for-testing-public
-  CHROME_VALIDATED_VERSION: linux-120.0.6099.71
   # Bump Node memory limit
   NODE_OPTIONS: "--max_old_space_size=4096"
 
@@ -36,24 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # install Chrome first, so the correct version of webdriver can be installed by chromedriver
-      # when setting up the repo
-      #
-      # Note: we only need to check the chrome version change in one job as the warning annotation
-      # is appended to the entire workflow results, not just this job's results.
+      # when setting up the repo.
       - name: install Chrome stable
-        env:
-          CHROME_VERSION_MISMATCH_MESSAGE: "The Chrome version doesn't match the previously validated version. Consider updating CHROME_VALIDATED_VERSION in the GitHub workflow if tests pass."
         run: |
           npx @puppeteer/browsers install chrome@stable
-          chromeVersionString=$(ls chrome)
-          if [ "$CHROME_VALIDATED_VERSION" != "$chromeVersionString" ]; then
-          echo "::warning ::The Chrome version doesn't match the previously validated version. Consider updating CHROME_VALIDATED_VERSION in the GitHub workflow if tests pass."
-          echo "::warning ::Previously validated version: ${CHROME_VALIDATED_VERSION} vs. Installed version: $chromeVersionString"
-          echo "CHROME_VERSION_NOTES=$CHROME_VERSION_MISMATCH_MESSAGE" >> "$GITHUB_ENV"
-          fi
-      - name: Test Evn TEMP
-        run: |
-         echo $CHROME_VERSION_NOTES=$CHROME_VERSION_MISMATCH_MESSAGE
       - name: Checkout Repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
         with:


### PR DESCRIPTION
### Discussion

Remove the workflow annoation that notes the last tested Chrome version. This was meant to help Auth engineers debug when CI suddenly starts to fail, but that team no longer works with us, and the last tested version hasn't been updated in a while. The annoation has become noise at this point.

### Testing

CI.

### API Changes

None.