### PR TITLE
feat(ai): deprecate sampling, penalty, and candidate parameters in GenerationConfig and LiveGenerationConfig

### DIFF
--- a/.changeset/deprecate-ai-generation-params.md
+++ b/.changeset/deprecate-ai-generation-params.md
@@ -3,4 +3,4 @@
 'firebase': minor
 ---
 
-Deprecate `candidateCount`, `temperature`, `topP`, `topK`, `presencePenalty`, and `frequencyPenalty` in `GenerationConfig` and `LiveGenerationConfig`.
+Deprecated `candidateCount`, `temperature`, `topP`, `topK`, `presencePenalty`, and `frequencyPenalty` in both `GenerationConfig` and `LiveGenerationConfig`. These parameters are unsupported in Gemini 3.x and later models.

--- a/.changeset/deprecate-ai-generation-params.md
+++ b/.changeset/deprecate-ai-generation-params.md
@@ -1,0 +1,6 @@
+---
+'@firebase/ai': minor
+'firebase': minor
+---
+
+Deprecate `candidateCount`, `temperature`, `topP`, `topK`, `presencePenalty`, and `frequencyPenalty` in `GenerationConfig` and `LiveGenerationConfig`.

--- a/common/api-review/ai.api.md
+++ b/common/api-review/ai.api.md
@@ -993,20 +993,20 @@ export interface LatLng {
 // @beta
 export interface LiveGenerationConfig {
     contextWindowCompression?: ContextWindowCompressionConfig;
-    // @deprecated (undocumented)
+    // @deprecated
     frequencyPenalty?: number;
     inputAudioTranscription?: AudioTranscriptionConfig;
     maxOutputTokens?: number;
     outputAudioTranscription?: AudioTranscriptionConfig;
-    // @deprecated (undocumented)
+    // @deprecated
     presencePenalty?: number;
     responseModalities?: ResponseModality[];
     speechConfig?: SpeechConfig;
-    // @deprecated (undocumented)
+    // @deprecated
     temperature?: number;
-    // @deprecated (undocumented)
+    // @deprecated
     topK?: number;
-    // @deprecated (undocumented)
+    // @deprecated
     topP?: number;
 }
 

--- a/common/api-review/ai.api.md
+++ b/common/api-review/ai.api.md
@@ -69,7 +69,7 @@ export abstract class AIModel {
     readonly model: string;
     // @internal
     static normalizeModelName(modelName: string, backendType: BackendType): string;
-    }
+}
 
 // @public
 export interface AIOptions {
@@ -319,7 +319,6 @@ interface Date_2 {
     // (undocumented)
     year: number;
 }
-
 export { Date_2 as Date }
 
 // @public
@@ -574,14 +573,14 @@ export interface GenerateContentStreamResult {
 
 // @public
 export interface GenerationConfig {
-    // (undocumented)
+    // @deprecated (undocumented)
     candidateCount?: number;
-    // (undocumented)
+    // @deprecated (undocumented)
     frequencyPenalty?: number;
     imageConfig?: ImageConfig;
     // (undocumented)
     maxOutputTokens?: number;
-    // (undocumented)
+    // @deprecated (undocumented)
     presencePenalty?: number;
     responseJsonSchema?: {
         [key: string]: unknown;
@@ -594,12 +593,12 @@ export interface GenerationConfig {
     speechConfig?: SpeechConfig;
     // (undocumented)
     stopSequences?: string[];
-    // (undocumented)
+    // @deprecated (undocumented)
     temperature?: number;
     thinkingConfig?: ThinkingConfig;
-    // (undocumented)
+    // @deprecated (undocumented)
     topK?: number;
-    // (undocumented)
+    // @deprecated (undocumented)
     topP?: number;
 }
 
@@ -994,15 +993,20 @@ export interface LatLng {
 // @beta
 export interface LiveGenerationConfig {
     contextWindowCompression?: ContextWindowCompressionConfig;
+    // @deprecated (undocumented)
     frequencyPenalty?: number;
     inputAudioTranscription?: AudioTranscriptionConfig;
     maxOutputTokens?: number;
     outputAudioTranscription?: AudioTranscriptionConfig;
+    // @deprecated (undocumented)
     presencePenalty?: number;
     responseModalities?: ResponseModality[];
     speechConfig?: SpeechConfig;
+    // @deprecated (undocumented)
     temperature?: number;
+    // @deprecated (undocumented)
     topK?: number;
+    // @deprecated (undocumented)
     topP?: number;
 }
 
@@ -1022,7 +1026,7 @@ export class LiveGenerativeModel extends AIModel {
     toolConfig?: ToolConfig;
     // (undocumented)
     tools?: Tool[];
-    }
+}
 
 // @beta
 export interface LiveModelParams {
@@ -1103,7 +1107,7 @@ export class LiveSession {
     sendMediaStream(mediaChunkStream: ReadableStream<GenerativeContentBlob>): Promise<void>;
     sendTextRealtime(text: string): Promise<void>;
     sendVideoRealtime(blob: GenerativeContentBlob): Promise<void>;
-    }
+}
 
 // @beta
 export interface LiveSessionResumptionUpdate {
@@ -1677,6 +1681,5 @@ export interface WebGroundingChunk {
     title?: string;
     uri?: string;
 }
-
 
 ```

--- a/docs-devsite/ai.generationconfig.md
+++ b/docs-devsite/ai.generationconfig.md
@@ -40,6 +40,11 @@ export interface GenerationConfig
 
 ## GenerationConfig.candidateCount
 
+> Warning: This API is now obsolete.
+> 
+> Not supported in newer Gemini models (Gemini 2.0+). Make parallel requests instead.
+> 
+
 <b>Signature:</b>
 
 ```typescript
@@ -47,6 +52,11 @@ candidateCount?: number;
 ```
 
 ## GenerationConfig.frequencyPenalty
+
+> Warning: This API is now obsolete.
+> 
+> Not supported in newer Gemini models (Gemini 2.5+). Omit this parameter.
+> 
 
 <b>Signature:</b>
 
@@ -73,6 +83,11 @@ maxOutputTokens?: number;
 ```
 
 ## GenerationConfig.presencePenalty
+
+> Warning: This API is now obsolete.
+> 
+> Not supported in newer Gemini models (Gemini 2.5+). Omit this parameter.
+> 
 
 <b>Signature:</b>
 
@@ -152,6 +167,11 @@ stopSequences?: string[];
 
 ## GenerationConfig.temperature
 
+> Warning: This API is now obsolete.
+> 
+> Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
+> 
+
 <b>Signature:</b>
 
 ```typescript
@@ -170,6 +190,11 @@ thinkingConfig?: ThinkingConfig;
 
 ## GenerationConfig.topK
 
+> Warning: This API is now obsolete.
+> 
+> Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
+> 
+
 <b>Signature:</b>
 
 ```typescript
@@ -177,6 +202,11 @@ topK?: number;
 ```
 
 ## GenerationConfig.topP
+
+> Warning: This API is now obsolete.
+> 
+> Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
+> 
 
 <b>Signature:</b>
 

--- a/docs-devsite/ai.generationconfig.md
+++ b/docs-devsite/ai.generationconfig.md
@@ -42,7 +42,7 @@ export interface GenerationConfig
 
 > Warning: This API is now obsolete.
 > 
-> Not supported in Gemini 3.x and later models. Requests that include this parameter will fail with a 400 error. Make parallel requests instead.
+> Not supported in Gemini 3.x and later models. The model will ignore this parameter if it's included in a request. Make parallel requests instead.
 > 
 
 <b>Signature:</b>

--- a/docs-devsite/ai.generationconfig.md
+++ b/docs-devsite/ai.generationconfig.md
@@ -42,7 +42,7 @@ export interface GenerationConfig
 
 > Warning: This API is now obsolete.
 > 
-> Not supported in newer Gemini models (Gemini 2.0+). Make parallel requests instead.
+> Not supported in Gemini 3.x and later models. Requests that include this parameter will fail with a 400 error. Make parallel requests instead.
 > 
 
 <b>Signature:</b>
@@ -55,7 +55,7 @@ candidateCount?: number;
 
 > Warning: This API is now obsolete.
 > 
-> Not supported in newer Gemini models (Gemini 2.5+). Omit this parameter.
+> Not supported in Gemini 3.x and later models. Requests that include this parameter will fail with a 400 error. Omit this parameter.
 > 
 
 <b>Signature:</b>
@@ -86,7 +86,7 @@ maxOutputTokens?: number;
 
 > Warning: This API is now obsolete.
 > 
-> Not supported in newer Gemini models (Gemini 2.5+). Omit this parameter.
+> Not supported in Gemini 3.x and later models. Requests that include this parameter will fail with a 400 error. Omit this parameter.
 > 
 
 <b>Signature:</b>
@@ -169,7 +169,7 @@ stopSequences?: string[];
 
 > Warning: This API is now obsolete.
 > 
-> Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
+> Not supported in Gemini 3.x and later models. The model will ignore this parameter if it's included in a request. Omit this parameter and let the model manage sampling automatically.
 > 
 
 <b>Signature:</b>
@@ -192,7 +192,7 @@ thinkingConfig?: ThinkingConfig;
 
 > Warning: This API is now obsolete.
 > 
-> Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
+> Not supported in Gemini 3.x and later models. The model will ignore this parameter if it's included in a request. Omit this parameter and let the model manage sampling automatically.
 > 
 
 <b>Signature:</b>
@@ -205,7 +205,7 @@ topK?: number;
 
 > Warning: This API is now obsolete.
 > 
-> Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
+> Not supported in Gemini 3.x and later models. The model will ignore this parameter if it's included in a request. Omit this parameter and let the model manage sampling automatically.
 > 
 
 <b>Signature:</b>

--- a/docs-devsite/ai.livegenerationconfig.md
+++ b/docs-devsite/ai.livegenerationconfig.md
@@ -26,16 +26,16 @@ export interface LiveGenerationConfig
 |  Property | Type | Description |
 |  --- | --- | --- |
 |  [contextWindowCompression](./ai.livegenerationconfig.md#livegenerationconfigcontextwindowcompression) | [ContextWindowCompressionConfig](./ai.contextwindowcompressionconfig.md#contextwindowcompressionconfig_interface) | <b><i>(Public Preview)</i></b> The context window compression configuration. |
-|  [frequencyPenalty](./ai.livegenerationconfig.md#livegenerationconfigfrequencypenalty) | number | <b><i>(Public Preview)</i></b> |
+|  [frequencyPenalty](./ai.livegenerationconfig.md#livegenerationconfigfrequencypenalty) | number | <b><i>(Public Preview)</i></b> Frequency penalties. |
 |  [inputAudioTranscription](./ai.livegenerationconfig.md#livegenerationconfiginputaudiotranscription) | [AudioTranscriptionConfig](./ai.audiotranscriptionconfig.md#audiotranscriptionconfig_interface) | <b><i>(Public Preview)</i></b> Enables transcription of audio input.<!-- -->When enabled, the model will respond with transcriptions of your audio input in the <code>inputTranscriptions</code> property in [LiveServerContent](./ai.liveservercontent.md#liveservercontent_interface) messages. Note that the transcriptions are broken up across messages, so you may only receive small amounts of text per message. For example, if you ask the model "How are you today?", the model may transcribe that input across three messages, broken up as "How a", "re yo", "u today?". |
 |  [maxOutputTokens](./ai.livegenerationconfig.md#livegenerationconfigmaxoutputtokens) | number | <b><i>(Public Preview)</i></b> Specifies the maximum number of tokens that can be generated in the response. The number of tokens per word varies depending on the language outputted. Is unbounded by default. |
 |  [outputAudioTranscription](./ai.livegenerationconfig.md#livegenerationconfigoutputaudiotranscription) | [AudioTranscriptionConfig](./ai.audiotranscriptionconfig.md#audiotranscriptionconfig_interface) | <b><i>(Public Preview)</i></b> Enables transcription of audio input.<!-- -->When enabled, the model will respond with transcriptions of its audio output in the <code>outputTranscription</code> property in [LiveServerContent](./ai.liveservercontent.md#liveservercontent_interface) messages. Note that the transcriptions are broken up across messages, so you may only receive small amounts of text per message. For example, if the model says "How are you today?", the model may transcribe that output across three messages, broken up as "How a", "re yo", "u today?". |
-|  [presencePenalty](./ai.livegenerationconfig.md#livegenerationconfigpresencepenalty) | number | <b><i>(Public Preview)</i></b> |
+|  [presencePenalty](./ai.livegenerationconfig.md#livegenerationconfigpresencepenalty) | number | <b><i>(Public Preview)</i></b> Positive penalties. |
 |  [responseModalities](./ai.livegenerationconfig.md#livegenerationconfigresponsemodalities) | [ResponseModality](./ai.md#responsemodality)<!-- -->\[\] | <b><i>(Public Preview)</i></b> The modalities of the response. |
 |  [speechConfig](./ai.livegenerationconfig.md#livegenerationconfigspeechconfig) | [SpeechConfig](./ai.md#speechconfig) | <b><i>(Public Preview)</i></b> Configuration for speech synthesis for Live API Models. |
-|  [temperature](./ai.livegenerationconfig.md#livegenerationconfigtemperature) | number | <b><i>(Public Preview)</i></b> |
-|  [topK](./ai.livegenerationconfig.md#livegenerationconfigtopk) | number | <b><i>(Public Preview)</i></b> |
-|  [topP](./ai.livegenerationconfig.md#livegenerationconfigtopp) | number | <b><i>(Public Preview)</i></b> |
+|  [temperature](./ai.livegenerationconfig.md#livegenerationconfigtemperature) | number | <b><i>(Public Preview)</i></b> Controls the degree of randomness in token selection. A <code>temperature</code> value of 0 means that the highest probability tokens are always selected. In this case, responses for a given prompt are mostly deterministic, but a small amount of variation is still possible. |
+|  [topK](./ai.livegenerationconfig.md#livegenerationconfigtopk) | number | <b><i>(Public Preview)</i></b> Changes how the model selects token for output. A <code>topK</code> value of 1 means the select token is the most probable among all tokens in the model's vocabulary, while a <code>topK</code> value 3 means that the next token is selected from among the 3 most probably using probabilities sampled. Tokens are then further filtered with the highest selected <code>temperature</code> sampling. Defaults to 40 if unspecified. |
+|  [topP](./ai.livegenerationconfig.md#livegenerationconfigtopp) | number | <b><i>(Public Preview)</i></b> Changes how the model selects tokens for output. Tokens are selected from the most to least probable until the sum of their probabilities equals the <code>topP</code> value. For example, if tokens A, B, and C have probabilities of 0.3, 0.2, and 0.1 respectively and the <code>topP</code> value is 0.5, then the model will select either A or B as the next token by using the <code>temperature</code> and exclude C as a candidate. Defaults to 0.95 if unset. |
 
 ## LiveGenerationConfig.contextWindowCompression
 
@@ -59,8 +59,8 @@ contextWindowCompression?: ContextWindowCompressionConfig;
 > 
 > Not supported in newer Gemini models (Gemini 2.5+). Omit this parameter.
 > 
-> Frequency penalties.
-> 
+
+Frequency penalties.
 
 <b>Signature:</b>
 
@@ -120,8 +120,8 @@ outputAudioTranscription?: AudioTranscriptionConfig;
 > 
 > Not supported in newer Gemini models (Gemini 2.5+). Omit this parameter.
 > 
-> Positive penalties.
-> 
+
+Positive penalties.
 
 <b>Signature:</b>
 
@@ -164,8 +164,8 @@ speechConfig?: SpeechConfig;
 > 
 > Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
 > 
-> Controls the degree of randomness in token selection. A `temperature` value of 0 means that the highest probability tokens are always selected. In this case, responses for a given prompt are mostly deterministic, but a small amount of variation is still possible.
-> 
+
+Controls the degree of randomness in token selection. A `temperature` value of 0 means that the highest probability tokens are always selected. In this case, responses for a given prompt are mostly deterministic, but a small amount of variation is still possible.
 
 <b>Signature:</b>
 
@@ -182,8 +182,8 @@ temperature?: number;
 > 
 > Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
 > 
-> Changes how the model selects token for output. A `topK` value of 1 means the select token is the most probable among all tokens in the model's vocabulary, while a `topK` value 3 means that the next token is selected from among the 3 most probably using probabilities sampled. Tokens are then further filtered with the highest selected `temperature` sampling. Defaults to 40 if unspecified.
-> 
+
+Changes how the model selects token for output. A `topK` value of 1 means the select token is the most probable among all tokens in the model's vocabulary, while a `topK` value 3 means that the next token is selected from among the 3 most probably using probabilities sampled. Tokens are then further filtered with the highest selected `temperature` sampling. Defaults to 40 if unspecified.
 
 <b>Signature:</b>
 
@@ -200,8 +200,8 @@ topK?: number;
 > 
 > Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
 > 
-> Changes how the model selects tokens for output. Tokens are selected from the most to least probable until the sum of their probabilities equals the `topP` value. For example, if tokens A, B, and C have probabilities of 0.3, 0.2, and 0.1 respectively and the `topP` value is 0.5, then the model will select either A or B as the next token by using the `temperature` and exclude C as a candidate. Defaults to 0.95 if unset.
-> 
+
+Changes how the model selects tokens for output. Tokens are selected from the most to least probable until the sum of their probabilities equals the `topP` value. For example, if tokens A, B, and C have probabilities of 0.3, 0.2, and 0.1 respectively and the `topP` value is 0.5, then the model will select either A or B as the next token by using the `temperature` and exclude C as a candidate. Defaults to 0.95 if unset.
 
 <b>Signature:</b>
 

--- a/docs-devsite/ai.livegenerationconfig.md
+++ b/docs-devsite/ai.livegenerationconfig.md
@@ -57,7 +57,7 @@ contextWindowCompression?: ContextWindowCompressionConfig;
 
 > Warning: This API is now obsolete.
 > 
-> Not supported in newer Gemini models (Gemini 2.5+). Omit this parameter.
+> Not supported in Gemini 3.x and later models. Requests that include this parameter will fail with a 400 error. Omit this parameter.
 > 
 
 Frequency penalties.
@@ -118,7 +118,7 @@ outputAudioTranscription?: AudioTranscriptionConfig;
 
 > Warning: This API is now obsolete.
 > 
-> Not supported in newer Gemini models (Gemini 2.5+). Omit this parameter.
+> Not supported in Gemini 3.x and later models. Requests that include this parameter will fail with a 400 error. Omit this parameter.
 > 
 
 Positive penalties.
@@ -162,7 +162,7 @@ speechConfig?: SpeechConfig;
 
 > Warning: This API is now obsolete.
 > 
-> Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
+> Not supported in Gemini 3.x and later models. The model will ignore this parameter if it's included in a request. Omit this parameter and let the model manage sampling automatically.
 > 
 
 Controls the degree of randomness in token selection. A `temperature` value of 0 means that the highest probability tokens are always selected. In this case, responses for a given prompt are mostly deterministic, but a small amount of variation is still possible.
@@ -180,7 +180,7 @@ temperature?: number;
 
 > Warning: This API is now obsolete.
 > 
-> Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
+> Not supported in Gemini 3.x and later models. The model will ignore this parameter if it's included in a request. Omit this parameter and let the model manage sampling automatically.
 > 
 
 Changes how the model selects token for output. A `topK` value of 1 means the select token is the most probable among all tokens in the model's vocabulary, while a `topK` value 3 means that the next token is selected from among the 3 most probably using probabilities sampled. Tokens are then further filtered with the highest selected `temperature` sampling. Defaults to 40 if unspecified.
@@ -198,7 +198,7 @@ topK?: number;
 
 > Warning: This API is now obsolete.
 > 
-> Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
+> Not supported in Gemini 3.x and later models. The model will ignore this parameter if it's included in a request. Omit this parameter and let the model manage sampling automatically.
 > 
 
 Changes how the model selects tokens for output. Tokens are selected from the most to least probable until the sum of their probabilities equals the `topP` value. For example, if tokens A, B, and C have probabilities of 0.3, 0.2, and 0.1 respectively and the `topP` value is 0.5, then the model will select either A or B as the next token by using the `temperature` and exclude C as a candidate. Defaults to 0.95 if unset.

--- a/docs-devsite/ai.livegenerationconfig.md
+++ b/docs-devsite/ai.livegenerationconfig.md
@@ -26,16 +26,16 @@ export interface LiveGenerationConfig
 |  Property | Type | Description |
 |  --- | --- | --- |
 |  [contextWindowCompression](./ai.livegenerationconfig.md#livegenerationconfigcontextwindowcompression) | [ContextWindowCompressionConfig](./ai.contextwindowcompressionconfig.md#contextwindowcompressionconfig_interface) | <b><i>(Public Preview)</i></b> The context window compression configuration. |
-|  [frequencyPenalty](./ai.livegenerationconfig.md#livegenerationconfigfrequencypenalty) | number | <b><i>(Public Preview)</i></b> Frequency penalties. |
+|  [frequencyPenalty](./ai.livegenerationconfig.md#livegenerationconfigfrequencypenalty) | number | <b><i>(Public Preview)</i></b> |
 |  [inputAudioTranscription](./ai.livegenerationconfig.md#livegenerationconfiginputaudiotranscription) | [AudioTranscriptionConfig](./ai.audiotranscriptionconfig.md#audiotranscriptionconfig_interface) | <b><i>(Public Preview)</i></b> Enables transcription of audio input.<!-- -->When enabled, the model will respond with transcriptions of your audio input in the <code>inputTranscriptions</code> property in [LiveServerContent](./ai.liveservercontent.md#liveservercontent_interface) messages. Note that the transcriptions are broken up across messages, so you may only receive small amounts of text per message. For example, if you ask the model "How are you today?", the model may transcribe that input across three messages, broken up as "How a", "re yo", "u today?". |
 |  [maxOutputTokens](./ai.livegenerationconfig.md#livegenerationconfigmaxoutputtokens) | number | <b><i>(Public Preview)</i></b> Specifies the maximum number of tokens that can be generated in the response. The number of tokens per word varies depending on the language outputted. Is unbounded by default. |
 |  [outputAudioTranscription](./ai.livegenerationconfig.md#livegenerationconfigoutputaudiotranscription) | [AudioTranscriptionConfig](./ai.audiotranscriptionconfig.md#audiotranscriptionconfig_interface) | <b><i>(Public Preview)</i></b> Enables transcription of audio input.<!-- -->When enabled, the model will respond with transcriptions of its audio output in the <code>outputTranscription</code> property in [LiveServerContent](./ai.liveservercontent.md#liveservercontent_interface) messages. Note that the transcriptions are broken up across messages, so you may only receive small amounts of text per message. For example, if the model says "How are you today?", the model may transcribe that output across three messages, broken up as "How a", "re yo", "u today?". |
-|  [presencePenalty](./ai.livegenerationconfig.md#livegenerationconfigpresencepenalty) | number | <b><i>(Public Preview)</i></b> Positive penalties. |
+|  [presencePenalty](./ai.livegenerationconfig.md#livegenerationconfigpresencepenalty) | number | <b><i>(Public Preview)</i></b> |
 |  [responseModalities](./ai.livegenerationconfig.md#livegenerationconfigresponsemodalities) | [ResponseModality](./ai.md#responsemodality)<!-- -->\[\] | <b><i>(Public Preview)</i></b> The modalities of the response. |
 |  [speechConfig](./ai.livegenerationconfig.md#livegenerationconfigspeechconfig) | [SpeechConfig](./ai.md#speechconfig) | <b><i>(Public Preview)</i></b> Configuration for speech synthesis for Live API Models. |
-|  [temperature](./ai.livegenerationconfig.md#livegenerationconfigtemperature) | number | <b><i>(Public Preview)</i></b> Controls the degree of randomness in token selection. A <code>temperature</code> value of 0 means that the highest probability tokens are always selected. In this case, responses for a given prompt are mostly deterministic, but a small amount of variation is still possible. |
-|  [topK](./ai.livegenerationconfig.md#livegenerationconfigtopk) | number | <b><i>(Public Preview)</i></b> Changes how the model selects token for output. A <code>topK</code> value of 1 means the select token is the most probable among all tokens in the model's vocabulary, while a <code>topK</code> value 3 means that the next token is selected from among the 3 most probably using probabilities sampled. Tokens are then further filtered with the highest selected <code>temperature</code> sampling. Defaults to 40 if unspecified. |
-|  [topP](./ai.livegenerationconfig.md#livegenerationconfigtopp) | number | <b><i>(Public Preview)</i></b> Changes how the model selects tokens for output. Tokens are selected from the most to least probable until the sum of their probabilities equals the <code>topP</code> value. For example, if tokens A, B, and C have probabilities of 0.3, 0.2, and 0.1 respectively and the <code>topP</code> value is 0.5, then the model will select either A or B as the next token by using the <code>temperature</code> and exclude C as a candidate. Defaults to 0.95 if unset. |
+|  [temperature](./ai.livegenerationconfig.md#livegenerationconfigtemperature) | number | <b><i>(Public Preview)</i></b> |
+|  [topK](./ai.livegenerationconfig.md#livegenerationconfigtopk) | number | <b><i>(Public Preview)</i></b> |
+|  [topP](./ai.livegenerationconfig.md#livegenerationconfigtopp) | number | <b><i>(Public Preview)</i></b> |
 
 ## LiveGenerationConfig.contextWindowCompression
 
@@ -55,7 +55,12 @@ contextWindowCompression?: ContextWindowCompressionConfig;
 > This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
-Frequency penalties.
+> Warning: This API is now obsolete.
+> 
+> Not supported in newer Gemini models (Gemini 2.5+). Omit this parameter.
+> 
+> Frequency penalties.
+> 
 
 <b>Signature:</b>
 
@@ -111,7 +116,12 @@ outputAudioTranscription?: AudioTranscriptionConfig;
 > This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
-Positive penalties.
+> Warning: This API is now obsolete.
+> 
+> Not supported in newer Gemini models (Gemini 2.5+). Omit this parameter.
+> 
+> Positive penalties.
+> 
 
 <b>Signature:</b>
 
@@ -150,7 +160,12 @@ speechConfig?: SpeechConfig;
 > This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
-Controls the degree of randomness in token selection. A `temperature` value of 0 means that the highest probability tokens are always selected. In this case, responses for a given prompt are mostly deterministic, but a small amount of variation is still possible.
+> Warning: This API is now obsolete.
+> 
+> Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
+> 
+> Controls the degree of randomness in token selection. A `temperature` value of 0 means that the highest probability tokens are always selected. In this case, responses for a given prompt are mostly deterministic, but a small amount of variation is still possible.
+> 
 
 <b>Signature:</b>
 
@@ -163,7 +178,12 @@ temperature?: number;
 > This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
-Changes how the model selects token for output. A `topK` value of 1 means the select token is the most probable among all tokens in the model's vocabulary, while a `topK` value 3 means that the next token is selected from among the 3 most probably using probabilities sampled. Tokens are then further filtered with the highest selected `temperature` sampling. Defaults to 40 if unspecified.
+> Warning: This API is now obsolete.
+> 
+> Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
+> 
+> Changes how the model selects token for output. A `topK` value of 1 means the select token is the most probable among all tokens in the model's vocabulary, while a `topK` value 3 means that the next token is selected from among the 3 most probably using probabilities sampled. Tokens are then further filtered with the highest selected `temperature` sampling. Defaults to 40 if unspecified.
+> 
 
 <b>Signature:</b>
 
@@ -176,7 +196,12 @@ topK?: number;
 > This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
 
-Changes how the model selects tokens for output. Tokens are selected from the most to least probable until the sum of their probabilities equals the `topP` value. For example, if tokens A, B, and C have probabilities of 0.3, 0.2, and 0.1 respectively and the `topP` value is 0.5, then the model will select either A or B as the next token by using the `temperature` and exclude C as a candidate. Defaults to 0.95 if unset.
+> Warning: This API is now obsolete.
+> 
+> Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
+> 
+> Changes how the model selects tokens for output. Tokens are selected from the most to least probable until the sum of their probabilities equals the `topP` value. For example, if tokens A, B, and C have probabilities of 0.3, 0.2, and 0.1 respectively and the `topP` value is 0.5, then the model will select either A or B as the next token by using the `temperature` and exclude C as a candidate. Defaults to 0.95 if unset.
+> 
 
 <b>Signature:</b>
 

--- a/packages/ai/src/types/requests.ts
+++ b/packages/ai/src/types/requests.ts
@@ -136,13 +136,31 @@ export interface ImageConfig {
  * @public
  */
 export interface GenerationConfig {
+  /**
+   * @deprecated Not supported in newer Gemini models (Gemini 2.0+). Make parallel requests instead.
+   */
   candidateCount?: number;
   stopSequences?: string[];
   maxOutputTokens?: number;
+  /**
+   * @deprecated Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
+   */
   temperature?: number;
+  /**
+   * @deprecated Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
+   */
   topP?: number;
+  /**
+   * @deprecated Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
+   */
   topK?: number;
+  /**
+   * @deprecated Not supported in newer Gemini models (Gemini 2.5+). Omit this parameter.
+   */
   presencePenalty?: number;
+  /**
+   * @deprecated Not supported in newer Gemini models (Gemini 2.5+). Omit this parameter.
+   */
   frequencyPenalty?: number;
 
   /**
@@ -212,12 +230,16 @@ export interface LiveGenerationConfig {
    */
   maxOutputTokens?: number;
   /**
+   * @deprecated Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
+   *
    * Controls the degree of randomness in token selection. A `temperature` value of 0 means that the highest
    * probability tokens are always selected. In this case, responses for a given prompt are mostly
    * deterministic, but a small amount of variation is still possible.
    */
   temperature?: number;
   /**
+   * @deprecated Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
+   *
    * Changes how the model selects tokens for output. Tokens are
    * selected from the most to least probable until the sum of their probabilities equals the `topP`
    * value. For example, if tokens A, B, and C have probabilities of 0.3, 0.2, and 0.1 respectively
@@ -226,6 +248,8 @@ export interface LiveGenerationConfig {
    */
   topP?: number;
   /**
+   * @deprecated Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
+   *
    * Changes how the model selects token for output. A `topK` value of 1 means the select token is
    * the most probable among all tokens in the model's vocabulary, while a `topK` value 3 means that
    * the next token is selected from among the 3 most probably using probabilities sampled. Tokens
@@ -234,10 +258,14 @@ export interface LiveGenerationConfig {
    */
   topK?: number;
   /**
+   * @deprecated Not supported in newer Gemini models (Gemini 2.5+). Omit this parameter.
+   *
    * Positive penalties.
    */
   presencePenalty?: number;
   /**
+   * @deprecated Not supported in newer Gemini models (Gemini 2.5+). Omit this parameter.
+   *
    * Frequency penalties.
    */
   frequencyPenalty?: number;

--- a/packages/ai/src/types/requests.ts
+++ b/packages/ai/src/types/requests.ts
@@ -230,43 +230,43 @@ export interface LiveGenerationConfig {
    */
   maxOutputTokens?: number;
   /**
-   * @deprecated Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
-   *
    * Controls the degree of randomness in token selection. A `temperature` value of 0 means that the highest
    * probability tokens are always selected. In this case, responses for a given prompt are mostly
    * deterministic, but a small amount of variation is still possible.
+   *
+   * @deprecated Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
    */
   temperature?: number;
   /**
-   * @deprecated Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
-   *
    * Changes how the model selects tokens for output. Tokens are
    * selected from the most to least probable until the sum of their probabilities equals the `topP`
    * value. For example, if tokens A, B, and C have probabilities of 0.3, 0.2, and 0.1 respectively
    * and the `topP` value is 0.5, then the model will select either A or B as the next token by using
    * the `temperature` and exclude C as a candidate. Defaults to 0.95 if unset.
+   *
+   * @deprecated Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
    */
   topP?: number;
   /**
-   * @deprecated Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
-   *
    * Changes how the model selects token for output. A `topK` value of 1 means the select token is
    * the most probable among all tokens in the model's vocabulary, while a `topK` value 3 means that
    * the next token is selected from among the 3 most probably using probabilities sampled. Tokens
    * are then further filtered with the highest selected `temperature` sampling. Defaults to 40
    * if unspecified.
+   *
+   * @deprecated Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
    */
   topK?: number;
   /**
-   * @deprecated Not supported in newer Gemini models (Gemini 2.5+). Omit this parameter.
-   *
    * Positive penalties.
+   *
+   * @deprecated Not supported in newer Gemini models (Gemini 2.5+). Omit this parameter.
    */
   presencePenalty?: number;
   /**
-   * @deprecated Not supported in newer Gemini models (Gemini 2.5+). Omit this parameter.
-   *
    * Frequency penalties.
+   *
+   * @deprecated Not supported in newer Gemini models (Gemini 2.5+). Omit this parameter.
    */
   frequencyPenalty?: number;
   /**

--- a/packages/ai/src/types/requests.ts
+++ b/packages/ai/src/types/requests.ts
@@ -137,29 +137,29 @@ export interface ImageConfig {
  */
 export interface GenerationConfig {
   /**
-   * @deprecated Not supported in newer Gemini models (Gemini 2.0+). Make parallel requests instead.
+   * @deprecated Not supported in Gemini 3.x and later models. Requests that include this parameter will fail with a 400 error. Make parallel requests instead.
    */
   candidateCount?: number;
   stopSequences?: string[];
   maxOutputTokens?: number;
   /**
-   * @deprecated Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
+   * @deprecated Not supported in Gemini 3.x and later models. The model will ignore this parameter if it's included in a request. Omit this parameter and let the model manage sampling automatically.
    */
   temperature?: number;
   /**
-   * @deprecated Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
+   * @deprecated Not supported in Gemini 3.x and later models. The model will ignore this parameter if it's included in a request. Omit this parameter and let the model manage sampling automatically.
    */
   topP?: number;
   /**
-   * @deprecated Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
+   * @deprecated Not supported in Gemini 3.x and later models. The model will ignore this parameter if it's included in a request. Omit this parameter and let the model manage sampling automatically.
    */
   topK?: number;
   /**
-   * @deprecated Not supported in newer Gemini models (Gemini 2.5+). Omit this parameter.
+   * @deprecated Not supported in Gemini 3.x and later models. Requests that include this parameter will fail with a 400 error. Omit this parameter.
    */
   presencePenalty?: number;
   /**
-   * @deprecated Not supported in newer Gemini models (Gemini 2.5+). Omit this parameter.
+   * @deprecated Not supported in Gemini 3.x and later models. Requests that include this parameter will fail with a 400 error. Omit this parameter.
    */
   frequencyPenalty?: number;
 
@@ -234,7 +234,7 @@ export interface LiveGenerationConfig {
    * probability tokens are always selected. In this case, responses for a given prompt are mostly
    * deterministic, but a small amount of variation is still possible.
    *
-   * @deprecated Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
+   * @deprecated Not supported in Gemini 3.x and later models. The model will ignore this parameter if it's included in a request. Omit this parameter and let the model manage sampling automatically.
    */
   temperature?: number;
   /**
@@ -244,7 +244,7 @@ export interface LiveGenerationConfig {
    * and the `topP` value is 0.5, then the model will select either A or B as the next token by using
    * the `temperature` and exclude C as a candidate. Defaults to 0.95 if unset.
    *
-   * @deprecated Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
+   * @deprecated Not supported in Gemini 3.x and later models. The model will ignore this parameter if it's included in a request. Omit this parameter and let the model manage sampling automatically.
    */
   topP?: number;
   /**
@@ -254,19 +254,19 @@ export interface LiveGenerationConfig {
    * are then further filtered with the highest selected `temperature` sampling. Defaults to 40
    * if unspecified.
    *
-   * @deprecated Deprecated for Gemini 3 models. Omit this parameter and let the model manage sampling automatically.
+   * @deprecated Not supported in Gemini 3.x and later models. The model will ignore this parameter if it's included in a request. Omit this parameter and let the model manage sampling automatically.
    */
   topK?: number;
   /**
    * Positive penalties.
    *
-   * @deprecated Not supported in newer Gemini models (Gemini 2.5+). Omit this parameter.
+   * @deprecated Not supported in Gemini 3.x and later models. Requests that include this parameter will fail with a 400 error. Omit this parameter.
    */
   presencePenalty?: number;
   /**
    * Frequency penalties.
    *
-   * @deprecated Not supported in newer Gemini models (Gemini 2.5+). Omit this parameter.
+   * @deprecated Not supported in Gemini 3.x and later models. Requests that include this parameter will fail with a 400 error. Omit this parameter.
    */
   frequencyPenalty?: number;
   /**

--- a/packages/ai/src/types/requests.ts
+++ b/packages/ai/src/types/requests.ts
@@ -137,7 +137,7 @@ export interface ImageConfig {
  */
 export interface GenerationConfig {
   /**
-   * @deprecated Not supported in Gemini 3.x and later models. Requests that include this parameter will fail with a 400 error. Make parallel requests instead.
+   * @deprecated Not supported in Gemini 3.x and later models. The model will ignore this parameter if it's included in a request. Make parallel requests instead.
    */
   candidateCount?: number;
   stopSequences?: string[];


### PR DESCRIPTION
Deprecates `candidateCount`, `temperature`, `topP`, `topK`, `presencePenalty`, and `frequencyPenalty` in `GenerationConfig` and `LiveGenerationConfig` to align with the latest Gemini model guidelines.