### PR TITLE
chore: Require yarn ^1.22.22 for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ https://yarnpkg.com/en/docs/install
 
 This repo currently supports building with yarn `1.x`. For instance, after installing yarn, run
 ```bash
-$ yarn set version 1.22.11
+$ yarn set version 1.22.22
 ```
 
 #### Java
@@ -67,7 +67,7 @@ $ java -version
 ```
 
 Your `node` version should be `20.19.0` or greater, your `yarn` version should
-be between `1.0.0` and `1.22.11`, and your `java` version should be `11.0` or greater.
+be `^1.22.22` (Yarn 1.x), and your `java` version should be `11.0` or greater.
 
 _NOTE: We will update the documentation as new versions are required, however
 for continuing development on the SDK, staying up to date on the stable versions

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20.11.0"
+    "node": ">=20.11.0",
+    "yarn": "^1.22.22"
   },
+  "packageManager": "yarn@1.22.22",
   "homepage": "https://github.com/firebase/firebase-js-sdk",
   "keywords": [
     "authentication",


### PR DESCRIPTION
Versions of Yarn 1 before 1.22.22 have a bug where yarn tries to merge entries in yarn.lock so that a dependency and its aliases are on the same line, causing it to ignore the names after the first alias: https://github.com/yarnpkg/yarn/pull/9023

This causes errors with transitive deps like `string-width` and `strip-ansi` every time a user using a Yarn version earlier than 1.22.22 updates yarn.lock.

This change updates package.json so that yarn 1.22.22 is required - using `engines` for yarn 1+ and `packageManager` for newer package managers.