### PR TITLE
adding dedup protection for child spans

### DIFF
--- a/packages/crashlytics/src/telemetry-store.test.ts
+++ b/packages/crashlytics/src/telemetry-store.test.ts
@@ -22,12 +22,24 @@ import { SdkLogRecord } from '@opentelemetry/sdk-logs';
 import { SeverityNumber } from '@opentelemetry/api-logs';
 
 describe('TelemetryStore', () => {
+  let spanIdCounter = 0;
+
+  /**
+   * Generates a unique, incrementing span ID for mocking OpenTelemetry spans.
+   */
+  function nextSpanId(): string {
+    return `span-${++spanIdCounter}`;
+  }
+
   /**
    * Helper to create a mock OpenTelemetry parent/root span.
    */
-  function createMockRootSpan(traceId: string): ReadableSpan {
+  function createMockRootSpan(
+    traceId: string,
+    spanId = nextSpanId()
+  ): ReadableSpan {
     return {
-      spanContext: () => ({ traceId }),
+      spanContext: () => ({ traceId, spanId }),
       parentSpanContext: undefined
     } as unknown as ReadableSpan;
   }
@@ -35,9 +47,12 @@ describe('TelemetryStore', () => {
   /**
    * Helper to create a mock OpenTelemetry child span.
    */
-  function createMockChildSpan(traceId: string): ReadableSpan {
+  function createMockChildSpan(
+    traceId: string,
+    spanId = nextSpanId()
+  ): ReadableSpan {
     return {
-      spanContext: () => ({ traceId }),
+      spanContext: () => ({ traceId, spanId }),
       parentSpanContext: { traceId, spanId: 'parent-span-id' }
     } as unknown as ReadableSpan;
   }
@@ -66,6 +81,7 @@ describe('TelemetryStore', () => {
   function setupState({ bufferLimit = 1, queueLimit = 1 } = {}): {
     store: TelemetryStore;
   } {
+    spanIdCounter = 0;
     const store = new TelemetryStore(bufferLimit, queueLimit);
     return { store };
   }
@@ -323,40 +339,40 @@ describe('TelemetryStore', () => {
     });
   });
 
-  describe('Test assumption that events can only be considered the same if they point to the same memory', () => {
-    it('should treat two identical child spans of different memory as different events', () => {
+  describe('Test assertion that duplicated spans will be treated identically while duplicated logs will be treated differently', () => {
+    it('should treat two identical child spans of different memory as the same event', () => {
       const { store } = setupState({ bufferLimit: 4, queueLimit: 2 });
 
       const existingRootSpan = createMockRootSpan('trace-1');
-      const existingChildSpan1 = createMockChildSpan('trace-1');
-      const existingChildSpan2 = createMockChildSpan('trace-1');
-
-      store.add(existingRootSpan);
-      store.add(existingChildSpan1);
-      store.add(existingChildSpan2);
-      store.update(existingRootSpan);
-
-      expect(store.getSpansToExport()).to.have.deep.members([
-        existingRootSpan,
-        existingChildSpan1,
-        existingChildSpan2
-      ]);
-    });
-
-    it('should treat two identical child spans of same memory as same events', () => {
-      const { store } = setupState({ bufferLimit: 4, queueLimit: 2 });
-
-      const existingRootSpan = createMockRootSpan('trace-1');
-      const existingChildSpan = createMockChildSpan('trace-1');
+      const existingChildSpan = createMockChildSpan('trace-1', 'span-2');
+      const ignoredChildSpanCopy = createMockChildSpan('trace-1', 'span-2'); // Struturally identical
 
       store.add(existingRootSpan);
       store.add(existingChildSpan);
-      store.add(existingChildSpan);
+      store.add(ignoredChildSpanCopy);
       store.update(existingRootSpan);
 
       expect(store.getSpansToExport()).to.have.deep.members([
         existingRootSpan,
         existingChildSpan
+      ]);
+    });
+
+    it('should treat two identical child logs of different memory as different events', () => {
+      const { store } = setupState({ bufferLimit: 4, queueLimit: 2 });
+
+      const existingRootSpan = createMockRootSpan('trace-1');
+      const existingChildLog = createMockChildLog('trace-1');
+      const expectedChildLogCopy = createMockChildLog('trace-1'); // Structurally identical
+
+      store.add(existingRootSpan);
+      store.add(existingChildLog);
+      store.add(expectedChildLogCopy);
+      store.update(existingRootSpan);
+
+      expect(store.getLogsToExport()).to.have.deep.members([
+        existingChildLog,
+        expectedChildLogCopy
       ]);
     });
   });

--- a/packages/crashlytics/src/telemetry-store.test.ts
+++ b/packages/crashlytics/src/telemetry-store.test.ts
@@ -21,78 +21,83 @@ import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { SdkLogRecord } from '@opentelemetry/sdk-logs';
 import { SeverityNumber } from '@opentelemetry/api-logs';
 
-describe('TelemetryStore', () => {
-  let spanIdCounter = 0;
+/**
+ * Factory class to generate mock OpenTelemetry spans and log records for testing.
+ * Scopes state (like span ID counters) locally to the instance to ensure test isolation.
+ */
+class MockEventFactory {
+  /** Counter used to generate unique, auto-incrementing span IDs. */
+  private _spanIdCounter = 0;
 
   /**
-   * Generates a unique, incrementing span ID for mocking OpenTelemetry spans.
+   * Creates a mock OpenTelemetry parent/root span.
+   *
+   * @param traceId - The trace ID the span belongs to.
+   * @param spanId - Optional custom span ID. If omitted, an auto-incrementing ID is generated.
    */
-  function nextSpanId(): string {
-    return `span-${++spanIdCounter}`;
-  }
-
-  /**
-   * Helper to create a mock OpenTelemetry parent/root span.
-   */
-  function createMockRootSpan(
-    traceId: string,
-    spanId = nextSpanId()
-  ): ReadableSpan {
+  createRootSpan(traceId: string, spanId?: string): ReadableSpan {
+    const id = spanId ?? `span-${++this._spanIdCounter}`;
     return {
-      spanContext: () => ({ traceId, spanId }),
+      spanContext: () => ({ traceId, spanId: id }),
       parentSpanContext: undefined
     } as unknown as ReadableSpan;
   }
 
   /**
-   * Helper to create a mock OpenTelemetry child span.
+   * Creates a mock OpenTelemetry child span.
+   *
+   * @param traceId - The trace ID the span belongs to.
+   * @param spanId - Optional custom span ID. If omitted, an auto-incrementing ID is generated.
    */
-  function createMockChildSpan(
-    traceId: string,
-    spanId = nextSpanId()
-  ): ReadableSpan {
+  createChildSpan(traceId: string, spanId?: string): ReadableSpan {
+    const id = spanId ?? `span-${++this._spanIdCounter}`;
     return {
-      spanContext: () => ({ traceId, spanId }),
+      spanContext: () => ({ traceId, spanId: id }),
       parentSpanContext: { traceId, spanId: 'parent-span-id' }
     } as unknown as ReadableSpan;
   }
 
   /**
-   * Helper to create a mock OpenTelemetry root/standalone log record.
+   * Creates a mock OpenTelemetry root/standalone log record.
    */
-  function createMockRootLog(): SdkLogRecord {
+  createRootLog(): SdkLogRecord {
     return {
       spanContext: undefined
     } as unknown as SdkLogRecord;
   }
 
   /**
-   * Helper to create a mock OpenTelemetry child log record.
+   * Creates a mock OpenTelemetry child log record.
+   *
+   * @param traceId - The trace ID the log record is associated with.
    */
-  function createMockChildLog(traceId: string): SdkLogRecord {
+  createChildLog(traceId: string): SdkLogRecord {
     return {
       spanContext: { traceId }
     } as unknown as SdkLogRecord;
   }
+}
 
+describe('TelemetryStore', () => {
   /**
    * Helper used to initialize a new TelemetryStore instance with specified capacity limits for testing.
    */
   function setupState({ bufferLimit = 1, queueLimit = 1 } = {}): {
     store: TelemetryStore;
+    factory: MockEventFactory;
   } {
-    spanIdCounter = 0;
     const store = new TelemetryStore(bufferLimit, queueLimit);
-    return { store };
+    const factory = new MockEventFactory();
+    return { store, factory };
   }
 
   describe('Event is added but not made exportable; buffer size < limit and queue size < limit', () => {
     it('should add root span with children but not be exportable', () => {
-      const { store } = setupState({ bufferLimit: 3, queueLimit: 1 });
+      const { store, factory } = setupState({ bufferLimit: 3, queueLimit: 1 });
 
-      const expectedRootSpan = createMockRootSpan('trace-1');
-      const expectedChildSpan = createMockChildSpan('trace-1');
-      const expectedChildLog = createMockChildLog('trace-1');
+      const expectedRootSpan = factory.createRootSpan('trace-1');
+      const expectedChildSpan = factory.createChildSpan('trace-1');
+      const expectedChildLog = factory.createChildLog('trace-1');
 
       store.add(expectedRootSpan);
       store.add(expectedChildSpan);
@@ -106,11 +111,11 @@ describe('TelemetryStore', () => {
 
   describe('Event is added and made exportable; buffer size < limit and queue size < limit', () => {
     it('should create an exportable root span with children successfully', () => {
-      const { store } = setupState({ bufferLimit: 3, queueLimit: 1 });
+      const { store, factory } = setupState({ bufferLimit: 3, queueLimit: 1 });
 
-      const expectedRootSpan = createMockRootSpan('trace-1');
-      const expectedChildSpan = createMockChildSpan('trace-1');
-      const expectedChildLog = createMockChildLog('trace-1');
+      const expectedRootSpan = factory.createRootSpan('trace-1');
+      const expectedChildSpan = factory.createChildSpan('trace-1');
+      const expectedChildLog = factory.createChildLog('trace-1');
 
       store.add(expectedRootSpan);
       store.add(expectedChildSpan);
@@ -126,9 +131,9 @@ describe('TelemetryStore', () => {
     });
 
     it('should create an exportable root log successfully', () => {
-      const { store } = setupState({ bufferLimit: 1, queueLimit: 1 });
+      const { store, factory } = setupState({ bufferLimit: 1, queueLimit: 1 });
 
-      const expectedRootLog = createMockRootLog();
+      const expectedRootLog = factory.createRootLog();
 
       store.add(expectedRootLog);
 
@@ -139,12 +144,12 @@ describe('TelemetryStore', () => {
 
   describe('Event is added and made exportable after evicting the oldest root and all associated spans/logs', () => {
     it('should create an exportable root span and evict oldest root id if queue size == limit and buffer size < limit', () => {
-      const { store } = setupState({ bufferLimit: 4, queueLimit: 1 });
+      const { store, factory } = setupState({ bufferLimit: 4, queueLimit: 1 });
 
-      const existingRootSpan = createMockRootSpan('trace-1');
-      const existingChildSpan = createMockChildSpan('trace-1');
-      const existingChildLog = createMockChildLog('trace-1');
-      const expectedRootSpan = createMockRootSpan('trace-2');
+      const existingRootSpan = factory.createRootSpan('trace-1');
+      const existingChildSpan = factory.createChildSpan('trace-1');
+      const existingChildLog = factory.createChildLog('trace-1');
+      const expectedRootSpan = factory.createRootSpan('trace-2');
 
       store.add(existingRootSpan);
       store.add(existingChildSpan);
@@ -160,12 +165,12 @@ describe('TelemetryStore', () => {
     });
 
     it('should create an exportable root log and evict oldest root id if queue size == limit and buffer size < limit', () => {
-      const { store } = setupState({ bufferLimit: 3, queueLimit: 2 });
+      const { store, factory } = setupState({ bufferLimit: 3, queueLimit: 2 });
 
-      const existingRootSpan = createMockRootSpan('trace-1');
-      const existingChildSpan = createMockChildSpan('trace-1');
-      const existingChildLog = createMockChildLog('trace-1');
-      const expectedRootLog = createMockRootLog();
+      const existingRootSpan = factory.createRootSpan('trace-1');
+      const existingChildSpan = factory.createChildSpan('trace-1');
+      const existingChildLog = factory.createChildLog('trace-1');
+      const expectedRootLog = factory.createRootLog();
 
       store.add(existingRootSpan);
       store.add(existingChildSpan);
@@ -180,18 +185,18 @@ describe('TelemetryStore', () => {
     });
 
     it('should create an exportable event and evict oldest root id if queue size < limit and buffer size == limit', () => {
-      const { store } = setupState({ bufferLimit: 3, queueLimit: 2 });
+      const { store, factory } = setupState({ bufferLimit: 3, queueLimit: 2 });
 
-      const existingRootSpan = createMockRootSpan('trace-1');
-      const existingChildSpan = createMockChildSpan('trace-1');
-      const existingChildLog = createMockChildLog('trace-1');
+      const existingRootSpan = factory.createRootSpan('trace-1');
+      const existingChildSpan = factory.createChildSpan('trace-1');
+      const existingChildLog = factory.createChildLog('trace-1');
 
       store.add(existingRootSpan);
       store.add(existingChildSpan);
       store.add(existingChildLog);
       store.update(existingRootSpan);
 
-      const expectedRootSpan = createMockRootSpan('trace-2');
+      const expectedRootSpan = factory.createRootSpan('trace-2');
       store.add(expectedRootSpan);
       store.update(expectedRootSpan);
 
@@ -203,9 +208,9 @@ describe('TelemetryStore', () => {
 
   describe('Event is not added', () => {
     it('should not add any additional event and export limit log if queue size == 0 and buffer size == limit', () => {
-      const { store } = setupState({ bufferLimit: 0, queueLimit: 2 });
+      const { store, factory } = setupState({ bufferLimit: 0, queueLimit: 2 });
 
-      const ignoredRootLog = createMockRootLog();
+      const ignoredRootLog = factory.createRootLog();
 
       store.add(ignoredRootLog);
 
@@ -219,9 +224,9 @@ describe('TelemetryStore', () => {
     });
 
     it('should not add and as a result not export any additional root event if already added', () => {
-      const { store } = setupState({ bufferLimit: 3, queueLimit: 3 });
+      const { store, factory } = setupState({ bufferLimit: 3, queueLimit: 3 });
 
-      const expectedRootSpan = createMockRootSpan('trace-1');
+      const expectedRootSpan = factory.createRootSpan('trace-1');
 
       store.add(expectedRootSpan);
       store.add(expectedRootSpan); // should not add again
@@ -233,10 +238,10 @@ describe('TelemetryStore', () => {
     });
 
     it('should not add and as a result not export any additional child event if already added', () => {
-      const { store } = setupState({ bufferLimit: 3, queueLimit: 3 });
+      const { store, factory } = setupState({ bufferLimit: 3, queueLimit: 3 });
 
-      const existingRootSpan = createMockRootSpan('trace-1');
-      const expectedChildSpan = createMockChildSpan('trace-1');
+      const existingRootSpan = factory.createRootSpan('trace-1');
+      const expectedChildSpan = factory.createChildSpan('trace-1');
 
       store.add(existingRootSpan);
       store.add(expectedChildSpan);
@@ -251,10 +256,10 @@ describe('TelemetryStore', () => {
     });
 
     it('should not add any child event if its root span has not been added', () => {
-      const { store } = setupState({ bufferLimit: 3, queueLimit: 3 });
+      const { store, factory } = setupState({ bufferLimit: 3, queueLimit: 3 });
 
-      const ignoredChildSpan = createMockChildSpan('trace-1');
-      const ignoredChildLog = createMockChildSpan('trace-1');
+      const ignoredChildSpan = factory.createChildSpan('trace-1');
+      const ignoredChildLog = factory.createChildSpan('trace-1');
 
       store.add(ignoredChildSpan);
       store.add(ignoredChildLog);
@@ -263,10 +268,10 @@ describe('TelemetryStore', () => {
     });
 
     it('should not add any child event if its root span must be evicted in the add', () => {
-      const { store } = setupState({ bufferLimit: 1, queueLimit: 1 });
+      const { store, factory } = setupState({ bufferLimit: 1, queueLimit: 1 });
 
-      const existingRootSpan = createMockRootSpan('trace-1');
-      const ignoredChildLog = createMockChildLog('trace-1');
+      const existingRootSpan = factory.createRootSpan('trace-1');
+      const ignoredChildLog = factory.createChildLog('trace-1');
 
       store.add(existingRootSpan);
       store.update(existingRootSpan);
@@ -278,9 +283,9 @@ describe('TelemetryStore', () => {
 
   describe('Event cannot be made exportable', () => {
     it('should not create any additional exportable root span if already exportable', () => {
-      const { store } = setupState({ bufferLimit: 3, queueLimit: 3 });
+      const { store, factory } = setupState({ bufferLimit: 3, queueLimit: 3 });
 
-      const expectedRootSpan = createMockRootSpan('trace-1');
+      const expectedRootSpan = factory.createRootSpan('trace-1');
 
       store.add(expectedRootSpan);
       store.update(expectedRootSpan);
@@ -291,10 +296,10 @@ describe('TelemetryStore', () => {
     });
 
     it('should not create an exportable child span if child span is directly queued for export', () => {
-      const { store } = setupState({ bufferLimit: 3, queueLimit: 3 });
+      const { store, factory } = setupState({ bufferLimit: 3, queueLimit: 3 });
 
-      const existingRootSpan = createMockRootSpan('trace-1');
-      const ignoredChildSpan = createMockChildSpan('trace-1');
+      const existingRootSpan = factory.createRootSpan('trace-1');
+      const ignoredChildSpan = factory.createChildSpan('trace-1');
 
       store.add(existingRootSpan);
       store.add(ignoredChildSpan);
@@ -306,12 +311,12 @@ describe('TelemetryStore', () => {
 
   describe('Clear events from store', () => {
     it('should reset telemetry count to 0 and return no spans/logs for export', () => {
-      const { store } = setupState({ bufferLimit: 4, queueLimit: 2 });
+      const { store, factory } = setupState({ bufferLimit: 4, queueLimit: 2 });
 
-      const existingRootSpan = createMockRootSpan('trace-1');
-      const existingChildSpan = createMockChildSpan('trace-1');
-      const existingChildLog = createMockChildLog('trace-1');
-      const existingRootLog = createMockRootLog();
+      const existingRootSpan = factory.createRootSpan('trace-1');
+      const existingChildSpan = factory.createChildSpan('trace-1');
+      const existingChildLog = factory.createChildLog('trace-1');
+      const existingRootLog = factory.createRootLog();
 
       store.add(existingRootSpan);
       store.add(existingChildSpan);
@@ -327,9 +332,9 @@ describe('TelemetryStore', () => {
     });
 
     it('should return no limit log for export if previously triggered', () => {
-      const { store } = setupState({ bufferLimit: 0, queueLimit: 2 });
+      const { store, factory } = setupState({ bufferLimit: 0, queueLimit: 2 });
 
-      const ignoredRootLog = createMockRootLog();
+      const ignoredRootLog = factory.createRootLog();
 
       store.add(ignoredRootLog); // triggers limit log to be exported as root log is dropped
 
@@ -341,11 +346,11 @@ describe('TelemetryStore', () => {
 
   describe('Test assertion that duplicated spans will be treated identically while duplicated logs will be treated differently', () => {
     it('should treat two identical child spans of different memory as the same event', () => {
-      const { store } = setupState({ bufferLimit: 4, queueLimit: 2 });
+      const { store, factory } = setupState({ bufferLimit: 4, queueLimit: 2 });
 
-      const existingRootSpan = createMockRootSpan('trace-1');
-      const existingChildSpan = createMockChildSpan('trace-1', 'span-2');
-      const ignoredChildSpanCopy = createMockChildSpan('trace-1', 'span-2'); // Struturally identical
+      const existingRootSpan = factory.createRootSpan('trace-1');
+      const existingChildSpan = factory.createChildSpan('trace-1', 'span-2');
+      const ignoredChildSpanCopy = factory.createChildSpan('trace-1', 'span-2'); // Structurally identical
 
       store.add(existingRootSpan);
       store.add(existingChildSpan);
@@ -359,11 +364,11 @@ describe('TelemetryStore', () => {
     });
 
     it('should treat two identical child logs of different memory as different events', () => {
-      const { store } = setupState({ bufferLimit: 4, queueLimit: 2 });
+      const { store, factory } = setupState({ bufferLimit: 4, queueLimit: 2 });
 
-      const existingRootSpan = createMockRootSpan('trace-1');
-      const existingChildLog = createMockChildLog('trace-1');
-      const expectedChildLogCopy = createMockChildLog('trace-1'); // Structurally identical
+      const existingRootSpan = factory.createRootSpan('trace-1');
+      const existingChildLog = factory.createChildLog('trace-1');
+      const expectedChildLogCopy = factory.createChildLog('trace-1'); // Structurally identical
 
       store.add(existingRootSpan);
       store.add(existingChildLog);

--- a/packages/crashlytics/src/telemetry-store.ts
+++ b/packages/crashlytics/src/telemetry-store.ts
@@ -21,6 +21,32 @@ import { SeverityNumber } from '@opentelemetry/api-logs';
 import { generateUuid } from './helpers';
 
 /**
+ * Represents the type of a telemetry event.
+ */
+enum EventType {
+  RootSpan,
+  RootLog,
+  ChildSpan,
+  ChildLog
+}
+
+/**
+ * Represents the identifier for a telemetry event buffer, which can be a trace ID or a generated UUID.
+ */
+type EventId = string;
+
+/**
+ * Represents the type of telemetry data buffered in memory.
+ * Can be a TraceEvents collection containing spans and logs for a trace, or a standalone SdkLogRecord.
+ */
+type EventData = TraceEvents | SdkLogRecord;
+
+/**
+ * Represents the unique identifier for a span, typically a 16-character hexadecimal string.
+ */
+type SpanId = string;
+
+/**
  * Checks if a telemetry event is a Span.
  *
  * @param event - The telemetry event to check.
@@ -97,32 +123,6 @@ class TraceEvents {
       : this.logs.has(event);
   }
 }
-
-/**
- * Represents the type of a telemetry event.
- */
-enum EventType {
-  RootSpan,
-  RootLog,
-  ChildSpan,
-  ChildLog
-}
-
-/**
- * Represents the unique identifier for a span, typically a 16-character hexadecimal string.
- */
-type SpanId = string;
-
-/**
- * Represents the identifier for a telemetry event buffer, which can be a trace ID or a generated UUID.
- */
-type EventId = string;
-
-/**
- * Represents the type of telemetry data buffered in memory.
- * Can be a TraceEvents collection containing spans and logs for a trace, or a standalone SdkLogRecord.
- */
-type EventData = TraceEvents | SdkLogRecord;
 
 /**
  * A shared storage engine that buffers telemetry logs and spans in memory,

--- a/packages/crashlytics/src/telemetry-store.ts
+++ b/packages/crashlytics/src/telemetry-store.ts
@@ -30,6 +30,15 @@ function isSpan(event: ReadableSpan | SdkLogRecord): event is ReadableSpan {
 }
 
 /**
+ * Retrieves the SpanId associated with a span.
+ *
+ * @param span - The span.
+ */
+function getSpanId(span: ReadableSpan): SpanId {
+  return span.spanContext().spanId;
+}
+
+/**
  * Checks if a telemetry event (span or log) is a root event.
  *
  * @param event - The telemetry event to check.
@@ -61,7 +70,7 @@ function getEventType(event: ReadableSpan | SdkLogRecord): EventType {
 class TraceEvents {
   // TODO: add unique id mappings to handle idempotency issue with duplicated events of different references
   logs = new Set<SdkLogRecord>();
-  spans = new Set<ReadableSpan>();
+  spans = new Map<SpanId, ReadableSpan>();
   isTraceQueuedForExport = false;
 
   /**
@@ -71,7 +80,7 @@ class TraceEvents {
    */
   add(event: ReadableSpan | SdkLogRecord): void {
     if (isSpan(event)) {
-      this.spans.add(event);
+      this.spans.set(getSpanId(event), event);
     } else {
       this.logs.add(event);
     }
@@ -83,7 +92,9 @@ class TraceEvents {
    * @param event - The telemetry event to check.
    */
   has(event: ReadableSpan | SdkLogRecord): boolean {
-    return isSpan(event) ? this.spans.has(event) : this.logs.has(event);
+    return isSpan(event)
+      ? this.spans.has(getSpanId(event))
+      : this.logs.has(event);
   }
 }
 
@@ -96,6 +107,11 @@ enum EventType {
   ChildSpan,
   ChildLog
 }
+
+/**
+ * Represents the unique identifier for a span, typically a 16-character hexadecimal string.
+ */
+type SpanId = string;
 
 /**
  * Represents the identifier for a telemetry event buffer, which can be a trace ID or a generated UUID.
@@ -238,7 +254,7 @@ export class TelemetryStore {
     for (const key of this._rootTelemetryQueue.getValues()) {
       const item = this._telemetryBufferMap.get(key);
       if (item instanceof TraceEvents) {
-        spans.push(...item.spans);
+        spans.push(...item.spans.values());
       }
     }
     return spans;


### PR DESCRIPTION
- replaces spans set in TraceEvents with a map of <SpanId,ReadableSpan> so that duplicated spans of the same span id point to a singleton.
