### PR TITLE
fix(firestore): fix fetch connection error message

### DIFF
--- a/.changeset/lemon-flies-yawn.md
+++ b/.changeset/lemon-flies-yawn.md
@@ -1,0 +1,5 @@
+---
+'@firebase/firestore': patch
+---
+
+Fixes fetch connection error messages that were undefined.

--- a/packages/firestore/src/platform/browser_lite/fetch_connection.ts
+++ b/packages/firestore/src/platform/browser_lite/fetch_connection.ts
@@ -55,10 +55,19 @@ export class FetchConnection extends RestConnection {
       }
       response = await fetch(url, fetchArgs);
     } catch (e) {
-      const err = e as { status: number | undefined; statusText: string };
+      const err = e as {
+        message?: string;
+        status?: number;
+        statusText?: string;
+        cause?: unknown;
+      };
+      const errorMessage =
+        (err?.cause ? `${err.message} (${err.cause})` : err?.message) ??
+        err?.statusText ??
+        String(e);
       throw new FirestoreError(
-        mapCodeFromHttpStatus(err.status),
-        'Request failed with error: ' + err.statusText
+        mapCodeFromHttpStatus(err?.status),
+        `Request failed with error: ${errorMessage}`
       );
     }
 

--- a/packages/firestore/src/platform/browser_lite/fetch_connection.ts
+++ b/packages/firestore/src/platform/browser_lite/fetch_connection.ts
@@ -61,8 +61,10 @@ export class FetchConnection extends RestConnection {
         statusText?: string;
         cause?: unknown;
       };
+      const message = err?.message;
+      const cause = err?.cause ? String(err.cause) : undefined;
       const errorMessage =
-        (err?.cause ? `${err.message} (${err.cause})` : err?.message) ??
+        (message && cause ? `${message} (${cause})` : (message ?? cause)) ??
         err?.statusText ??
         String(e);
       throw new FirestoreError(


### PR DESCRIPTION
Fixes fetch connection error messages. We now read the thrown error's `message` and `cause` instead of attempting to read a potentially non-existent `statusText` from an `Error` object, preventing connection failures like `ECONNREFUSED` from being displayed as `undefined`.

In tests, we see errors like this
```
    145) Vectors
         can be read and written using the lite SDK:
       FirebaseError: [code=unknown]: Request failed with error: undefined
```
Now, they will look like this:
```
    145) Vectors
         can be read and written using the lite SDK:
       FirebaseError: [code=unknown]: Request failed with error: fetch
  failed (Error: connect ECONNREFUSED 127.0.0.1:8080)
```

This will also impact users. 

Before:
```
    FirebaseError: [code=unknown]: Request failed with error: undefined
```

Now:
```
    FirebaseError: [code=unknown]: Request failed with error: fetch failed
  (ConnectTimeoutError: Connect Timeout Error)
```