### PR TITLE
Add license field to placeholder package.json files (#9326)

### DIFF
--- a/.changeset/great-poems-repeat.md
+++ b/.changeset/great-poems-repeat.md
@@ -1,0 +1,10 @@
+---
+'@firebase/auth': patch
+'@firebase/database-compat': patch
+'@firebase/firestore': patch
+'@firebase/messaging': patch
+'@firebase/webchannel-wrapper': patch
+'firebase': patch
+---
+
+Add the license field to placeholder sub-package.json files so that SBOM tools like Syft can detect the license of these entry points.

--- a/packages/auth/cordova/package.json
+++ b/packages/auth/cordova/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@firebase/auth-cordova",
   "description": "A Cordova-specific build of the Firebase Auth JS SDK",
+  "license": "Apache-2.0",
   "browser": "../dist/cordova/index.js",
   "module": "../dist/cordova/index.js",
   "typings": "../dist/cordova/auth-cordova-public.d.ts"

--- a/packages/auth/internal/package.json
+++ b/packages/auth/internal/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@firebase/auth/internal",
   "description": "An internal version of the Auth SDK for use in the compatibility layer",
+  "license": "Apache-2.0",
   "main": "../dist/node/internal.js",
   "module": "../dist/esm/internal.js",
   "browser": "../dist/esm/internal.js",

--- a/packages/auth/web-extension/package.json
+++ b/packages/auth/web-extension/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@firebase/auth-web-extension",
   "description": "A Chrome-Manifest-v3-specific build of the Firebase Auth JS SDK",
+  "license": "Apache-2.0",
   "main": "../dist/web-extension-cjs/index.js",
   "browser": "../dist/web-extension-esm/index.js",
   "module": "../dist/web-extension-esm/index.js",

--- a/packages/database-compat/standalone/package.json
+++ b/packages/database-compat/standalone/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@firebase/database-compat/standalone",
   "description": "The entry point for sharing code with Admin SDK",
+  "license": "Apache-2.0",
   "main": "../dist/index.standalone.js",
   "typings": "../dist/database-compat/src/index.standalone.d.ts",
   "private": true

--- a/packages/firebase/ai/package.json
+++ b/packages/firebase/ai/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/ai",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/analytics/package.json
+++ b/packages/firebase/analytics/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/analytics",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/app-check/package.json
+++ b/packages/firebase/app-check/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/app-check",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/app/package.json
+++ b/packages/firebase/app/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/app",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/auth/cordova/package.json
+++ b/packages/firebase/auth/cordova/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/auth/cordova",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/auth/package.json
+++ b/packages/firebase/auth/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/auth",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/auth/web-extension/package.json
+++ b/packages/firebase/auth/web-extension/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/auth/web-extension",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/compat/analytics/package.json
+++ b/packages/firebase/compat/analytics/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/compat/analytics",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/compat/app-check/package.json
+++ b/packages/firebase/compat/app-check/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/compat/app-check",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/compat/app/package.json
+++ b/packages/firebase/compat/app/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/compat/app",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/compat/auth/package.json
+++ b/packages/firebase/compat/auth/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/compat/auth",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/compat/database/package.json
+++ b/packages/firebase/compat/database/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/compat/database",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/compat/firestore/package.json
+++ b/packages/firebase/compat/firestore/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/compat/firestore",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/compat/functions/package.json
+++ b/packages/firebase/compat/functions/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/compat/functions",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/compat/installations/package.json
+++ b/packages/firebase/compat/installations/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/compat/installations",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/compat/messaging/package.json
+++ b/packages/firebase/compat/messaging/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/compat/messaging",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/compat/package.json
+++ b/packages/firebase/compat/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/compat",
+  "license": "Apache-2.0",
   "main": "dist/index.node.cjs",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/compat/performance/package.json
+++ b/packages/firebase/compat/performance/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/compat/performance",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/compat/remote-config/package.json
+++ b/packages/firebase/compat/remote-config/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/compat/remote-config",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/compat/storage/package.json
+++ b/packages/firebase/compat/storage/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/compat/storage",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/data-connect/package.json
+++ b/packages/firebase/data-connect/package.json
@@ -1,5 +1,6 @@
 {
     "name": "firebase/data-connect",
+  "license": "Apache-2.0",
     "main": "dist/index.cjs.js",
     "browser": "dist/esm/index.esm.js",
     "module": "dist/esm/index.esm.js",

--- a/packages/firebase/database/package.json
+++ b/packages/firebase/database/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/database",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/firestore/lite/package.json
+++ b/packages/firebase/firestore/lite/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/firestore/lite",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/firestore/lite/pipelines/package.json
+++ b/packages/firebase/firestore/lite/pipelines/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/firestore/lite/pipelines",
+  "license": "Apache-2.0",
   "main": "dist/pipelines.cjs.js",
   "browser": "dist/esm/pipelines.esm.js",
   "module": "dist/esm/pipelines.esm.js",

--- a/packages/firebase/firestore/package.json
+++ b/packages/firebase/firestore/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/firestore",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/firestore/pipelines/package.json
+++ b/packages/firebase/firestore/pipelines/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/firestore/pipelines",
+  "license": "Apache-2.0",
   "main": "dist/pipelines.cjs.js",
   "browser": "dist/esm/pipelines.esm.js",
   "module": "dist/esm/pipelines.esm.js",

--- a/packages/firebase/functions/package.json
+++ b/packages/firebase/functions/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/functions",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/installations/package.json
+++ b/packages/firebase/installations/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/installations",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/messaging/package.json
+++ b/packages/firebase/messaging/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/messaging",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/messaging/sw/package.json
+++ b/packages/firebase/messaging/sw/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/messaging/sw",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/performance/package.json
+++ b/packages/firebase/performance/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/performance",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/remote-config/package.json
+++ b/packages/firebase/remote-config/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/remote-config",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firebase/storage/package.json
+++ b/packages/firebase/storage/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/storage",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "browser": "dist/esm/index.esm.js",
   "module": "dist/esm/index.esm.js",

--- a/packages/firestore/lite/package.json
+++ b/packages/firestore/lite/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@firebase/firestore-lite",
   "description": "A lite version of the Firestore SDK",
+  "license": "Apache-2.0",
   "main": "../dist/lite/index.node.cjs.js",
   "main-esm": "../dist/lite/index.node.mjs",
   "module": "../dist/lite/index.browser.esm.js",

--- a/packages/firestore/lite/pipelines/package.json
+++ b/packages/firestore/lite/pipelines/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@firebase/firestore-lite-pipelines",
   "description": "Pipelines for the lite Firestore SDK",
+  "license": "Apache-2.0",
   "main": "../../dist/lite/pipelines.node.cjs.js",
   "main-esm": "../../dist/lite/pipelines.node.mjs",
   "module": "../../dist/lite/pipelines.browser.esm.js",

--- a/packages/firestore/pipelines/package.json
+++ b/packages/firestore/pipelines/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@firebase/firestore-pipelines",
   "description": "pipelines",
+  "license": "Apache-2.0",
   "main": "../dist/pipelines.node.cjs.js",
   "main-esm": "../dist/pipelines.node.mjs",
   "module": "../dist/pipelines.esm.js",

--- a/packages/messaging/sw/package.json
+++ b/packages/messaging/sw/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@firebase/messaging-sw",
   "description": "",
+  "license": "Apache-2.0",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "main": "../dist/index.sw.cjs",
   "module": "../dist/esm/index.sw.esm.js",

--- a/packages/webchannel-wrapper/bloom-blob/package.json
+++ b/packages/webchannel-wrapper/bloom-blob/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@firebase/webchannel-wrapper/bloom-blob",
   "description": "Bloom filter related code from the Closure library.",
+  "license": "Apache-2.0",
   "main": "../dist/bloom-blob/bloom_blob_es2018.js",
   "browser": "../dist/bloom-blob/esm/bloom_blob_es2018.js",
   "module": "../dist/bloom-blob/esm/bloom_blob_es2018.js",

--- a/packages/webchannel-wrapper/webchannel-blob/package.json
+++ b/packages/webchannel-wrapper/webchannel-blob/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@firebase/webchannel-wrapper/webchannel-blob",
   "description": "Webchannel related code from the Closure library.",
+  "license": "Apache-2.0",
   "main": "../dist/webchannel-blob/webchannel_blob_es2018.js",
   "browser": "../dist/webchannel-blob/esm/webchannel_blob_es2018.js",
   "module": "../dist/webchannel-blob/esm/webchannel_blob_es2018.js",


### PR DESCRIPTION
Fixes #9326

### Discussion

This change was discussed in #9326, where @hsubox76 confirmed the approach:
adding the `license` field to these placeholder files "shouldn't be too hard"
and was added to the backlog.

Some placeholder sub-package.json files (entry points for legacy bundlers) do
not declare a `license` field, which causes SBOM tools like Syft to report an
unknown license for these entry points.

This PR adds `"license": "Apache-2.0"` (matching the parent packages) to the
8 files listed in the issue:

- `packages/messaging/sw/package.json`
- `packages/auth/cordova/package.json`
- `packages/auth/web-extension/package.json`
- `packages/auth/internal/package.json`
- `packages/database-compat/standalone/package.json`
- `packages/firestore/lite/package.json`
- `packages/webchannel-wrapper/bloom-blob/package.json`
- `packages/webchannel-wrapper/webchannel-blob/package.json`

### Testing

This is a metadata-only change (no code is affected), so no new tests were
added. Existing tests are unaffected.

### API Changes

None. This does not affect the public API.