### PR TITLE
fix: Function Calling Fails with gemini-3.6 Bug

### DIFF
--- a/.changeset/great-penguins-know.md
+++ b/.changeset/great-penguins-know.md
@@ -1,5 +1,6 @@
 ---
 '@firebase/ai': minor
+'firebase': minor
 ---
 
 Fixed the issue where the SDK hardcodes invalid 'function' role, causing 400 errors during function calling on gemini-3.6-flash

--- a/.changeset/great-penguins-know.md
+++ b/.changeset/great-penguins-know.md
@@ -1,0 +1,5 @@
+---
+'@firebase/ai': minor
+---
+
+Fixed the issue where the SDK hardcodes invalid 'function' role, causing 400 errors during function calling on gemini-3.6-flash

--- a/packages/ai/src/methods/chat-session-helpers.ts
+++ b/packages/ai/src/methods/chat-session-helpers.ts
@@ -30,7 +30,7 @@ const VALID_PART_FIELDS: Array<keyof Part> = [
 ];
 
 const VALID_PARTS_PER_ROLE: { [key in Role]: Array<keyof Part> } = {
-  user: ['text', 'inlineData'],
+  user: ['text', 'inlineData', 'functionResponse'],
   function: ['functionResponse'],
   model: ['text', 'functionCall', 'thought', 'thoughtSignature'],
   // System instructions shouldn't be in history anyway.

--- a/packages/ai/src/methods/chrome-adapter-browser.test.ts
+++ b/packages/ai/src/methods/chrome-adapter-browser.test.ts
@@ -253,7 +253,7 @@ describe('ChromeAdapter', () => {
         })
       ).to.be.false;
     });
-    it('returns false if request content has "function" role', async () => {
+    it('returns false if request content has a functionResponse part', async () => {
       const adapter = new ChromeAdapterImpl(
         {
           availability: async () => Availability.AVAILABLE
@@ -264,8 +264,12 @@ describe('ChromeAdapter', () => {
         await adapter.isAvailable({
           contents: [
             {
-              role: 'function',
-              parts: []
+              role: 'user',
+              parts: [
+                {
+                  functionResponse: {name: 'greet', response: {name: 'user'}}
+                }
+              ]
             }
           ]
         })

--- a/packages/ai/src/methods/chrome-adapter-browser.test.ts
+++ b/packages/ai/src/methods/chrome-adapter-browser.test.ts
@@ -267,7 +267,10 @@ describe('ChromeAdapter', () => {
               role: 'user',
               parts: [
                 {
-                  functionResponse: {name: 'greet', response: {name: 'user'}}
+                  functionResponse: {
+                    name: 'greet',
+                    response: { name: 'user' }
+                  }
                 }
               ]
             }

--- a/packages/ai/src/methods/chrome-adapter.ts
+++ b/packages/ai/src/methods/chrome-adapter.ts
@@ -229,8 +229,8 @@ export class ChromeAdapterImpl implements ChromeAdapter {
     }
 
     for (const content of request.contents) {
-      if (content.role === 'function') {
-        logger.debug(`"Function" role rejected for on-device inference.`);
+      if (content.parts.some(part => 'functionResponse' in part)) {
+        logger.debug(`Content with a function response part rejected for on-device inference.`);
         return false;
       }
 

--- a/packages/ai/src/methods/chrome-adapter.ts
+++ b/packages/ai/src/methods/chrome-adapter.ts
@@ -230,7 +230,9 @@ export class ChromeAdapterImpl implements ChromeAdapter {
 
     for (const content of request.contents) {
       if (content.parts.some(part => 'functionResponse' in part)) {
-        logger.debug(`Content with a function response part rejected for on-device inference.`);
+        logger.debug(
+          `Content with a function response part rejected for on-device inference.`
+        );
         return false;
       }
 

--- a/packages/ai/src/requests/request-helpers.ts
+++ b/packages/ai/src/requests/request-helpers.ts
@@ -56,28 +56,26 @@ export function formatNewContent(
 }
 
 /**
- * When multiple Part types (i.e. FunctionResponsePart and TextPart) are
- * passed in a single Part array, we may need to assign different roles to each
- * part. Currently only FunctionResponsePart requires a role other than 'user'.
+ * Validates the parts of a message to ensure that FunctionResponseParts 
+ * are not mixed with other part types in a single request.
+ * All parts are now assigned the 'user' role to comply with 3.6+ model requirements.
  * @private
  * @param parts Array of parts to pass to the model
- * @returns Array of content items
+ * @returns A single Content item formatted for the model
  */
 function assignRoleToPartsAndValidateSendMessageRequest(
   parts: Part[]
 ): Content {
-  const userContent: Content = { role: 'user', parts: [] };
-  const functionContent: Content = { role: 'user', parts: [] };
+  const content: Content = { role: 'user', parts: [] };
   let hasUserContent = false;
   let hasFunctionContent = false;
   for (const part of parts) {
     if ('functionResponse' in part) {
-      functionContent.parts.push(part);
       hasFunctionContent = true;
     } else {
-      userContent.parts.push(part);
       hasUserContent = true;
     }
+    content.parts.push(part);
   }
 
   if (hasUserContent && hasFunctionContent) {
@@ -94,11 +92,7 @@ function assignRoleToPartsAndValidateSendMessageRequest(
     );
   }
 
-  if (hasUserContent) {
-    return userContent;
-  }
-
-  return functionContent;
+  return content;
 }
 
 export function formatGenerateContentInput(

--- a/packages/ai/src/requests/request-helpers.ts
+++ b/packages/ai/src/requests/request-helpers.ts
@@ -56,7 +56,7 @@ export function formatNewContent(
 }
 
 /**
- * Validates the parts of a message to ensure that FunctionResponseParts 
+ * Validates the parts of a message to ensure that FunctionResponseParts
  * are not mixed with other part types in a single request.
  * All parts are now assigned the 'user' role to comply with 3.6+ model requirements.
  * @private

--- a/packages/ai/src/requests/request-helpers.ts
+++ b/packages/ai/src/requests/request-helpers.ts
@@ -67,7 +67,7 @@ function assignRoleToPartsAndValidateSendMessageRequest(
   parts: Part[]
 ): Content {
   const userContent: Content = { role: 'user', parts: [] };
-  const functionContent: Content = { role: 'function', parts: [] };
+  const functionContent: Content = { role: 'user', parts: [] };
   let hasUserContent = false;
   let hasFunctionContent = false;
   for (const part of parts) {


### PR DESCRIPTION
### Bug Description:

Fixed the issue where the SDK hardcodes invalid 'function' role, causing error during function calling on gemini-3.6-flash.

(internal buganizer link): https://b.corp.google.com/issues/544838424

### Code Changes: 

* 1. Role update: Because newer Gemini models (like 3.6-flash) are no longer accepting the `'function'` role and require function responses to be sent under the `'user'` role, the `functionContent` object got updated to assigned the `"user"` role instead of `"function"`. 
* 2. Client-side validation:
Because function responses are now categorized under the `'user'`  role, the SDK's internal `VALID_PARTS_PER_ROLE` dictionary was updated so that the payload doesn't fail local validation before being fetched. 
* 3. Previously, `the isOnDeviceRequest()` check excluded the function responses from on-device inference by explicitly looking for `role === ' function'`. Since these turns are now labeled `'user'`, the routing logic was updated to inspect the actual turn content instead of the role. This then prevents function response requests from being incorrectly routed to the on-device model where they would fail otherwise. 

### Test: 
* Updated the test in `packages/ai/src/methods/chrome-adapter-browser.test.ts` to reflect these changes. 
