### PR TITLE
fix(database): use the priority index for child event snapshots

### DIFF
--- a/.changeset/rtdb-child-event-snapshot-index.md
+++ b/.changeset/rtdb-child-event-snapshot-index.md
@@ -1,0 +1,5 @@
+---
+'@firebase/database': patch
+---
+
+Fix `DataSnapshot.forEach()` throwing `No index defined for <path>` on snapshots delivered to `onChildAdded()`, `onChildChanged()`, and `onChildMoved()` listeners registered on an `orderByChild()` or `orderByValue()` query. Child event snapshots now iterate their own children by priority, matching `get()` and nested `forEach()` snapshots; the query's index continues to order the children of the queried location.

--- a/packages/database/src/api/Reference_impl.ts
+++ b/packages/database/src/api/Reference_impl.ts
@@ -915,11 +915,15 @@ export class ChildEventRegistration implements EventRegistration {
       new ReferenceImpl(query._repo, query._path),
       change.childName
     );
-    const index = query._queryParams.getIndex();
+    // The query's index orders the children of the queried location, not the
+    // children of an individual child. `change.snapshotNode` is one of those
+    // children, so it is indexed by priority like any other nested snapshot --
+    // using the query index here would make `forEach()` look up an index that
+    // the child node does not maintain.
     return new DataEvent(
       change.type as EventType,
       this,
-      new DataSnapshot(change.snapshotNode, childRef, index),
+      new DataSnapshot(change.snapshotNode, childRef, PRIORITY_INDEX),
       change.prevName
     );
   }

--- a/packages/database/test/childevent.test.ts
+++ b/packages/database/test/childevent.test.ts
@@ -64,12 +64,19 @@ describe('Child event snapshots', () => {
    * callback: `onChildAdded` dispatches synchronously when the location is
    * already cached, and in that case the callback runs before `unsubscribe`
    * has been bound.
+   *
+   * A cancelled listener rejects rather than leaving the promise pending, so
+   * a failure surfaces as the underlying error instead of a test timeout.
    */
   async function firstChildAdded(q: Query): Promise<DataSnapshot> {
     let unsubscribe: (() => void) | undefined;
     try {
-      return await new Promise<DataSnapshot>(resolve => {
-        unsubscribe = onChildAdded(q, snapshot => resolve(snapshot));
+      return await new Promise<DataSnapshot>((resolve, reject) => {
+        unsubscribe = onChildAdded(
+          q,
+          snapshot => resolve(snapshot),
+          error => reject(error)
+        );
       });
     } finally {
       unsubscribe?.();

--- a/packages/database/test/childevent.test.ts
+++ b/packages/database/test/childevent.test.ts
@@ -1,0 +1,149 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { deleteApp, FirebaseApp } from '@firebase/app';
+import { expect } from 'chai';
+
+import {
+  DataSnapshot,
+  Query,
+  getDatabase,
+  goOffline,
+  onChildAdded,
+  orderByChild,
+  orderByValue,
+  query,
+  ref,
+  set
+} from '../src';
+
+import { createTestApp } from './exp/integration.test';
+
+/**
+ * Exercises the snapshots handed to child event listeners (`onChildAdded` and
+ * friends) for queries that use an explicit `orderBy*()`.
+ *
+ * These run entirely against the local cache: `goOffline()` is called before
+ * any write, so listeners fire from the locally applied `set()` and no
+ * emulator or network access is needed. Because the client is offline the
+ * promise returned by `set()` stays pending until a server ack that never
+ * arrives, so it is deliberately not awaited.
+ */
+describe('Child event snapshots', () => {
+  let app: FirebaseApp;
+
+  beforeEach(() => {
+    app = createTestApp();
+  });
+
+  afterEach(async () => {
+    if (app) {
+      await deleteApp(app);
+    }
+  });
+
+  /**
+   * Resolves with the first snapshot delivered to a child_added listener on
+   * `q`, then unsubscribes.
+   */
+  function firstChildAdded(q: Query): Promise<DataSnapshot> {
+    return new Promise<DataSnapshot>(resolve => {
+      const unsubscribe = onChildAdded(q, snapshot => {
+        unsubscribe();
+        resolve(snapshot);
+      });
+    });
+  }
+
+  /** Applies a write to the local cache without waiting for a server ack. */
+  function writeLocally(location: ReturnType<typeof ref>, value: unknown) {
+    // The returned promise only settles once the client reconnects, and is
+    // rejected when the app is torn down in `afterEach`. Neither is
+    // interesting here, so the result is intentionally discarded.
+    set(location, value).catch(() => {});
+  }
+
+  it('supports forEach() on child_added snapshots from an orderByChild() query', async () => {
+    const db = getDatabase(app);
+    goOffline(db);
+
+    const itemsRef = ref(db, 'items');
+    const snapshotPromise = firstChildAdded(
+      query(itemsRef, orderByChild('createdAt'))
+    );
+
+    writeLocally(itemsRef, {
+      item1: { createdAt: 1741445778252, name: 'first' }
+    });
+
+    const snapshot = await snapshotPromise;
+
+    const seen: Array<[string | null, unknown]> = [];
+    expect(() =>
+      snapshot.forEach(child => {
+        seen.push([child.key, child.val()]);
+      })
+    ).to.not.throw();
+    expect(seen).to.deep.equal([
+      ['createdAt', 1741445778252],
+      ['name', 'first']
+    ]);
+  });
+
+  it('supports forEach() on child_added snapshots from an orderByValue() query', async () => {
+    const db = getDatabase(app);
+    goOffline(db);
+
+    const scoresRef = ref(db, 'scores');
+    const snapshotPromise = firstChildAdded(query(scoresRef, orderByValue()));
+
+    writeLocally(scoresRef, { player1: { a: 1, b: 2 } });
+
+    const snapshot = await snapshotPromise;
+
+    const keys: Array<string | null> = [];
+    expect(() =>
+      snapshot.forEach(child => {
+        keys.push(child.key);
+      })
+    ).to.not.throw();
+    expect(keys).to.deep.equal(['a', 'b']);
+  });
+
+  it('orders the children of a child_added snapshot by key, not by the query index', async () => {
+    const db = getDatabase(app);
+    goOffline(db);
+
+    const itemsRef = ref(db, 'ordered');
+    const snapshotPromise = firstChildAdded(
+      query(itemsRef, orderByChild('createdAt'))
+    );
+
+    // `zebra` sorts last by key, which is the ordering a snapshot of `item1`
+    // should use -- the query's `createdAt` index applies to the children of
+    // `ordered`, not to the fields of `item1`.
+    writeLocally(itemsRef, { item1: { createdAt: 3, apple: 1, zebra: 2 } });
+
+    const snapshot = await snapshotPromise;
+
+    const keys: Array<string | null> = [];
+    snapshot.forEach(child => {
+      keys.push(child.key);
+    });
+    expect(keys).to.deep.equal(['apple', 'createdAt', 'zebra']);
+  });
+});

--- a/packages/database/test/childevent.test.ts
+++ b/packages/database/test/childevent.test.ts
@@ -59,14 +59,21 @@ describe('Child event snapshots', () => {
   /**
    * Resolves with the first snapshot delivered to a child_added listener on
    * `q`, then unsubscribes.
+   *
+   * The listener is torn down from `finally` rather than from inside the
+   * callback: `onChildAdded` dispatches synchronously when the location is
+   * already cached, and in that case the callback runs before `unsubscribe`
+   * has been bound.
    */
-  function firstChildAdded(q: Query): Promise<DataSnapshot> {
-    return new Promise<DataSnapshot>(resolve => {
-      const unsubscribe = onChildAdded(q, snapshot => {
-        unsubscribe();
-        resolve(snapshot);
+  async function firstChildAdded(q: Query): Promise<DataSnapshot> {
+    let unsubscribe: (() => void) | undefined;
+    try {
+      return await new Promise<DataSnapshot>(resolve => {
+        unsubscribe = onChildAdded(q, snapshot => resolve(snapshot));
       });
-    });
+    } finally {
+      unsubscribe?.();
+    }
   }
 
   /** Applies a write to the local cache without waiting for a server ack. */


### PR DESCRIPTION
Fixes #9266. Root cause and reasoning were written up in [this comment](https://github.com/firebase/firebase-js-sdk/issues/9266#issuecomment-5363108940) on the issue first; summarizing here.

### Problem

`snapshot.forEach()` throws `Error: No index defined for <path>` on snapshots delivered to `onChildAdded()` (and the other child event types) when the listener is registered on an `orderByChild()` or `orderByValue()` query:

```
Error: No index defined for createdAt
    at IndexMap.get (src/core/snap/IndexMap.ts:60)
    at ChildrenNode.resolveIndex_ (src/core/snap/ChildrenNode.ts:463)
    at ChildrenNode.forEachChild (src/core/snap/ChildrenNode.ts:318)
    at DataSnapshot.forEach (src/api/Reference_impl.ts:403)
```

`ChildEventRegistration.createEvent` built the event's `DataSnapshot` with the **query's** index, but `change.snapshotNode` is the *child* node — and that node's `IndexMap` never had the query's index built, because the index is maintained on the queried location whose children the query orders.

The query index is also the wrong ordering for that snapshot. `orderByChild('createdAt')` defines the order of the children of `items`, not the order of the *fields* of `items/item1`. `DataSnapshot._index` is read in exactly one place — `forEach()` — so the query index served no other purpose on a child event snapshot.

This is not a regression from the modular rewrite; the same `query.getQueryParams().getIndex()` was in the v8 `core/view/EventRegistration.ts`.

### Fix

Use `PRIORITY_INDEX` for child event snapshots. This aligns with what every comparable snapshot already does rather than introducing new semantics:

- `QueryParams.index_` defaults to `PRIORITY_INDEX`, so child events from a **non-query** ref already use it — which is why this only reproduces once an `orderBy*()` is added. **The default path is unchanged.**
- `DataSnapshot.forEach()` already constructs its own children with `PRIORITY_INDEX` (`Reference_impl.ts:405`), as does `Transaction.ts`.
- It matches `get(snapshot.ref)`, the workaround reported in the issue.
- It matches the Android SDK, where `Change.childAddedChange(...)` wraps the node with `IndexedNode.from(node)`.

### Scope

Only `orderByChild()` and `orderByValue()` were affected. `orderByKey()` short-circuits to `null` in `resolveIndex_`, and `orderByPriority()` is always present in the default `IndexMap`, so neither ever threw.

One observable edge case worth flagging for review: if a child node *happened* to already have the query's index built (e.g. from a separate query at that deeper location), `forEach()` previously ordered that child's fields by the query index rather than throwing. That ordering was incoherent, so this change does not preserve it.

### Testing

Added `packages/database/test/childevent.test.ts`, which reproduces the issue offline — it calls `goOffline()` before writing, as in the original report, so the listener fires from the local cache and no emulator or network is needed. Note `set()` is intentionally not awaited there, since offline it stays pending until an ack that never arrives.

Coverage: `orderByChild()`, `orderByValue()`, and a case asserting the child's own fields come back in key order rather than in query-index order.

- Without the fix: fails with `No index defined for createdAt` and `No index defined for .value`.
- With the fix: passes.
- Full `packages/database` Node suite against the RTDB emulator: **269 passing, 4 pending, 0 failing.**
- `prettier` and `eslint` clean on the changed files.

No public API surface changes.
