### PR TITLE
fix(auth): add persistence fallback and error boundary to auth initialization (#10311)

### DIFF
--- a/.changeset/auth-persistence-fallback-10311.md
+++ b/.changeset/auth-persistence-fallback-10311.md
@@ -1,0 +1,5 @@
+---
+'@firebase/auth': patch
+---
+
+Gracefully fall back to in-memory persistence when persistence initialization fails or storage is inaccessible, preventing initialization deadlocks and ensuring `authStateReady()` resolves.

--- a/packages/auth/src/core/auth/auth_impl.test.ts
+++ b/packages/auth/src/core/auth/auth_impl.test.ts
@@ -33,7 +33,7 @@ import {
 } from '../../../test/helpers/mock_auth';
 import { AuthInternal } from '../../model/auth';
 import { UserInternal } from '../../model/user';
-import { PersistenceInternal } from '../persistence';
+import { PersistenceInternal, PersistenceType } from '../persistence';
 import { inMemoryPersistence } from '../persistence/in_memory';
 import { _getInstance } from '../util/instantiator';
 import * as navigator from '../util/navigator';
@@ -1154,6 +1154,132 @@ describe('core/auth/auth_impl', () => {
             throw new Error(error);
           });
       }, 10000);
+    });
+  });
+
+  describe('_initializeWithPersistence error boundaries and fallbacks', () => {
+    it('falls back to in-memory persistence when persistence manager creation fails', async () => {
+      const authImpl = new AuthImpl(
+        FAKE_APP,
+        FAKE_HEARTBEAT_CONTROLLER_PROVIDER,
+        FAKE_APP_CHECK_CONTROLLER_PROVIDER,
+        {
+          apiKey: FAKE_APP.options.apiKey!,
+          apiHost: DefaultConfig.API_HOST,
+          apiScheme: DefaultConfig.API_SCHEME,
+          tokenApiHost: DefaultConfig.TOKEN_API_HOST,
+          clientPlatform: ClientPlatform.BROWSER,
+          sdkClientVersion: 'v'
+        }
+      );
+
+      const erroringPersistence: PersistenceInternal = {
+        type: PersistenceType.LOCAL,
+        _isAvailable: () => Promise.reject(new Error('Storage disabled')),
+        _set: async () => {},
+        _get: async () => null,
+        _remove: async () => {},
+        _addListener: () => {
+          throw new Error('Storage disabled');
+        },
+        _removeListener: () => {},
+        _shouldAllowMigration: false
+      };
+
+      await authImpl._initializeWithPersistence([erroringPersistence]);
+      expect(authImpl._isInitialized).to.be.true;
+      expect(authImpl.currentUser).to.be.null;
+      await expect(authImpl._persistenceManagerAvailable).to.be.fulfilled;
+      await expect(authImpl.authStateReady()).to.be.fulfilled;
+    });
+
+    it('falls back to currentUser = null when initializeCurrentUser fails', async () => {
+      const authImpl = new AuthImpl(
+        FAKE_APP,
+        FAKE_HEARTBEAT_CONTROLLER_PROVIDER,
+        FAKE_APP_CHECK_CONTROLLER_PROVIDER,
+        {
+          apiKey: FAKE_APP.options.apiKey!,
+          apiHost: DefaultConfig.API_HOST,
+          apiScheme: DefaultConfig.API_SCHEME,
+          tokenApiHost: DefaultConfig.TOKEN_API_HOST,
+          clientPlatform: ClientPlatform.BROWSER,
+          sdkClientVersion: 'v'
+        }
+      );
+
+      sinon
+        .stub(authImpl as any, 'initializeCurrentUser')
+        .rejects(new Error('Corrupt storage'));
+
+      await authImpl._initializeWithPersistence([
+        _getInstance(inMemoryPersistence)
+      ]);
+      expect(authImpl._isInitialized).to.be.true;
+      expect(authImpl.currentUser).to.be.null;
+      await expect(authImpl.authStateReady()).to.be.fulfilled;
+    });
+  });
+
+  describe('registerStateListener rejection handling', () => {
+    it('calls observer error callback if initialization promise rejects', async () => {
+      const authImpl = new AuthImpl(
+        FAKE_APP,
+        FAKE_HEARTBEAT_CONTROLLER_PROVIDER,
+        FAKE_APP_CHECK_CONTROLLER_PROVIDER,
+        {
+          apiKey: FAKE_APP.options.apiKey!,
+          apiHost: DefaultConfig.API_HOST,
+          apiScheme: DefaultConfig.API_SCHEME,
+          tokenApiHost: DefaultConfig.TOKEN_API_HOST,
+          clientPlatform: ClientPlatform.BROWSER,
+          sdkClientVersion: 'v'
+        }
+      );
+
+      const initError = new Error('Fatal initialization failure');
+      (authImpl as any)._initializationPromise = Promise.reject(initError);
+
+      const nextSpy = sinon.spy();
+      const errorSpy = sinon.spy();
+
+      authImpl.onAuthStateChanged({
+        next: nextSpy,
+        error: errorSpy,
+        complete: sinon.spy()
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+      expect(nextSpy).not.to.have.been.called;
+      expect(errorSpy).to.have.been.calledWith(initError);
+    });
+
+    it('calls error function parameter if initialization promise rejects', async () => {
+      const authImpl = new AuthImpl(
+        FAKE_APP,
+        FAKE_HEARTBEAT_CONTROLLER_PROVIDER,
+        FAKE_APP_CHECK_CONTROLLER_PROVIDER,
+        {
+          apiKey: FAKE_APP.options.apiKey!,
+          apiHost: DefaultConfig.API_HOST,
+          apiScheme: DefaultConfig.API_SCHEME,
+          tokenApiHost: DefaultConfig.TOKEN_API_HOST,
+          clientPlatform: ClientPlatform.BROWSER,
+          sdkClientVersion: 'v'
+        }
+      );
+
+      const initError = new Error('Fatal initialization failure');
+      (authImpl as any)._initializationPromise = Promise.reject(initError);
+
+      const nextSpy = sinon.spy();
+      const errorSpy = sinon.spy();
+
+      authImpl.onAuthStateChanged(nextSpy, errorSpy);
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+      expect(nextSpy).not.to.have.been.called;
+      expect(errorSpy).to.have.been.calledWith(initError);
     });
   });
 });

--- a/packages/auth/src/core/auth/auth_impl.ts
+++ b/packages/auth/src/core/auth/auth_impl.ts
@@ -776,6 +776,8 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
           nextOrObserver.error(err);
         } else if (error) {
           error(err);
+        } else {
+          throw err;
         }
       });
 

--- a/packages/auth/src/core/auth/auth_impl.ts
+++ b/packages/auth/src/core/auth/auth_impl.ts
@@ -61,7 +61,6 @@ import {
   KeyName,
   PersistenceUserManager
 } from '../persistence/persistence_user_manager';
-import { inMemoryPersistence } from '../persistence/in_memory';
 import { _reloadWithoutSaving } from '../user/reload';
 import {
   _assert,
@@ -172,14 +171,10 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
         );
       } catch (e) {
         _logWarn(`Failed to initialize persistence: ${e}`);
-        try {
-          this.persistenceManager = await PersistenceUserManager.create(
-            this,
-            [_getInstance(inMemoryPersistence)]
-          );
-        } catch {
-          // If inMemory also fails, fallback is handled gracefully
-        }
+        this.persistenceManager = await PersistenceUserManager.create(
+          this,
+          []
+        );
       } finally {
         this._resolvePersistenceManagerAvailable?.();
       }

--- a/packages/auth/src/core/auth/auth_impl.ts
+++ b/packages/auth/src/core/auth/auth_impl.ts
@@ -819,9 +819,9 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
 
     if (this.persistenceManager) {
       if (user) {
-        await this.assertedPersistence.setCurrentUser(user);
+        await this.persistenceManager.setCurrentUser(user);
       } else {
-        await this.assertedPersistence.removeCurrentUser();
+        await this.persistenceManager.removeCurrentUser();
       }
     }
   }

--- a/packages/auth/src/core/auth/auth_impl.ts
+++ b/packages/auth/src/core/auth/auth_impl.ts
@@ -61,6 +61,7 @@ import {
   KeyName,
   PersistenceUserManager
 } from '../persistence/persistence_user_manager';
+import { inMemoryPersistence } from '../persistence/in_memory';
 import { _reloadWithoutSaving } from '../user/reload';
 import {
   _assert,
@@ -164,11 +165,24 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
         return;
       }
 
-      this.persistenceManager = await PersistenceUserManager.create(
-        this,
-        persistenceHierarchy
-      );
-      this._resolvePersistenceManagerAvailable?.();
+      try {
+        this.persistenceManager = await PersistenceUserManager.create(
+          this,
+          persistenceHierarchy
+        );
+      } catch (e) {
+        _logWarn(`Failed to initialize persistence: ${e}`);
+        try {
+          this.persistenceManager = await PersistenceUserManager.create(
+            this,
+            [_getInstance(inMemoryPersistence)]
+          );
+        } catch {
+          // If inMemory also fails, fallback is handled gracefully
+        }
+      } finally {
+        this._resolvePersistenceManagerAvailable?.();
+      }
 
       if (this._deleted) {
         return;
@@ -185,7 +199,12 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
         }
       }
 
-      await this.initializeCurrentUser(popupRedirectResolver);
+      try {
+        await this.initializeCurrentUser(popupRedirectResolver);
+      } catch (e) {
+        _logWarn(`Failed to initialize current user: ${e}`);
+        await this.directlySetCurrentUser(null).catch(() => {});
+      }
 
       this.lastNotifiedUid = this.currentUser?.uid || null;
 
@@ -747,12 +766,23 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
     _assert(promise, this, AuthErrorCode.INTERNAL_ERROR);
     // The callback needs to be called asynchronously per the spec.
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    promise.then(() => {
-      if (isUnsubscribed) {
-        return;
-      }
-      cb(this.currentUser);
-    });
+    promise
+      .then(() => {
+        if (isUnsubscribed) {
+          return;
+        }
+        cb(this.currentUser);
+      })
+      .catch(err => {
+        if (isUnsubscribed) {
+          return;
+        }
+        if (typeof nextOrObserver !== 'function' && nextOrObserver.error) {
+          nextOrObserver.error(err);
+        } else if (error) {
+          error(err);
+        }
+      });
 
     if (typeof nextOrObserver === 'function') {
       const unsubscribe = subscription.addObserver(
@@ -790,10 +820,12 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
 
     this.currentUser = user;
 
-    if (user) {
-      await this.assertedPersistence.setCurrentUser(user);
-    } else {
-      await this.assertedPersistence.removeCurrentUser();
+    if (this.persistenceManager) {
+      if (user) {
+        await this.assertedPersistence.setCurrentUser(user);
+      } else {
+        await this.assertedPersistence.removeCurrentUser();
+      }
     }
   }
 

--- a/packages/auth/src/core/auth/auth_impl.ts
+++ b/packages/auth/src/core/auth/auth_impl.ts
@@ -171,10 +171,7 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
         );
       } catch (e) {
         _logWarn(`Failed to initialize persistence: ${e}`);
-        this.persistenceManager = await PersistenceUserManager.create(
-          this,
-          []
-        );
+        this.persistenceManager = await PersistenceUserManager.create(this, []);
       } finally {
         this._resolvePersistenceManagerAvailable?.();
       }

--- a/packages/auth/src/core/persistence/persistence_user_manager.test.ts
+++ b/packages/auth/src/core/persistence/persistence_user_manager.test.ts
@@ -71,6 +71,21 @@ describe('core/persistence/persistence_user_manager', () => {
       expect(manager.persistence).to.eq(_getInstance(inMemoryPersistence));
     });
 
+    it('handles _isAvailable throwing an error and falls back to inMemory', async () => {
+      const { persistence, stub } = makePersistence();
+      stub._isAvailable.rejects(new Error('IndexedDB blocked'));
+      const manager = await PersistenceUserManager.create(auth, [persistence]);
+      expect(manager.persistence).to.eq(_getInstance(inMemoryPersistence));
+    });
+
+    it('does not throw in constructor if _addListener throws', async () => {
+      const { persistence, stub } = makePersistence();
+      stub._addListener.throws(new Error('addListener not supported'));
+      stub._isAvailable.resolves(true);
+      const manager = await PersistenceUserManager.create(auth, [persistence]);
+      expect(manager.persistence).to.eq(persistence);
+    });
+
     it('chooses the first one with a user', async () => {
       const a = makePersistence();
       const b = makePersistence();

--- a/packages/auth/src/core/persistence/persistence_user_manager.ts
+++ b/packages/auth/src/core/persistence/persistence_user_manager.ts
@@ -59,7 +59,11 @@ export class PersistenceUserManager {
       name
     );
     this.boundEventHandler = auth._onStorageEvent.bind(auth);
-    this.persistence._addListener(this.fullUserKey, this.boundEventHandler);
+    try {
+      this.persistence._addListener(this.fullUserKey, this.boundEventHandler);
+    } catch {
+      // Best effort; ignore errors if addListener throws
+    }
   }
 
   setCurrentUser(user: UserInternal): Promise<void> {
@@ -112,7 +116,9 @@ export class PersistenceUserManager {
   }
 
   delete(): void {
-    this.persistence._removeListener(this.fullUserKey, this.boundEventHandler);
+    try {
+      this.persistence._removeListener(this.fullUserKey, this.boundEventHandler);
+    } catch {}
   }
 
   static async create(
@@ -132,8 +138,12 @@ export class PersistenceUserManager {
     const availablePersistences = (
       await Promise.all(
         persistenceHierarchy.map(async persistence => {
-          if (await persistence._isAvailable()) {
-            return persistence;
+          try {
+            if (await persistence._isAvailable()) {
+              return persistence;
+            }
+          } catch {
+            return undefined;
           }
           return undefined;
         })

--- a/packages/auth/src/core/persistence/persistence_user_manager.ts
+++ b/packages/auth/src/core/persistence/persistence_user_manager.ts
@@ -117,7 +117,10 @@ export class PersistenceUserManager {
 
   delete(): void {
     try {
-      this.persistence._removeListener(this.fullUserKey, this.boundEventHandler);
+      this.persistence._removeListener(
+        this.fullUserKey,
+        this.boundEventHandler
+      );
     } catch {}
   }
 


### PR DESCRIPTION
Fixes #10311
When IndexedDB or other storage mechanisms fail unexpectedly during SDK startup (e.g. corrupted database, lock timeouts, or strict privacy restrictions), _initializeWithPersistence threw an unhandled error, leaving _isInitialized = false, authStateReady() hanging indefinitely, and API requests deadlocked on _persistenceManagerAvailable.
This PR:
- Catches errors during PersistenceUserManager.create and gracefully falls back to inMemoryPersistence.
- Catches errors during initializeCurrentUser and defaults to signed-out (currentUser = null).
- Guarantees _persistenceManagerAvailable and _isInitialized are resolved so authStateReady() and listeners always fire.
- Adds error callback routing in registerStateListener.