### PR TITLE
test: remove chai, sinon dependencies from util, logger, component, template and use vitest instead

### DIFF
--- a/config/vitest.base.mjs
+++ b/config/vitest.base.mjs
@@ -44,9 +44,6 @@ export function createBaseConfig(importMetaUrl, customConfig = {}) {
   const setupFiles = fs.existsSync(setupFile) ? [setupFile] : [];
 
   const base = defineConfig({
-    optimizeDeps: {
-      include: ['chai', 'chai-as-promised', 'sinon', 'sinon-chai']
-    },
     test: {
       globals: true,
       reporters: process.env.GITHUB_ACTIONS ? ['default', 'github-actions'] : ['default'],

--- a/packages/component/src/component_container.test.ts
+++ b/packages/component/src/component_container.test.ts
@@ -62,7 +62,7 @@ describe('Component Container', () => {
     );
     container.addComponent(component);
 
-    expect(setComponentStub).has.been.calledWith(component);
+    expect(setComponentStub).toHaveBeenCalledWith(component);
   });
 
   it('throws when registering multiple components with the same name, when overwrite is false', () => {

--- a/packages/component/src/component_container.test.ts
+++ b/packages/component/src/component_container.test.ts
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai';
-import { stub } from 'sinon';
+import { expect, vi } from 'vitest';
 import { ComponentContainer } from './component_container';
 import '../test/setup';
 import { Provider } from './provider';
@@ -54,7 +53,7 @@ describe('Component Container', () => {
 
   it('calls setComponent() on provider with the same name when registering a component', () => {
     const provider = container.getProvider('fireball');
-    const setComponentStub = stub(provider, 'setComponent').callThrough();
+    const setComponentStub = vi.spyOn(provider, 'setComponent');
     const component = getFakeComponent(
       'fireball',
       () => ({ test: 1 }),

--- a/packages/component/src/provider.test.ts
+++ b/packages/component/src/provider.test.ts
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai';
-import { fake, SinonSpy, match } from 'sinon';
+import { expect, vi, MockInstance } from 'vitest';
 import { ComponentContainer } from './component_container';
 import { FirebaseService } from '@firebase/app-types/private';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -127,7 +126,7 @@ describe('Provider', () => {
       expect((instance as any).options).to.deep.equal(options);
     });
 
-    it('resolve pending promises created by Provider.get() with the same identifier', () => {
+    it('resolve pending promises created by Provider.get() with the same identifier', async () => {
       provider.setComponent(
         getFakeComponent(
           'test',
@@ -141,7 +140,7 @@ describe('Provider', () => {
 
       provider.initialize();
       expect((provider as any).instances.size).to.equal(1);
-      return expect(servicePromise).to.eventually.deep.equal({ test: true });
+      await expect(servicePromise).resolves.toEqual({ test: true });
     });
 
     it('invokes onInit callbacks synchronously', () => {
@@ -153,7 +152,7 @@ describe('Provider', () => {
           InstantiationMode.EXPLICIT
         )
       );
-      const callback1 = fake();
+      const callback1 = vi.fn();
       provider.onInit(callback1);
 
       provider.initialize();
@@ -171,8 +170,8 @@ describe('Provider', () => {
           InstantiationMode.EXPLICIT
         )
       );
-      const callback1 = fake();
-      const callback2 = fake();
+      const callback1 = vi.fn();
+      const callback2 = vi.fn();
       provider.onInit(callback1);
       provider.onInit(callback2);
 
@@ -190,7 +189,7 @@ describe('Provider', () => {
           InstantiationMode.EXPLICIT
         )
       );
-      const callback = fake();
+      const callback = vi.fn();
       provider.initialize();
       provider.onInit(callback);
 
@@ -200,7 +199,7 @@ describe('Provider', () => {
     it('passes service instance', () => {
       const serviceInstance = { test: true };
       provider.setComponent(getFakeComponent('test', () => serviceInstance));
-      const callback = fake();
+      const callback = vi.fn();
 
       // initialize the service instance
       provider.getImmediate();
@@ -208,7 +207,10 @@ describe('Provider', () => {
       provider.onInit(callback);
 
       expect(callback).to.have.been.calledOnce;
-      expect(callback).to.have.been.calledWith(serviceInstance);
+      expect(callback).to.have.been.calledWith(
+        serviceInstance,
+        expect.anything()
+      );
     });
 
     it('passes instance identifier', () => {
@@ -220,8 +222,8 @@ describe('Provider', () => {
           InstantiationMode.EAGER
         )
       );
-      const callback1 = fake();
-      const callback2 = fake();
+      const callback1 = vi.fn();
+      const callback2 = vi.fn();
 
       provider.getImmediate({ identifier: 'id1' });
       provider.getImmediate({ identifier: 'id2' });
@@ -230,9 +232,9 @@ describe('Provider', () => {
       provider.onInit(callback2, 'id2');
 
       expect(callback1).to.have.been.calledOnce;
-      expect(callback1).to.have.been.calledWith(match.any, 'id1');
+      expect(callback1).to.have.been.calledWith(expect.anything(), 'id1');
       expect(callback2).to.have.been.calledOnce;
-      expect(callback2).to.have.been.calledWith(match.any, 'id2');
+      expect(callback2).to.have.been.calledWith(expect.anything(), 'id2');
     });
 
     it('returns a function to unregister the callback', () => {
@@ -244,8 +246,8 @@ describe('Provider', () => {
           InstantiationMode.EXPLICIT
         )
       );
-      const callback1 = fake();
-      const callback2 = fake();
+      const callback1 = vi.fn();
+      const callback2 = vi.fn();
       provider.onInit(callback1);
       const unregister = provider.onInit(callback2);
       unregister();
@@ -295,18 +297,14 @@ describe('Provider', () => {
     describe('get()', () => {
       it('get the service instance asynchronously', async () => {
         provider.setComponent(getFakeComponent('test', () => ({ test: true })));
-        await expect(provider.get()).to.eventually.deep.equal({ test: true });
+        await expect(provider.get()).resolves.toEqual({ test: true });
       });
 
       it('ignore parameter identifier and return the default service instance async', async () => {
         provider.setComponent(getFakeComponent('test', () => ({ test: true })));
         const defaultService = provider.getImmediate();
-        await expect(provider.get('spider1')).to.eventually.equal(
-          defaultService
-        );
-        await expect(provider.get('spider2')).to.eventually.equal(
-          defaultService
-        );
+        await expect(provider.get('spider1')).resolves.toBe(defaultService);
+        await expect(provider.get('spider2')).resolves.toBe(defaultService);
       });
     });
 
@@ -351,14 +349,14 @@ describe('Provider', () => {
 
         const defaultService = provider.getImmediate();
 
-        await expect(promise1).to.eventually.equal(defaultService);
-        await expect(promise2).to.eventually.equal(defaultService);
+        await expect(promise1).resolves.toBe(defaultService);
+        await expect(promise2).resolves.toBe(defaultService);
       });
     });
 
     describe('delete()', () => {
       it('calls delete() on the service instance that implements legacy FirebaseService', () => {
-        const deleteFake = fake();
+        const deleteFake = vi.fn();
         const myService: FirebaseService = {
           app: getFakeApp(),
           INTERNAL: {
@@ -382,7 +380,7 @@ describe('Provider', () => {
       });
 
       it('calls delete() on the service instance that implements next FirebaseService', () => {
-        const deleteFake = fake();
+        const deleteFake = vi.fn();
         const myService: _FirebaseService = {
           app: getFakeApp(),
           _delete: deleteFake
@@ -515,10 +513,10 @@ describe('Provider', () => {
 
     describe('delete()', () => {
       it('calls delete() on all service instances that implement FirebaseService', () => {
-        const deleteFakes: SinonSpy[] = [];
+        const deleteFakes: MockInstance[] = [];
 
         function getService(): FirebaseService {
-          const deleteFake = fake();
+          const deleteFake = vi.fn();
           deleteFakes.push(deleteFake);
           return {
             app: getFakeApp(),

--- a/packages/component/src/provider.test.ts
+++ b/packages/component/src/provider.test.ts
@@ -156,7 +156,7 @@ describe('Provider', () => {
       provider.onInit(callback1);
 
       provider.initialize();
-      expect(callback1).to.have.been.calledOnce;
+      expect(callback1).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -176,8 +176,8 @@ describe('Provider', () => {
       provider.onInit(callback2);
 
       provider.initialize();
-      expect(callback1).to.have.been.calledOnce;
-      expect(callback2).to.have.been.calledOnce;
+      expect(callback1).toHaveBeenCalledTimes(1);
+      expect(callback2).toHaveBeenCalledTimes(1);
     });
 
     it('invokes callback for existing instance', () => {
@@ -193,7 +193,7 @@ describe('Provider', () => {
       provider.initialize();
       provider.onInit(callback);
 
-      expect(callback).to.have.been.calledOnce;
+      expect(callback).toHaveBeenCalledTimes(1);
     });
 
     it('passes service instance', () => {
@@ -206,11 +206,8 @@ describe('Provider', () => {
 
       provider.onInit(callback);
 
-      expect(callback).to.have.been.calledOnce;
-      expect(callback).to.have.been.calledWith(
-        serviceInstance,
-        expect.anything()
-      );
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith(serviceInstance, expect.anything());
     });
 
     it('passes instance identifier', () => {
@@ -231,10 +228,10 @@ describe('Provider', () => {
       provider.onInit(callback1, 'id1');
       provider.onInit(callback2, 'id2');
 
-      expect(callback1).to.have.been.calledOnce;
-      expect(callback1).to.have.been.calledWith(expect.anything(), 'id1');
-      expect(callback2).to.have.been.calledOnce;
-      expect(callback2).to.have.been.calledWith(expect.anything(), 'id2');
+      expect(callback1).toHaveBeenCalledTimes(1);
+      expect(callback1).toHaveBeenCalledWith(expect.anything(), 'id1');
+      expect(callback2).toHaveBeenCalledTimes(1);
+      expect(callback2).toHaveBeenCalledWith(expect.anything(), 'id2');
     });
 
     it('returns a function to unregister the callback', () => {
@@ -253,8 +250,8 @@ describe('Provider', () => {
       unregister();
 
       provider.initialize();
-      expect(callback1).to.have.been.calledOnce;
-      expect(callback2).to.not.have.been.called;
+      expect(callback1).toHaveBeenCalledTimes(1);
+      expect(callback2).not.toHaveBeenCalled();
     });
   });
 
@@ -376,7 +373,7 @@ describe('Provider', () => {
 
         void provider.delete();
 
-        expect(deleteFake).to.have.been.called;
+        expect(deleteFake).toHaveBeenCalled();
       });
 
       it('calls delete() on the service instance that implements next FirebaseService', () => {
@@ -398,7 +395,7 @@ describe('Provider', () => {
 
         void provider.delete();
 
-        expect(deleteFake).to.have.been.called;
+        expect(deleteFake).toHaveBeenCalled();
       });
     });
 
@@ -537,7 +534,7 @@ describe('Provider', () => {
 
         expect(deleteFakes.length).to.equal(2);
         for (const f of deleteFakes) {
-          expect(f).to.have.been.called;
+          expect(f).toHaveBeenCalled();
         }
       });
     });

--- a/packages/component/test/setup.ts
+++ b/packages/component/test/setup.ts
@@ -15,14 +15,8 @@
  * limitations under the License.
  */
 
-import { use } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
-import { restore } from 'sinon';
-import sinonChai from 'sinon-chai';
-
-use(chaiAsPromised);
-use(sinonChai);
+import { vi } from 'vitest';
 
 afterEach(async () => {
-  restore();
+  vi.restoreAllMocks();
 });

--- a/packages/logger/test/custom-logger.test.ts
+++ b/packages/logger/test/custom-logger.test.ts
@@ -15,11 +15,9 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai';
-import { spy } from 'sinon';
+import { expect, vi } from 'vitest';
 import { Logger, setLogLevel } from '../src/logger';
 import { setUserLogHandler } from '../index';
-
 describe(`Custom log handler`, () => {
   const client1 = new Logger('@firebase/test-logger');
   const client2 = new Logger('@firebase/other-logger');
@@ -36,18 +34,18 @@ describe(`Custom log handler`, () => {
     beforeEach(() => {
       result = null;
       spies = {
-        logSpy: spy(console, 'log'),
-        infoSpy: spy(console, 'info'),
-        warnSpy: spy(console, 'warn'),
-        errorSpy: spy(console, 'error')
+        logSpy: vi.spyOn(console, 'log'),
+        infoSpy: vi.spyOn(console, 'info'),
+        warnSpy: vi.spyOn(console, 'warn'),
+        errorSpy: vi.spyOn(console, 'error')
       };
     });
 
     afterEach(() => {
-      spies.logSpy.restore();
-      spies.infoSpy.restore();
-      spies.warnSpy.restore();
-      spies.errorSpy.restore();
+      spies.logSpy.mockRestore();
+      spies.infoSpy.mockRestore();
+      spies.warnSpy.mockRestore();
+      spies.errorSpy.mockRestore();
     });
 
     it('calls custom callback with correct data for calling instance', () => {
@@ -57,14 +55,14 @@ describe(`Custom log handler`, () => {
       expect(result.args[0]).to.equal('info message!');
       expect(result.level).to.equal('info');
       expect(result.type).to.equal('@firebase/test-logger');
-      expect(spies.infoSpy.called).to.be.true;
-      spies.infoSpy.resetHistory();
+      expect(spies.infoSpy.mock.calls.length > 0).to.be.true;
+      spies.infoSpy.mockClear();
       client2.info('another info message!');
       expect(result.message).to.equal('another info message!');
       expect(result.args[0]).to.equal('another info message!');
       expect(result.level).to.equal('info');
       expect(result.type).to.equal('@firebase/other-logger');
-      expect(spies.infoSpy.called).to.be.true;
+      expect(spies.infoSpy.mock.calls.length > 0).to.be.true;
     });
 
     it('parses multiple arguments correctly', () => {
@@ -87,21 +85,21 @@ describe(`Custom log handler`, () => {
       client1.warn('warning message!');
       expect(result.message).to.equal('warning message!');
       expect(result.level).to.equal('warn');
-      expect(spies.warnSpy.called).to.be.true;
+      expect(spies.warnSpy.mock.calls.length > 0).to.be.true;
       client1.error('error message!');
       expect(result.message).to.equal('error message!');
       expect(result.level).to.equal('error');
-      expect(spies.errorSpy.called).to.be.true;
+      expect(spies.errorSpy.mock.calls.length > 0).to.be.true;
     });
 
     it('does not call custom callback when log call is not above set log level', () => {
       // Default log level is INFO.
       client1.log('message you should not see');
       expect(result).to.be.null;
-      expect(spies.logSpy.called).to.be.false;
+      expect(spies.logSpy.mock.calls.length > 0).to.be.false;
       client1.debug('message you should not see');
       expect(result).to.be.null;
-      expect(spies.logSpy.called).to.be.false;
+      expect(spies.logSpy.mock.calls.length > 0).to.be.false;
     });
   });
 
@@ -118,18 +116,18 @@ describe(`Custom log handler`, () => {
     beforeEach(() => {
       result = null;
       spies = {
-        logSpy: spy(console, 'log'),
-        infoSpy: spy(console, 'info'),
-        warnSpy: spy(console, 'warn'),
-        errorSpy: spy(console, 'error')
+        logSpy: vi.spyOn(console, 'log'),
+        infoSpy: vi.spyOn(console, 'info'),
+        warnSpy: vi.spyOn(console, 'warn'),
+        errorSpy: vi.spyOn(console, 'error')
       };
     });
 
     afterEach(() => {
-      spies.logSpy.restore();
-      spies.infoSpy.restore();
-      spies.warnSpy.restore();
-      spies.errorSpy.restore();
+      spies.logSpy.mockRestore();
+      spies.infoSpy.mockRestore();
+      spies.warnSpy.mockRestore();
+      spies.errorSpy.mockRestore();
     });
 
     it('calls custom callback when log call is above set log level', () => {
@@ -138,20 +136,20 @@ describe(`Custom log handler`, () => {
       expect(result.args[0]).to.equal('warning message!');
       expect(result.level).to.equal('warn');
       expect(result.type).to.equal('@firebase/test-logger');
-      expect(spies.warnSpy.called).to.be.true;
+      expect(spies.warnSpy.mock.calls.length > 0).to.be.true;
       client1.error('error message!');
       expect(result.message).to.equal('error message!');
       expect(result.level).to.equal('error');
-      expect(spies.errorSpy.called).to.be.true;
+      expect(spies.errorSpy.mock.calls.length > 0).to.be.true;
     });
 
     it('does not call custom callback when log call is not above set log level', () => {
       client1.debug('message you should not see');
       expect(result).to.be.null;
-      expect(spies.logSpy.called).to.be.false;
+      expect(spies.logSpy.mock.calls.length > 0).to.be.false;
       client1.log('message you should not see');
       expect(result).to.be.null;
-      expect(spies.logSpy.called).to.be.false;
+      expect(spies.logSpy.mock.calls.length > 0).to.be.false;
       client1.info('message you should not see');
       expect(result).to.be.null;
     });
@@ -159,7 +157,7 @@ describe(`Custom log handler`, () => {
     it('logLevel set in setUserLogHandler should not affect internal logging level', () => {
       client1.info('message you should not see');
       expect(result).to.be.null;
-      expect(spies.infoSpy.called).to.be.true;
+      expect(spies.infoSpy.mock.calls.length > 0).to.be.true;
     });
   });
 
@@ -174,43 +172,43 @@ describe(`Custom log handler`, () => {
     beforeEach(() => {
       result = null;
       spies = {
-        logSpy: spy(console, 'log'),
-        infoSpy: spy(console, 'info'),
-        warnSpy: spy(console, 'warn'),
-        errorSpy: spy(console, 'error')
+        logSpy: vi.spyOn(console, 'log'),
+        infoSpy: vi.spyOn(console, 'info'),
+        warnSpy: vi.spyOn(console, 'warn'),
+        errorSpy: vi.spyOn(console, 'error')
       };
     });
 
     afterEach(() => {
-      spies.logSpy.restore();
-      spies.infoSpy.restore();
-      spies.warnSpy.restore();
-      spies.errorSpy.restore();
+      spies.logSpy.mockRestore();
+      spies.infoSpy.mockRestore();
+      spies.warnSpy.mockRestore();
+      spies.errorSpy.mockRestore();
     });
 
     it('calls custom callback when log call is above set log level', () => {
       client1.log('log message!');
       expect(result.message).to.equal('log message!');
       expect(result.level).to.equal('verbose');
-      expect(spies.logSpy.called).to.be.true;
+      expect(spies.logSpy.mock.calls.length > 0).to.be.true;
       client1.info('info message!');
       expect(result.message).to.equal('info message!');
       expect(result.level).to.equal('info');
-      expect(spies.infoSpy.called).to.be.true;
+      expect(spies.infoSpy.mock.calls.length > 0).to.be.true;
       client1.warn('warning message!');
       expect(result.message).to.equal('warning message!');
       expect(result.level).to.equal('warn');
-      expect(spies.warnSpy.called).to.be.true;
+      expect(spies.warnSpy.mock.calls.length > 0).to.be.true;
       client1.error('error message!');
       expect(result.message).to.equal('error message!');
       expect(result.level).to.equal('error');
-      expect(spies.errorSpy.called).to.be.true;
+      expect(spies.errorSpy.mock.calls.length > 0).to.be.true;
     });
 
     it('does not call custom callback when log call is not above set log level', () => {
       client1.debug('message you should not see');
       expect(result).to.be.null;
-      expect(spies.logSpy.called).to.be.false;
+      expect(spies.logSpy.mock.calls.length > 0).to.be.false;
     });
   });
 });

--- a/packages/logger/test/custom-logger.test.ts
+++ b/packages/logger/test/custom-logger.test.ts
@@ -34,10 +34,10 @@ describe(`Custom log handler`, () => {
     beforeEach(() => {
       result = null;
       spies = {
-        logSpy: vi.spyOn(console, 'log'),
-        infoSpy: vi.spyOn(console, 'info'),
-        warnSpy: vi.spyOn(console, 'warn'),
-        errorSpy: vi.spyOn(console, 'error')
+        logSpy: vi.spyOn(console, 'log').mockImplementation(() => {}),
+        infoSpy: vi.spyOn(console, 'info').mockImplementation(() => {}),
+        warnSpy: vi.spyOn(console, 'warn').mockImplementation(() => {}),
+        errorSpy: vi.spyOn(console, 'error').mockImplementation(() => {})
       };
     });
 
@@ -116,10 +116,10 @@ describe(`Custom log handler`, () => {
     beforeEach(() => {
       result = null;
       spies = {
-        logSpy: vi.spyOn(console, 'log'),
-        infoSpy: vi.spyOn(console, 'info'),
-        warnSpy: vi.spyOn(console, 'warn'),
-        errorSpy: vi.spyOn(console, 'error')
+        logSpy: vi.spyOn(console, 'log').mockImplementation(() => {}),
+        infoSpy: vi.spyOn(console, 'info').mockImplementation(() => {}),
+        warnSpy: vi.spyOn(console, 'warn').mockImplementation(() => {}),
+        errorSpy: vi.spyOn(console, 'error').mockImplementation(() => {})
       };
     });
 
@@ -172,10 +172,10 @@ describe(`Custom log handler`, () => {
     beforeEach(() => {
       result = null;
       spies = {
-        logSpy: vi.spyOn(console, 'log'),
-        infoSpy: vi.spyOn(console, 'info'),
-        warnSpy: vi.spyOn(console, 'warn'),
-        errorSpy: vi.spyOn(console, 'error')
+        logSpy: vi.spyOn(console, 'log').mockImplementation(() => {}),
+        infoSpy: vi.spyOn(console, 'info').mockImplementation(() => {}),
+        warnSpy: vi.spyOn(console, 'warn').mockImplementation(() => {}),
+        errorSpy: vi.spyOn(console, 'error').mockImplementation(() => {})
       };
     });
 

--- a/packages/logger/test/logger.test.ts
+++ b/packages/logger/test/logger.test.ts
@@ -31,10 +31,10 @@ describe('@firebase/logger', () => {
     client = new Logger('@firebase/test-logger');
 
     spies = {
-      logSpy: vi.spyOn(console, 'log'),
-      infoSpy: vi.spyOn(console, 'info'),
-      warnSpy: vi.spyOn(console, 'warn'),
-      errorSpy: vi.spyOn(console, 'error')
+      logSpy: vi.spyOn(console, 'log').mockImplementation(() => {}),
+      infoSpy: vi.spyOn(console, 'info').mockImplementation(() => {}),
+      warnSpy: vi.spyOn(console, 'warn').mockImplementation(() => {}),
+      errorSpy: vi.spyOn(console, 'error').mockImplementation(() => {})
     };
   });
 

--- a/packages/logger/test/logger.test.ts
+++ b/packages/logger/test/logger.test.ts
@@ -15,16 +15,14 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai';
-import { spy as Spy, SinonSpy } from 'sinon';
+import { expect, vi, MockInstance } from 'vitest';
 import { Logger, LogLevel } from '../src/logger';
 import { setLogLevel } from '../index';
-
 describe('@firebase/logger', () => {
   const message = 'Hello there!';
   let client: Logger;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let spies: { [key: string]: SinonSpy<any[], void> };
+  let spies: { [key: string]: MockInstance };
   /**
    * Before each test, instantiate a new instance of Logger and establish spies
    * on all of the console methods so we can assert against them as needed
@@ -33,18 +31,18 @@ describe('@firebase/logger', () => {
     client = new Logger('@firebase/test-logger');
 
     spies = {
-      logSpy: Spy(console, 'log'),
-      infoSpy: Spy(console, 'info'),
-      warnSpy: Spy(console, 'warn'),
-      errorSpy: Spy(console, 'error')
+      logSpy: vi.spyOn(console, 'log'),
+      infoSpy: vi.spyOn(console, 'info'),
+      warnSpy: vi.spyOn(console, 'warn'),
+      errorSpy: vi.spyOn(console, 'error')
     };
   });
 
   afterEach(() => {
-    spies.logSpy.restore();
-    spies.infoSpy.restore();
-    spies.warnSpy.restore();
-    spies.errorSpy.restore();
+    spies.logSpy.mockRestore();
+    spies.infoSpy.mockRestore();
+    spies.warnSpy.mockRestore();
+    spies.errorSpy.mockRestore();
   });
 
   function testLog(message: string, channel: string, shouldLog: boolean): void {
@@ -60,7 +58,7 @@ describe('@firebase/logger', () => {
       // @ts-ignore It's not worth making a dedicated enum for a test.
       client[channel](message);
       expect(
-        spies[`${channel}Spy`]!.called,
+        spies[`${channel}Spy`]!.mock.calls.length > 0,
         `Expected ${channel} to ${shouldLog ? '' : 'not'} log`
       ).to.be[shouldLog ? 'true' : 'false'];
     });

--- a/packages/logger/test/setup.ts
+++ b/packages/logger/test/setup.ts
@@ -15,17 +15,10 @@
  * limitations under the License.
  */
 
-/* eslint-disable import/no-extraneous-dependencies */
-import sinon from 'sinon';
-import chai from 'chai';
-import sinonChai from 'sinon-chai';
-import chaiAsPromised from 'chai-as-promised';
-
-chai.use(sinonChai);
-chai.use(chaiAsPromised);
+import { vi } from 'vitest';
 
 afterEach(() => {
-  sinon.restore();
+  vi.restoreAllMocks();
 });
 
 export function getTestTitle(ctx: any): string {

--- a/packages/template/src/index.test.ts
+++ b/packages/template/src/index.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai';
+import { expect } from 'vitest';
 import { testFxn } from './index';
 
 describe('Simple test', () => {

--- a/packages/template/test/setup.ts
+++ b/packages/template/test/setup.ts
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-import { use } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
+import { vi } from 'vitest';
 
-use(chaiAsPromised);
+afterEach(() => {
+  vi.restoreAllMocks();
+});

--- a/packages/util/test/base64.test.ts
+++ b/packages/util/test/base64.test.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert } from 'chai';
+import { assert } from 'vitest';
 import { base64Encode, base64Decode } from '../src/crypt';
 
 describe('base64', () => {

--- a/packages/util/test/compat.test.ts
+++ b/packages/util/test/compat.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai';
+import { expect } from 'vitest';
 import { getModularInstance } from '../src/compat';
 
 describe('getModularInstance()', () => {

--- a/packages/util/test/deepCopy.test.ts
+++ b/packages/util/test/deepCopy.test.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { expect } from 'chai';
+import { expect } from 'vitest';
 import { deepCopy, deepExtend } from '../src/deepCopy';
 
 describe('deepCopy()', () => {

--- a/packages/util/test/defaults.test.ts
+++ b/packages/util/test/defaults.test.ts
@@ -77,7 +77,7 @@ describe('getDefaultEmulatorHost', () => {
         },
         configurable: true
       });
-      consoleInfoStub = vi.spyOn(console, 'info');
+      consoleInfoStub = vi.spyOn(console, 'info').mockImplementation(() => {});
     });
     afterAll(() => {
       delete getGlobal().__FIREBASE_DEFAULTS__;

--- a/packages/util/test/defaults.test.ts
+++ b/packages/util/test/defaults.test.ts
@@ -14,17 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { expect, use } from 'chai';
-import { match, restore, SinonStub, stub } from 'sinon';
-import sinonChai from 'sinon-chai';
-import { beforeAll, afterAll } from 'vitest';
+import { expect, beforeAll, afterAll, vi, MockInstance } from 'vitest';
 import {
   getDefaultEmulatorHost,
   getDefaultEmulatorHostnameAndPort
 } from '../src/defaults';
 import { getGlobal } from '../src/global';
-
-use(sinonChai);
 
 describe('getDefaultEmulatorHost', () => {
   afterAll(() => {
@@ -40,12 +35,14 @@ describe('getDefaultEmulatorHost', () => {
   describe('with no config and process.env undefined', () => {
     it('returns undefined and does not throw', () => {
       if (typeof process !== 'undefined') {
-        const envStub = stub(process, 'env').value(undefined);
+        const envStub = vi
+          .spyOn(process, 'env', 'get')
+          .mockReturnValue(undefined as any);
         try {
           expect(getDefaultEmulatorHost('firestore')).to.be.undefined;
           expect(getDefaultEmulatorHost('firestore')).to.not.throw;
         } finally {
-          envStub.restore();
+          envStub.mockRestore();
         }
       } else {
         expect(getDefaultEmulatorHost('firestore')).to.be.undefined;
@@ -57,11 +54,13 @@ describe('getDefaultEmulatorHost', () => {
   describe('with no config and no document or document.cookie throws', () => {
     beforeAll(() => {
       if (typeof document !== 'undefined') {
-        stub(document, 'cookie').get(() => new Error('aaaah'));
+        vi.spyOn(document, 'cookie', 'get').mockReturnValue(
+          new Error('aaaah') as any
+        );
       }
     });
     afterAll(() => {
-      restore();
+      vi.restoreAllMocks();
     });
     it('returns undefined and does not throw', () => {
       expect(getDefaultEmulatorHost('firestore')).to.be.undefined;
@@ -70,7 +69,7 @@ describe('getDefaultEmulatorHost', () => {
   });
 
   describe('with no config and something unexpected throws', () => {
-    let consoleInfoStub: SinonStub;
+    let consoleInfoStub: MockInstance;
     beforeAll(() => {
       Object.defineProperty(getGlobal(), '__FIREBASE_DEFAULTS__', {
         get() {
@@ -78,15 +77,17 @@ describe('getDefaultEmulatorHost', () => {
         },
         configurable: true
       });
-      consoleInfoStub = stub(console, 'info');
+      consoleInfoStub = vi.spyOn(console, 'info');
     });
     afterAll(() => {
       delete getGlobal().__FIREBASE_DEFAULTS__;
-      restore();
+      vi.restoreAllMocks();
     });
     it('returns undefined and calls console.info with the error', () => {
       expect(getDefaultEmulatorHost('firestore')).to.be.undefined;
-      expect(consoleInfoStub).to.be.calledWith(match('getGlobal threw!'));
+      expect(consoleInfoStub).toHaveBeenCalledWith(
+        expect.stringContaining('getGlobal threw!')
+      );
     });
   });
 

--- a/packages/util/test/emulator.test.ts
+++ b/packages/util/test/emulator.test.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { expect } from 'chai';
+import { expect } from 'vitest';
 import { base64 } from '../src/crypt';
 import { createMockUserToken, EmulatorMockTokenOptions } from '../src/emulator';
 

--- a/packages/util/test/environments.test.ts
+++ b/packages/util/test/environments.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai';
+import { expect } from 'vitest';
 import { isNode } from '../src/environment';
 import { getGlobal } from '../src/global';
 import { FirebaseDefaults } from '../src/defaults';

--- a/packages/util/test/errors.test.ts
+++ b/packages/util/test/errors.test.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert } from 'chai';
+import { assert } from 'vitest';
 import { ErrorFactory, ErrorMap, FirebaseError } from '../src/errors';
 
 type ErrorCode =

--- a/packages/util/test/exponential_backoff.test.ts
+++ b/packages/util/test/exponential_backoff.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai';
+import { expect } from 'vitest';
 import {
   calculateBackoffMillis,
   MAX_VALUE_MILLIS,

--- a/packages/util/test/object.test.ts
+++ b/packages/util/test/object.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai';
+import { expect } from 'vitest';
 import { deepEqual } from '../src/obj';
 
 describe('deepEqual()', () => {

--- a/packages/util/test/setup.ts
+++ b/packages/util/test/setup.ts
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-import { use } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
+import { vi } from 'vitest';
 
-use(chaiAsPromised);
+afterEach(() => {
+  vi.restoreAllMocks();
+});

--- a/packages/util/test/subscribe.test.ts
+++ b/packages/util/test/subscribe.test.ts
@@ -15,19 +15,18 @@
  * limitations under the License.
  */
 
-import { assert } from 'chai';
-import * as sinon from 'sinon';
+import { assert, vi, expect, MockInstance } from 'vitest';
 import { async, createSubscribe, Observer, Subscribe } from '../src/subscribe';
 
 describe('createSubscribe', () => {
-  let spy: any;
+  let spy: MockInstance;
   beforeEach(() => {
     // Listen to console.error calls.
-    spy = sinon.spy(console, 'error');
+    spy = vi.spyOn(console, 'error');
   });
 
   afterEach(() => {
-    spy.restore();
+    spy.mockRestore();
   });
 
   it('Creation', done => {
@@ -58,7 +57,7 @@ describe('createSubscribe', () => {
       },
       complete() {
         // By this point, the error should have been logged.
-        assert.ok(spy.calledWith(uncatchableError));
+        expect(spy).toHaveBeenCalledWith(uncatchableError);
         done();
       }
     });


### PR DESCRIPTION
Migrate test suites from sinon, sinon-chai, chai, and chai-as-promised to native vitest APIs across @firebase/template, @firebase/logger, @firebase/component, and @firebase/util

- Replace sinon spies, stubs, and fakes with vi.fn() and vi.spyOn()
- Replace sinon.restore() with vi.restoreAllMocks()
- Replace chai-as-promised .to.eventually assertions with native vitest .resolves matchers
- Replace chai expect and assert imports with native vitest equivalents
- Remove optimizeDeps: { include: ['chai', 'chai-as-promised', 'sinon', 'sinon-chai'] } from config/vitest.base.mjs

