### PR TITLE
fix(firestore): include Temporal namespace declaration in global_index.d.ts

### DIFF
--- a/.changeset/temporal-global-dts.md
+++ b/.changeset/temporal-global-dts.md
@@ -1,0 +1,5 @@
+---
+"@firebase/firestore": patch
+---
+
+Include `Temporal` namespace declaration in `global_index.d.ts`.

--- a/packages/firestore/src/global.ts
+++ b/packages/firestore/src/global.ts
@@ -21,6 +21,17 @@
 import * as pipelines from './api_pipelines';
 export * from './api';
 export { pipelines };
+// Type definitions for ECMAScript Temporal API
+declare global {
+  namespace Temporal {
+    interface Instant {
+      readonly [Symbol.toStringTag]?: string;
+      readonly epochMilliseconds: number;
+      readonly epochNanoseconds: bigint;
+      toString(): string;
+    }
+  }
+}
 
 // Console specific exports
 export {


### PR DESCRIPTION
### Description
In #10301, `Timestamp.fromInstant` and `Timestamp.toInstant` were introduced with parameter and return type `Temporal.Instant`. While `Temporal` was declared in `src/core/temporal.d.ts`, the bundled declaration file `global_index.d.ts` (generated from `src/global.ts` for internal console bundles) did not include the ambient `Temporal` namespace declaration. This caused downstream TypeScript compilation errors (`TS2503: Cannot find namespace 'Temporal'`) in consumers of `global_index.d.ts`.

This change adds the ambient `Temporal.Instant` interface declaration to `src/global.ts` so that `rollup-plugin-dts` bundles it into `dist/firestore/src/global_index.d.ts`.

### Testing
- Ran `tsc --emitDeclarationOnly --declaration -p tsconfig.json` and `rollup -c rollup.config.js`. Verified that `dist/firestore/src/global_index.d.ts` contains `declare global { namespace Temporal { interface Instant { ... } } }`.
- Ran `yarn api-report:main` and verified it passes.
- Ran `yarn lint` and verified it passes.
