### PR TITLE
Decimal128 Increment spec test

### DIFF
--- a/common/api-review/firestore-lite.api.md
+++ b/common/api-review/firestore-lite.api.md
@@ -206,6 +206,7 @@ export class Decimal128Value {
   isEqual(other: Decimal128Value): boolean;
   // (undocumented)
   readonly stringValue: string;
+  toJSON(): object;
   }
 
 // @public

--- a/common/api-review/firestore.api.md
+++ b/common/api-review/firestore.api.md
@@ -214,6 +214,7 @@ export class Decimal128Value {
   isEqual(other: Decimal128Value): boolean;
   // (undocumented)
   readonly stringValue: string;
+  toJSON(): object;
   }
 
 // @public

--- a/docs-devsite/firestore_.decimal128value.md
+++ b/docs-devsite/firestore_.decimal128value.md
@@ -37,6 +37,7 @@ export declare class Decimal128Value
 |  Method | Modifiers | Description |
 |  --- | --- | --- |
 |  [isEqual(other)](./firestore_.decimal128value.md#decimal128valueisequal) |  | Returns true if this <code>Decimal128Value</code> is equal to the provided one. |
+|  [toJSON()](./firestore_.decimal128value.md#decimal128valuetojson) |  | Returns a JSON-serializable representation of this <code>Decimal128Value</code> instance. |
 
 ## Decimal128Value.(constructor)
 
@@ -81,4 +82,19 @@ isEqual(other: Decimal128Value): boolean;
 <b>Returns:</b>
 
 boolean
+
+## Decimal128Value.toJSON()
+
+Returns a JSON-serializable representation of this `Decimal128Value` instance.
+
+<b>Signature:</b>
+
+```typescript
+toJSON(): object;
+```
+<b>Returns:</b>
+
+object
+
+a JSON representation of this object.
 

--- a/docs-devsite/firestore_lite.decimal128value.md
+++ b/docs-devsite/firestore_lite.decimal128value.md
@@ -37,6 +37,7 @@ export declare class Decimal128Value
 |  Method | Modifiers | Description |
 |  --- | --- | --- |
 |  [isEqual(other)](./firestore_lite.decimal128value.md#decimal128valueisequal) |  | Returns true if this <code>Decimal128Value</code> is equal to the provided one. |
+|  [toJSON()](./firestore_lite.decimal128value.md#decimal128valuetojson) |  | Returns a JSON-serializable representation of this <code>Decimal128Value</code> instance. |
 
 ## Decimal128Value.(constructor)
 
@@ -81,4 +82,19 @@ isEqual(other: Decimal128Value): boolean;
 <b>Returns:</b>
 
 boolean
+
+## Decimal128Value.toJSON()
+
+Returns a JSON-serializable representation of this `Decimal128Value` instance.
+
+<b>Signature:</b>
+
+```typescript
+toJSON(): object;
+```
+<b>Returns:</b>
+
+object
+
+a JSON representation of this object.
 

--- a/packages/firestore/src/lite-api/decimal128_value.ts
+++ b/packages/firestore/src/lite-api/decimal128_value.ts
@@ -44,4 +44,15 @@ export class Decimal128Value {
     }
     return this.value.compareTo(other.value) === 0;
   }
+
+  /**
+   * Returns a JSON-serializable representation of this `Decimal128Value` instance.
+   *
+   * @returns a JSON representation of this object.
+   */
+  toJSON(): object {
+    return {
+      __decimal128__: { stringValue: this.stringValue }
+    };
+  }
 }

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -48,8 +48,10 @@ import { DocumentKey } from '../../../src/model/document_key';
 import { FieldIndex } from '../../../src/model/field_index';
 import { JsonObject } from '../../../src/model/object_value';
 import { ResourcePath } from '../../../src/model/path';
-import * as api from '../../../src/protos/firestore_proto_api';
-import { BloomFilter as ProtoBloomFilter } from '../../../src/protos/firestore_proto_api';
+import {
+  BloomFilter as ProtoBloomFilter,
+  Value as ProtoValue
+} from '../../../src/protos/firestore_proto_api';
 import {
   isPermanentWriteError,
   mapCodeFromRpcCode,
@@ -739,7 +741,7 @@ export class SpecBuilder {
     options?: {
       expectUserCallback?: boolean;
       keepInQueue?: boolean;
-      transformResults?: api.Value[];
+      transformResults?: ProtoValue[];
     }
   ): this {
     this.nextStep();

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -48,6 +48,7 @@ import { DocumentKey } from '../../../src/model/document_key';
 import { FieldIndex } from '../../../src/model/field_index';
 import { JsonObject } from '../../../src/model/object_value';
 import { ResourcePath } from '../../../src/model/path';
+import * as api from '../../../src/protos/firestore_proto_api';
 import { BloomFilter as ProtoBloomFilter } from '../../../src/protos/firestore_proto_api';
 import {
   isPermanentWriteError,
@@ -735,7 +736,11 @@ export class SpecBuilder {
   writeAcks(
     doc: string,
     version: TestSnapshotVersion,
-    options?: { expectUserCallback?: boolean; keepInQueue?: boolean }
+    options?: {
+      expectUserCallback?: boolean;
+      keepInQueue?: boolean;
+      transformResults?: api.Value[];
+    }
   ): this {
     this.nextStep();
     options = options || {};
@@ -743,6 +748,9 @@ export class SpecBuilder {
     const writeAck: SpecWriteAck = { version };
     if (options.keepInQueue) {
       writeAck.keepInQueue = true;
+    }
+    if (options.transformResults) {
+      writeAck.transformResults = options.transformResults;
     }
     this.currentStep = { writeAck };
 

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -945,8 +945,14 @@ abstract class TestRunner {
     const nextMutation = writeAck.keepInQueue
       ? this.sharedWrites.peek()
       : this.sharedWrites.shift();
+    const mutationResults: api.WriteResult[] = [
+      {
+        updateTime,
+        transformResults: writeAck.transformResults
+      }
+    ];
     return this.validateNextWriteRequest(nextMutation).then(() => {
-      this.connection.ackWrite(updateTime, [{ updateTime }]);
+      this.connection.ackWrite(updateTime, mutationResults);
     });
   }
 
@@ -1870,6 +1876,8 @@ export interface SpecWriteAck {
    */
   // PORTING NOTE: Multi-Tab only.
   keepInQueue?: boolean;
+
+  transformResults?: api.Value[];
 }
 
 export interface SpecWriteFailure {

--- a/packages/firestore/test/unit/specs/write_spec.test.ts
+++ b/packages/firestore/test/unit/specs/write_spec.test.ts
@@ -1506,4 +1506,59 @@ describeSpec('Writes:', [], () => {
       );
     }
   );
+
+  specTest(
+    'Decimal128 increment loses precision locally and recovers when watch arrives before server ack',
+    [],
+    () => {
+      const query1 = query('collection/doc');
+
+      const docInitial = doc('collection/doc', 1000, {
+        sum: new Decimal128Value('1.000000000000000000000000000000001')
+      });
+
+      const docLocal = doc('collection/doc', 1000, {
+        sum: new Decimal128Value('2')
+      }).setHasLocalMutations();
+
+      const docRemote = doc('collection/doc', 2000, {
+        sum: new Decimal128Value('2.000000000000000000000000000000001')
+      });
+
+      return (
+        spec()
+          // Listen to receive initial document
+          .userListens(query1)
+          .watchAcksFull(query1, 1000, docInitial)
+          .expectEvents(query1, { added: [docInitial] })
+
+          // User writes increment
+          .userPatches('collection/doc', { sum: increment(1) })
+
+          // Local cache writes increment
+          .expectEvents(query1, {
+            hasPendingWrites: true,
+            modified: [docLocal]
+          })
+
+          // Watch stream delivers updated document and snapshot
+          .watchSends({ affects: [query1] }, docRemote)
+          .watchSnapshots(2000)
+
+          // Server acknowledges write on write stream with transform result
+          .writeAcks('collection/doc', 2000, {
+            transformResults: [
+              wrap(new Decimal128Value('2.000000000000000000000000000000001'))
+            ]
+          })
+
+          // Local cache updates document with correct increment result
+          .expectEvents(query1, {
+            hasPendingWrites: false,
+            modified: [docRemote]
+          })
+      );
+    }
+  );
 });
+

--- a/packages/firestore/test/unit/specs/write_spec.test.ts
+++ b/packages/firestore/test/unit/specs/write_spec.test.ts
@@ -15,10 +15,12 @@
  * limitations under the License.
  */
 
+import { Decimal128Value } from '../../../src/lite-api/decimal128_value';
+import { increment } from '../../../src/lite-api/field_value_impl';
 import { MutableDocument } from '../../../src/model/document';
 import { TimerId } from '../../../src/util/async_queue';
 import { Code } from '../../../src/util/error';
-import { doc, query } from '../../util/helpers';
+import { doc, query, wrap } from '../../util/helpers';
 
 import { describeSpec, specTest } from './describe_spec';
 import { client, spec } from './spec_builder';
@@ -1448,6 +1450,60 @@ describeSpec('Writes:', [], () => {
         .client(2)
         .expectUserCallbacks({ acknowledged: ['collection/c'] })
         .expectWaitForPendingWritesEvent(/* count= */ 1);
+    }
+  );
+
+  specTest(
+    'Decimal128 increment loses precision locally and recovers on server ack',
+    [],
+    () => {
+      const query1 = query('collection/doc');
+
+      const docInitial = doc('collection/doc', 1000, {
+        sum: new Decimal128Value('1.000000000000000000000000000000001')
+      });
+
+      const docLocal = doc('collection/doc', 1000, {
+        sum: new Decimal128Value('2')
+      }).setHasLocalMutations();
+
+      const docRemote = doc('collection/doc', 2000, {
+        sum: new Decimal128Value('2.000000000000000000000000000000001')
+      });
+
+      return (
+        spec()
+          // Listen to receive initial document
+          .userListens(query1)
+          .watchAcksFull(query1, 1000, docInitial)
+          .expectEvents(query1, { added: [docInitial] })
+
+          // User writes increment
+          .userPatches('collection/doc', { sum: increment(1) })
+
+          // Local cache writes increment
+          .expectEvents(query1, {
+            hasPendingWrites: true,
+            modified: [docLocal]
+          })
+
+          // Server acknowledges write on write stream with transform result
+          .writeAcks('collection/doc', 2000, {
+            transformResults: [
+              wrap(new Decimal128Value('2.000000000000000000000000000000001'))
+            ]
+          })
+
+          // Watch stream delivers updated document and snapshot
+          .watchSends({ affects: [query1] }, docRemote)
+          .watchSnapshots(2000)
+
+          // Local cache updates document with correct increment result
+          .expectEvents(query1, {
+            hasPendingWrites: false,
+            modified: [docRemote]
+          })
+      );
     }
   );
 });

--- a/packages/firestore/test/unit/specs/write_spec.test.ts
+++ b/packages/firestore/test/unit/specs/write_spec.test.ts
@@ -1561,4 +1561,3 @@ describeSpec('Writes:', [], () => {
     }
   );
 });
-


### PR DESCRIPTION
Added spec test for `Decimal128` increment, verifying that
1. Decimal128 can lose precision after local `increment`
2. The correct Decimal128 increment result is overwritten when received from remote.

Added `transformOperations` to `writeAck` to allow transform operations to be part of the ack.