### PR TITLE
fix(performance): append queued events in place

### DIFF
--- a/packages/performance/src/services/transport_service.ts
+++ b/packages/performance/src/services/transport_service.ts
@@ -157,8 +157,9 @@ function addToQueue(evt: BatchEvent): void {
   if (!evt.eventTime || !evt.message) {
     throw ERROR_FACTORY.create(ErrorCode.INVALID_CC_LOG);
   }
-  // Add the new event to the queue.
-  queue = [...queue, evt];
+  // Append in place; rebuilding the array here is O(N) per event and the queue
+  // can grow unbounded once processQueue stops draining.
+  queue.push(evt);
 }
 
 /** Log handler for cc service to send the performance logs to the server. */


### PR DESCRIPTION
`addToQueue` rebuilds the whole queue array on every event:

```ts
queue = [...queue, evt];
```

That's an O(N) copy per event, so queueing N events costs O(N^2). `queue.push(evt)` makes it O(N).

Most of the time this doesn't matter, since the queue drains every 10s in batches of up to 1000 and N stays small. It matters once the drain stops. `processQueue` returns without rescheduling when `remainingTries` hits 0, which takes three consecutive send failures and is only reset by a success, so a transport endpoint blocked by an ad blocker or a corporate proxy stalls it permanently. From then on the queue grows for the rest of the page's life and every append gets slower.

(#9067 looked related, but #9120 fixed that by capping the sendBeacon payload at 64 KB and left the append path alone.)

Timing just the queueing loop on node 22, arm64 mac:

| events | before | after |
| --- | --- | --- |
| 100k | 13.2s | 0.010s |
| 250k | 85.6s | 0.016s |

2.5x the events costs 6.5x the time before, against the 6.25x a quadratic predicts. After, it's flat.

`queue` is module-private and never aliased, and `dispatchQueueEvents` stages events with `splice`, which returns a new array, so appending in place is equivalent for every reader in the file.

No new tests. Behaviour is unchanged, and `sends up to the maximum event limit in one request if payload is under 64 KB` already asserts ordering across dispatch batches. The package's karma suite passes locally, 136/136.

Can add a changeset if you'd like this in a patch release.
