### PR TITLE
ci: separate post-release git tagging and github release into a second job

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -126,6 +126,29 @@ jobs:
         $RELEASE_TRACKER_URL/logProduction
       env:
         STEPS_GET_VERSION_OUTPUTS_BASE_VERSION: ${{ steps.get-version.outputs.BASE_VERSION }}
+
+  publish-tags-and-release:
+    environment: release
+    name: Publish Tags & GitHub Release
+    needs: deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - name: Set up node (22)
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7
+      with:
+        node-version: 22.23.2
+    - name: Checkout release branch (with history)
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
+      with:
+        # Release script requires git history and tags.
+        fetch-depth: 0
+        ref: ${{ github.event.inputs.release-branch }}
+        persist-credentials: false
+    - name: Yarn install
+      run: yarn
     # Fetch short-lived token from the GitHub App for 
     # publishing git tags (contents: write)
     # publishing Github release (contents: write, pull-requests: read)
@@ -143,9 +166,7 @@ jobs:
         git config --global user.name "google-oss-bot"
         git config --global user.email "firebase-oss-bot@google.com"
     - name: Publish git tags
-      # This commonly runs into permissions errors. Should not block the rest
-      # of the workflow. But should fail workflow so we notice it. So putting
-      # near the end.
+      # Publishes git tags
       run: yarn ts-node scripts/release/publish-git-tags.ts
       # The script injects this token (generated above) into the git push command
       env:
@@ -183,3 +204,4 @@ jobs:
           --title "$NEWEST_TAG" \
           --notes "$RELEASE_NOTES" \
           --verify-tag
+

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebase/ai",
-  "version": "2.15.0",
+  "version": "2.14.0",
   "description": "The Firebase AI SDK",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "engines": {

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebase/ai",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "description": "The Firebase AI SDK",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "engines": {

--- a/scripts/release/publish-git-tags.ts
+++ b/scripts/release/publish-git-tags.ts
@@ -73,12 +73,12 @@ async function createTags(dryRun: boolean): Promise<string[]> {
         mainJson.version !== releaseJson.version
       ) {
         const tag = `${releaseJson.name}@${releaseJson.version}`;
-        tags.push(tag);
         const { stdout: tagExistOutput } = await exec(`git tag -l ${tag}`, {
           cwd: projectRoot
         });
         if (!tagExistOutput.trim()) {
           console.log(`Adding tag: ${tag}`);
+          tags.push(tag);
           if (!dryRun) {
             await exec(`git tag ${tag}`, { cwd: projectRoot });
           }
@@ -110,11 +110,11 @@ async function pushReleaseTagsToGithub() {
     console.warn('Warning: Failed to fetch tags from origin.', err);
   }
 
-  console.log('Diffing tags in this branch vs origin/main.');
+  console.log('Diffing versions in this branch vs origin/main.');
   const tags = await createTags(dryRun);
 
-  if (!tags || tags.length === 0) {
-    console.error('No tags found or added. Exiting.');
+  if (tags.length === 0) {
+    console.error('No tags added. Exiting.');
     process.exit(1);
   }
 

--- a/scripts/release/publish-git-tags.ts
+++ b/scripts/release/publish-git-tags.ts
@@ -17,21 +17,44 @@
 
 import { exec } from 'child-process-promise';
 import { projectRoot as root } from '../utils';
+import { getAllPackages, mapPkgNameToPkgJson } from './utils/workspace';
 
 async function pushReleaseTagsToGithub() {
+  let tags;
+  let { stdout: currentBranch } = await exec(`git rev-parse --abbrev-ref HEAD`);
+  currentBranch = currentBranch.trim();
   // Get tags pointing to HEAD
   // When running the release script, these tags should be release tags created by changeset
   const { stdout: rawTags } = await exec(`git tag --points-at HEAD`);
 
-  if (!rawTags.trim()) {
-    console.error('No tags found pointing to HEAD.');
-    process.exit(1);
+  if (rawTags.trim()) {
+    tags = rawTags.split(/\r?\n/);
+  } else {
+    console.log(
+      'No tags found pointing to HEAD. Diffing tags in this branch vs main.'
+    );
+    const pkgNames = await getAllPackages();
+    const mainVersions = new Map();
+    await exec('git checkout main');
+    await exec('git pull origin main');
+    for (const pkgName of pkgNames) {
+      const json = await mapPkgNameToPkgJson(pkgName);
+      mainVersions.set(pkgName, json.version);
+    }
+    await exec(`git checkout ${currentBranch}`);
+    for (const pkgName of pkgNames) {
+      const json = await mapPkgNameToPkgJson(pkgName);
+      if (mainVersions.get(pkgName) !== json.version) {
+        console.log('diff found');
+        const tag = `${pkgName}@${json.version}`;
+        const tagExists = await exec(`git tag -l ${tag}`);
+        if (!tagExists) {
+          console.log('going to tag', tag);
+          // await exec(`git tag ${tag}`);
+        }
+      }
+    }
   }
-
-  const tags = rawTags.split(/\r?\n/);
-
-  let { stdout: currentBranch } = await exec(`git rev-parse --abbrev-ref HEAD`);
-  currentBranch = currentBranch.trim();
 
   const token = process.env.GITHUB_TOKEN;
   if (!token) {
@@ -39,17 +62,17 @@ async function pushReleaseTagsToGithub() {
     process.exit(1);
   }
 
-  const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
+  // const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
 
-  await exec(
-    'git -c http.extraHeader="Authorization: Basic ' +
-      authHeader +
-      '"' +
-      ` push origin ${currentBranch} ${tags.join(' ')} --no-verify`,
-    {
-      cwd: root
-    }
-  );
+  // await exec(
+  //   'git -c http.extraHeader="Authorization: Basic ' +
+  //     authHeader +
+  //     '"' +
+  //     ` push origin ${currentBranch} ${tags.join(' ')} --no-verify`,
+  //   {
+  //     cwd: root
+  //   }
+  // );
 }
 
 pushReleaseTagsToGithub();

--- a/scripts/release/publish-git-tags.ts
+++ b/scripts/release/publish-git-tags.ts
@@ -18,27 +18,35 @@
 import { exec } from 'child-process-promise';
 import { projectRoot } from '../utils';
 import { join } from 'path';
-import { existsSync, readdirSync } from 'fs';
+import { existsSync, readdirSync, readFileSync } from 'fs';
 
-async function createTags(currentBranch: string) {
-  let tags = [];
+async function createTags(): Promise<string[]> {
+  const tags: string[] = [];
   const dirs = readdirSync(join(projectRoot, 'packages'));
   for (const dir of dirs) {
-    const pkgPath = join('packages', dir, 'package.json');
-    if (existsSync(pkgPath)) {
-      const { stdout: mainText } = await exec(`git show main:${pkgPath}`);
-      const mainJson = JSON.parse(mainText);
-      const { stdout: releaseText } = await exec(
-        `git show ${currentBranch}:${pkgPath}`
-      );
-      const releaseJson = JSON.parse(releaseText);
+    const fullPkgPath = join(projectRoot, 'packages', dir, 'package.json');
+    if (existsSync(fullPkgPath)) {
+      const pkgPath = join('packages', dir, 'package.json');
+      let mainJson: Record<string, any> = {};
+      try {
+        const { stdout: mainText } = await exec(
+          `git show origin/main:${pkgPath}`,
+          { cwd: projectRoot }
+        );
+        mainJson = JSON.parse(mainText);
+      } catch {
+        mainJson = {};
+      }
+      const releaseJson = JSON.parse(readFileSync(fullPkgPath, 'utf8'));
       if (!releaseJson.private && mainJson.version !== releaseJson.version) {
         const tag = `${releaseJson.name}@${releaseJson.version}`;
-        const { stdout: tagExistOutput } = await exec(`git tag -l ${tag}`);
+        const { stdout: tagExistOutput } = await exec(`git tag -l ${tag}`, {
+          cwd: projectRoot
+        });
         if (!tagExistOutput.trim()) {
           console.log(`Adding tag: ${tag}`);
           tags.push(tag);
-          await exec(`git tag ${tag}`);
+          await exec(`git tag ${tag}`, { cwd: projectRoot });
         }
       }
     }
@@ -48,23 +56,34 @@ async function createTags(currentBranch: string) {
 
 async function pushReleaseTagsToGithub() {
   let tags: string[] = [];
-  let { stdout: currentBranch } = await exec(`git rev-parse --abbrev-ref HEAD`);
+  let { stdout: currentBranch } = await exec(
+    `git rev-parse --abbrev-ref HEAD`,
+    {
+      cwd: projectRoot
+    }
+  );
   currentBranch = currentBranch.trim();
 
   // Get tags pointing to HEAD
   // When running the release script, these tags should be release tags created by changeset
-  const { stdout: rawTags } = await exec(`git tag --points-at HEAD`);
+  const { stdout: rawTags } = await exec(`git tag --points-at HEAD`, {
+    cwd: projectRoot
+  });
 
   if (rawTags.trim()) {
-    tags = rawTags.split(/\r?\n/);
+    tags = rawTags.trim().split(/\r?\n/).filter(Boolean);
   } else {
+    // This can happen if the workflow was interrupted but the npm publish was partially
+    // or entirely complete, so the git tags will not be regenerated on the second
+    // run. In this case, diff against origin/main package.jsons to see which packages had
+    // version bumps and require new tags, and create them.
     console.log(
-      'No tags found pointing to HEAD. Diffing tags in this branch vs main.'
+      'No tags found pointing to HEAD. Diffing tags in this branch vs origin/main.'
     );
-    tags = await createTags(currentBranch);
+    tags = await createTags();
   }
 
-  if (!tags) {
+  if (!tags || tags.length === 0) {
     console.error('No tags found or added. Exiting.');
     process.exit(1);
   }

--- a/scripts/release/publish-git-tags.ts
+++ b/scripts/release/publish-git-tags.ts
@@ -48,6 +48,7 @@ async function pushReleaseTagsToGithub() {
         console.log('diff found');
         const tag = `${pkgName}@${json.version}`;
         const tagExists = await exec(`git tag -l ${tag}`);
+        console.log(tag, 'exists');
         if (!tagExists) {
           console.log('going to tag', tag);
           // await exec(`git tag ${tag}`);

--- a/scripts/release/publish-git-tags.ts
+++ b/scripts/release/publish-git-tags.ts
@@ -37,7 +37,12 @@ async function createTags(dryRun: boolean): Promise<string[]> {
   } catch {
     try {
       console.log('origin/main not found locally. Fetching...');
-      await exec('git fetch origin main --depth=1', { cwd: projectRoot });
+      // Fetch only the latest commit of main and explicitly map it to
+      // refs/remotes/origin/main so git show origin/main:<pkgPath> can resolve it.
+      await exec('git fetch origin main:refs/remotes/origin/main --depth=1', {
+        cwd: projectRoot
+      });
+      await exec('git rev-parse --verify origin/main', { cwd: projectRoot });
     } catch (err) {
       throw new Error(
         'Unable to resolve origin/main and failed to fetch it. Error: ' + err

--- a/scripts/release/publish-git-tags.ts
+++ b/scripts/release/publish-git-tags.ts
@@ -40,8 +40,7 @@ async function createTags(dryRun: boolean): Promise<string[]> {
       await exec('git fetch origin main --depth=1', { cwd: projectRoot });
     } catch (err) {
       throw new Error(
-        'Unable to resolve origin/main and failed to fetch it. Error: ' +
-        err
+        'Unable to resolve origin/main and failed to fetch it. Error: ' + err
       );
     }
   }
@@ -69,12 +68,12 @@ async function createTags(dryRun: boolean): Promise<string[]> {
         mainJson.version !== releaseJson.version
       ) {
         const tag = `${releaseJson.name}@${releaseJson.version}`;
+        tags.push(tag);
         const { stdout: tagExistOutput } = await exec(`git tag -l ${tag}`, {
           cwd: projectRoot
         });
         if (!tagExistOutput.trim()) {
           console.log(`Adding tag: ${tag}`);
-          tags.push(tag);
           if (!dryRun) {
             await exec(`git tag ${tag}`, { cwd: projectRoot });
           }
@@ -91,7 +90,6 @@ async function pushReleaseTagsToGithub() {
     console.log('Running in dry-run mode. No tags will be created or pushed.');
   }
 
-  let tags: string[] = [];
   let { stdout: currentBranch } = await exec(
     `git rev-parse --abbrev-ref HEAD`,
     {
@@ -107,24 +105,8 @@ async function pushReleaseTagsToGithub() {
     console.warn('Warning: Failed to fetch tags from origin.', err);
   }
 
-  // Get tags pointing to HEAD
-  // When running the release script, these tags should be release tags created by changeset
-  const { stdout: rawTags } = await exec(`git tag --points-at HEAD`, {
-    cwd: projectRoot
-  });
-
-  if (rawTags.trim()) {
-    tags = rawTags.trim().split(/\r?\n/).filter(Boolean);
-  } else {
-    // This can happen if the workflow was interrupted but the npm publish was partially
-    // or entirely complete, so the git tags will not be regenerated on the second
-    // run. In this case, diff against origin/main package.jsons to see which packages had
-    // version bumps and require new tags, and create them.
-    console.log(
-      'No tags found pointing to HEAD. Diffing tags in this branch vs origin/main.'
-    );
-    tags = await createTags(dryRun);
-  }
+  console.log('Diffing tags in this branch vs origin/main.');
+  const tags = await createTags(dryRun);
 
   if (!tags || tags.length === 0) {
     console.error('No tags found or added. Exiting.');
@@ -149,9 +131,9 @@ async function pushReleaseTagsToGithub() {
 
   await exec(
     'git -c http.extraHeader="Authorization: Basic ' +
-    authHeader +
-    '"' +
-    ` push origin ${currentBranch} ${tags.join(' ')} --no-verify`,
+      authHeader +
+      '"' +
+      ` push origin ${currentBranch} ${tags.join(' ')} --no-verify`,
     {
       cwd: projectRoot
     }

--- a/scripts/release/publish-git-tags.ts
+++ b/scripts/release/publish-git-tags.ts
@@ -40,8 +40,8 @@ async function createTags(dryRun: boolean): Promise<string[]> {
       await exec('git fetch origin main --depth=1', { cwd: projectRoot });
     } catch (err) {
       throw new Error(
-        'Unable to resolve origin/main and failed to fetch it. Aborting to prevent incorrect tagging. Error: ' +
-          err
+        'Unable to resolve origin/main and failed to fetch it. Error: ' +
+        err
       );
     }
   }
@@ -149,13 +149,16 @@ async function pushReleaseTagsToGithub() {
 
   await exec(
     'git -c http.extraHeader="Authorization: Basic ' +
-      authHeader +
-      '"' +
-      ` push origin ${currentBranch} ${tags.join(' ')} --no-verify`,
+    authHeader +
+    '"' +
+    ` push origin ${currentBranch} ${tags.join(' ')} --no-verify`,
     {
       cwd: projectRoot
     }
   );
 }
 
-pushReleaseTagsToGithub();
+pushReleaseTagsToGithub().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/release/publish-git-tags.ts
+++ b/scripts/release/publish-git-tags.ts
@@ -16,13 +16,41 @@
  */
 
 import { exec } from 'child-process-promise';
-import { projectRoot as root } from '../utils';
-import { getAllPackages, mapPkgNameToPkgJson } from './utils/workspace';
+import { projectRoot } from '../utils';
+import { join } from 'path';
+import { existsSync, readdirSync } from 'fs';
+
+async function createTags(currentBranch: string) {
+  let tags = [];
+  const dirs = readdirSync(join(projectRoot, 'packages'));
+  for (const dir of dirs) {
+    const pkgPath = join('packages', dir, 'package.json');
+    if (existsSync(pkgPath)) {
+      const { stdout: mainText } = await exec(`git show main:${pkgPath}`);
+      const mainJson = JSON.parse(mainText);
+      const { stdout: releaseText } = await exec(
+        `git show ${currentBranch}:${pkgPath}`
+      );
+      const releaseJson = JSON.parse(releaseText);
+      if (!releaseJson.private && mainJson.version !== releaseJson.version) {
+        const tag = `${releaseJson.name}@${releaseJson.version}`;
+        const { stdout: tagExistOutput } = await exec(`git tag -l ${tag}`);
+        if (!tagExistOutput.trim()) {
+          console.log(`Adding tag: ${tag}`);
+          tags.push(tag);
+          await exec(`git tag ${tag}`);
+        }
+      }
+    }
+  }
+  return tags;
+}
 
 async function pushReleaseTagsToGithub() {
-  let tags;
+  let tags: string[] = [];
   let { stdout: currentBranch } = await exec(`git rev-parse --abbrev-ref HEAD`);
   currentBranch = currentBranch.trim();
+
   // Get tags pointing to HEAD
   // When running the release script, these tags should be release tags created by changeset
   const { stdout: rawTags } = await exec(`git tag --points-at HEAD`);
@@ -33,28 +61,12 @@ async function pushReleaseTagsToGithub() {
     console.log(
       'No tags found pointing to HEAD. Diffing tags in this branch vs main.'
     );
-    const pkgNames = await getAllPackages();
-    const mainVersions = new Map();
-    await exec('git checkout main');
-    await exec('git pull origin main');
-    for (const pkgName of pkgNames) {
-      const json = await mapPkgNameToPkgJson(pkgName);
-      mainVersions.set(pkgName, json.version);
-    }
-    await exec(`git checkout ${currentBranch}`);
-    for (const pkgName of pkgNames) {
-      const json = await mapPkgNameToPkgJson(pkgName);
-      if (mainVersions.get(pkgName) !== json.version) {
-        console.log('diff found');
-        const tag = `${pkgName}@${json.version}`;
-        const tagExists = await exec(`git tag -l ${tag}`);
-        console.log(tag, 'exists');
-        if (!tagExists) {
-          console.log('going to tag', tag);
-          // await exec(`git tag ${tag}`);
-        }
-      }
-    }
+    tags = await createTags(currentBranch);
+  }
+
+  if (!tags) {
+    console.error('No tags found or added. Exiting.');
+    process.exit(1);
   }
 
   const token = process.env.GITHUB_TOKEN;
@@ -63,17 +75,17 @@ async function pushReleaseTagsToGithub() {
     process.exit(1);
   }
 
-  // const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
+  const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
 
-  // await exec(
-  //   'git -c http.extraHeader="Authorization: Basic ' +
-  //     authHeader +
-  //     '"' +
-  //     ` push origin ${currentBranch} ${tags.join(' ')} --no-verify`,
-  //   {
-  //     cwd: root
-  //   }
-  // );
+  await exec(
+    'git -c http.extraHeader="Authorization: Basic ' +
+      authHeader +
+      '"' +
+      ` push origin ${currentBranch} ${tags.join(' ')} --no-verify`,
+    {
+      cwd: projectRoot
+    }
+  );
 }
 
 pushReleaseTagsToGithub();

--- a/scripts/release/publish-git-tags.ts
+++ b/scripts/release/publish-git-tags.ts
@@ -19,8 +19,33 @@ import { exec } from 'child-process-promise';
 import { projectRoot } from '../utils';
 import { join } from 'path';
 import { existsSync, readdirSync, readFileSync } from 'fs';
+import * as yargs from 'yargs';
 
-async function createTags(): Promise<string[]> {
+const argv = yargs
+  .options({
+    dryRun: {
+      type: 'boolean',
+      default: false,
+      desc: 'Log tags to be created and pushed without creating tags or pushing anywhere.'
+    }
+  })
+  .parseSync();
+
+async function createTags(dryRun: boolean): Promise<string[]> {
+  try {
+    await exec('git rev-parse --verify origin/main', { cwd: projectRoot });
+  } catch {
+    try {
+      console.log('origin/main not found locally. Fetching...');
+      await exec('git fetch origin main --depth=1', { cwd: projectRoot });
+    } catch (err) {
+      throw new Error(
+        'Unable to resolve origin/main and failed to fetch it. Aborting to prevent incorrect tagging. Error: ' +
+          err
+      );
+    }
+  }
+
   const tags: string[] = [];
   const dirs = readdirSync(join(projectRoot, 'packages'));
   for (const dir of dirs) {
@@ -38,7 +63,11 @@ async function createTags(): Promise<string[]> {
         mainJson = {};
       }
       const releaseJson = JSON.parse(readFileSync(fullPkgPath, 'utf8'));
-      if (!releaseJson.private && mainJson.version !== releaseJson.version) {
+      if (
+        !releaseJson.private &&
+        releaseJson.version &&
+        mainJson.version !== releaseJson.version
+      ) {
         const tag = `${releaseJson.name}@${releaseJson.version}`;
         const { stdout: tagExistOutput } = await exec(`git tag -l ${tag}`, {
           cwd: projectRoot
@@ -46,7 +75,9 @@ async function createTags(): Promise<string[]> {
         if (!tagExistOutput.trim()) {
           console.log(`Adding tag: ${tag}`);
           tags.push(tag);
-          await exec(`git tag ${tag}`, { cwd: projectRoot });
+          if (!dryRun) {
+            await exec(`git tag ${tag}`, { cwd: projectRoot });
+          }
         }
       }
     }
@@ -55,6 +86,11 @@ async function createTags(): Promise<string[]> {
 }
 
 async function pushReleaseTagsToGithub() {
+  const dryRun = argv.dryRun;
+  if (dryRun) {
+    console.log('Running in dry-run mode. No tags will be created or pushed.');
+  }
+
   let tags: string[] = [];
   let { stdout: currentBranch } = await exec(
     `git rev-parse --abbrev-ref HEAD`,
@@ -63,6 +99,13 @@ async function pushReleaseTagsToGithub() {
     }
   );
   currentBranch = currentBranch.trim();
+
+  // Fetch tags from remote to ensure we have the latest tags locally
+  try {
+    await exec('git fetch origin --tags', { cwd: projectRoot });
+  } catch (err) {
+    console.warn('Warning: Failed to fetch tags from origin.', err);
+  }
 
   // Get tags pointing to HEAD
   // When running the release script, these tags should be release tags created by changeset
@@ -80,12 +123,20 @@ async function pushReleaseTagsToGithub() {
     console.log(
       'No tags found pointing to HEAD. Diffing tags in this branch vs origin/main.'
     );
-    tags = await createTags();
+    tags = await createTags(dryRun);
   }
 
   if (!tags || tags.length === 0) {
     console.error('No tags found or added. Exiting.');
     process.exit(1);
+  }
+
+  if (dryRun) {
+    console.log(
+      `[DRY RUN] Would push branch '${currentBranch}' and tags to origin:`
+    );
+    console.log(tags.join('\n'));
+    return;
   }
 
   const token = process.env.GITHUB_TOKEN;


### PR DESCRIPTION
Separated the post-publish git tagging and Github release tasks into a second job that can be re-run without having to go through the npm publish step. This enables rerunning just the git tagging and github release steps if a prod workflow failed during npm publish or shortly after.

- Rewrote git tagging script to create the git tags after publish is complete by looking at the version diffs on release branch vs main.
- This won't work if you've already merged release to main.
- Added a dry-run flag for testing and debugging.