### PR TITLE
chore: format all files with prettier 3

### DIFF
--- a/e2e/data-connect/dataconnect-generated/js/default-connector/index.d.ts
+++ b/e2e/data-connect/dataconnect-generated/js/default-connector/index.d.ts
@@ -57,15 +57,14 @@ export interface Movie_Key {
 
 interface CreateMovieRef {
   /* Allow users to create refs without passing in DataConnect */
-  (vars: CreateMovieVariables): MutationRef<
-    CreateMovieData,
-    CreateMovieVariables
-  >;
+  (
+    vars: CreateMovieVariables
+  ): MutationRef<CreateMovieData, CreateMovieVariables>;
   /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: CreateMovieVariables): MutationRef<
-    CreateMovieData,
-    CreateMovieVariables
-  >;
+  (
+    dc: DataConnect,
+    vars: CreateMovieVariables
+  ): MutationRef<CreateMovieData, CreateMovieVariables>;
   operationName: string;
 }
 export const createMovieRef: CreateMovieRef;

--- a/packages/ai/src/methods/chat-session-base.ts
+++ b/packages/ai/src/methods/chat-session-base.ts
@@ -63,8 +63,7 @@ export abstract class ChatSessionBase<
   ParamsType extends StartChatParams | StartTemplateChatParams,
   RequestType,
   FunctionDeclarationsToolType extends
-    | FunctionDeclarationsTool
-    | TemplateFunctionDeclarationsTool
+    FunctionDeclarationsTool | TemplateFunctionDeclarationsTool
 > {
   protected _apiSettings: ApiSettings;
   protected _history: Content[] = [];
@@ -156,9 +155,8 @@ export abstract class ChatSessionBase<
 
         if (functionCalls) {
           functionCallTurnCount++;
-          const functionResponseParts = await this._callFunctionsAsNeeded(
-            functionCalls
-          );
+          const functionResponseParts =
+            await this._callFunctionsAsNeeded(functionCalls);
           formattedContent = formatNewContent(functionResponseParts);
         } else {
           formattedContent = formatNewContent(request);
@@ -251,9 +249,8 @@ export abstract class ChatSessionBase<
 
           if (functionCalls) {
             functionCallTurnCount++;
-            const functionResponseParts = await this._callFunctionsAsNeeded(
-              functionCalls
-            );
+            const functionResponseParts =
+              await this._callFunctionsAsNeeded(functionCalls);
             formattedContent = formatNewContent(functionResponseParts);
           } else {
             formattedContent = formatNewContent(request);

--- a/packages/ai/src/types/language-model.ts
+++ b/packages/ai/src/types/language-model.ts
@@ -102,8 +102,7 @@ export interface LanguageModelDownloadMonitor {
  * Configures the creation of an on-device language model session.
  * @public
  */
-export interface LanguageModelCreateOptions
-  extends LanguageModelCreateCoreOptions {
+export interface LanguageModelCreateOptions extends LanguageModelCreateCoreOptions {
   signal?: AbortSignal;
   initialPrompts?: LanguageModelMessage[];
 }
@@ -166,7 +165,4 @@ export type LanguageModelMessageType = 'text' | 'image' | 'audio';
  * @public
  */
 export type LanguageModelMessageContentValue =
-  | ImageBitmapSource
-  | AudioBuffer
-  | BufferSource
-  | string;
+  ImageBitmapSource | AudioBuffer | BufferSource | string;

--- a/packages/analytics/src/get-config.test.ts
+++ b/packages/analytics/src/get-config.test.ts
@@ -59,9 +59,7 @@ describe('Dynamic Config Fetch Functions', () => {
     });
     it('throws error on failed response', async () => {
       stubFetch(500, {
-        error: {
-          /* no message */
-        }
+        error: {/* no message */}
       });
       const app = getFakeApp(fakeAppParams);
       await expect(
@@ -93,9 +91,7 @@ describe('Dynamic Config Fetch Functions', () => {
     });
     it('throws error on non-retriable failed response', async () => {
       stubFetch(404, {
-        error: {
-          /* no message */
-        }
+        error: {/* no message */}
       });
       const app = getFakeApp(fakeAppParams);
       await expect(fetchDynamicConfigWithRetry(app)).to.be.rejectedWith(
@@ -104,9 +100,7 @@ describe('Dynamic Config Fetch Functions', () => {
     });
     it('warns on non-retriable failed response if local measurementId available', async () => {
       stubFetch(404, {
-        error: {
-          /* no message */
-        }
+        error: {/* no message */}
       });
       const consoleStub = stub(console, 'warn');
       const app = getFakeApp({

--- a/packages/app-check-compat/src/service.ts
+++ b/packages/app-check-compat/src/service.ts
@@ -45,9 +45,7 @@ export class AppCheckService
     isTokenAutoRefreshEnabled?: boolean
   ): void {
     let provider:
-      | ReCaptchaV3Provider
-      | CustomProvider
-      | ReCaptchaEnterpriseProvider;
+      ReCaptchaV3Provider | CustomProvider | ReCaptchaEnterpriseProvider;
     if (typeof siteKeyOrProvider === 'string') {
       provider = new ReCaptchaV3Provider(siteKeyOrProvider);
     } else if (

--- a/packages/app-check-types/index.d.ts
+++ b/packages/app-check-types/index.d.ts
@@ -33,10 +33,7 @@ export interface FirebaseAppCheck {
    */
   activate(
     siteKeyOrProvider:
-      | string
-      | AppCheckProvider
-      | CustomProvider
-      | ReCaptchaV3Provider,
+      string | AppCheckProvider | CustomProvider | ReCaptchaV3Provider,
     isTokenAutoRefreshEnabled?: boolean
   ): void;
 

--- a/packages/app-check/src/types.ts
+++ b/packages/app-check/src/types.ts
@@ -38,8 +38,7 @@ export interface FirebaseAppCheckInternal {
   removeTokenListener(listener: AppCheckTokenListener): void;
 }
 
-export interface AppCheckTokenObserver
-  extends PartialObserver<AppCheckTokenResult> {
+export interface AppCheckTokenObserver extends PartialObserver<AppCheckTokenResult> {
   // required
   next: AppCheckTokenListener;
   type: ListenerType;

--- a/packages/app-compat/test/util.ts
+++ b/packages/app-compat/test/util.ts
@@ -21,7 +21,10 @@ import { ComponentType, Component } from '@firebase/component';
 
 export class TestService implements _FirebaseService {
   readonly _delegate = {};
-  constructor(private app_: FirebaseApp, public instanceIdentifier?: string) {}
+  constructor(
+    private app_: FirebaseApp,
+    public instanceIdentifier?: string
+  ) {}
 
   get app(): FirebaseApp {
     return this.app_;

--- a/packages/app/src/heartbeatService.test.ts
+++ b/packages/app/src/heartbeatService.test.ts
@@ -77,7 +77,7 @@ describe('HeartbeatServiceImpl', () => {
             ({
               options: { appId: 'an-app-id' },
               name: 'an-app-name'
-            } as FirebaseApp),
+            }) as FirebaseApp,
           ComponentType.VERSION
         )
       );
@@ -195,7 +195,7 @@ describe('HeartbeatServiceImpl', () => {
             ({
               options: { appId: 'an-app-id' },
               name: 'an-app-name'
-            } as FirebaseApp),
+            }) as FirebaseApp,
           ComponentType.VERSION
         )
       );
@@ -335,7 +335,7 @@ describe('HeartbeatServiceImpl', () => {
             ({
               options: { appId: 'an-app-id' },
               name: 'an-app-name'
-            } as FirebaseApp),
+            }) as FirebaseApp,
           ComponentType.VERSION
         )
       );

--- a/packages/app/test/util.ts
+++ b/packages/app/test/util.ts
@@ -19,7 +19,10 @@ import { FirebaseApp, _FirebaseService } from '../src/public-types';
 import { ComponentType, Component } from '@firebase/component';
 
 export class TestService implements _FirebaseService {
-  constructor(private app_: FirebaseApp, public instanceIdentifier?: string) {}
+  constructor(
+    private app_: FirebaseApp,
+    public instanceIdentifier?: string
+  ) {}
 
   get app(): FirebaseApp {
     return this.app_;

--- a/packages/auth-compat/src/auth.ts
+++ b/packages/auth-compat/src/auth.ts
@@ -44,7 +44,10 @@ export class Auth
   static Persistence = Persistence;
   readonly _delegate: exp.AuthImpl;
 
-  constructor(readonly app: FirebaseApp, provider: Provider<'auth'>) {
+  constructor(
+    readonly app: FirebaseApp,
+    provider: Provider<'auth'>
+  ) {
     if (provider.isInitialized()) {
       this._delegate = provider.getImmediate() as exp.AuthImpl;
       this.linkUnderlyingAuth();

--- a/packages/auth/demo/src/index.js
+++ b/packages/auth/demo/src/index.js
@@ -895,9 +895,8 @@ async function onStartEnrollWithTotpMultiFactor() {
   }
   try {
     multiFactorSession = await multiFactor(activeUser()).getSession();
-    totpSecret = await TotpMultiFactorGenerator.generateSecret(
-      multiFactorSession
-    );
+    totpSecret =
+      await TotpMultiFactorGenerator.generateSecret(multiFactorSession);
     const url = totpSecret.generateQrCodeUrl('test', 'testissuer');
     console.log('TOTP URL is ' + url);
     console.log(
@@ -916,9 +915,8 @@ async function onStartEnrollWithTotpMultiFactor() {
         var minutes = Math.floor(t / (1000 * 60));
         var seconds = Math.floor((t % (60 * 1000)) / 1000);
         // accessing the field using $ does not work here.
-        document.getElementById(
-          'totp-deadline'
-        ).innerText = `Time left - ${minutes} minutes, ${seconds} seconds.`;
+        document.getElementById('totp-deadline').innerText =
+          `Time left - ${minutes} minutes, ${seconds} seconds.`;
       }
     }, 1000);
     // Use the QRServer API documented at https://goqr.me/api/doc/
@@ -1703,8 +1701,7 @@ function onGetRedirectResult() {
     }
     logAdditionalUserInfo(response);
     console.log(response);
-  },
-  onAuthError);
+  }, onAuthError);
 }
 
 /**
@@ -2201,8 +2198,7 @@ function initApp() {
   ) {
     refreshUserData();
     logAdditionalUserInfo(response);
-  },
-  onAuthError);
+  }, onAuthError);
 
   // Try sign in with redirect once upon page load, not on subsequent loads.
   // This will demonstrate the behavior when signInWithRedirect is called before

--- a/packages/auth/src/api/account_management/mfa.ts
+++ b/packages/auth/src/api/account_management/mfa.ts
@@ -95,8 +95,7 @@ export interface FinalizePhoneMfaEnrollmentRequest {
   tenantId?: string;
 }
 
-export interface FinalizePhoneMfaEnrollmentResponse
-  extends FinalizeMfaResponse {}
+export interface FinalizePhoneMfaEnrollmentResponse extends FinalizeMfaResponse {}
 
 export function finalizeEnrollPhoneMfa(
   auth: AuthInternal,
@@ -155,8 +154,7 @@ export interface FinalizeTotpMfaEnrollmentRequest {
   tenantId?: string;
 }
 
-export interface FinalizeTotpMfaEnrollmentResponse
-  extends FinalizeMfaResponse {}
+export interface FinalizeTotpMfaEnrollmentResponse extends FinalizeMfaResponse {}
 
 export function finalizeEnrollTotpMfa(
   auth: AuthInternal,

--- a/packages/auth/src/api/authentication/email_link.ts
+++ b/packages/auth/src/api/authentication/email_link.ts
@@ -50,8 +50,7 @@ export async function signInWithEmailLink(
   );
 }
 
-export interface SignInWithEmailLinkForLinkingRequest
-  extends SignInWithEmailLinkRequest {
+export interface SignInWithEmailLinkForLinkingRequest extends SignInWithEmailLinkRequest {
   idToken: string;
 }
 

--- a/packages/auth/src/api/authentication/mfa.ts
+++ b/packages/auth/src/api/authentication/mfa.ts
@@ -134,6 +134,4 @@ export function finalizeSignInTotpMfa(
  * @internal
  */
 export type PhoneOrOauthTokenResponse =
-  | SignInWithPhoneNumberResponse
-  | SignInWithIdpResponse
-  | IdTokenResponse;
+  SignInWithPhoneNumberResponse | SignInWithIdpResponse | IdTokenResponse;

--- a/packages/auth/src/api/authentication/sms.ts
+++ b/packages/auth/src/api/authentication/sms.ts
@@ -71,8 +71,7 @@ export interface SignInWithPhoneNumberRequest {
   tenantId?: string;
 }
 
-export interface LinkWithPhoneNumberRequest
-  extends SignInWithPhoneNumberRequest {
+export interface LinkWithPhoneNumberRequest extends SignInWithPhoneNumberRequest {
   idToken: string;
 }
 
@@ -118,8 +117,7 @@ export async function linkWithPhoneNumber(
   return response;
 }
 
-interface VerifyPhoneNumberForExistingRequest
-  extends SignInWithPhoneNumberRequest {
+interface VerifyPhoneNumberForExistingRequest extends SignInWithPhoneNumberRequest {
   operation: 'REAUTH';
 }
 

--- a/packages/auth/src/core/auth/auth_impl.ts
+++ b/packages/auth/src/core/auth/auth_impl.ts
@@ -121,8 +121,7 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
   _projectPasswordPolicy: PasswordPolicyInternal | null = null;
   _tenantPasswordPolicies: Record<string, PasswordPolicyInternal> = {};
   _resolvePersistenceManagerAvailable:
-    | ((value: void | PromiseLike<void>) => void)
-    | undefined = undefined;
+    ((value: void | PromiseLike<void>) => void) | undefined = undefined;
   _persistenceManagerAvailable: Promise<void>;
   readonly name: string;
 

--- a/packages/auth/src/core/errors.ts
+++ b/packages/auth/src/core/errors.ts
@@ -443,15 +443,17 @@ export interface NamedErrorParams {
  * @internal
  */
 type GenericAuthErrorParams = {
-  [key in Exclude<
-    AuthErrorCode,
-    | AuthErrorCode.ARGUMENT_ERROR
-    | AuthErrorCode.DEPENDENT_SDK_INIT_BEFORE_AUTH
-    | AuthErrorCode.INTERNAL_ERROR
-    | AuthErrorCode.MFA_REQUIRED
-    | AuthErrorCode.NO_AUTH_EVENT
-    | AuthErrorCode.OPERATION_NOT_SUPPORTED
-  >]: {
+  [
+    key in Exclude<
+      AuthErrorCode,
+      | AuthErrorCode.ARGUMENT_ERROR
+      | AuthErrorCode.DEPENDENT_SDK_INIT_BEFORE_AUTH
+      | AuthErrorCode.INTERNAL_ERROR
+      | AuthErrorCode.MFA_REQUIRED
+      | AuthErrorCode.NO_AUTH_EVENT
+      | AuthErrorCode.OPERATION_NOT_SUPPORTED
+    >
+  ]: {
     appName?: AppName;
     email?: string;
     phoneNumber?: string;

--- a/packages/auth/src/core/strategies/abstract_popup_redirect_operation.ts
+++ b/packages/auth/src/core/strategies/abstract_popup_redirect_operation.ts
@@ -45,9 +45,7 @@ interface PendingPromise {
  * Popup event manager. Handles the popup's entire lifecycle; listens to auth
  * events
  */
-export abstract class AbstractPopupRedirectOperation
-  implements AuthEventConsumer
-{
+export abstract class AbstractPopupRedirectOperation implements AuthEventConsumer {
   private pendingPromise: PendingPromise | null = null;
   private eventManager: EventManager | null = null;
   readonly filter: AuthEventType[];

--- a/packages/auth/src/mfa/mfa_info.ts
+++ b/packages/auth/src/mfa/mfa_info.ts
@@ -35,7 +35,10 @@ export abstract class MultiFactorInfoImpl implements MultiFactorInfo {
   readonly displayName?: string | null;
   readonly enrollmentTime: string;
 
-  protected constructor(readonly factorId: FactorId, response: MfaEnrollment) {
+  protected constructor(
+    readonly factorId: FactorId,
+    response: MfaEnrollment
+  ) {
     this.uid = response.mfaEnrollmentId;
     this.enrollmentTime = new Date(response.enrolledAt).toUTCString();
     this.displayName = response.displayName;

--- a/packages/auth/src/model/password_policy.ts
+++ b/packages/auth/src/model/password_policy.ts
@@ -79,8 +79,7 @@ export interface PasswordPolicyCustomStrengthOptions {
  *
  * @internal
  */
-export interface PasswordValidationStatusInternal
-  extends PasswordValidationStatus {
+export interface PasswordValidationStatusInternal extends PasswordValidationStatus {
   /**
    * Whether the password meets all requirements.
    */

--- a/packages/auth/src/model/user.ts
+++ b/packages/auth/src/model/user.ts
@@ -94,7 +94,6 @@ export interface UserInternal extends User {
  * @internal
  */
 export interface UserCredentialInternal
-  extends UserCredential,
-    TaggedWithTokenResponse {
+  extends UserCredential, TaggedWithTokenResponse {
   user: UserInternal;
 }

--- a/packages/auth/src/platform_browser/messagechannel/index.ts
+++ b/packages/auth/src/platform_browser/messagechannel/index.ts
@@ -92,8 +92,9 @@ export interface ReceiverHandler<
 }
 
 /** Full message sent by Sender  */
-export interface SenderMessageEvent<T extends _SenderRequest>
-  extends MessageEvent {
+export interface SenderMessageEvent<
+  T extends _SenderRequest
+> extends MessageEvent {
   data: T;
 }
 
@@ -102,8 +103,9 @@ export type _ReceiverMessageResponse<T extends _ReceiverResponse> = Array<
 > | null;
 
 /** Full message sent by Receiver */
-export interface ReceiverMessageEvent<T extends _ReceiverResponse>
-  extends MessageEvent {
+export interface ReceiverMessageEvent<
+  T extends _ReceiverResponse
+> extends MessageEvent {
   status: _Status;
   response: _ReceiverMessageResponse<T>;
 }

--- a/packages/auth/src/platform_browser/messagechannel/promise.ts
+++ b/packages/auth/src/platform_browser/messagechannel/promise.ts
@@ -28,8 +28,7 @@ interface PromiseRejectedResult {
 }
 
 export type PromiseSettledResult<T> =
-  | PromiseFulfilledResult<T>
-  | PromiseRejectedResult;
+  PromiseFulfilledResult<T> | PromiseRejectedResult;
 
 /**
  * Shim for Promise.allSettled, note the slightly different format of `fulfilled` vs `status`.

--- a/packages/auth/src/platform_browser/popup_redirect.test.ts
+++ b/packages/auth/src/platform_browser/popup_redirect.test.ts
@@ -59,8 +59,9 @@ describe('platform_browser/popup_redirect', () => {
 
   beforeEach(async () => {
     auth = await testAuth();
-    resolver =
-      new (browserPopupRedirectResolver as SingletonInstantiator<PopupRedirectResolverInternal>)();
+    resolver = new (
+      browserPopupRedirectResolver as SingletonInstantiator<PopupRedirectResolverInternal>
+    )();
 
     sinon.stub(validateOrigin, '_validateOrigin').returns(Promise.resolve());
     iframeSendStub = sinon.stub();

--- a/packages/auth/src/platform_browser/strategies/phone.test.ts
+++ b/packages/auth/src/platform_browser/strategies/phone.test.ts
@@ -830,7 +830,9 @@ describe('platform_browser/strategies/phone', () => {
         return;
       }
       const mutVerifier: {
-        -readonly [K in keyof ApplicationVerifierInternal]: ApplicationVerifierInternal[K];
+        -readonly [
+          K in keyof ApplicationVerifierInternal
+        ]: ApplicationVerifierInternal[K];
       } = v2Verifier;
       mutVerifier.type = 'not-recaptcha-thats-for-sure';
       await expect(

--- a/packages/auth/src/platform_cordova/popup_redirect/popup_redirect.test.ts
+++ b/packages/auth/src/platform_cordova/popup_redirect/popup_redirect.test.ts
@@ -55,14 +55,14 @@ describe('platform_cordova/popup_redirect/popup_redirect', () => {
   let utilsStubs: sinon.SinonStubbedInstance<typeof utils>;
   let eventsStubs: sinon.SinonStubbedInstance<Partial<typeof events>>;
   let universalLinksCb:
-    | ((eventData: Record<string, string> | null) => unknown)
-    | null;
+    ((eventData: Record<string, string> | null) => unknown) | null;
   let tripNoEventTimer: TimerTripFn;
 
   beforeEach(async () => {
     auth = await testAuth();
-    resolver =
-      new (cordovaPopupRedirectResolver as SingletonInstantiator<PopupRedirectResolverInternal>)();
+    resolver = new (
+      cordovaPopupRedirectResolver as SingletonInstantiator<PopupRedirectResolverInternal>
+    )();
     provider = new GoogleAuthProvider();
     utilsStubs = sinon.stub(utils);
     eventsStubs = {

--- a/packages/auth/test/helpers/integration/emulator_rest_helpers.ts
+++ b/packages/auth/test/helpers/integration/emulator_rest_helpers.ts
@@ -44,10 +44,13 @@ export async function getPhoneVerificationCodes(): Promise<
   const url = buildEmulatorUrlForPath('verificationCodes');
   const response: VerificationCodesResponse = await (await doFetch(url)).json();
 
-  return response.verificationCodes.reduce((accum, session) => {
-    accum[session.sessionInfo] = session;
-    return accum;
-  }, {} as Record<string, VerificationSession>);
+  return response.verificationCodes.reduce(
+    (accum, session) => {
+      accum[session.sessionInfo] = session;
+      return accum;
+    },
+    {} as Record<string, VerificationSession>
+  );
 }
 
 export async function getOobCodes(): Promise<OobCodeSession[]> {

--- a/packages/auth/test/integration/flows/oob.local.test.ts
+++ b/packages/auth/test/integration/flows/oob.local.test.ts
@@ -338,9 +338,7 @@ describe('Integration test: oob codes', () => {
     const { user } = await signInWithEmailLink(
       auth,
       email,
-      (
-        await code(email)
-      ).oobLink
+      (await code(email)).oobLink
     );
     await verifyBeforeUpdateEmail(user, updatedEmail, BASE_SETTINGS);
     expect(user.email).to.eq(email);

--- a/packages/data-connect/src/api/Mutation.ts
+++ b/packages/data-connect/src/api/Mutation.ts
@@ -25,8 +25,10 @@ import {
   SOURCE_SERVER
 } from './Reference';
 
-export interface MutationRef<Data, Variables>
-  extends OperationRef<Data, Variables> {
+export interface MutationRef<Data, Variables> extends OperationRef<
+  Data,
+  Variables
+> {
   refType: typeof MUTATION_STR;
 }
 
@@ -105,15 +107,18 @@ export class MutationManager {
 /**
  * Mutation Result from `executeMutation`
  */
-export interface MutationResult<Data, Variables>
-  extends DataConnectResult<Data, Variables> {
+export interface MutationResult<Data, Variables> extends DataConnectResult<
+  Data,
+  Variables
+> {
   ref: MutationRef<Data, Variables>;
 }
 /**
  * Mutation return value from `executeMutation`
  */
-export interface MutationPromise<Data, Variables>
-  extends Promise<MutationResult<Data, Variables>> {
+export interface MutationPromise<Data, Variables> extends Promise<
+  MutationResult<Data, Variables>
+> {
   // reserved for special actions like cancellation
 }
 

--- a/packages/data-connect/src/api/query.ts
+++ b/packages/data-connect/src/api/query.ts
@@ -33,8 +33,10 @@ import {
 /**
  * QueryRef object
  */
-export interface QueryRef<Data, Variables>
-  extends OperationRef<Data, Variables> {
+export interface QueryRef<Data, Variables> extends OperationRef<
+  Data,
+  Variables
+> {
   refType: typeof QUERY_STR;
 }
 
@@ -52,16 +54,19 @@ export type InternalQueryResult<Data, Variables> = QueryResult<
 /**
  * Result of `executeQuery`
  */
-export interface QueryResult<Data, Variables>
-  extends DataConnectResult<Data, Variables> {
+export interface QueryResult<Data, Variables> extends DataConnectResult<
+  Data,
+  Variables
+> {
   ref: QueryRef<Data, Variables>;
   toJSON: () => SerializedRef<Data, Variables>;
 }
 /**
  * Promise returned from `executeQuery`
  */
-export interface QueryPromise<Data, Variables>
-  extends Promise<QueryResult<Data, Variables>> {
+export interface QueryPromise<Data, Variables> extends Promise<
+  QueryResult<Data, Variables>
+> {
   // reserved for special actions like cancellation
 }
 

--- a/packages/data-connect/src/core/query/subscribe.ts
+++ b/packages/data-connect/src/core/query/subscribe.ts
@@ -65,8 +65,7 @@ export interface DataConnectSubscription<Data, Variables> {
  */
 export function subscribe<Data, Variables>(
   queryRefOrSerializedResult:
-    | QueryRef<Data, Variables>
-    | SerializedRef<Data, Variables>,
+    QueryRef<Data, Variables> | SerializedRef<Data, Variables>,
   observer: SubscriptionOptions<Data, Variables>
 ): QueryUnsubscribe;
 /**
@@ -79,8 +78,7 @@ export function subscribe<Data, Variables>(
  */
 export function subscribe<Data, Variables>(
   queryRefOrSerializedResult:
-    | QueryRef<Data, Variables>
-    | SerializedRef<Data, Variables>,
+    QueryRef<Data, Variables> | SerializedRef<Data, Variables>,
   onNext: OnResultSubscription<Data, Variables>,
   onError?: OnErrorSubscription,
   onComplete?: OnCompleteSubscription
@@ -95,8 +93,7 @@ export function subscribe<Data, Variables>(
  */
 export function subscribe<Data, Variables>(
   queryRefOrSerializedResult:
-    | QueryRef<Data, Variables>
-    | SerializedRef<Data, Variables>,
+    QueryRef<Data, Variables> | SerializedRef<Data, Variables>,
   observerOrOnNext:
     | SubscriptionOptions<Data, Variables>
     | OnResultSubscription<Data, Variables>,

--- a/packages/data-connect/src/network/manager.ts
+++ b/packages/data-connect/src/network/manager.ts
@@ -35,9 +35,7 @@ import {
  * Entry point for the transport layer. Manages routing between transport implementations.
  * @internal
  */
-export class DataConnectTransportManager
-  implements DataConnectTransportInterface
-{
+export class DataConnectTransportManager implements DataConnectTransportInterface {
   private restTransport: RESTTransport;
   private streamTransport?: AbstractDataConnectStreamTransport;
   private isUsingEmulator = false;

--- a/packages/data-connect/src/network/transport.ts
+++ b/packages/data-connect/src/network/transport.ts
@@ -207,9 +207,7 @@ export function getGoogApiClientValue(
  * should extend this class and implement the abstract {@link DataConnectTransportInterface} methods.
  * @internal
  */
-export abstract class AbstractDataConnectTransport
-  implements DataConnectTransportInterface
-{
+export abstract class AbstractDataConnectTransport implements DataConnectTransportInterface {
   protected _host = '';
   protected _port: number | undefined;
   protected _location = 'l';

--- a/packages/data-connect/src/util/encoder.ts
+++ b/packages/data-connect/src/util/encoder.ts
@@ -28,10 +28,13 @@ export function setDecoder(decoder: DecodeHmacImpl): void {
 function sortKeysForObj(o: Record<string, unknown>): Record<string, unknown> {
   return Object.keys(o)
     .sort()
-    .reduce((accumulator, currentKey) => {
-      accumulator[currentKey] = o[currentKey];
-      return accumulator;
-    }, {} as Record<string, unknown>);
+    .reduce(
+      (accumulator, currentKey) => {
+        accumulator[currentKey] = o[currentKey];
+        return accumulator;
+      },
+      {} as Record<string, unknown>
+    );
 }
 setEncoder((o: Record<string, unknown>) => JSON.stringify(sortKeysForObj(o)));
 setDecoder(s => sortKeysForObj(JSON.parse(s)));

--- a/packages/database-compat/src/api/Database.ts
+++ b/packages/database-compat/src/api/Database.ts
@@ -50,7 +50,10 @@ export class Database implements FirebaseService, Compat<ModularDatabase> {
   /**
    * The constructor should not be called by users of our public API.
    */
-  constructor(readonly _delegate: ModularDatabase, readonly app: FirebaseApp) {}
+  constructor(
+    readonly _delegate: ModularDatabase,
+    readonly app: FirebaseApp
+  ) {}
 
   INTERNAL = {
     delete: () => this._delegate._delete(),

--- a/packages/database-compat/src/api/Reference.ts
+++ b/packages/database-compat/src/api/Reference.ts
@@ -226,7 +226,10 @@ export interface SnapshotCallback {
  * Since every Firebase reference is a query, Firebase inherits from this object.
  */
 export class Query implements Compat<ExpQuery> {
-  constructor(readonly database: Database, readonly _delegate: ExpQuery) {}
+  constructor(
+    readonly database: Database,
+    readonly _delegate: ExpQuery
+  ) {}
 
   on(
     eventType: string,

--- a/packages/database-compat/src/api/TransactionResult.ts
+++ b/packages/database-compat/src/api/TransactionResult.ts
@@ -23,7 +23,10 @@ export class TransactionResult {
   /**
    * A type for the resolve value of Firebase.transaction.
    */
-  constructor(public committed: boolean, public snapshot: DataSnapshot) {}
+  constructor(
+    public committed: boolean,
+    public snapshot: DataSnapshot
+  ) {}
 
   // Do not create public documentation. This is intended to make JSON serialization work but is otherwise unnecessary
   // for end-users

--- a/packages/database-compat/test/query.test.ts
+++ b/packages/database-compat/test/query.test.ts
@@ -4525,11 +4525,11 @@ describe('Query Tests', () => {
     data['a'] = true;
     ref.set(data, () => {
       ref.endBefore(null, '' + INTEGER_32_MAX).once('value', s => {
-        expect(s.val()).to.deep.equal(integerData),
+        (expect(s.val()).to.deep.equal(integerData),
           ref.startAfter(null, '' + INTEGER_32_MAX).once('value', s => {
             expect(s.val()).to.deep.equal({ 'a': true });
             done();
-          });
+          }));
       });
     });
   });

--- a/packages/database-types/index.d.ts
+++ b/packages/database-types/index.d.ts
@@ -84,11 +84,7 @@ export interface OnDisconnect {
 }
 
 type EventType =
-  | 'value'
-  | 'child_added'
-  | 'child_changed'
-  | 'child_moved'
-  | 'child_removed';
+  'value' | 'child_added' | 'child_changed' | 'child_moved' | 'child_removed';
 
 export interface Query {
   endBefore(value: number | string | boolean | null, key?: string): Query;
@@ -163,8 +159,7 @@ export interface TransactionResult {
 }
 
 export interface ThenableReference
-  extends Reference,
-    Pick<Promise<Reference>, 'then' | 'catch'> {
+  extends Reference, Pick<Promise<Reference>, 'then' | 'catch'> {
   key: string;
   parent: Reference;
 }

--- a/packages/database/src/api/OnDisconnect.ts
+++ b/packages/database/src/api/OnDisconnect.ts
@@ -54,7 +54,10 @@ import {
  */
 export class OnDisconnect {
   /** @hideconstructor */
-  constructor(private _repo: Repo, private _path: Path) {}
+  constructor(
+    private _repo: Repo,
+    private _path: Path
+  ) {}
 
   /**
    * Cancels all previously queued `onDisconnect()` set or update events for this

--- a/packages/database/src/api/Reference.ts
+++ b/packages/database/src/api/Reference.ts
@@ -118,7 +118,8 @@ export interface DatabaseReference extends Query {
  * as the write to the backend completes.
  */
 export interface ThenableReference
-  extends DatabaseReference,
+  extends
+    DatabaseReference,
     Pick<Promise<DatabaseReference>, 'then' | 'catch'> {
   key: string;
   parent: DatabaseReference;

--- a/packages/database/src/api/Reference_impl.ts
+++ b/packages/database/src/api/Reference_impl.ts
@@ -567,8 +567,7 @@ export function onDisconnect(ref: DatabaseReference): OnDisconnect {
 }
 
 export interface ThenableReferenceImpl
-  extends ReferenceImpl,
-    Pick<Promise<ReferenceImpl>, 'then' | 'catch'> {
+  extends ReferenceImpl, Pick<Promise<ReferenceImpl>, 'then' | 'catch'> {
   key: string;
   parent: ReferenceImpl;
 }

--- a/packages/database/src/core/operation/ListenComplete.ts
+++ b/packages/database/src/core/operation/ListenComplete.ts
@@ -23,7 +23,10 @@ export class ListenComplete implements Operation {
   /** @inheritDoc */
   type = OperationType.LISTEN_COMPLETE;
 
-  constructor(public source: OperationSource, public path: Path) {}
+  constructor(
+    public source: OperationSource,
+    public path: Path
+  ) {}
 
   operationForChild(childName: string): ListenComplete {
     if (pathIsEmpty(this.path)) {

--- a/packages/database/src/core/snap/Node.ts
+++ b/packages/database/src/core/snap/Node.ts
@@ -144,7 +144,10 @@ export interface Node {
 }
 
 export class NamedNode {
-  constructor(public name: string, public node: Node) {}
+  constructor(
+    public name: string,
+    public node: Node
+  ) {}
 
   static Wrap(name: string, node: Node) {
     return new NamedNode(name, node);

--- a/packages/database/src/core/stats/StatsReporter.ts
+++ b/packages/database/src/core/stats/StatsReporter.ts
@@ -36,7 +36,10 @@ export class StatsReporter {
   private statsListener_: StatsListener;
   statsToReport_: { [k: string]: boolean } = {};
 
-  constructor(collection: StatsCollection, private server_: ServerActions) {
+  constructor(
+    collection: StatsCollection,
+    private server_: ServerActions
+  ) {
     this.statsListener_ = new StatsListener(collection);
 
     const timeout =

--- a/packages/database/src/core/util/Path.ts
+++ b/packages/database/src/core/util/Path.ts
@@ -267,7 +267,10 @@ export class ValidationPath {
    * @param path - Initial Path.
    * @param errorPrefix_ - Prefix for any error messages.
    */
-  constructor(path: Path, public errorPrefix_: string) {
+  constructor(
+    path: Path,
+    public errorPrefix_: string
+  ) {
     this.parts_ = pathSlice(path, 0);
     /** Initialize to number of '/' chars needed in path. */
     this.byteLength_ = Math.max(1, this.parts_.length);

--- a/packages/database/src/core/util/ServerValues.ts
+++ b/packages/database/src/core/util/ServerValues.ts
@@ -197,11 +197,7 @@ function resolveDeferredValue(
   serverValues: Indexable
 ): Node {
   const rawPri = node.getPriority().val() as
-    | Indexable
-    | boolean
-    | null
-    | number
-    | string;
+    Indexable | boolean | null | number | string;
   const priority = resolveDeferredLeafValue(
     rawPri,
     existingVal.getImmediateChild('.priority'),

--- a/packages/database/src/core/view/Event.ts
+++ b/packages/database/src/core/view/Event.ts
@@ -41,11 +41,7 @@ export interface Event {
  * "child_removed", or "child_moved."
  */
 export type EventType =
-  | 'value'
-  | 'child_added'
-  | 'child_changed'
-  | 'child_moved'
-  | 'child_removed';
+  'value' | 'child_added' | 'child_changed' | 'child_moved' | 'child_removed';
 
 /**
  * Encapsulates the data needed to raise an event

--- a/packages/database/src/core/view/View.ts
+++ b/packages/database/src/core/view/View.ts
@@ -62,7 +62,10 @@ export class View {
   eventRegistrations_: EventRegistration[] = [];
   eventGenerator_: EventGenerator;
 
-  constructor(private query_: QueryContext, initialViewCache: ViewCache) {
+  constructor(
+    private query_: QueryContext,
+    initialViewCache: ViewCache
+  ) {
     const params = this.query_._queryParams;
 
     const indexFilter = new IndexedFilter(params.getIndex());

--- a/packages/firebase/compat/index.d.ts
+++ b/packages/firebase/compat/index.d.ts
@@ -1076,8 +1076,7 @@ declare namespace firebase {
   }
 
   export type EmulatorMockTokenOptions = (
-    | { user_id: string }
-    | { sub: string }
+    { user_id: string } | { sub: string }
   ) &
     Partial<FirebaseIdToken>;
 
@@ -2755,8 +2754,7 @@ declare namespace firebase.auth {
      */
     onAuthStateChanged(
       nextOrObserver:
-        | firebase.Observer<any>
-        | ((a: firebase.User | null) => any),
+        firebase.Observer<any> | ((a: firebase.User | null) => any),
       error?: (a: firebase.auth.Error) => any,
       completed?: firebase.Unsubscribe
     ): firebase.Unsubscribe;
@@ -2782,8 +2780,7 @@ declare namespace firebase.auth {
      */
     onIdTokenChanged(
       nextOrObserver:
-        | firebase.Observer<any>
-        | ((a: firebase.User | null) => any),
+        firebase.Observer<any> | ((a: firebase.User | null) => any),
       error?: (a: firebase.auth.Error) => any,
       completed?: firebase.Unsubscribe
     ): firebase.Unsubscribe;
@@ -6295,11 +6292,7 @@ declare namespace firebase.database {
   }
 
   type EventType =
-    | 'value'
-    | 'child_added'
-    | 'child_changed'
-    | 'child_moved'
-    | 'child_removed';
+    'value' | 'child_added' | 'child_changed' | 'child_moved' | 'child_removed';
 
   /**
    * A `Query` sorts and filters the data at a Database location so only a subset
@@ -7369,7 +7362,8 @@ declare namespace firebase.database {
   }
 
   interface ThenableReference
-    extends firebase.database.Reference,
+    extends
+      firebase.database.Reference,
       Pick<Promise<Reference>, 'then' | 'catch'> {
     key: string;
     parent: Reference;
@@ -7525,8 +7519,7 @@ declare namespace firebase.messaging {
      */
     onBackgroundMessage(
       nextOrObserver:
-        | firebase.NextFn<MessagePayload>
-        | firebase.Observer<MessagePayload>
+        firebase.NextFn<MessagePayload> | firebase.Observer<MessagePayload>
     ): firebase.Unsubscribe;
   }
 
@@ -8218,8 +8211,7 @@ declare namespace firebase.storage {
      */
     then(
       onFulfilled?:
-        | ((snapshot: firebase.storage.UploadTaskSnapshot) => any)
-        | null,
+        ((snapshot: firebase.storage.UploadTaskSnapshot) => any) | null,
       onRejected?: ((error: FirebaseStorageError) => any) | null
     ): Promise<any>;
   }

--- a/packages/firestore-compat/src/api/database.ts
+++ b/packages/firestore-compat/src/api/database.ts
@@ -990,7 +990,10 @@ export class Query<T = PublicDocumentData>
 {
   private readonly _userDataWriter: UserDataWriter;
 
-  constructor(readonly firestore: Firestore, readonly _delegate: ExpQuery<T>) {
+  constructor(
+    readonly firestore: Firestore,
+    readonly _delegate: ExpQuery<T>
+  ) {
     this._userDataWriter = new UserDataWriter(firestore);
   }
 

--- a/packages/firestore-compat/test/batch_writes.test.ts
+++ b/packages/firestore-compat/test/batch_writes.test.ts
@@ -340,7 +340,10 @@ apiDescribe('Database batch writes', (persistence: boolean) => {
   // only to web.
   apiDescribe('withConverter() support', (persistence: boolean) => {
     class Post {
-      constructor(readonly title: string, readonly author: string) {}
+      constructor(
+        readonly title: string,
+        readonly author: string
+      ) {}
       byline(): string {
         return this.title + ', by ' + this.author;
       }

--- a/packages/firestore-compat/test/transactions.test.ts
+++ b/packages/firestore-compat/test/transactions.test.ts
@@ -625,7 +625,10 @@ apiDescribe('Database transactions', (persistence: boolean) => {
   // only to web.
   apiDescribe('withConverter() support', (persistence: boolean) => {
     class Post {
-      constructor(readonly title: string, readonly author: string) {}
+      constructor(
+        readonly title: string,
+        readonly author: string
+      ) {}
       byline(): string {
         return this.title + ', by ' + this.author;
       }

--- a/packages/firestore-types/index.d.ts
+++ b/packages/firestore-types/index.d.ts
@@ -40,12 +40,7 @@ export interface PersistenceSettings {
 }
 
 export type LogLevel =
-  | 'debug'
-  | 'error'
-  | 'silent'
-  | 'warn'
-  | 'info'
-  | 'verbose';
+  'debug' | 'error' | 'silent' | 'warn' | 'info' | 'verbose';
 
 export function setLogLevel(logLevel: LogLevel): void;
 

--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -62,8 +62,7 @@ export interface ProviderCredentialsSettings {
 
 /** Settings for private credentials */
 export type CredentialsSettings =
-  | FirstPartyCredentialsSettings
-  | ProviderCredentialsSettings;
+  FirstPartyCredentialsSettings | ProviderCredentialsSettings;
 
 export type TokenType = 'OAuth' | 'FirstParty' | 'AppCheck';
 export interface Token {
@@ -85,7 +84,10 @@ export class OAuthToken implements Token {
   type = 'OAuth' as TokenType;
   headers = new Map();
 
-  constructor(value: string, public user: User) {
+  constructor(
+    value: string,
+    public user: User
+  ) {
     this.headers.set('Authorization', `Bearer ${value}`);
   }
 }
@@ -152,9 +154,7 @@ export class EmptyAuthCredentialsProvider implements CredentialsProvider<User> {
  * A CredentialsProvider that always returns a constant token. Used for
  * emulator token mocking.
  */
-export class EmulatorAuthCredentialsProvider
-  implements CredentialsProvider<User>
-{
+export class EmulatorAuthCredentialsProvider implements CredentialsProvider<User> {
   constructor(private token: Token) {}
 
   /**
@@ -231,9 +231,7 @@ export class LiteAuthCredentialsProvider implements CredentialsProvider<User> {
   shutdown(): void {}
 }
 
-export class FirebaseAuthCredentialsProvider
-  implements CredentialsProvider<User>
-{
+export class FirebaseAuthCredentialsProvider implements CredentialsProvider<User> {
   /**
    * The auth token listener registered with FirebaseApp, retained here so we
    * can unregister it.
@@ -449,9 +447,7 @@ export class FirstPartyToken implements Token {
  * to authenticate the user, using technique that is only available
  * to applications hosted by Google.
  */
-export class FirstPartyAuthCredentialsProvider
-  implements CredentialsProvider<User>
-{
+export class FirstPartyAuthCredentialsProvider implements CredentialsProvider<User> {
   constructor(
     private sessionIndex: string,
     private iamToken: string | null,
@@ -492,9 +488,7 @@ export class AppCheckToken implements Token {
   }
 }
 
-export class FirebaseAppCheckTokenProvider
-  implements CredentialsProvider<string>
-{
+export class FirebaseAppCheckTokenProvider implements CredentialsProvider<string> {
   /**
    * The AppCheck token listener registered with FirebaseApp, retained here so
    * we can unregister it.

--- a/packages/firestore/src/core/bound.ts
+++ b/packages/firestore/src/core/bound.ts
@@ -38,7 +38,10 @@ import { Direction, OrderBy } from './order_by';
  * just after the provided values.
  */
 export class Bound {
-  constructor(readonly position: ProtoValue[], readonly inclusive: boolean) {}
+  constructor(
+    readonly position: ProtoValue[],
+    readonly inclusive: boolean
+  ) {}
 }
 
 function boundCompareToDocument(

--- a/packages/firestore/src/core/component_provider.ts
+++ b/packages/firestore/src/core/component_provider.ts
@@ -113,9 +113,7 @@ export interface OfflineComponentProvider {
  * Provides all components needed for Firestore with in-memory persistence.
  * Uses EagerGC garbage collection.
  */
-export class MemoryOfflineComponentProvider
-  implements OfflineComponentProvider
-{
+export class MemoryOfflineComponentProvider implements OfflineComponentProvider {
   kind: Kind = 'memory';
 
   static readonly provider: OfflineComponentProviderFactory = {

--- a/packages/firestore/src/core/expressions.ts
+++ b/packages/firestore/src/core/expressions.ts
@@ -439,8 +439,7 @@ export class CoreListOfExprs implements EvaluableExpr {
 
 function asDouble(
   protoNumber:
-    | { doubleValue: number | string }
-    | { integerValue: number | string }
+    { doubleValue: number | string } | { integerValue: number | string }
 ): number {
   if (isDouble(protoNumber)) {
     return Number(protoNumber.doubleValue);
@@ -2817,12 +2816,7 @@ export class CoreTimestampToUnixSeconds extends TimestampToUnix {
 }
 
 type TimeUnit =
-  | 'microsecond'
-  | 'millisecond'
-  | 'second'
-  | 'minute'
-  | 'hour'
-  | 'day';
+  'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day';
 function asTimeUnit(unit?: string): TimeUnit | undefined {
   switch (unit) {
     case 'microsecond':

--- a/packages/firestore/src/core/listen_sequence.ts
+++ b/packages/firestore/src/core/listen_sequence.ts
@@ -27,8 +27,7 @@ export interface SequenceNumberSyncer {
   // Setting this property allows the syncer to notify when a sequence number has been used, and
   // and lets the ListenSequence adjust its internal previous value accordingly.
   sequenceNumberHandler:
-    | ((sequenceNumber: ListenSequenceNumber) => void)
-    | null;
+    ((sequenceNumber: ListenSequenceNumber) => void) | null;
 }
 
 /**

--- a/packages/firestore/src/core/pipeline-util.ts
+++ b/packages/firestore/src/core/pipeline-util.ts
@@ -400,10 +400,7 @@ export function pipelineEq(left: CorePipeline, right: CorePipeline): boolean {
 export type PipelineFlavor = 'exact' | 'augmented' | 'keyless';
 
 export type PipelineSourceType =
-  | 'collection'
-  | 'collection_group'
-  | 'database'
-  | 'documents';
+  'collection' | 'collection_group' | 'database' | 'documents';
 
 export function asCollectionPipelineAtPath(
   pipeline: CorePipeline,

--- a/packages/firestore/src/core/structured_pipeline.ts
+++ b/packages/firestore/src/core/structured_pipeline.ts
@@ -50,9 +50,7 @@ export class StructuredPipelineOptions implements UserData {
   }
 }
 
-export class StructuredPipeline
-  implements ProtoSerializable<StructuredPipelineProto>
-{
+export class StructuredPipeline implements ProtoSerializable<StructuredPipelineProto> {
   constructor(
     private pipeline: ProtoSerializable<PipelineProto>,
     private options: StructuredPipelineOptions

--- a/packages/firestore/src/lite-api/expressions.ts
+++ b/packages/firestore/src/lite-api/expressions.ts
@@ -3545,12 +3545,7 @@ export abstract class Expression implements ProtoValueSerializable, UserData {
  * Specify time units for expressions.
  */
 export type TimeUnit =
-  | 'microsecond'
-  | 'millisecond'
-  | 'second'
-  | 'minute'
-  | 'hour'
-  | 'day';
+  'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day';
 
 /**
  * Specify time granularity for expressions.
@@ -3606,7 +3601,10 @@ export class AggregateFunction implements ProtoValueSerializable, UserData {
    */
   _methodName?: string;
 
-  constructor(private name: string, private params: Expression[]) {}
+  constructor(
+    private name: string,
+    private params: Expression[]
+  ) {}
 
   /**
    * @internal
@@ -4181,8 +4179,8 @@ export class FunctionExpression extends Expression {
    * @internal
    */
   _optionsProto:
-    | ApiClientObjectMap<firestoreV1ApiClientInterfaces.Value>
-    | undefined = undefined;
+    ApiClientObjectMap<firestoreV1ApiClientInterfaces.Value> | undefined =
+    undefined;
 
   /**
    * @private

--- a/packages/firestore/src/lite-api/pipeline.ts
+++ b/packages/firestore/src/lite-api/pipeline.ts
@@ -978,7 +978,7 @@ export class Pipeline implements ProtoSerializable<ProtoPipeline>, UserData {
       targetOrOptions
     )
       ? []
-      : targetOrOptions.groups ?? [];
+      : (targetOrOptions.groups ?? []);
 
     // Convert user land convenience types to internal types
     const convertedAccumulators: Map<string, AggregateFunction> =

--- a/packages/firestore/src/lite-api/query.ts
+++ b/packages/firestore/src/lite-api/query.ts
@@ -365,8 +365,7 @@ export type QueryNonFilterConstraint =
  * {@link QueryFieldFilterConstraint} and {@link QueryCompositeFilterConstraint}.
  */
 export type QueryFilterConstraint =
-  | QueryFieldFilterConstraint
-  | QueryCompositeFilterConstraint;
+  QueryFieldFilterConstraint | QueryCompositeFilterConstraint;
 
 /**
  * Creates a new {@link QueryCompositeFilterConstraint} that is a disjunction of

--- a/packages/firestore/src/lite-api/reference.ts
+++ b/packages/firestore/src/lite-api/reference.ts
@@ -62,8 +62,8 @@ export type PartialWithFieldValue<T> =
   | (T extends Primitive
       ? T
       : T extends {}
-      ? { [K in keyof T]?: PartialWithFieldValue<T[K]> | FieldValue }
-      : never);
+        ? { [K in keyof T]?: PartialWithFieldValue<T[K]> | FieldValue }
+        : never);
 
 /**
  * Allows FieldValues to be passed in as a property value while maintaining
@@ -74,8 +74,8 @@ export type WithFieldValue<T> =
   | (T extends Primitive
       ? T
       : T extends {}
-      ? { [K in keyof T]: WithFieldValue<T[K]> | FieldValue }
-      : never);
+        ? { [K in keyof T]: WithFieldValue<T[K]> | FieldValue }
+        : never);
 
 /**
  * Update data (for use with {@link (updateDoc:1)}) that consists of field paths
@@ -86,8 +86,8 @@ export type WithFieldValue<T> =
 export type UpdateData<T> = T extends Primitive
   ? T
   : T extends {}
-  ? { [K in keyof T]?: UpdateData<T[K]> | FieldValue } & NestedUpdateFields<T>
-  : Partial<T>;
+    ? { [K in keyof T]?: UpdateData<T[K]> | FieldValue } & NestedUpdateFields<T>
+    : Partial<T>;
 /**
  * An options object that configures the behavior of {@link @firebase/firestore/lite#(setDoc:1)}, {@link
  * @firebase/firestore/lite#(WriteBatch.set:1)} and {@link @firebase/firestore/lite#(Transaction.set:1)} calls. These calls can be

--- a/packages/firestore/src/lite-api/snapshot.ts
+++ b/packages/firestore/src/lite-api/snapshot.ts
@@ -377,8 +377,7 @@ export class DocumentSnapshot<
    * if the document doesn't exist.
    */
   _fieldsProto():
-    | { [key: string]: firestoreV1ApiClientInterfaces.Value }
-    | undefined {
+    { [key: string]: firestoreV1ApiClientInterfaces.Value } | undefined {
     // Return a cloned value to prevent manipulation of the Snapshot's data
     return this._document?.data.clone().value.mapValue.fields ?? undefined;
   }

--- a/packages/firestore/src/lite-api/stage.ts
+++ b/packages/firestore/src/lite-api/stage.ts
@@ -53,8 +53,8 @@ export abstract class Stage implements ProtoSerializable<ProtoStage>, UserData {
    * @protected
    */
   protected optionsProto:
-    | ApiClientObjectMap<firestoreV1ApiClientInterfaces.Value>
-    | undefined = undefined;
+    ApiClientObjectMap<firestoreV1ApiClientInterfaces.Value> | undefined =
+    undefined;
   protected knownOptions: Record<string, unknown>;
   protected rawOptions?: Record<string, unknown>;
 
@@ -118,7 +118,10 @@ export class RemoveFields extends Stage {
     return new OptionsUtil({});
   }
 
-  constructor(private fields: Field[], options: StageOptions) {
+  constructor(
+    private fields: Field[],
+    options: StageOptions
+  ) {
     super(options);
   }
 
@@ -299,7 +302,10 @@ export class CollectionGroupSource extends Stage {
     });
   }
 
-  constructor(public readonly collectionId: string, options: StageOptions) {
+  constructor(
+    public readonly collectionId: string,
+    options: StageOptions
+  ) {
     super(options);
   }
 
@@ -328,7 +334,10 @@ export class SubcollectionSource extends Stage {
     return new OptionsUtil({});
   }
 
-  constructor(private path: string, options: StageOptions) {
+  constructor(
+    private path: string,
+    options: StageOptions
+  ) {
     super(options);
   }
 
@@ -510,7 +519,10 @@ export class Limit extends Stage {
     return new OptionsUtil({});
   }
 
-  constructor(public readonly limit: number, options: StageOptions) {
+  constructor(
+    public readonly limit: number,
+    options: StageOptions
+  ) {
     hardAssert(
       !isNaN(limit) && limit !== Infinity && limit !== -Infinity,
       0x882c,
@@ -539,7 +551,10 @@ export class Offset extends Stage {
     return new OptionsUtil({});
   }
 
-  constructor(public readonly offset: number, options: StageOptions) {
+  constructor(
+    public readonly offset: number,
+    options: StageOptions
+  ) {
     super(options);
   }
 
@@ -596,7 +611,10 @@ export class Sort extends Stage {
     return new OptionsUtil({});
   }
 
-  constructor(public readonly orderings: Ordering[], options: StageOptions) {
+  constructor(
+    public readonly orderings: Ordering[],
+    options: StageOptions
+  ) {
     super(options);
   }
 
@@ -654,7 +672,10 @@ export class Union extends Stage {
     return new OptionsUtil({});
   }
 
-  constructor(private other: Pipeline, options: StageOptions) {
+  constructor(
+    private other: Pipeline,
+    options: StageOptions
+  ) {
     super(options);
   }
 
@@ -719,7 +740,10 @@ export class Replace extends Stage {
     return new OptionsUtil({});
   }
 
-  constructor(private map: Expression, options: StageOptions) {
+  constructor(
+    private map: Expression,
+    options: StageOptions
+  ) {
     super(options);
   }
 
@@ -874,10 +898,7 @@ export class RawStage extends Stage {
  */
 function readUserDataHelper<
   T extends
-    | Map<string, UserData>
-    | Record<string, UserData>
-    | UserData[]
-    | UserData
+    Map<string, UserData> | Record<string, UserData> | UserData[] | UserData
 >(expressionMap: T, context: ParseContext): T {
   if (isUserData(expressionMap)) {
     expressionMap._readUserData(context);

--- a/packages/firestore/src/lite-api/user_data_reader.ts
+++ b/packages/firestore/src/lite-api/user_data_reader.ts
@@ -491,7 +491,10 @@ export class ServerTimestampFieldValueImpl extends FieldValue {
 }
 
 export class ArrayUnionFieldValueImpl extends FieldValue {
-  constructor(methodName: string, private readonly _elements: unknown[]) {
+  constructor(
+    methodName: string,
+    private readonly _elements: unknown[]
+  ) {
     super(methodName);
   }
 
@@ -501,8 +504,8 @@ export class ArrayUnionFieldValueImpl extends FieldValue {
       context,
       /*array=*/ true
     );
-    const parsedElements = this._elements.map(
-      element => parseData(element, parseContext)!
+    const parsedElements = this._elements.map(element =>
+      parseData(element, parseContext)!
     );
     const arrayUnion = new ArrayUnionTransformOperation(parsedElements);
     return new FieldTransform(context.path!, arrayUnion);
@@ -517,7 +520,10 @@ export class ArrayUnionFieldValueImpl extends FieldValue {
 }
 
 export class ArrayRemoveFieldValueImpl extends FieldValue {
-  constructor(methodName: string, private readonly _elements: unknown[]) {
+  constructor(
+    methodName: string,
+    private readonly _elements: unknown[]
+  ) {
     super(methodName);
   }
 
@@ -527,8 +533,8 @@ export class ArrayRemoveFieldValueImpl extends FieldValue {
       context,
       /*array=*/ true
     );
-    const parsedElements = this._elements.map(
-      element => parseData(element, parseContext)!
+    const parsedElements = this._elements.map(element =>
+      parseData(element, parseContext)!
     );
     const arrayUnion = new ArrayRemoveTransformOperation(parsedElements);
     return new FieldTransform(context.path!, arrayUnion);
@@ -543,7 +549,10 @@ export class ArrayRemoveFieldValueImpl extends FieldValue {
 }
 
 export class NumericIncrementFieldValueImpl extends FieldValue {
-  constructor(methodName: string, private readonly _operand: number) {
+  constructor(
+    methodName: string,
+    private readonly _operand: number
+  ) {
     super(methodName);
   }
 
@@ -565,7 +574,10 @@ export class NumericIncrementFieldValueImpl extends FieldValue {
 }
 
 export class NumericMinimumFieldValueImpl extends FieldValue {
-  constructor(methodName: string, private readonly _operand: number) {
+  constructor(
+    methodName: string,
+    private readonly _operand: number
+  ) {
     super(methodName);
   }
 
@@ -587,7 +599,10 @@ export class NumericMinimumFieldValueImpl extends FieldValue {
 }
 
 export class NumericMaximumFieldValueImpl extends FieldValue {
-  constructor(methodName: string, private readonly _operand: number) {
+  constructor(
+    methodName: string,
+    private readonly _operand: number
+  ) {
     super(methodName);
   }
 

--- a/packages/firestore/src/local/encoded_resource_path.ts
+++ b/packages/firestore/src/local/encoded_resource_path.ts
@@ -136,7 +136,7 @@ export function decodeResourcePath(path: EncodedResourcePath): ResourcePath {
   const segments: string[] = [];
   let segmentBuilder = '';
 
-  for (let start = 0; start < length; ) {
+  for (let start = 0; start < length;) {
     // The last two characters of a valid encoded path must be a separator, so
     // there must be an end to this segment.
     const end = path.indexOf(escapeChar, start);

--- a/packages/firestore/src/local/indexeddb_index_manager.ts
+++ b/packages/firestore/src/local/indexeddb_index_manager.ts
@@ -136,7 +136,10 @@ export class IndexedDbIndexManager implements IndexManager {
     (l, r) => targetEquals(l, r)
   );
 
-  constructor(user: User, private readonly databaseId: DatabaseId) {
+  constructor(
+    user: User,
+    private readonly databaseId: DatabaseId
+  ) {
     this.uid = user.uid || '';
   }
 

--- a/packages/firestore/src/local/indexeddb_lru_delegate_impl.ts
+++ b/packages/firestore/src/local/indexeddb_lru_delegate_impl.ts
@@ -48,7 +48,10 @@ import { TargetData } from './target_data';
 export class IndexedDbLruDelegateImpl implements IndexedDbLruDelegate {
   readonly garbageCollector: LruGarbageCollector;
 
-  constructor(private readonly db: Persistence, params: LruParams) {
+  constructor(
+    private readonly db: Persistence,
+    params: LruParams
+  ) {
     this.garbageCollector = newLruGarbageCollector(this, params);
   }
 

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -257,9 +257,7 @@ export interface DbRemoteDocumentGlobal {
  * order to avoid writing extra serialization logic.
  */
 export type DbQuery =
-  | ProtoQueryTarget
-  | ProtoDocumentsTarget
-  | ProtoPipelineQueryTarget;
+  ProtoQueryTarget | ProtoDocumentsTarget | ProtoPipelineQueryTarget;
 
 /**
  * An object to be stored in the 'targets' store in IndexedDb.

--- a/packages/firestore/src/local/persistence_promise.ts
+++ b/packages/firestore/src/local/persistence_promise.ts
@@ -18,11 +18,9 @@
 import { fail } from '../util/assert';
 
 export type FulfilledHandler<T, R> =
-  | ((result: T) => R | PersistencePromise<R>)
-  | null;
+  ((result: T) => R | PersistencePromise<R>) | null;
 export type RejectedHandler<R> =
-  | ((reason: Error) => R | PersistencePromise<R>)
-  | null;
+  ((reason: Error) => R | PersistencePromise<R>) | null;
 export type Resolver<T> = (value?: T) => void;
 export type Rejector = (error: Error) => void;
 

--- a/packages/firestore/src/local/persistence_transaction.ts
+++ b/packages/firestore/src/local/persistence_transaction.ts
@@ -22,9 +22,7 @@ export const PRIMARY_LEASE_LOST_ERROR_MSG =
 
 /** The different modes supported by `Persistence.runTransaction()`. */
 export type PersistenceTransactionMode =
-  | 'readonly'
-  | 'readwrite'
-  | 'readwrite-primary';
+  'readonly' | 'readwrite' | 'readwrite-primary';
 
 /**
  * A base class representing a persistence transaction, encapsulating both the

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -79,8 +79,7 @@ export type ClientId = string;
 export interface SharedClientState {
   onlineStateHandler: ((onlineState: OnlineState) => void) | null;
   sequenceNumberHandler:
-    | ((sequenceNumber: ListenSequenceNumber) => void)
-    | null;
+    ((sequenceNumber: ListenSequenceNumber) => void) | null;
 
   /** Registers the Mutation Batch ID of a newly pending mutation. */
   addPendingMutation(batchId: BatchId): void;
@@ -410,7 +409,10 @@ class RemoteClientState implements ClientState {
  * used in secondary clients to update their query views.
  */
 export class SharedOnlineState {
-  constructor(readonly clientId: string, readonly onlineState: OnlineState) {}
+  constructor(
+    readonly clientId: string,
+    readonly onlineState: OnlineState
+  ) {}
 
   /**
    * Parses a SharedOnlineState from its JSON representation in WebStorage.
@@ -481,8 +483,7 @@ export class WebStorageSharedClientState implements SharedClientState {
   syncEngine: SharedClientStateSyncer | null = null;
   onlineStateHandler: ((onlineState: OnlineState) => void) | null = null;
   sequenceNumberHandler:
-    | ((sequenceNumber: ListenSequenceNumber) => void)
-    | null = null;
+    ((sequenceNumber: ListenSequenceNumber) => void) | null = null;
 
   private readonly storage: Storage;
   private readonly localClientStorageKey: string;
@@ -1107,8 +1108,7 @@ export class MemorySharedClientState implements SharedClientState {
   private queryState: { [targetId: number]: QueryTargetState } = {};
   onlineStateHandler: ((onlineState: OnlineState) => void) | null = null;
   sequenceNumberHandler:
-    | ((sequenceNumber: ListenSequenceNumber) => void)
-    | null = null;
+    ((sequenceNumber: ListenSequenceNumber) => void) | null = null;
 
   addPendingMutation(batchId: BatchId): void {
     // No op.

--- a/packages/firestore/src/model/mutation.ts
+++ b/packages/firestore/src/model/mutation.ts
@@ -682,7 +682,10 @@ function localTransformResults(
 
 /** A mutation that deletes the document at the given key. */
 export class DeleteMutation extends Mutation {
-  constructor(readonly key: DocumentKey, readonly precondition: Precondition) {
+  constructor(
+    readonly key: DocumentKey,
+    readonly precondition: Precondition
+  ) {
     super();
   }
 
@@ -736,7 +739,10 @@ function deleteMutationApplyToLocalView(
  * primarily to facilitate serialization into protos.
  */
 export class VerifyMutation extends Mutation {
-  constructor(readonly key: DocumentKey, readonly precondition: Precondition) {
+  constructor(
+    readonly key: DocumentKey,
+    readonly precondition: Precondition
+  ) {
     super();
   }
 

--- a/packages/firestore/src/model/overlay.ts
+++ b/packages/firestore/src/model/overlay.ts
@@ -25,7 +25,10 @@ import { Mutation } from './mutation';
  * the mutation was created.
  */
 export class Overlay {
-  constructor(readonly largestBatchId: number, readonly mutation: Mutation) {}
+  constructor(
+    readonly largestBatchId: number,
+    readonly mutation: Mutation
+  ) {}
 
   getKey(): DocumentKey {
     return this.mutation.key;

--- a/packages/firestore/src/model/transform_operation.ts
+++ b/packages/firestore/src/model/transform_operation.ts
@@ -202,7 +202,10 @@ function applyArrayRemoveTransformOperation(
  * arithmetic is used and precision loss can occur for values greater than 2^53.
  */
 export abstract class NumericTransformOperation extends TransformOperation {
-  constructor(readonly serializer: Serializer, readonly operand: ProtoValue) {
+  constructor(
+    readonly serializer: Serializer,
+    readonly operand: ProtoValue
+  ) {
     super();
     debugAssert(
       isNumber(operand),

--- a/packages/firestore/src/model/values.ts
+++ b/packages/firestore/src/model/values.ts
@@ -629,8 +629,7 @@ export function isDouble(
 export function isNumber(
   value?: Value | null
 ): value is
-  | { doubleValue: string | number }
-  | { integerValue: string | number } {
+  { doubleValue: string | number } | { integerValue: string | number } {
   return isInteger(value) || isDouble(value);
 }
 

--- a/packages/firestore/src/platform/format_json.ts
+++ b/packages/firestore/src/platform/format_json.ts
@@ -17,9 +17,9 @@
 
 // This file is only used under ts-node.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const platform = require(`./${
-  process.env.TEST_PLATFORM ?? 'node'
-}/format_json`);
+const platform = require(
+  `./${process.env.TEST_PLATFORM ?? 'node'}/format_json`
+);
 
 /** Formats an object as a JSON string, suitable for logging. */
 export function formatJSON(value: unknown): string {

--- a/packages/firestore/src/platform/random_bytes.ts
+++ b/packages/firestore/src/platform/random_bytes.ts
@@ -17,9 +17,9 @@
 
 // This file is only used under ts-node.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const platform = require(`./${
-  process.env.TEST_PLATFORM ?? 'node'
-}/random_bytes`);
+const platform = require(
+  `./${process.env.TEST_PLATFORM ?? 'node'}/random_bytes`
+);
 
 /**
  * Generates `nBytes` of random bytes.

--- a/packages/firestore/src/platform/snapshot_to_json.ts
+++ b/packages/firestore/src/platform/snapshot_to_json.ts
@@ -22,9 +22,9 @@ import { Document } from '../model/document';
 
 // This file is only used under ts-node.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const platform = require(`./${
-  process.env.TEST_PLATFORM ?? 'node'
-}/snapshot_to_json`);
+const platform = require(
+  `./${process.env.TEST_PLATFORM ?? 'node'}/snapshot_to_json`
+);
 
 /**
  * Constructs the bundle data for a DocumentSnapshot used in its toJSON serialization.

--- a/packages/firestore/src/protos/firestore_proto_api.ts
+++ b/packages/firestore/src/protos/firestore_proto_api.ts
@@ -27,8 +27,7 @@ export interface ApiClientObjectMap<T> {
   [k: string]: T;
 }
 export declare type Timestamp =
-  | string
-  | { seconds?: string | number; nanos?: number };
+  string | { seconds?: string | number; nanos?: number };
 
 export declare type CompositeFilterOp = 'OPERATOR_UNSPECIFIED' | 'AND' | 'OR';
 export interface ICompositeFilterOpEnum {
@@ -65,8 +64,7 @@ export interface IFieldFilterOpEnum {
 }
 export declare const FieldFilterOpEnum: IFieldFilterOpEnum;
 export declare type FieldTransformSetToServerValue =
-  | 'SERVER_VALUE_UNSPECIFIED'
-  | 'REQUEST_TIME';
+  'SERVER_VALUE_UNSPECIFIED' | 'REQUEST_TIME';
 export interface IFieldTransformSetToServerValueEnum {
   SERVER_VALUE_UNSPECIFIED: FieldTransformSetToServerValue;
   REQUEST_TIME: FieldTransformSetToServerValue;
@@ -74,9 +72,7 @@ export interface IFieldTransformSetToServerValueEnum {
 }
 export declare const FieldTransformSetToServerValueEnum: IFieldTransformSetToServerValueEnum;
 export declare type IndexFieldMode =
-  | 'MODE_UNSPECIFIED'
-  | 'ASCENDING'
-  | 'DESCENDING';
+  'MODE_UNSPECIFIED' | 'ASCENDING' | 'DESCENDING';
 export interface IIndexFieldModeEnum {
   MODE_UNSPECIFIED: IndexFieldMode;
   ASCENDING: IndexFieldMode;
@@ -85,10 +81,7 @@ export interface IIndexFieldModeEnum {
 }
 export declare const IndexFieldModeEnum: IIndexFieldModeEnum;
 export declare type IndexState =
-  | 'STATE_UNSPECIFIED'
-  | 'CREATING'
-  | 'READY'
-  | 'ERROR';
+  'STATE_UNSPECIFIED' | 'CREATING' | 'READY' | 'ERROR';
 export interface IIndexStateEnum {
   STATE_UNSPECIFIED: IndexState;
   CREATING: IndexState;
@@ -98,9 +91,7 @@ export interface IIndexStateEnum {
 }
 export declare const IndexStateEnum: IIndexStateEnum;
 export declare type OrderDirection =
-  | 'DIRECTION_UNSPECIFIED'
-  | 'ASCENDING'
-  | 'DESCENDING';
+  'DIRECTION_UNSPECIFIED' | 'ASCENDING' | 'DESCENDING';
 export interface IOrderDirectionEnum {
   DIRECTION_UNSPECIFIED: OrderDirection;
   ASCENDING: OrderDirection;
@@ -109,11 +100,7 @@ export interface IOrderDirectionEnum {
 }
 export declare const OrderDirectionEnum: IOrderDirectionEnum;
 export declare type TargetChangeTargetChangeType =
-  | 'NO_CHANGE'
-  | 'ADD'
-  | 'REMOVE'
-  | 'CURRENT'
-  | 'RESET';
+  'NO_CHANGE' | 'ADD' | 'REMOVE' | 'CURRENT' | 'RESET';
 export interface ITargetChangeTargetChangeTypeEnum {
   NO_CHANGE: TargetChangeTargetChangeType;
   ADD: TargetChangeTargetChangeType;
@@ -124,11 +111,7 @@ export interface ITargetChangeTargetChangeTypeEnum {
 }
 export declare const TargetChangeTargetChangeTypeEnum: ITargetChangeTargetChangeTypeEnum;
 export declare type UnaryFilterOp =
-  | 'OPERATOR_UNSPECIFIED'
-  | 'IS_NAN'
-  | 'IS_NULL'
-  | 'IS_NOT_NAN'
-  | 'IS_NOT_NULL';
+  'OPERATOR_UNSPECIFIED' | 'IS_NAN' | 'IS_NULL' | 'IS_NOT_NAN' | 'IS_NOT_NULL';
 export interface IUnaryFilterOpEnum {
   OPERATOR_UNSPECIFIED: UnaryFilterOp;
   IS_NAN: UnaryFilterOp;
@@ -602,9 +585,7 @@ export interface IProjectsDatabasesDocumentsApiClient$XgafvEnum {
 }
 export declare const ProjectsDatabasesDocumentsApiClient$XgafvEnum: IProjectsDatabasesDocumentsApiClient$XgafvEnum;
 export declare type ProjectsDatabasesDocumentsApiClientAlt =
-  | 'json'
-  | 'media'
-  | 'proto';
+  'json' | 'media' | 'proto';
 export interface IProjectsDatabasesDocumentsApiClientAltEnum {
   JSON: ProjectsDatabasesDocumentsApiClientAlt;
   MEDIA: ProjectsDatabasesDocumentsApiClientAlt;
@@ -895,9 +876,7 @@ export abstract class ProjectsDatabasesDocumentsApiClient {
     __namedParams__?: ProjectsDatabasesDocumentsWriteNamedParameters & object
   ): Promise<WriteResponse>;
 }
-export declare class ProjectsDatabasesDocumentsApiClientImpl
-  implements ProjectsDatabasesDocumentsApiClient
-{
+export declare class ProjectsDatabasesDocumentsApiClientImpl implements ProjectsDatabasesDocumentsApiClient {
   private gapiVersion;
   private $apiClient;
   constructor(
@@ -1178,9 +1157,7 @@ export interface IProjectsDatabasesIndexesApiClient$XgafvEnum {
 }
 export declare const ProjectsDatabasesIndexesApiClient$XgafvEnum: IProjectsDatabasesIndexesApiClient$XgafvEnum;
 export declare type ProjectsDatabasesIndexesApiClientAlt =
-  | 'json'
-  | 'media'
-  | 'proto';
+  'json' | 'media' | 'proto';
 export interface IProjectsDatabasesIndexesApiClientAltEnum {
   JSON: ProjectsDatabasesIndexesApiClientAlt;
   MEDIA: ProjectsDatabasesIndexesApiClientAlt;
@@ -1271,9 +1248,7 @@ export abstract class ProjectsDatabasesIndexesApiClient {
     __namedParams__?: ProjectsDatabasesIndexesListNamedParameters & object
   ): Promise<ListIndexesResponse>;
 }
-export declare class ProjectsDatabasesIndexesApiClientImpl
-  implements ProjectsDatabasesIndexesApiClient
-{
+export declare class ProjectsDatabasesIndexesApiClientImpl implements ProjectsDatabasesIndexesApiClient {
   private gapiVersion;
   private $apiClient;
   constructor(

--- a/packages/firestore/src/remote/existence_filter.ts
+++ b/packages/firestore/src/remote/existence_filter.ts
@@ -18,5 +18,8 @@
 import { BloomFilter as ProtoBloomFilter } from '../protos/firestore_proto_api';
 
 export class ExistenceFilter {
-  constructor(public count: number, public unchangedNames?: ProtoBloomFilter) {}
+  constructor(
+    public count: number,
+    public unchangedNames?: ProtoBloomFilter
+  ) {}
 }

--- a/packages/firestore/src/remote/watch_change.ts
+++ b/packages/firestore/src/remote/watch_change.ts
@@ -53,9 +53,7 @@ import { RemoteEvent, TargetChange } from './remote_event';
  * Internal representation of the watcher API protocol buffers.
  */
 export type WatchChange =
-  | DocumentWatchChange
-  | WatchTargetChange
-  | ExistenceFilterChange;
+  DocumentWatchChange | WatchTargetChange | ExistenceFilterChange;
 
 /**
  * Represents a changed document and a list of target ids to which this change

--- a/packages/firestore/src/util/bundle_builder_impl.ts
+++ b/packages/firestore/src/util/bundle_builder_impl.ts
@@ -66,7 +66,10 @@ export class BundleBuilder {
   private readonly serializer: JsonProtoSerializer;
   private readonly userDataReader: UserDataReader;
 
-  constructor(private firestore: Firestore, readonly bundleId: string) {
+  constructor(
+    private firestore: Firestore,
+    readonly bundleId: string
+  ) {
     this.databaseId = firestore._databaseId;
 
     // useProto3Json is true because the objects will be serialized to JSON string

--- a/packages/firestore/src/util/bundle_reader.ts
+++ b/packages/firestore/src/util/bundle_reader.ts
@@ -38,9 +38,7 @@ export class SizedBundleElement {
 }
 
 export type BundleSource =
-  | ReadableStream<Uint8Array>
-  | ArrayBuffer
-  | Uint8Array;
+  ReadableStream<Uint8Array> | ArrayBuffer | Uint8Array;
 
 /**
  * A class representing a bundle.

--- a/packages/firestore/src/util/json_validation.ts
+++ b/packages/firestore/src/util/json_validation.ts
@@ -25,12 +25,7 @@ import { Code, FirestoreError } from './error';
  * @internal
  */
 export type JsonTypeDesc =
-  | 'object'
-  | 'string'
-  | 'number'
-  | 'boolean'
-  | 'null'
-  | 'undefined';
+  'object' | 'string' | 'number' | 'boolean' | 'null' | 'undefined';
 
 /**
  * An association of JsonTypeDesc values to their native types.
@@ -40,16 +35,16 @@ export type JsonTypeDesc =
 export type TSType<T extends JsonTypeDesc> = T extends 'object'
   ? object
   : T extends 'string'
-  ? string
-  : T extends 'number'
-  ? number
-  : T extends 'boolean'
-  ? boolean
-  : T extends 'null'
-  ? null
-  : T extends 'undefined'
-  ? undefined
-  : never;
+    ? string
+    : T extends 'number'
+      ? number
+      : T extends 'boolean'
+        ? boolean
+        : T extends 'null'
+          ? null
+          : T extends 'undefined'
+            ? undefined
+            : never;
 
 /**
  * The representation of a JSON object property name and its type value.

--- a/packages/firestore/src/util/misc.ts
+++ b/packages/firestore/src/util/misc.ts
@@ -119,8 +119,8 @@ export function compareUtf8Strings(left: string, right: string): number {
       return isSurrogate(leftChar) === isSurrogate(rightChar)
         ? primitiveComparator(leftChar, rightChar)
         : isSurrogate(leftChar)
-        ? 1
-        : -1;
+          ? 1
+          : -1;
     }
   }
 

--- a/packages/firestore/test/integration/api/batch_writes.test.ts
+++ b/packages/firestore/test/integration/api/batch_writes.test.ts
@@ -330,7 +330,10 @@ apiDescribe('Database batch writes', persistence => {
   // only to web.
   apiDescribe('withConverter() support', persistence => {
     class Post {
-      constructor(readonly title: string, readonly author: string) {}
+      constructor(
+        readonly title: string,
+        readonly author: string
+      ) {}
       byline(): string {
         return this.title + ', by ' + this.author;
       }

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -710,10 +710,13 @@ apiDescribe('Database', persistence => {
         { embedding: { hello: 'world' } }
       ];
 
-      const docs = docsInOrder.reduce((obj, doc) => {
-        obj[Math.random().toString()] = doc;
-        return obj;
-      }, {} as { [i: string]: DocumentData });
+      const docs = docsInOrder.reduce(
+        (obj, doc) => {
+          obj[Math.random().toString()] = doc;
+          return obj;
+        },
+        {} as { [i: string]: DocumentData }
+      );
 
       return withTestCollection(persistence, docs, async randomCol => {
         // We validate that the SDK orders the vector field the same way as the backend
@@ -775,12 +778,15 @@ apiDescribe('Database', persistence => {
         ];
 
         const documentIds: string[] = [];
-        const docs = docsInOrder.reduce((obj, doc, index) => {
-          const documentId = index.toString();
-          documentIds.push(documentId);
-          obj[documentId] = doc;
-          return obj;
-        }, {} as { [i: string]: DocumentData });
+        const docs = docsInOrder.reduce(
+          (obj, doc, index) => {
+            const documentId = index.toString();
+            documentIds.push(documentId);
+            obj[documentId] = doc;
+            return obj;
+          },
+          {} as { [i: string]: DocumentData }
+        );
 
         return withTestCollection(persistence, docs, async randomCol => {
           const orderedQuery = query(randomCol, orderBy('embedding'));

--- a/packages/firestore/test/integration/api/pipeline.query.test.ts
+++ b/packages/firestore/test/integration/api/pipeline.query.test.ts
@@ -723,8 +723,7 @@ apiPipelineDescribe('Queries', (persistence, pipelineMode) => {
         query1,
         (
           result:
-            | QuerySnapshot<DocumentData, DocumentData>
-            | RealtimePipelineSnapshot
+            QuerySnapshot<DocumentData, DocumentData> | RealtimePipelineSnapshot
         ) => {
           expect(toDataArray(result)).to.deep.equal([
             testDocs[1],
@@ -2491,10 +2490,13 @@ apiPipelineDescribe('Queries', (persistence, pipelineMode) => {
 
       // Create the mapping from document ID to document data for the document
       // IDs specified in `testDocIds`.
-      const testDocs = testDocIds.reduce((map, docId) => {
-        map[docId] = { foo: 42 };
-        return map;
-      }, {} as { [key: string]: DocumentData });
+      const testDocs = testDocIds.reduce(
+        (map, docId) => {
+          map[docId] = { foo: 42 };
+          return map;
+        },
+        {} as { [key: string]: DocumentData }
+      );
 
       // Ensure that the local cache is configured to use LRU garbage collection
       // (rather than eager garbage collection) so that the resume token and

--- a/packages/firestore/test/integration/api/transactions.test.ts
+++ b/packages/firestore/test/integration/api/transactions.test.ts
@@ -755,7 +755,10 @@ apiDescribe('Database transactions', persistence => {
   // only to web.
   apiDescribe('withConverter() support', persistence => {
     class Post {
-      constructor(readonly title: string, readonly author: string) {}
+      constructor(
+        readonly title: string,
+        readonly author: string
+      ) {}
       byline(): string {
         return this.title + ', by ' + this.author;
       }

--- a/packages/firestore/test/integration/api_internal/query.test.ts
+++ b/packages/firestore/test/integration/api_internal/query.test.ts
@@ -374,10 +374,13 @@ apiDescribe('Queries', persistence => {
 
       // Create the mapping from document ID to document data for the document
       // IDs specified in `testDocIds`.
-      const testDocs = testDocIds.reduce((map, docId) => {
-        map[docId] = { foo: 42 };
-        return map;
-      }, {} as { [key: string]: DocumentData });
+      const testDocs = testDocIds.reduce(
+        (map, docId) => {
+          map[docId] = { foo: 42 };
+          return map;
+        },
+        {} as { [key: string]: DocumentData }
+      );
 
       // Ensure that the local cache is configured to use LRU garbage collection
       // (rather than eager garbage collection) so that the resume token and

--- a/packages/firestore/test/integration/remote/stream.test.ts
+++ b/packages/firestore/test/integration/remote/stream.test.ts
@@ -113,9 +113,7 @@ class StreamStatusListener implements WatchStreamListener, WriteStreamListener {
 
   onWatchChange(
     watchChange:
-      | DocumentWatchChange
-      | WatchTargetChange
-      | ExistenceFilterChange,
+      DocumentWatchChange | WatchTargetChange | ExistenceFilterChange,
     snapshot: SnapshotVersion
   ): Promise<void> {
     return this.resolvePending('watchChange');

--- a/packages/firestore/test/integration/util/composite_index_test_helper.ts
+++ b/packages/firestore/test/integration/util/composite_index_test_helper.ts
@@ -132,7 +132,8 @@ export class CompositeIndexTestHelper {
     return {
       ...doc,
       [this.TEST_ID_FIELD]: this.testId,
-      [this.TTL_FIELD]: new Timestamp( // Expire test data after 24 hours
+      [this.TTL_FIELD]: new Timestamp(
+        // Expire test data after 24 hours
         Timestamp.now().seconds + 24 * 60 * 60,
         Timestamp.now().nanoseconds
       )

--- a/packages/firestore/test/integration/util/helpers.ts
+++ b/packages/firestore/test/integration/util/helpers.ts
@@ -611,9 +611,7 @@ export async function checkOnlineAndOfflineResultsMatch(
 export function itIf(
   condition: boolean | 'only'
 ):
-  | Mocha.TestFunction
-  | Mocha.PendingTestFunction
-  | Mocha.ExclusiveTestFunction {
+  Mocha.TestFunction | Mocha.PendingTestFunction | Mocha.ExclusiveTestFunction {
   // eslint-disable-next-line no-restricted-properties
   return condition === 'only' ? it.only : condition ? it : it.skip;
 }

--- a/packages/firestore/test/unit/core/event_manager.test.ts
+++ b/packages/firestore/test/unit/core/event_manager.test.ts
@@ -440,8 +440,11 @@ describe('QueryListener', () => {
     const view = new View(query1, documentKeySet());
     const snap1 = applyDocChanges(view, doc1, doc2).snapshot!;
     const snap2 = applyDocChanges(view, doc1Committed, doc2Modified).snapshot!;
-    const snap3 = applyDocChanges(view, doc1Acknowledged, doc2Acknowledged)
-      .snapshot!;
+    const snap3 = applyDocChanges(
+      view,
+      doc1Acknowledged,
+      doc2Acknowledged
+    ).snapshot!;
 
     listener.onViewSnapshot(snap1);
     listener.onViewSnapshot(snap2);
@@ -478,8 +481,11 @@ describe('QueryListener', () => {
     const changes2 = view.computeDocChanges(documentUpdates(doc2));
     const snap2 = view.applyChanges(changes2, true).snapshot!;
     const changes3 = view.computeDocChanges(documentUpdates());
-    const snap3 = view.applyChanges(changes3, true, ackTarget(doc1, doc2))
-      .snapshot!;
+    const snap3 = view.applyChanges(
+      changes3,
+      true,
+      ackTarget(doc1, doc2)
+    ).snapshot!;
 
     listener.applyOnlineStateChange(OnlineState.Online); // no event
     listener.onViewSnapshot(snap1); // no event

--- a/packages/firestore/test/unit/core/listen_sequence.test.ts
+++ b/packages/firestore/test/unit/core/listen_sequence.test.ts
@@ -40,8 +40,7 @@ describe('ListenSequence', () => {
   it('bumps the next value based on notifications from the syncer', () => {
     const syncParams = {
       sequenceNumberHandler: null as
-        | ((sequenceNumber: ListenSequenceNumber) => void)
-        | null,
+        ((sequenceNumber: ListenSequenceNumber) => void) | null,
       writeSequenceNumber: (sequenceNumber: ListenSequenceNumber): void => {}
     };
     const listenSequence = new ListenSequence(0, syncParams);

--- a/packages/firestore/test/unit/core/view.test.ts
+++ b/packages/firestore/test/unit/core/view.test.ts
@@ -78,8 +78,11 @@ describe('View', () => {
 
     // delete doc2, add doc3
     const changes = view.computeDocChanges(documentUpdates(doc2.key, doc3));
-    const snapshot = view.applyChanges(changes, true, ackTarget(doc1, doc3))
-      .snapshot!;
+    const snapshot = view.applyChanges(
+      changes,
+      true,
+      ackTarget(doc1, doc3)
+    ).snapshot!;
 
     expect(snapshot.query).to.deep.equal(query1);
     expect(documentSetAsArray(snapshot.docs)).to.deep.equal([doc1, doc3]);
@@ -123,8 +126,14 @@ describe('View', () => {
     const doc4 = doc('rooms/eros/messages/4', 0, {}); // no sort, no match
     const doc5 = doc('rooms/eros/messages/5', 0, { sort: 1 });
 
-    const snapshot = applyDocChanges(view, doc1, doc2, doc3, doc4, doc5)
-      .snapshot!;
+    const snapshot = applyDocChanges(
+      view,
+      doc1,
+      doc2,
+      doc3,
+      doc4,
+      doc5
+    ).snapshot!;
 
     expect(snapshot.query).to.deep.equal(query1);
     expect(documentSetAsArray(snapshot.docs)).to.deep.equal([doc1, doc5, doc2]);

--- a/packages/firestore/test/unit/local/index_backfiller.test.ts
+++ b/packages/firestore/test/unit/local/index_backfiller.test.ts
@@ -700,9 +700,8 @@ function genericIndexBackfillerTests(
   }
 
   async function getFieldIndex(collectionGroup: string): Promise<FieldIndex> {
-    const fieldIndexes = await testIndexManager.getFieldIndexes(
-      collectionGroup
-    );
+    const fieldIndexes =
+      await testIndexManager.getFieldIndexes(collectionGroup);
     expect(fieldIndexes).length(1);
     return fieldIndexes[0];
   }

--- a/packages/firestore/test/unit/local/mutation_queue.test.ts
+++ b/packages/firestore/test/unit/local/mutation_queue.test.ts
@@ -272,9 +272,8 @@ function genericMutationQueueTests(): void {
     }
     const expected = [batches[1], batches[2], batches[4]];
     const query1 = query('foo');
-    const matches = await mutationQueue.getAllMutationBatchesAffectingQuery(
-      query1
-    );
+    const matches =
+      await mutationQueue.getAllMutationBatchesAffectingQuery(query1);
     expectEqualArrays(matches, expected);
   });
 
@@ -290,9 +289,8 @@ function genericMutationQueueTests(): void {
     ]);
     const expected = [batch1, batch2];
     const query1 = query('foo');
-    const matches = await mutationQueue.getAllMutationBatchesAffectingQuery(
-      query1
-    );
+    const matches =
+      await mutationQueue.getAllMutationBatchesAffectingQuery(query1);
     expectEqualArrays(matches, expected);
   });
 

--- a/packages/firestore/test/unit/local/query_engine.test.ts
+++ b/packages/firestore/test/unit/local/query_engine.test.ts
@@ -1032,9 +1032,8 @@ function genericQueryEngineTest(
 
       const q = query('coll', filter('foo', '==', 'match'));
       const target = queryToTarget(q);
-      const preQueryExecutionIndexType = await indexManager.getIndexType(
-        target
-      );
+      const preQueryExecutionIndexType =
+        await indexManager.getIndexType(target);
       expect(
         preQueryExecutionIndexType,
         'index type for target _before_ running the query is ' +
@@ -1048,9 +1047,8 @@ function genericQueryEngineTest(
       );
       verifyResult(result, matchingDocuments);
 
-      const postQueryExecutionIndexType = await indexManager.getIndexType(
-        target
-      );
+      const postQueryExecutionIndexType =
+        await indexManager.getIndexType(target);
       expect(
         postQueryExecutionIndexType,
         'index type for target _after_ running the query is ' +

--- a/packages/firestore/test/unit/local/test_index_manager.ts
+++ b/packages/firestore/test/unit/local/test_index_manager.ts
@@ -80,10 +80,13 @@ export class TestIndexManager {
   }
 
   getFieldIndexes(collectionGroup?: string): Promise<FieldIndex[]> {
-    return this.persistence.runTransaction('getFieldIndexes', 'readonly', txn =>
-      collectionGroup
-        ? this.indexManager.getFieldIndexes(txn, collectionGroup)
-        : this.indexManager.getFieldIndexes(txn)
+    return this.persistence.runTransaction(
+      'getFieldIndexes',
+      'readonly',
+      txn =>
+        collectionGroup
+          ? this.indexManager.getFieldIndexes(txn, collectionGroup)
+          : this.indexManager.getFieldIndexes(txn)
     );
   }
 

--- a/packages/firestore/test/unit/local/test_mutation_queue.ts
+++ b/packages/firestore/test/unit/local/test_mutation_queue.ts
@@ -31,7 +31,10 @@ import { SortedMap } from '../../../src/util/sorted_map';
  * transaction around every operation to reduce test boilerplate.
  */
 export class TestMutationQueue {
-  constructor(public persistence: Persistence, public queue: MutationQueue) {}
+  constructor(
+    public persistence: Persistence,
+    public queue: MutationQueue
+  ) {}
 
   checkEmpty(): Promise<boolean> {
     return this.persistence.runTransaction('checkEmpty', 'readonly', txn => {

--- a/packages/firestore/test/unit/local/test_target_cache.ts
+++ b/packages/firestore/test/unit/local/test_target_cache.ts
@@ -29,7 +29,10 @@ import { DocumentKey } from '../../../src/model/document_key';
  * transaction around every operation to reduce test boilerplate.
  */
 export class TestTargetCache {
-  constructor(public persistence: Persistence, public cache: TargetCache) {}
+  constructor(
+    public persistence: Persistence,
+    public cache: TargetCache
+  ) {}
 
   addTargetData(targetData: TargetData): Promise<void> {
     return this.persistence.runTransaction(

--- a/packages/firestore/test/unit/remote/remote_event.test.ts
+++ b/packages/firestore/test/unit/remote/remote_event.test.ts
@@ -625,9 +625,10 @@ describe('RemoteEvent', () => {
   it("doesn't synthesize deletes in the wrong state", () => {
     const targets = limboListens(1);
     const limboKey = key('coll/limbo');
-    const wrongState = new WatchTargetChange(WatchTargetChangeState.NoChange, [
-      1
-    ]);
+    const wrongState = new WatchTargetChange(
+      WatchTargetChangeState.NoChange,
+      [1]
+    );
 
     const event = createRemoteEvent({
       snapshotVersion: 1,

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -528,12 +528,12 @@ abstract class TestRunner {
       querySpec instanceof CorePipeline
         ? querySpec
         : this.convertToPipeline
-        ? toCorePipeline(
-            pipelineFromStages(
-              toPipelineStages(parseQuery(querySpec), newTestFirestore())
+          ? toCorePipeline(
+              pipelineFromStages(
+                toPipelineStages(parseQuery(querySpec), newTestFirestore())
+              )
             )
-          )
-        : parseQuery(querySpec);
+          : parseQuery(querySpec);
 
     const aggregator = new EventAggregator(query, e => {
       if (e.error) {
@@ -605,12 +605,12 @@ abstract class TestRunner {
       querySpec instanceof CorePipeline
         ? querySpec
         : this.convertToPipeline
-        ? toCorePipeline(
-            pipelineFromStages(
-              toPipelineStages(parseQuery(querySpec), newTestFirestore())
+          ? toCorePipeline(
+              pipelineFromStages(
+                toPipelineStages(parseQuery(querySpec), newTestFirestore())
+              )
             )
-          )
-        : parseQuery(querySpec);
+          : parseQuery(querySpec);
     const eventEmitter = this.queryListeners.get(query);
     debugAssert(!!eventEmitter, 'There must be a query to unlisten too!');
     this.queryListeners.delete(query);

--- a/packages/firestore/test/unit/util/misc.test.ts
+++ b/packages/firestore/test/unit/util/misc.test.ts
@@ -90,7 +90,10 @@ describe('CompareUtf8Strings', () => {
   }).timeout(20000);
 
   class StringPair {
-    constructor(readonly s1: string, readonly s2: string) {}
+    constructor(
+      readonly s1: string,
+      readonly s2: string
+    ) {}
   }
 
   class StringPairGenerator {

--- a/packages/firestore/test/unit/util/obj_map.test.ts
+++ b/packages/firestore/test/unit/util/obj_map.test.ts
@@ -20,7 +20,10 @@ import { expect } from 'chai';
 import { ObjectMap } from '../../../src/util/obj_map';
 
 class TestKey {
-  constructor(private id: number, private equalityKey: number) {}
+  constructor(
+    private id: number,
+    private equalityKey: number
+  ) {}
 
   get mapKey(): string {
     return 'id:' + this.id;

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -596,7 +596,10 @@ export function castTargetIds<T extends TargetId | RemoteTargetId>(
 }
 
 export class TestBundledDocuments {
-  constructor(public documents: BundledDocuments, public bundleName: string) {}
+  constructor(
+    public documents: BundledDocuments,
+    public bundleName: string
+  ) {}
 }
 
 export function bundledDocuments(

--- a/packages/firestore/test/util/mocha_extensions.ts
+++ b/packages/firestore/test/util/mocha_extensions.ts
@@ -35,11 +35,9 @@ interface ExtendMochaTypeWithHelpers<T> {
 declare module 'mocha' {
   // TODO add mocha types that must be extended
   interface TestFunction extends ExtendMochaTypeWithHelpers<TestFunction> {}
-  interface PendingTestFunction
-    extends ExtendMochaTypeWithHelpers<PendingTestFunction> {}
+  interface PendingTestFunction extends ExtendMochaTypeWithHelpers<PendingTestFunction> {}
   interface SuiteFunction extends ExtendMochaTypeWithHelpers<SuiteFunction> {}
-  interface PendingSuiteFunction
-    extends ExtendMochaTypeWithHelpers<PendingTestFunction> {}
+  interface PendingSuiteFunction extends ExtendMochaTypeWithHelpers<PendingTestFunction> {}
 }
 
 // Define helpers

--- a/packages/installations-compat/src/installationsCompat.ts
+++ b/packages/installations-compat/src/installationsCompat.ts
@@ -30,7 +30,10 @@ import {
 export class InstallationsCompat
   implements FirebaseInstallationsCompat, _FirebaseService
 {
-  constructor(public app: FirebaseApp, readonly _delegate: Installations) {}
+  constructor(
+    public app: FirebaseApp,
+    readonly _delegate: Installations
+  ) {}
 
   getId(): Promise<string> {
     return getId(this._delegate);

--- a/packages/installations/src/api/get-id.ts
+++ b/packages/installations/src/api/get-id.ts
@@ -29,9 +29,8 @@ import { Installations } from '../interfaces/public-types';
  */
 export async function getId(installations: Installations): Promise<string> {
   const installationsImpl = installations as FirebaseInstallationsImpl;
-  const { installationEntry, registrationPromise } = await getInstallationEntry(
-    installationsImpl
-  );
+  const { installationEntry, registrationPromise } =
+    await getInstallationEntry(installationsImpl);
 
   if (registrationPromise) {
     registrationPromise.catch(console.error);

--- a/packages/installations/src/helpers/get-installation-entry.test.ts
+++ b/packages/installations/src/helpers/get-installation-entry.test.ts
@@ -175,12 +175,10 @@ describe('getInstallationEntry', () => {
   });
 
   it('returns the same FID on subsequent calls', async () => {
-    const { installationEntry: entry1 } = await getInstallationEntry(
-      fakeInstallations
-    );
-    const { installationEntry: entry2 } = await getInstallationEntry(
-      fakeInstallations
-    );
+    const { installationEntry: entry1 } =
+      await getInstallationEntry(fakeInstallations);
+    const { installationEntry: entry2 } =
+      await getInstallationEntry(fakeInstallations);
     expect(entry1.fid).to.equal(entry2.fid);
   });
 
@@ -217,9 +215,8 @@ describe('getInstallationEntry', () => {
     it('returns a new unregistered InstallationEntry if app is offline', async () => {
       stub(navigator, 'onLine').value(false);
 
-      const { installationEntry } = await getInstallationEntry(
-        fakeInstallations
-      );
+      const { installationEntry } =
+        await getInstallationEntry(fakeInstallations);
 
       expect(installationEntry).to.deep.equal({
         fid: FID,
@@ -237,12 +234,10 @@ describe('getInstallationEntry', () => {
     });
 
     it('returns a registrationPromise on subsequent calls before initial promise resolves', async () => {
-      const { registrationPromise: promise1 } = await getInstallationEntry(
-        fakeInstallations
-      );
-      const { registrationPromise: promise2 } = await getInstallationEntry(
-        fakeInstallations
-      );
+      const { registrationPromise: promise1 } =
+        await getInstallationEntry(fakeInstallations);
+      const { registrationPromise: promise2 } =
+        await getInstallationEntry(fakeInstallations);
 
       expect(createInstallationRequestSpy).to.be.calledOnce;
       expect(promise1).to.be.an.instanceOf(Promise);
@@ -250,17 +245,15 @@ describe('getInstallationEntry', () => {
     });
 
     it('does not return a registrationPromise on subsequent calls after initial promise resolves', async () => {
-      const { registrationPromise: promise1 } = await getInstallationEntry(
-        fakeInstallations
-      );
+      const { registrationPromise: promise1 } =
+        await getInstallationEntry(fakeInstallations);
       expect(promise1).to.be.an.instanceOf(Promise);
 
       clock.next(); // Finish registration request.
       await expect(promise1).to.be.fulfilled;
 
-      const { registrationPromise: promise2 } = await getInstallationEntry(
-        fakeInstallations
-      );
+      const { registrationPromise: promise2 } =
+        await getInstallationEntry(fakeInstallations);
       expect(promise2).to.be.undefined;
 
       expect(createInstallationRequestSpy).to.be.calledOnce;
@@ -270,8 +263,7 @@ describe('getInstallationEntry', () => {
       clock.restore();
       clock = useFakeTimers({
         now: 1_000_000,
-        shouldAdvanceTime:
-          true /* Needed to allow the createInstallation request to complete. */
+        shouldAdvanceTime: true /* Needed to allow the createInstallation request to complete. */
       });
 
       // FID generation fails.
@@ -318,9 +310,8 @@ describe('getInstallationEntry', () => {
     it('returns the same InstallationEntry if the app is offline', async () => {
       stub(navigator, 'onLine').value(false);
 
-      const { installationEntry } = await getInstallationEntry(
-        fakeInstallations
-      );
+      const { installationEntry } =
+        await getInstallationEntry(fakeInstallations);
 
       expect(installationEntry).to.deep.equal({
         fid: FID,
@@ -343,9 +334,8 @@ describe('getInstallationEntry', () => {
     it("returns the same InstallationEntry if the request hasn't timed out", async () => {
       clock.now = 1_001_000; // One second after the request was initiated.
 
-      const { installationEntry } = await getInstallationEntry(
-        fakeInstallations
-      );
+      const { installationEntry } =
+        await getInstallationEntry(fakeInstallations);
 
       expect(installationEntry).to.deep.equal({
         fid: FID,
@@ -359,8 +349,7 @@ describe('getInstallationEntry', () => {
       clock.restore();
       clock = useFakeTimers({
         now: 1_001_000 /* One second after the request was initiated. */,
-        shouldAdvanceTime:
-          true /* Needed to allow the createInstallation request to complete. */
+        shouldAdvanceTime: true /* Needed to allow the createInstallation request to complete. */
       });
 
       const installationEntryPromise = getInstallationEntry(fakeInstallations);
@@ -401,8 +390,7 @@ describe('getInstallationEntry', () => {
       clock.restore();
       clock = useFakeTimers({
         now: 1_001_000 /* One second after the request was initiated. */,
-        shouldAdvanceTime:
-          true /* Needed to allow the createInstallation request to complete. */
+        shouldAdvanceTime: true /* Needed to allow the createInstallation request to complete. */
       });
 
       const installationEntryPromise = getInstallationEntry(fakeInstallations);
@@ -434,9 +422,8 @@ describe('getInstallationEntry', () => {
     it('returns a new pending InstallationEntry and triggers createInstallation if the request had already timed out', async () => {
       clock.now = 1_015_000; // Fifteen seconds after the request was initiated.
 
-      const { installationEntry } = await getInstallationEntry(
-        fakeInstallations
-      );
+      const { installationEntry } =
+        await getInstallationEntry(fakeInstallations);
 
       expect(installationEntry).to.deep.equal({
         fid: FID,
@@ -450,9 +437,8 @@ describe('getInstallationEntry', () => {
       stub(navigator, 'onLine').value(false);
       clock.now = 1_015_000; // Fifteen seconds after the request was initiated.
 
-      const { installationEntry } = await getInstallationEntry(
-        fakeInstallations
-      );
+      const { installationEntry } =
+        await getInstallationEntry(fakeInstallations);
 
       expect(installationEntry).to.deep.equal({
         fid: FID,
@@ -474,9 +460,8 @@ describe('getInstallationEntry', () => {
     });
 
     it('returns the InstallationEntry from the database', async () => {
-      const { installationEntry } = await getInstallationEntry(
-        fakeInstallations
-      );
+      const { installationEntry } =
+        await getInstallationEntry(fakeInstallations);
 
       expect(installationEntry).to.deep.equal({
         fid: FID,

--- a/packages/installations/src/interfaces/installation-entry.ts
+++ b/packages/installations/src/interfaces/installation-entry.ts
@@ -59,9 +59,7 @@ export interface CompletedAuthToken {
 }
 
 export type AuthToken =
-  | NotStartedAuthToken
-  | InProgressAuthToken
-  | CompletedAuthToken;
+  NotStartedAuthToken | InProgressAuthToken | CompletedAuthToken;
 
 export interface UnregisteredInstallationEntry {
   /** Status of the Firebase Installation registration on the server. */

--- a/packages/installations/src/interfaces/installation-impl.ts
+++ b/packages/installations/src/interfaces/installation-impl.ts
@@ -20,8 +20,7 @@ import { _FirebaseService } from '@firebase/app';
 import { Installations } from '../interfaces/public-types';
 
 export interface FirebaseInstallationsImpl
-  extends Installations,
-    _FirebaseService {
+  extends Installations, _FirebaseService {
   readonly appConfig: AppConfig;
   readonly heartbeatServiceProvider: Provider<'heartbeat'>;
 }

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -16,12 +16,7 @@
  */
 
 export type LogLevelString =
-  | 'debug'
-  | 'verbose'
-  | 'info'
-  | 'warn'
-  | 'error'
-  | 'silent';
+  'debug' | 'verbose' | 'info' | 'warn' | 'error' | 'silent';
 
 export interface LogOptions {
   level: LogLevelString;

--- a/packages/messaging-compat/src/messaging-compat.ts
+++ b/packages/messaging-compat/src/messaging-compat.ts
@@ -96,7 +96,10 @@ function isSwSupported(): boolean {
 }
 
 export class MessagingCompatImpl implements MessagingCompat, _FirebaseService {
-  constructor(readonly app: AppCompat, readonly _delegate: Messaging) {
+  constructor(
+    readonly app: AppCompat,
+    readonly _delegate: Messaging
+  ) {
     this.app = app;
     this._delegate = _delegate;
   }

--- a/packages/messaging/src/interfaces/internal-message-payload.ts
+++ b/packages/messaging/src/interfaces/internal-message-payload.ts
@@ -54,8 +54,7 @@ interface NotificationOptionsExperimental extends NotificationOptions {
   readonly vibrate?: VibratePattern;
 }
 
-export interface NotificationPayloadInternal
-  extends NotificationOptionsExperimental {
+export interface NotificationPayloadInternal extends NotificationOptionsExperimental {
   title: string;
   // Supported in the Legacy Send API.
   // See:https://firebase.google.com/docs/cloud-messaging/xmpp-server-ref.

--- a/packages/messaging/src/internals/requests.test.ts
+++ b/packages/messaging/src/internals/requests.test.ts
@@ -129,13 +129,7 @@ describe('API', () => {
         requestGetToken(firebaseDependencies, tokenDetails.subscriptionOptions!)
       ).to.be.rejectedWith('messaging/token-subscribe-failed');
 
-      fetchStub.resolves(
-        new Response(
-          JSON.stringify({
-            /* no token */
-          })
-        )
-      );
+      fetchStub.resolves(new Response(JSON.stringify({/* no token */})));
       await expect(
         requestGetToken(firebaseDependencies, tokenDetails.subscriptionOptions!)
       ).to.be.rejectedWith('messaging/token-subscribe-no-token');
@@ -376,13 +370,7 @@ describe('API', () => {
         requestUpdateToken(firebaseDependencies, tokenDetails)
       ).to.be.rejectedWith('messaging/token-update-failed');
 
-      fetchStub.resolves(
-        new Response(
-          JSON.stringify({
-            /* no token */
-          })
-        )
-      );
+      fetchStub.resolves(new Response(JSON.stringify({/* no token */})));
       await expect(
         requestUpdateToken(firebaseDependencies, tokenDetails)
       ).to.be.rejectedWith('messaging/token-update-no-token');

--- a/packages/messaging/src/listeners/sw-listeners.test.ts
+++ b/packages/messaging/src/listeners/sw-listeners.test.ts
@@ -434,9 +434,8 @@ describe('SwController', () => {
     });
 
     it('focuses on and sends the message to an open WindowClient', async () => {
-      const client: Writable<WindowClient> = (await self.clients.openWindow(
-        TEST_LINK
-      ))!;
+      const client: Writable<WindowClient> =
+        (await self.clients.openWindow(TEST_LINK))!;
       const focusSpy = spy(client, 'focus');
       const matchAllSpy = spy(self.clients, 'matchAll');
       const openWindowSpy = spy(self.clients, 'openWindow');

--- a/packages/messaging/src/messaging-service.ts
+++ b/packages/messaging/src/messaging-service.ts
@@ -38,9 +38,7 @@ export class MessagingService implements _FirebaseService {
   deliveryMetricsExportedToBigQueryEnabled: boolean = false;
 
   onBackgroundMessageHandler:
-    | NextFn<MessagePayload>
-    | Observer<MessagePayload>
-    | null = null;
+    NextFn<MessagePayload> | Observer<MessagePayload> | null = null;
 
   onMessageHandler: NextFn<MessagePayload> | Observer<MessagePayload> | null =
     null;

--- a/packages/messaging/src/testing/fakes/service-worker.ts
+++ b/packages/messaging/src/testing/fakes/service-worker.ts
@@ -100,9 +100,7 @@ class FakeWindowClient implements WindowClient {
   postMessage() {}
 }
 
-export class FakeServiceWorkerRegistration
-  implements ServiceWorkerRegistration
-{
+export class FakeServiceWorkerRegistration implements ServiceWorkerRegistration {
   active = null;
   installing = null;
   waiting = null;
@@ -211,7 +209,10 @@ export class FakeEvent implements ExtendableEvent {
     return [];
   }
 
-  constructor(public type: string, options: EventInit = {}) {
+  constructor(
+    public type: string,
+    options: EventInit = {}
+  ) {
     this.bubbles = options.bubbles ?? false;
     this.cancelable = options.cancelable ?? false;
     this.composed = options.composed ?? false;

--- a/packages/performance-compat/test/util.ts
+++ b/packages/performance-compat/test/util.ts
@@ -31,7 +31,7 @@ export function getFakeApp(): FirebaseApp {
       appId: '1:777777777777:web:d93b5ca1475efe57'
     },
     automaticDataCollectionEnabled: true,
-    performance: () => ({} as any),
+    performance: () => ({}) as any,
     delete: async () => {}
   };
 }

--- a/packages/performance/src/services/api_service.ts
+++ b/packages/performance/src/services/api_service.ts
@@ -38,12 +38,7 @@ let apiInstance: Api | undefined;
 let windowInstance: Window | undefined;
 
 export type EntryType =
-  | 'mark'
-  | 'measure'
-  | 'paint'
-  | 'resource'
-  | 'frame'
-  | 'navigation';
+  'mark' | 'measure' | 'paint' | 'resource' | 'frame' | 'navigation';
 
 /**
  * This class holds a reference to various browser related objects injected by

--- a/packages/remote-config-compat/src/remoteConfig.ts
+++ b/packages/remote-config-compat/src/remoteConfig.ts
@@ -43,7 +43,10 @@ export { isSupported };
 export class RemoteConfigCompatImpl
   implements RemoteConfigCompat, _FirebaseService
 {
-  constructor(public app: FirebaseApp, readonly _delegate: RemoteConfig) {}
+  constructor(
+    public app: FirebaseApp,
+    readonly _delegate: RemoteConfig
+  ) {}
 
   get defaultConfig(): { [key: string]: string | number | boolean } {
     return this._delegate.defaultConfig;

--- a/packages/remote-config/src/api.ts
+++ b/packages/remote-config/src/api.ts
@@ -204,10 +204,13 @@ export function getAll(remoteConfig: RemoteConfig): Record<string, Value> {
   return getAllKeys(
     rc._storageCache.getActiveConfig(),
     rc.defaultConfig
-  ).reduce((allConfigs, key) => {
-    allConfigs[key] = getValue(remoteConfig, key);
-    return allConfigs;
-  }, {} as Record<string, Value>);
+  ).reduce(
+    (allConfigs, key) => {
+      allConfigs[key] = getValue(remoteConfig, key);
+      return allConfigs;
+    },
+    {} as Record<string, Value>
+  );
 }
 
 /**

--- a/packages/remote-config/src/client/realtime_handler.ts
+++ b/packages/remote-config/src/client/realtime_handler.ts
@@ -481,9 +481,8 @@ export class RealtimeHandler {
 
       const lastFetchResponse =
         await this.storage.getLastSuccessfulFetchResponse();
-      const fetchResponse: FetchResponse = await this.cachingClient.fetch(
-        fetchRequest
-      );
+      const fetchResponse: FetchResponse =
+        await this.cachingClient.fetch(fetchRequest);
       let activatedConfigs = await this.storage.getActiveConfig();
 
       if (!this.fetchResponseIsUpToDate(fetchResponse, targetVersion)) {

--- a/packages/storage-compat/src/service.ts
+++ b/packages/storage-compat/src/service.ts
@@ -36,7 +36,10 @@ import { Compat, EmulatorMockTokenOptions } from '@firebase/util';
 export class StorageServiceCompat
   implements types.FirebaseStorage, Compat<FirebaseStorage>
 {
-  constructor(public app: FirebaseApp, readonly _delegate: FirebaseStorage) {}
+  constructor(
+    public app: FirebaseApp,
+    readonly _delegate: FirebaseStorage
+  ) {}
 
   get maxOperationRetryTime(): number {
     return this._delegate.maxOperationRetryTime;

--- a/packages/storage/src/implementation/connection.ts
+++ b/packages/storage/src/implementation/connection.ts
@@ -19,10 +19,7 @@ export type Headers = Record<string, string>;
 
 /** Response type exposed by the networking APIs. */
 export type ConnectionType =
-  | string
-  | ArrayBuffer
-  | Blob
-  | ReadableStream<Uint8Array>;
+  string | ArrayBuffer | Blob | ReadableStream<Uint8Array>;
 
 /**
  * A lightweight wrapper around XMLHttpRequest with a

--- a/packages/storage/src/implementation/error.ts
+++ b/packages/storage/src/implementation/error.ts
@@ -36,7 +36,11 @@ export class StorageError extends FirebaseError {
    * @param message  - Error message.
    * @param status_ - Corresponding HTTP Status Code
    */
-  constructor(code: StorageErrorCode, message: string, private status_ = 0) {
+  constructor(
+    code: StorageErrorCode,
+    message: string,
+    private status_ = 0
+  ) {
     super(
       prependCode(code),
       `Firebase Storage: ${message} (${prependCode(code)})`

--- a/packages/storage/src/implementation/location.ts
+++ b/packages/storage/src/implementation/location.ts
@@ -31,7 +31,10 @@ import { DEFAULT_HOST } from './constants';
 export class Location {
   private path_: string;
 
-  constructor(public readonly bucket: string, path: string) {
+  constructor(
+    public readonly bucket: string,
+    path: string
+  ) {
     this.path_ = path;
   }
 

--- a/packages/storage/src/implementation/string.ts
+++ b/packages/storage/src/implementation/string.ts
@@ -65,7 +65,10 @@ export const StringFormat = {
 export class StringData {
   contentType: string | null;
 
-  constructor(public data: Uint8Array, contentType?: string | null) {
+  constructor(
+    public data: Uint8Array,
+    contentType?: string | null
+  ) {
     this.contentType = contentType || null;
   }
 }

--- a/packages/storage/src/platform/browser/connection.ts
+++ b/packages/storage/src/platform/browser/connection.ts
@@ -31,9 +31,9 @@ let textFactoryOverride: (() => Connection<string>) | null = null;
  * Network layer for browsers. We use this instead of goog.net.XhrIo because
  * goog.net.XhrIo is hyuuuuge and doesn't work in React Native on Android.
  */
-abstract class XhrConnection<T extends ConnectionType>
-  implements Connection<T>
-{
+abstract class XhrConnection<
+  T extends ConnectionType
+> implements Connection<T> {
   protected xhr_: XMLHttpRequest;
   private errorCode_: ErrorCode;
   private sendPromise_: Promise<void>;

--- a/packages/storage/src/platform/node/connection.ts
+++ b/packages/storage/src/platform/node/connection.ts
@@ -32,9 +32,9 @@ let textFactoryOverride: (() => Connection<string>) | null = null;
  * This network implementation should not be used in browsers as it does not
  * support progress updates.
  */
-abstract class FetchConnection<T extends ConnectionType>
-  implements Connection<T>
-{
+abstract class FetchConnection<
+  T extends ConnectionType
+> implements Connection<T> {
   protected errorCode_: ErrorCode;
   protected statusCode_: number | undefined;
   protected body_: ArrayBuffer | undefined;

--- a/packages/util/src/crypt.ts
+++ b/packages/util/src/crypt.ts
@@ -269,7 +269,7 @@ export const base64: Base64 = {
 
     const output: number[] = [];
 
-    for (let i = 0; i < input.length; ) {
+    for (let i = 0; i < input.length;) {
       const byte1 = charToByteMap[input.charAt(i++)];
 
       const haveByte2 = i < input.length;

--- a/packages/util/src/environment.ts
+++ b/packages/util/src/environment.ts
@@ -122,8 +122,8 @@ export function isBrowserExtension(): boolean {
     typeof chrome === 'object'
       ? chrome.runtime
       : typeof browser === 'object'
-      ? browser.runtime
-      : undefined;
+        ? browser.runtime
+        : undefined;
   return typeof runtime === 'object' && runtime.id !== undefined;
 }
 

--- a/packages/util/src/postinstall.ts
+++ b/packages/util/src/postinstall.ts
@@ -19,5 +19,4 @@ import type { FirebaseDefaults } from './defaults';
 
 // This value is retrieved and hardcoded by the NPM postinstall script
 export const getDefaultsFromPostinstall: () =>
-  | FirebaseDefaults
-  | undefined = () => undefined;
+  FirebaseDefaults | undefined = () => undefined;

--- a/repo-scripts/api-documenter/src/markdown/MarkdownEmitter.ts
+++ b/repo-scripts/api-documenter/src/markdown/MarkdownEmitter.ts
@@ -125,8 +125,7 @@ export class MarkdownEmitter {
       case DocNodeKind.HtmlStartTag:
       case DocNodeKind.HtmlEndTag: {
         const docHtmlTag: DocHtmlStartTag | DocHtmlEndTag = docNode as
-          | DocHtmlStartTag
-          | DocHtmlEndTag;
+          DocHtmlStartTag | DocHtmlEndTag;
         // write the HTML element verbatim into the output
         writer.write(docHtmlTag.emitAsHtml());
         break;

--- a/repo-scripts/api-documenter/src/nodes/DocEmphasisSpan.ts
+++ b/repo-scripts/api-documenter/src/nodes/DocEmphasisSpan.ts
@@ -28,8 +28,7 @@ import { CustomDocNodeKind } from './CustomDocNodeKind';
 /**
  * Constructor parameters for {@link DocEmphasisSpan}.
  */
-export interface IDocEmphasisSpanParameters
-  extends IDocNodeContainerParameters {
+export interface IDocEmphasisSpanParameters extends IDocNodeContainerParameters {
   bold?: boolean;
   italic?: boolean;
 }

--- a/repo-scripts/api-documenter/src/plugin/PluginLoader.ts
+++ b/repo-scripts/api-documenter/src/plugin/PluginLoader.ts
@@ -115,8 +115,7 @@ export class PluginLoader {
             initialization._context = createContext();
 
             let markdownDocumenterFeature:
-              | MarkdownDocumenterFeature
-              | undefined = undefined;
+              MarkdownDocumenterFeature | undefined = undefined;
             try {
               markdownDocumenterFeature = new featureDefinition.subclass(
                 initialization

--- a/repo-scripts/size-analysis/package-analysis.ts
+++ b/repo-scripts/size-analysis/package-analysis.ts
@@ -100,9 +100,8 @@ export async function analyzePackageSize(
       writeFiles = true;
     }
 
-    const reports: Report[] = await generateReportForModules(
-      allModulesLocation
-    );
+    const reports: Report[] =
+      await generateReportForModules(allModulesLocation);
     if (writeFiles) {
       for (const report of reports) {
         writeReportToDirectory(

--- a/scripts/ci-test/tasks.ts
+++ b/scripts/ci-test/tasks.ts
@@ -155,10 +155,9 @@ export async function getTestTasks(): Promise<TestTask[]> {
           if (depGraph[pkgName].includes(changedPkg.name)) {
             const depData = packageInfo.find(item => item.name === pkgName);
             if (depData) {
-              const depPkgJson = require(resolve(
-                depData.location,
-                'package.json'
-              ));
+              const depPkgJson = require(
+                resolve(depData.location, 'package.json')
+              );
               if (depPkgJson) {
                 if (!testTasks.find(t => t.pkgName === depPkgJson.name)) {
                   testTasks.push(

--- a/scripts/ci/add_changeset.ts
+++ b/scripts/ci/add_changeset.ts
@@ -72,8 +72,9 @@ async function addChangeSet() {
     // The way actions/checkout works, there is no local `main` branch, but it
     // has access to the remote origin/main.
     await exec(`yarn changeset status --output changeset-temp.json`);
-    const changesets: ChangesetEntry[] =
-      require(`${projectRoot}/changeset-temp.json`).changesets;
+    const changesets: ChangesetEntry[] = require(
+      `${projectRoot}/changeset-temp.json`
+    ).changesets;
     // only add a changeset for @firebase/app if
     // 1. we are publishing a new firebase version. and
     // 2. @firebase/app is not already being published

--- a/scripts/release/utils/workspace.ts
+++ b/scripts/release/utils/workspace.ts
@@ -25,9 +25,9 @@ import clone from 'clone';
 
 const writeFile = promisify(_writeFile);
 
-const {
-  workspaces: rawWorkspaces
-}: { workspaces: string[] } = require(`${root}/package.json`);
+const { workspaces: rawWorkspaces }: { workspaces: string[] } = require(
+  `${root}/package.json`
+);
 const workspaces = rawWorkspaces.map(workspace => `${root}/${workspace}`);
 
 export function mapWorkspaceToPackages(

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -43,11 +43,9 @@ export async function getChangedPackages(
     // Check for changed files inside package dirs.
     const match = filename.match('^(packages/[a-zA-Z0-9-]+)/.*');
     if (match && match[1]) {
-      const changedPackage = require(resolve(
-        projectRoot,
-        match[1],
-        'package.json'
-      ));
+      const changedPackage = require(
+        resolve(projectRoot, match[1], 'package.json')
+      );
       changedPackages.add(changedPackage.name);
     }
   }


### PR DESCRIPTION
Formats all files using the new prettier version that was upgraded in  https://github.com/firebase/firebase-js-sdk/commit/081ebdca0023b3a608c3257a96bbac72de069720 with `yarn format --all`.

The incorrect formatting is causing formatting CI to fail on PRs that don't add any incorrect formatting, but touch files that already had incorrect formatting.

