### PR TITLE
fix(auth): wrap persistence errors in FirebaseError during currentUser updates

### DIFF
--- a/.changeset/auth-wrap-persistence-errors-10333.md
+++ b/.changeset/auth-wrap-persistence-errors-10333.md
@@ -1,0 +1,5 @@
+---
+'@firebase/auth': patch
+---
+
+Wrap storage and persistence errors in `FirebaseError` (`auth/internal-error`) during current user updates, ensuring `error.code` is always defined and attaching the underlying exception under `error.customData.originalError`.

--- a/packages/auth/src/core/auth/auth_impl.test.ts
+++ b/packages/auth/src/core/auth/auth_impl.test.ts
@@ -148,6 +148,41 @@ describe('core/auth/auth_impl', () => {
         '(auth/tenant-id-mismatch)'
       );
     });
+
+    it('wraps persistence setCurrentUser failure into FirebaseError (auth/internal-error)', async () => {
+      const user = testUser(auth, 'uid');
+      const originalError = new Error('Database is closing');
+      persistenceStub._set.rejects(originalError);
+
+      let caughtError: any;
+      try {
+        await auth._updateCurrentUser(user);
+      } catch (e) {
+        caughtError = e;
+      }
+
+      expect(caughtError).to.be.instanceOf(FirebaseError);
+      expect(caughtError.code).to.eq('auth/internal-error');
+      expect(caughtError.message).to.include('Database is closing');
+      expect(caughtError.customData?.originalError).to.eq(originalError);
+    });
+
+    it('wraps persistence removeCurrentUser failure into FirebaseError (auth/internal-error)', async () => {
+      const originalError = new Error('IndexedDB access denied');
+      persistenceStub._remove.rejects(originalError);
+
+      let caughtError: any;
+      try {
+        await auth._updateCurrentUser(null);
+      } catch (e) {
+        caughtError = e;
+      }
+
+      expect(caughtError).to.be.instanceOf(FirebaseError);
+      expect(caughtError.code).to.eq('auth/internal-error');
+      expect(caughtError.message).to.include('IndexedDB access denied');
+      expect(caughtError.customData?.originalError).to.eq(originalError);
+    });
   });
 
   describe('#signOut', () => {

--- a/packages/auth/src/core/auth/auth_impl.ts
+++ b/packages/auth/src/core/auth/auth_impl.ts
@@ -64,6 +64,7 @@ import {
 import { _reloadWithoutSaving } from '../user/reload';
 import {
   _assert,
+  _errorWithCustomMessage,
   _serverAppCurrentUserOperationNotSupportedError
 } from '../util/assert';
 import { _getInstance } from '../util/instantiator';
@@ -815,10 +816,21 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
     this.currentUser = user;
 
     if (this.persistenceManager) {
-      if (user) {
-        await this.persistenceManager.setCurrentUser(user);
-      } else {
-        await this.persistenceManager.removeCurrentUser();
+      try {
+        if (user) {
+          await this.persistenceManager.setCurrentUser(user);
+        } else {
+          await this.persistenceManager.removeCurrentUser();
+        }
+      } catch (e) {
+        const originalMessage = (e as Error)?.message || String(e);
+        const error = _errorWithCustomMessage(
+          this,
+          AuthErrorCode.INTERNAL_ERROR,
+          `An internal AuthError has occurred: ${originalMessage}`
+        );
+        error.customData = { originalError: e };
+        throw error;
       }
     }
   }

--- a/packages/auth/src/core/strategies/custom_token.test.ts
+++ b/packages/auth/src/core/strategies/custom_token.test.ts
@@ -91,4 +91,28 @@ describe('core/strategies/signInWithCustomToken', () => {
     const { user } = await signInWithCustomToken(auth, 'oh.no');
     expect(auth.currentUser).to.eq(user);
   });
+
+  it('wraps persistence failure into FirebaseError (auth/internal-error) after network token exchange', async () => {
+    const persistenceError = new Error('Database is closing/hidden');
+    (auth as any).persistenceManager.setCurrentUser = () =>
+      Promise.reject(persistenceError);
+
+    let caughtError: any;
+    try {
+      await signInWithCustomToken(auth, 'single-use-token');
+    } catch (e) {
+      caughtError = e;
+    }
+
+    expect(caughtError).to.be.ok;
+    expect(caughtError.code).to.eq('auth/internal-error');
+    expect(caughtError.message).to.include('Database is closing/hidden');
+    expect(caughtError.customData?.originalError).to.eq(persistenceError);
+    // Note: The network request already consumed the token
+    expect(signInRoute.calls.length).to.eq(1);
+    expect(signInRoute.calls[0].request).to.eql({
+      token: 'single-use-token',
+      returnSecureToken: true
+    });
+  });
 });


### PR DESCRIPTION
### Description
Partially addresses #10333.

In #10333, the author highlighted that when storage/persistence operations fail during `signInWithCustomToken` (or other auth operations), the raw JavaScript `Error` or `DOMException` escapes unwrapped with `error.code: undefined`. This forces developers to perform fragile substring matching on `error.message` to detect storage failures:

```typescript
try {
  await signInWithCustomToken(auth, customToken);
} catch (error) {
  // Forced to string-match error message because error.code is undefined
  const isDbClosing = (error as Error)?.message?.includes('Database is closing/hidden');
  if (isDbClosing) {
    // workaround
  }
}
```

> **Note:** The underlying IndexedDB reconnection race condition itself is resolved separately in #10325. This PR specifically resolves the unclassified error propagation by wrapping storage exceptions into standard `FirebaseError` objects.

### Changes
1. Wrapped `this.persistenceManager.setCurrentUser(user)` and `this.persistenceManager.removeCurrentUser()` in `directlySetCurrentUser()` to throw a `FirebaseError` with `AuthErrorCode.INTERNAL_ERROR` (`'auth/internal-error'`).
2. Used `_errorWithCustomMessage()` to preserve the underlying error's message in `error.message` (e.g. `An internal AuthError has occurred: <originalMessage>`) for logging and debugging.
3. Attached the original error object to `error.customData.originalError`.
4. Added unit tests in `auth_impl.test.ts` and `custom_token.test.ts` to verify that storage errors produce a `FirebaseError` with code `'auth/internal-error'` and preserve the underlying error details.

### Related Issues
* Related to #10333