### PR TITLE
fix(auth): fix indexeddb popup connection closing and error recovery (#10318)

### DIFF
--- a/.changeset/auth-indexeddb-popup-10318.md
+++ b/.changeset/auth-indexeddb-popup-10318.md
@@ -1,0 +1,5 @@
+---
+'@firebase/auth': patch
+---
+
+Allow IndexedDB persistence reconnection on demand after `pagehide` events, fixing `Database is closing` errors during `signInWithPopup` authentication on iPadOS and iOS Safari.

--- a/packages/auth/src/platform_browser/persistence/indexed_db.test.ts
+++ b/packages/auth/src/platform_browser/persistence/indexed_db.test.ts
@@ -514,9 +514,11 @@ describe('platform_browser/persistence/indexed_db', () => {
         }
       )._openDb();
       expect(openedDb).to.be.ok;
+      openedDb.close();
     });
 
     it('should allow persistence operations to succeed after pagehide', async () => {
+      persistence._addListener(key, callback);
       await persistence._set(key, value);
       window.dispatchEvent(new Event('pagehide'));
       expect((persistence as any).isClosing).to.be.true;

--- a/packages/auth/src/platform_browser/persistence/indexed_db.test.ts
+++ b/packages/auth/src/platform_browser/persistence/indexed_db.test.ts
@@ -506,6 +506,28 @@ describe('platform_browser/persistence/indexed_db', () => {
       expect(await persistence._get(key)).to.eq('another-value');
     });
 
+    it('should allow _openDb() to resolve and open database even when isClosing is true', async () => {
+      (persistence as any).isClosing = true;
+      const openedDb = await (
+        persistence as unknown as {
+          _openDb(): Promise<IDBDatabase>;
+        }
+      )._openDb();
+      expect(openedDb).to.be.ok;
+    });
+
+    it('should allow persistence operations to succeed after pagehide', async () => {
+      await persistence._set(key, value);
+      window.dispatchEvent(new Event('pagehide'));
+      expect((persistence as any).isClosing).to.be.true;
+
+      // Persistence operations should succeed by reopening connection
+      await persistence._set(key, 'value-after-pagehide');
+      expect(await persistence._get(key)).to.eq('value-after-pagehide');
+      await persistence._remove(key);
+      expect(await persistence._get(key)).to.be.null;
+    });
+
     it('should discard in-flight poll results if pagehide occurs before poll completes', async () => {
       // 1. Seed local cache and listener
       await persistence._set(key, value);

--- a/packages/auth/src/platform_browser/persistence/indexed_db.ts
+++ b/packages/auth/src/platform_browser/persistence/indexed_db.ts
@@ -246,11 +246,12 @@ class IndexedDBLocalPersistence implements InternalPersistence {
           throw e;
         }
         if (this.dbPromise) {
+          const dbPromise = this.dbPromise;
+          this.dbPromise = null;
           try {
-            const db = await this.dbPromise;
+            const db = await dbPromise;
             db.close();
           } catch {}
-          this.dbPromise = null;
         }
         // TODO: consider adding exponential backoff
       }

--- a/packages/auth/src/platform_browser/persistence/indexed_db.ts
+++ b/packages/auth/src/platform_browser/persistence/indexed_db.ts
@@ -224,9 +224,6 @@ class IndexedDBLocalPersistence implements InternalPersistence {
   }
 
   async _openDb(): Promise<IDBDatabase> {
-    if (this.isClosing) {
-      throw new Error('Database is closing');
-    }
     if (this.dbPromise) {
       return this.dbPromise;
     }
@@ -245,15 +242,14 @@ class IndexedDBLocalPersistence implements InternalPersistence {
         const db = await this._openDb();
         return await op(db);
       } catch (e) {
-        if (this.isClosing) {
-          throw e;
-        }
         if (numAttempts++ > _TRANSACTION_RETRY_COUNT) {
           throw e;
         }
         if (this.dbPromise) {
-          const db = await this.dbPromise;
-          db.close();
+          try {
+            const db = await this.dbPromise;
+            db.close();
+          } catch {}
           this.dbPromise = null;
         }
         // TODO: consider adding exponential backoff


### PR DESCRIPTION
Fixes #10318

On iPadOS and iOS Safari, opening a popup window (e.g. via signInWithPopup) fires a pagehide event on the opener page. Previously, this set isClosing = true and caused _openDb() to throw Error: Database is closing, breaking the post-popup credential persistence.
This PR:
- Allows _openDb() and _withRetries() to reconnect on demand if a write occurs after pagehide.
- Resets isClosing = false on pageshow.
- Preserves background polling suppression during page teardown to avoid regressions on #10041.