### PR TITLE
fix(messaging): initialize swRegistration in service worker

### DIFF
--- a/.changeset/fix-messaging-sw-registration.md
+++ b/.changeset/fix-messaging-sw-registration.md
@@ -1,0 +1,5 @@
+---
+'@firebase/messaging': patch
+---
+
+Fix "Cannot read properties of undefined (reading 'pushManager')" in the service worker by initializing `swRegistration` from `self.registration` when the messaging instance is created in the service worker context.

--- a/packages/messaging/src/helpers/register.test.ts
+++ b/packages/messaging/src/helpers/register.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '../testing/setup';
+
+import {
+  mockServiceWorker,
+  restoreServiceWorker
+} from '../testing/fakes/service-worker';
+import {
+  getFakeAnalyticsProvider,
+  getFakeApp,
+  getFakeInstallations
+} from '../testing/fakes/firebase-dependencies';
+import { ComponentContainer } from '@firebase/component';
+import { MessagingService } from '../messaging-service';
+import { ServiceWorkerGlobalScope } from '../util/sw-types';
+import { SwMessagingFactory } from './register';
+import { expect } from 'chai';
+import { stub } from 'sinon';
+
+// Add fake SW types.
+declare const self: ServiceWorkerGlobalScope;
+
+describe('SwMessagingFactory', () => {
+  beforeEach(() => {
+    mockServiceWorker();
+    stub(self, 'addEventListener');
+  });
+
+  afterEach(() => {
+    restoreServiceWorker();
+  });
+
+  it('sets swRegistration from the service worker global scope', () => {
+    const container = {
+      getProvider: (name: string) => {
+        switch (name) {
+          case 'app':
+            return { getImmediate: () => getFakeApp() };
+          case 'installations-internal':
+            return { getImmediate: () => getFakeInstallations() };
+          case 'analytics-internal':
+            return getFakeAnalyticsProvider();
+          default:
+            throw new Error(`Unexpected provider: ${name}`);
+        }
+      }
+    } as unknown as ComponentContainer;
+
+    const messaging = SwMessagingFactory(container, {
+      instanceIdentifier: undefined,
+      options: undefined
+    }) as MessagingService;
+
+    // Token operations triggered inside the service worker (e.g. the
+    // pushsubscriptionchange handler) dereference swRegistration, so the
+    // factory must initialize it. See issue #9213.
+    expect(messaging.swRegistration).to.equal(self.registration);
+  });
+});

--- a/packages/messaging/src/helpers/register.ts
+++ b/packages/messaging/src/helpers/register.ts
@@ -76,7 +76,7 @@ const WindowMessagingInternalFactory: InstanceFactory<'messaging-internal'> = (
 };
 
 declare const self: ServiceWorkerGlobalScope;
-const SwMessagingFactory: InstanceFactory<'messaging'> = (
+export const SwMessagingFactory: InstanceFactory<'messaging'> = (
   container: ComponentContainer
 ) => {
   const messaging = new MessagingService(
@@ -84,6 +84,11 @@ const SwMessagingFactory: InstanceFactory<'messaging'> = (
     container.getProvider('installations-internal').getImmediate(),
     container.getProvider('analytics-internal')
   );
+
+  // The token operations (e.g. in the pushsubscriptionchange handler)
+  // dereference swRegistration, which is otherwise never assigned in the
+  // service worker context.
+  messaging.swRegistration = self.registration;
 
   self.addEventListener('push', e => {
     e.waitUntil(onPush(e, messaging as MessagingService));


### PR DESCRIPTION
Hey there! So you want to contribute to a Firebase SDK? 
Before you file this pull request, please read these guidelines:

### Discussion

Close #9213.

This addresses #9213 where the service worker crashes with:

```
TypeError: Cannot read properties of undefined (reading 'pushManager')
```

### Testing

Added `packages/messaging/src/helpers/register.test.ts`, which runs `SwMessagingFactory` and asserts `swRegistration` is initialized from the service worker global scope. It fails without the fix (`swRegistration` is `undefined`) and passes with it. `SwMessagingFactory` is now exported from its (internal, non-public) module to make it testable.

### API Changes

None. The change is internal to the service worker instance factory.
