### PR TITLE
Firebase log processor

### DIFF
--- a/packages/crashlytics/src/logging/firebase-log-processor.test.ts
+++ b/packages/crashlytics/src/logging/firebase-log-processor.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { ReadableLogRecord } from '@opentelemetry/sdk-logs';
+import { AttributesStore } from '../attributes-store';
+import { FirebaseLogProcessor } from './firebase-log-processor';
+
+describe('FirebaseLogProcessor', () => {
+  let attributesStoreStub: sinon.SinonStubbedInstance<AttributesStore>;
+  let processor: FirebaseLogProcessor;
+
+  beforeEach(() => {
+    // Create a stub for AttributesStore
+    attributesStoreStub = sinon.createStubInstance(AttributesStore);
+    processor = new FirebaseLogProcessor(
+      attributesStoreStub as unknown as AttributesStore
+    );
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should assign log attributes from AttributesStore onto the log record', () => {
+    const mockAttributes = {
+      'app.build_id': '1.0.0',
+      'session.id': 'session-123',
+      'custom.key': 'custom.value'
+    };
+
+    attributesStoreStub.getLogAttributes.returns(mockAttributes);
+
+    const logRecord = {
+      attributes: {
+        'existing.key': 'existing.value'
+      }
+    } as unknown as ReadableLogRecord;
+
+    processor.onEmit(logRecord);
+
+    expect(logRecord.attributes).to.deep.equal({
+      'existing.key': 'existing.value',
+      'app.build_id': '1.0.0',
+      'session.id': 'session-123',
+      'custom.key': 'custom.value'
+    });
+    expect(attributesStoreStub.getLogAttributes.calledOnce).to.be.true;
+  });
+
+  it('should resolve forceFlush', async () => {
+    await expect(processor.forceFlush()).to.be.fulfilled;
+  });
+
+  it('should resolve shutdown', async () => {
+    await expect(processor.shutdown()).to.be.fulfilled;
+  });
+});

--- a/packages/crashlytics/src/logging/firebase-log-processor.test.ts
+++ b/packages/crashlytics/src/logging/firebase-log-processor.test.ts
@@ -26,7 +26,6 @@ describe('FirebaseLogProcessor', () => {
   let processor: FirebaseLogProcessor;
 
   beforeEach(() => {
-    // Create a stub for AttributesStore
     attributesStoreStub = sinon.createStubInstance(AttributesStore);
     processor = new FirebaseLogProcessor(
       attributesStoreStub as unknown as AttributesStore
@@ -38,36 +37,20 @@ describe('FirebaseLogProcessor', () => {
   });
 
   it('should assign log attributes from AttributesStore onto the log record', () => {
+    const logRecord = {
+      attributes: {}
+    } as unknown as ReadableLogRecord;
+
     const mockAttributes = {
-      'app.build_id': '1.0.0',
-      'session.id': 'session-123',
       'custom.key': 'custom.value'
     };
 
     attributesStoreStub.getLogAttributes.returns(mockAttributes);
 
-    const logRecord = {
-      attributes: {
-        'existing.key': 'existing.value'
-      }
-    } as unknown as ReadableLogRecord;
-
     processor.onEmit(logRecord);
 
     expect(logRecord.attributes).to.deep.equal({
-      'existing.key': 'existing.value',
-      'app.build_id': '1.0.0',
-      'session.id': 'session-123',
       'custom.key': 'custom.value'
     });
-    expect(attributesStoreStub.getLogAttributes.calledOnce).to.be.true;
-  });
-
-  it('should resolve forceFlush', async () => {
-    await expect(processor.forceFlush()).to.be.fulfilled;
-  });
-
-  it('should resolve shutdown', async () => {
-    await expect(processor.shutdown()).to.be.fulfilled;
   });
 });

--- a/packages/crashlytics/src/logging/firebase-log-processor.ts
+++ b/packages/crashlytics/src/logging/firebase-log-processor.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LogRecordProcessor, ReadableLogRecord } from '@opentelemetry/sdk-logs';
+import { AttributesStore } from '../attributes-store';
+
+/**
+ * A LogRecordProcessor that adds custom attributes from the attributes store to all emitted log records.
+ */
+export class FirebaseLogProcessor implements LogRecordProcessor {
+  constructor(private readonly _attributesStore: AttributesStore) {}
+
+  onEmit(logRecord: ReadableLogRecord): void {
+    Object.assign(logRecord.attributes, this._attributesStore.getLogAttributes());
+  }
+
+  forceFlush(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/packages/crashlytics/src/logging/firebase-log-processor.ts
+++ b/packages/crashlytics/src/logging/firebase-log-processor.ts
@@ -25,7 +25,10 @@ export class FirebaseLogProcessor implements LogRecordProcessor {
   constructor(private readonly _attributesStore: AttributesStore) {}
 
   onEmit(logRecord: ReadableLogRecord): void {
-    Object.assign(logRecord.attributes, this._attributesStore.getLogAttributes());
+    Object.assign(
+      logRecord.attributes,
+      this._attributesStore.getLogAttributes()
+    );
   }
 
   forceFlush(): Promise<void> {

--- a/packages/crashlytics/src/logging/logger-provider.ts
+++ b/packages/crashlytics/src/logging/logger-provider.ts
@@ -43,6 +43,7 @@ import {
 } from '../constants';
 import { AttributesStore } from '../attributes-store';
 import { OnErrorLogRecordProcessor } from './on-error-log-record-processor';
+import { FirebaseLogProcessor } from './firebase-log-processor';
 
 let unregisterInstrumentations: (() => void) | undefined;
 
@@ -95,13 +96,7 @@ export function createLoggerProvider(
 
   // TODO: Remove this custom processor and use applyCustomLogRecordData in the instrumentation config once
   // @opentelemetry/browser-instrumentation supports it across all standard/experimental packages.
-  const customAttributesProcessor = {
-    onEmit: (logRecord: ReadableLogRecord) => {
-      Object.assign(logRecord.attributes, attributesStore.getLogAttributes());
-    },
-    forceFlush: () => Promise.resolve(),
-    shutdown: () => Promise.resolve()
-  };
+  const customAttributesProcessor = new FirebaseLogProcessor(attributesStore);
 
   const loggerProvider = new LoggerProvider({
     resource,

--- a/packages/crashlytics/src/logging/logger-provider.ts
+++ b/packages/crashlytics/src/logging/logger-provider.ts
@@ -102,14 +102,6 @@ export function createLoggerProvider(
     logRecordLimits: {}
   });
 
-  // TODO: Enable once @opentelemetry/browser-instrumentation supports applyCustomLogRecordData across its packages
-  // const applyCustomLogRecordData = (logRecord: LogRecord): void => {
-  //   logRecord.attributes = {
-  //     ...logRecord.attributes,
-  //     ...attributesStore.getLogAttributes()
-  //   };
-  // };
-
   if (typeof window !== 'undefined') {
     /*
      * Initialize as disabled to prevent the instrumentation from auto-enabling during construction.

--- a/packages/crashlytics/src/logging/logger-provider.ts
+++ b/packages/crashlytics/src/logging/logger-provider.ts
@@ -92,15 +92,13 @@ export function createLoggerProvider(
     attributesStore
   );
 
-  const onErrorLogRecordProcessor = new OnErrorLogRecordProcessor(logExporter);
+  const firebaseLogProcessor = new FirebaseLogProcessor(attributesStore);
 
-  // TODO: Remove this custom processor and use applyCustomLogRecordData in the instrumentation config once
-  // @opentelemetry/browser-instrumentation supports it across all standard/experimental packages.
-  const customAttributesProcessor = new FirebaseLogProcessor(attributesStore);
+  const onErrorLogRecordProcessor = new OnErrorLogRecordProcessor(logExporter);
 
   const loggerProvider = new LoggerProvider({
     resource,
-    processors: [customAttributesProcessor, onErrorLogRecordProcessor],
+    processors: [firebaseLogProcessor, onErrorLogRecordProcessor],
     logRecordLimits: {}
   });
 


### PR DESCRIPTION
Creating previously in-lined log processor as an explicitly defined FirebaseLogProcessor class that assigns log attributes onEmit
