### PR TITLE
test(performance): migrate performance to Vitest

### DIFF
--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -24,10 +24,11 @@
     "build:deps": "lerna run build --scope @firebase/performance --include-dependencies",
     "build:release": "yarn build",
     "dev": "rollup -c -w",
-    "test": "run-p --npm-path npm lint test:browser",
-    "test:ci": "node ../../scripts/run_tests_in_ci.js -s test:browser",
-    "test:browser": "karma start",
-    "test:debug": "karma start --browsers=Chrome --auto-watch",
+    "test": "run-p --npm-path npm lint test:all",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js -s test:all",
+    "test:all": "vitest run",
+    "test:browser": "vitest run --project=browser",
+    "test:browser:debug": "vitest --project=browser --browser.headless=false",
     "trusted-type-check": "tsec -p tsconfig.json --noEmit",
     "prettier": "prettier --cache --write '{src,test}/**/*.{js,ts}'",
     "api-report": "api-extractor run --local --verbose",
@@ -61,11 +62,5 @@
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
   },
-  "typings": "dist/src/index.d.ts",
-  "nyc": {
-    "extension": [
-      ".ts"
-    ],
-    "reportDir": "./coverage/node"
-  }
+  "typings": "dist/src/index.d.ts"
 }

--- a/packages/performance/src/controllers/perf.test.ts
+++ b/packages/performance/src/controllers/perf.test.ts
@@ -49,7 +49,7 @@ describe('Firebase Performance Test', () => {
   describe('#constructor', () => {
     it('does not initialize performance if the required apis are not available', () => {
       vi.spyOn(Api.prototype, 'requiredApisAvailable').mockReturnValue(false);
-      vi.spyOn(consoleLogger, 'info');
+      vi.spyOn(consoleLogger, 'info').mockImplementation(() => {});
       const performanceController = new PerformanceController(
         fakeFirebaseApp,
         fakeInstallations

--- a/packages/performance/src/controllers/perf.test.ts
+++ b/packages/performance/src/controllers/perf.test.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai';
-import { stub } from 'sinon';
 import { PerformanceController } from '../controllers/perf';
 import { Api, setupApi } from '../services/api_service';
 import * as initializationService from '../services/initialization_service';
@@ -25,6 +23,9 @@ import { consoleLogger } from '../utils/console_logger';
 import { FirebaseApp } from '@firebase/app';
 import { _FirebaseInstallationsInternal } from '@firebase/installations';
 import '../../test/setup';
+import { vi } from 'vitest';
+
+vi.mock('../services/initialization_service', { spy: true });
 
 describe('Firebase Performance Test', () => {
   setupApi(window);
@@ -47,18 +48,19 @@ describe('Firebase Performance Test', () => {
 
   describe('#constructor', () => {
     it('does not initialize performance if the required apis are not available', () => {
-      stub(Api.prototype, 'requiredApisAvailable').returns(false);
-      stub(initializationService, 'getInitializationPromise');
-      stub(consoleLogger, 'info');
+      vi.spyOn(Api.prototype, 'requiredApisAvailable').mockReturnValue(false);
+      vi.spyOn(consoleLogger, 'info');
       const performanceController = new PerformanceController(
         fakeFirebaseApp,
         fakeInstallations
       );
       performanceController._init();
 
-      expect(initializationService.getInitializationPromise).not.be.called;
-      expect(consoleLogger.info).to.be.calledWithMatch(
-        /.*Fetch.*Promise.*cookies.*/
+      expect(
+        initializationService.getInitializationPromise
+      ).not.toHaveBeenCalled();
+      expect(consoleLogger.info).toHaveBeenCalledWith(
+        expect.stringMatching(/.*Fetch.*Promise.*cookies.*/)
       );
     });
   });
@@ -76,8 +78,8 @@ describe('Firebase Performance Test', () => {
       );
       performance._init(settings);
 
-      expect(performance.instrumentationEnabled).is.equal(false);
-      expect(performance.dataCollectionEnabled).is.equal(false);
+      expect(performance.instrumentationEnabled).toBe(false);
+      expect(performance.dataCollectionEnabled).toBe(false);
     });
 
     it('uses defaults when settings are not provided', async () => {
@@ -92,10 +94,10 @@ describe('Firebase Performance Test', () => {
       );
       performance._init();
 
-      expect(performance.instrumentationEnabled).is.equal(
+      expect(performance.instrumentationEnabled).toBe(
         expectedInstrumentationEnabled
       );
-      expect(performance.dataCollectionEnabled).is.equal(
+      expect(performance.dataCollectionEnabled).toBe(
         expectedDataCollectionEnabled
       );
     });
@@ -109,7 +111,7 @@ describe('Firebase Performance Test', () => {
         performance._init();
 
         performance.instrumentationEnabled = true;
-        expect(performance.instrumentationEnabled).is.equal(true);
+        expect(performance.instrumentationEnabled).toBe(true);
       });
 
       it('sets instrumentationEnabled to disabled', async () => {
@@ -120,7 +122,7 @@ describe('Firebase Performance Test', () => {
         performance._init();
 
         performance.instrumentationEnabled = false;
-        expect(performance.instrumentationEnabled).is.equal(false);
+        expect(performance.instrumentationEnabled).toBe(false);
       });
     });
 
@@ -133,7 +135,7 @@ describe('Firebase Performance Test', () => {
         performance._init();
 
         performance.dataCollectionEnabled = true;
-        expect(performance.dataCollectionEnabled).is.equal(true);
+        expect(performance.dataCollectionEnabled).toBe(true);
       });
 
       it('sets dataCollectionEnabled to disabled', () => {
@@ -144,7 +146,7 @@ describe('Firebase Performance Test', () => {
         performance._init();
 
         performance.dataCollectionEnabled = false;
-        expect(performance.dataCollectionEnabled).is.equal(false);
+        expect(performance.dataCollectionEnabled).toBe(false);
       });
     });
   });

--- a/packages/performance/src/index.test.ts
+++ b/packages/performance/src/index.test.ts
@@ -18,7 +18,13 @@
 import { initializePerformance } from './index';
 import { ERROR_FACTORY, ErrorCode } from './utils/errors';
 import '../test/setup';
-import { deleteApp, FirebaseApp, initializeApp } from '@firebase/app';
+import {
+  deleteApp,
+  FirebaseApp,
+  initializeApp,
+  _addOrOverwriteComponent
+} from '@firebase/app';
+import { Component, ComponentType } from '@firebase/component';
 import { PerformanceController } from './controllers/perf';
 import { vi } from 'vitest';
 
@@ -39,9 +45,23 @@ describe('Firebase Performance > initializePerformance()', () => {
       () => {}
     );
     app = initializeApp(fakeFirebaseConfig);
+    _addOrOverwriteComponent(
+      app,
+      new Component(
+        'heartbeat',
+        () =>
+          ({
+            triggerHeartbeat: () => {},
+            getHeartbeatsHeader: () => Promise.resolve('')
+          }) as any,
+        ComponentType.PUBLIC
+      )
+    );
   });
-  afterEach(() => {
-    return deleteApp(app);
+  afterEach(async () => {
+    if (app) {
+      await deleteApp(app);
+    }
   });
   it('returns same instance if given same (no) params a second time', () => {
     const performanceInstance = initializePerformance(app);

--- a/packages/performance/src/index.test.ts
+++ b/packages/performance/src/index.test.ts
@@ -15,11 +15,12 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai';
 import { initializePerformance } from './index';
 import { ERROR_FACTORY, ErrorCode } from './utils/errors';
 import '../test/setup';
 import { deleteApp, FirebaseApp, initializeApp } from '@firebase/app';
+import { PerformanceController } from './controllers/perf';
+import { vi } from 'vitest';
 
 const fakeFirebaseConfig = {
   apiKey: 'api-key',
@@ -34,6 +35,9 @@ const fakeFirebaseConfig = {
 describe('Firebase Performance > initializePerformance()', () => {
   let app: FirebaseApp;
   beforeEach(() => {
+    vi.spyOn(PerformanceController.prototype, '_init').mockImplementation(
+      () => {}
+    );
     app = initializeApp(fakeFirebaseConfig);
   });
   afterEach(() => {
@@ -41,33 +45,33 @@ describe('Firebase Performance > initializePerformance()', () => {
   });
   it('returns same instance if given same (no) params a second time', () => {
     const performanceInstance = initializePerformance(app);
-    expect(initializePerformance(app)).to.equal(performanceInstance);
+    expect(initializePerformance(app)).toBe(performanceInstance);
   });
   it('returns same instance if given same params a second time', () => {
     const performanceInstance = initializePerformance(app, {
       dataCollectionEnabled: false
     });
-    expect(
-      initializePerformance(app, { dataCollectionEnabled: false })
-    ).to.equal(performanceInstance);
+    expect(initializePerformance(app, { dataCollectionEnabled: false })).toBe(
+      performanceInstance
+    );
   });
   it('throws if called with params after being called with no params', () => {
     initializePerformance(app);
     const expectedError = ERROR_FACTORY.create(ErrorCode.ALREADY_INITIALIZED);
     expect(() =>
       initializePerformance(app, { dataCollectionEnabled: false })
-    ).to.throw(expectedError.message);
+    ).toThrow(expectedError.message);
   });
   it('throws if called with no params after being called with params', () => {
     initializePerformance(app, { instrumentationEnabled: false });
     const expectedError = ERROR_FACTORY.create(ErrorCode.ALREADY_INITIALIZED);
-    expect(() => initializePerformance(app)).to.throw(expectedError.message);
+    expect(() => initializePerformance(app)).toThrow(expectedError.message);
   });
   it('throws if called a second time with different params', () => {
     initializePerformance(app, { instrumentationEnabled: true });
     const expectedError = ERROR_FACTORY.create(ErrorCode.ALREADY_INITIALIZED);
     expect(() =>
       initializePerformance(app, { instrumentationEnabled: false })
-    ).to.throw(expectedError.message);
+    ).toThrow(expectedError.message);
   });
 });

--- a/packages/performance/src/index.ts
+++ b/packages/performance/src/index.ts
@@ -22,7 +22,7 @@
  * limitations under the License.
  */
 
-import {
+import type {
   FirebasePerformance,
   PerformanceSettings,
   PerformanceTrace
@@ -143,4 +143,4 @@ function registerPerformance(): void {
 
 registerPerformance();
 
-export { FirebasePerformance, PerformanceSettings, PerformanceTrace };
+export type { FirebasePerformance, PerformanceSettings, PerformanceTrace };

--- a/packages/performance/src/resources/network_request.test.ts
+++ b/packages/performance/src/resources/network_request.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2020 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,7 @@
  * limitations under the License.
  */
 
-import { stub, restore } from 'sinon';
 import { createNetworkRequestEntry } from '../../src/resources/network_request';
-import { expect } from 'chai';
 import { Api, setupApi } from '../services/api_service';
 import * as perfLogger from '../services/perf_logger';
 
@@ -25,6 +23,9 @@ import { FirebaseApp } from '@firebase/app';
 import { PerformanceController } from '../controllers/perf';
 import { FirebaseInstallations } from '@firebase/installations-types';
 import '../../test/setup';
+import { vi } from 'vitest';
+
+vi.mock('../services/perf_logger', { spy: true });
 
 describe('Firebase Performance > network_request', () => {
   setupApi(window);
@@ -40,12 +41,14 @@ describe('Firebase Performance > network_request', () => {
   );
 
   beforeEach(() => {
-    stub(Api.prototype, 'getTimeOrigin').returns(1528521843799.5032);
-    stub(perfLogger, 'logNetworkRequest');
+    vi.spyOn(Api.prototype, 'getTimeOrigin').mockReturnValue(
+      1528521843799.5032
+    );
   });
 
   afterEach(() => {
-    restore();
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
   describe('#createNetworkRequestEntry', () => {
@@ -69,11 +72,9 @@ describe('Firebase Performance > network_request', () => {
 
       createNetworkRequestEntry(performanceController, PERFORMANCE_ENTRY);
 
-      expect(
-        (perfLogger.logNetworkRequest as any).calledWith(
-          EXPECTED_NETWORK_REQUEST
-        )
-      ).to.be.true;
+      expect(perfLogger.logNetworkRequest).toHaveBeenCalledWith(
+        EXPECTED_NETWORK_REQUEST
+      );
     });
 
     it('doesnt log network request when responseStart is absent', () => {
@@ -86,7 +87,7 @@ describe('Firebase Performance > network_request', () => {
 
       createNetworkRequestEntry(performanceController, PERFORMANCE_ENTRY);
 
-      expect(perfLogger.logNetworkRequest).to.not.have.been.called;
+      expect(perfLogger.logNetworkRequest).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/performance/src/resources/trace.test.ts
+++ b/packages/performance/src/resources/trace.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2020 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,7 @@
  * limitations under the License.
  */
 
-import { spy, stub, restore } from 'sinon';
 import { Trace } from '../resources/trace';
-import { expect } from 'chai';
 import { Api, setupApi } from '../services/api_service';
 import * as perfLogger from '../services/perf_logger';
 import { PerformanceController } from '../controllers/perf';
@@ -25,6 +23,9 @@ import { FirebaseApp } from '@firebase/app';
 import { FirebaseInstallations } from '@firebase/installations-types';
 
 import '../../test/setup';
+import { vi } from 'vitest';
+
+vi.mock('../services/perf_logger', { spy: true });
 
 describe('Firebase Performance > trace', () => {
   setupApi(window);
@@ -54,13 +55,13 @@ describe('Firebase Performance > trace', () => {
   };
 
   beforeEach(() => {
-    spy(Api.prototype, 'mark');
-    stub(perfLogger, 'logTrace');
+    vi.spyOn(Api.prototype, 'mark');
     trace = createTrace();
   });
 
   afterEach(() => {
-    restore();
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
   describe('#start', () => {
@@ -69,11 +70,11 @@ describe('Firebase Performance > trace', () => {
     });
 
     it('uses the underlying api method', () => {
-      expect(Api.getInstance().mark).to.be.calledOnce;
+      expect(Api.getInstance().mark).toHaveBeenCalledTimes(1);
     });
 
     it('throws if a trace is started twice', () => {
-      expect(() => trace.start()).to.throw();
+      expect(() => trace.start()).toThrow();
     });
   });
 
@@ -82,46 +83,50 @@ describe('Firebase Performance > trace', () => {
       trace.start();
       trace.stop();
 
-      expect(Api.getInstance().mark).to.be.calledTwice;
+      expect(Api.getInstance().mark).toHaveBeenCalledTimes(2);
     });
 
     it('logs the trace', () => {
       trace.start();
       trace.stop();
 
-      expect((perfLogger.logTrace as any).calledOnceWith(trace)).to.be.true;
+      expect(perfLogger.logTrace).toHaveBeenCalledTimes(1);
+      expect(perfLogger.logTrace).toHaveBeenCalledWith(trace);
     });
   });
 
   describe('#record', () => {
     it('logs a custom trace with non-positive start time value', () => {
-      expect(() => trace.record(0, 20)).to.throw();
-      expect(() => trace.record(-100, 20)).to.throw();
+      expect(() => trace.record(0, 20)).toThrow();
+      expect(() => trace.record(-100, 20)).toThrow();
     });
 
     it('logs a custom trace with non-positive duration value', () => {
-      expect(() => trace.record(1000, 0)).to.throw();
-      expect(() => trace.record(1000, -200)).to.throw();
+      expect(() => trace.record(1000, 0)).toThrow();
+      expect(() => trace.record(1000, -200)).toThrow();
     });
 
     it('logs a trace without metrics or custom attributes', () => {
       trace.record(1, 20);
 
-      expect((perfLogger.logTrace as any).calledOnceWith(trace)).to.be.true;
+      expect(perfLogger.logTrace).toHaveBeenCalledTimes(1);
+      expect(perfLogger.logTrace).toHaveBeenCalledWith(trace);
     });
 
     it('logs a trace with metrics', () => {
       trace.record(1, 20, { metrics: { cacheHits: 1 } });
 
-      expect((perfLogger.logTrace as any).calledOnceWith(trace)).to.be.true;
-      expect(trace.getMetric('cacheHits')).to.eql(1);
+      expect(perfLogger.logTrace).toHaveBeenCalledTimes(1);
+      expect(perfLogger.logTrace).toHaveBeenCalledWith(trace);
+      expect(trace.getMetric('cacheHits')).toEqual(1);
     });
 
     it('logs a trace with custom attributes', () => {
       trace.record(1, 20, { attributes: { level: '1' } });
 
-      expect((perfLogger.logTrace as any).calledOnceWith(trace)).to.be.true;
-      expect(trace.getAttributes()).to.eql({ level: '1' });
+      expect(perfLogger.logTrace).toHaveBeenCalledTimes(1);
+      expect(perfLogger.logTrace).toHaveBeenCalledWith(trace);
+      expect(trace.getAttributes()).toEqual({ level: '1' });
     });
 
     it('logs a trace with custom attributes and metrics', () => {
@@ -130,9 +135,10 @@ describe('Firebase Performance > trace', () => {
         metrics: { cacheHits: 1 }
       });
 
-      expect((perfLogger.logTrace as any).calledOnceWith(trace)).to.be.true;
-      expect(trace.getAttributes()).to.eql({ level: '1' });
-      expect(trace.getMetric('cacheHits')).to.eql(1);
+      expect(perfLogger.logTrace).toHaveBeenCalledTimes(1);
+      expect(perfLogger.logTrace).toHaveBeenCalledWith(trace);
+      expect(trace.getAttributes()).toEqual({ level: '1' });
+      expect(trace.getMetric('cacheHits')).toEqual(1);
     });
 
     it('does not log counter with invalid counter value', () => {
@@ -140,8 +146,9 @@ describe('Firebase Performance > trace', () => {
         metrics: { level: NaN }
       });
 
-      expect((perfLogger.logTrace as any).calledOnceWith(trace)).to.be.true;
-      expect(trace.getMetric('level')).to.eql(0);
+      expect(perfLogger.logTrace).toHaveBeenCalledTimes(1);
+      expect(perfLogger.logTrace).toHaveBeenCalledWith(trace);
+      expect(trace.getMetric('level')).toEqual(0);
     });
   });
 
@@ -149,32 +156,32 @@ describe('Firebase Performance > trace', () => {
     it('creates new metric if one doesnt exist.', () => {
       trace.incrementMetric('cacheHits', 200);
 
-      expect(trace.getMetric('cacheHits')).to.eql(200);
+      expect(trace.getMetric('cacheHits')).toEqual(200);
     });
 
     it('increments metric if it already exists.', () => {
       trace.incrementMetric('cacheHits', 200);
       trace.incrementMetric('cacheHits', 400);
 
-      expect(trace.getMetric('cacheHits')).to.eql(600);
+      expect(trace.getMetric('cacheHits')).toEqual(600);
     });
 
     it('increments metric value as an integer even if the value is provided in float.', () => {
       trace.incrementMetric('cacheHits', 200);
       trace.incrementMetric('cacheHits', 400.38);
 
-      expect(trace.getMetric('cacheHits')).to.eql(600);
+      expect(trace.getMetric('cacheHits')).toEqual(600);
     });
 
     it('increments metric value with a negative float.', () => {
       trace.incrementMetric('cacheHits', 200);
       trace.incrementMetric('cacheHits', -230.38);
 
-      expect(trace.getMetric('cacheHits')).to.eql(-31);
+      expect(trace.getMetric('cacheHits')).toEqual(-31);
     });
 
     it('throws error if metric doesnt exist and has invalid name', () => {
-      expect(() => trace.incrementMetric('_invalidMetric', 1)).to.throw();
+      expect(() => trace.incrementMetric('_invalidMetric', 1)).toThrow();
     });
   });
 
@@ -182,58 +189,58 @@ describe('Firebase Performance > trace', () => {
     it('creates new metric if one doesnt exist and has valid name.', () => {
       trace.putMetric('cacheHits', 200);
 
-      expect(trace.getMetric('cacheHits')).to.eql(200);
+      expect(trace.getMetric('cacheHits')).toEqual(200);
     });
 
     it('sets the metric value as an integer even if the value is provided in float.', () => {
       trace.putMetric('timelapse', 200.48);
 
-      expect(trace.getMetric('timelapse')).to.eql(200);
+      expect(trace.getMetric('timelapse')).toEqual(200);
     });
 
     it('replaces metric if it already exists.', () => {
       trace.putMetric('cacheHits', 200);
       trace.putMetric('cacheHits', 400);
 
-      expect(trace.getMetric('cacheHits')).to.eql(400);
+      expect(trace.getMetric('cacheHits')).toEqual(400);
     });
 
     it('replaces undefined metrics with 0', () => {
       // @ts-ignore A non-TS user could provide undefined.
       trace.putMetric('cacheHits', undefined);
 
-      expect(trace.getMetric('cacheHits')).to.eql(0);
+      expect(trace.getMetric('cacheHits')).toEqual(0);
     });
 
     it('throws error if metric doesnt exist and has invalid name', () => {
-      expect(() => trace.putMetric('_invalidMetric', 1)).to.throw();
-      expect(() => trace.putMetric('_fid', 1)).to.throw();
+      expect(() => trace.putMetric('_invalidMetric', 1)).toThrow();
+      expect(() => trace.putMetric('_fid', 1)).toThrow();
     });
   });
 
   describe('#getMetric', () => {
     it('returns 0 if metric doesnt exist', () => {
-      expect(trace.getMetric('doesThisExist')).to.equal(0);
+      expect(trace.getMetric('doesThisExist')).toBe(0);
     });
 
     it('returns 0 if it exists and equals 0', () => {
       trace.putMetric('cacheHits', 0);
 
-      expect(trace.getMetric('cacheHits')).to.equal(0);
+      expect(trace.getMetric('cacheHits')).toBe(0);
     });
 
     it('returns metric if it exists', () => {
       trace.putMetric('cacheHits', 200);
 
-      expect(trace.getMetric('cacheHits')).to.equal(200);
+      expect(trace.getMetric('cacheHits')).toBe(200);
     });
 
     it('returns multiple metrics if they exist', () => {
       trace.putMetric('cacheHits', 200);
       trace.putMetric('bytesDownloaded', 25);
 
-      expect(trace.getMetric('cacheHits')).to.equal(200);
-      expect(trace.getMetric('bytesDownloaded')).to.equal(25);
+      expect(trace.getMetric('cacheHits')).toBe(200);
+      expect(trace.getMetric('bytesDownloaded')).toBe(25);
     });
   });
 
@@ -241,18 +248,18 @@ describe('Firebase Performance > trace', () => {
     it('creates new attribute if it doesnt exist', () => {
       trace.putAttribute('level', '4');
 
-      expect(trace.getAttributes()).to.eql({ level: '4' });
+      expect(trace.getAttributes()).toEqual({ level: '4' });
     });
 
     it('replaces attribute if it exists', () => {
       trace.putAttribute('level', '4');
       trace.putAttribute('level', '7');
 
-      expect(trace.getAttributes()).to.eql({ level: '7' });
+      expect(trace.getAttributes()).toEqual({ level: '7' });
     });
 
     it('throws error if attribute name is invalid', () => {
-      expect(() => trace.putAttribute('_invalidAttribute', '1')).to.throw();
+      expect(() => trace.putAttribute('_invalidAttribute', '1')).toThrow();
     });
 
     it('throws error if attribute value is invalid', () => {
@@ -261,26 +268,26 @@ describe('Firebase Performance > trace', () => {
         'hundred-charac';
       expect(() =>
         trace.putAttribute('validName', longAttributeValue)
-      ).to.throw();
+      ).toThrow();
     });
   });
 
   describe('#getAttribute', () => {
     it('returns undefined for attribute that doesnt exist', () => {
-      expect(trace.getAttribute('level')).to.be.undefined;
+      expect(trace.getAttribute('level')).toBeUndefined();
     });
 
     it('returns attribute if it exists', () => {
       trace.putAttribute('level', '4');
-      expect(trace.getAttribute('level')).to.equal('4');
+      expect(trace.getAttribute('level')).toBe('4');
     });
 
     it('returns separate attributes if they exist', () => {
       trace.putAttribute('level', '4');
       trace.putAttribute('stage', 'beginning');
 
-      expect(trace.getAttribute('level')).to.equal('4');
-      expect(trace.getAttribute('stage')).to.equal('beginning');
+      expect(trace.getAttribute('level')).toBe('4');
+      expect(trace.getAttribute('stage')).toBe('beginning');
     });
   });
 
@@ -291,10 +298,10 @@ describe('Firebase Performance > trace', () => {
 
     it('removes attribute if it exists', () => {
       trace.putAttribute('level', '4');
-      expect(trace.getAttribute('level')).to.equal('4');
+      expect(trace.getAttribute('level')).toBe('4');
 
       trace.removeAttribute('level');
-      expect(trace.getAttribute('level')).to.be.undefined;
+      expect(trace.getAttribute('level')).toBeUndefined();
     });
 
     it('retains other attributes', () => {
@@ -302,8 +309,8 @@ describe('Firebase Performance > trace', () => {
       trace.putAttribute('stage', 'beginning');
 
       trace.removeAttribute('level');
-      expect(trace.getAttribute('level')).to.be.undefined;
-      expect(trace.getAttribute('stage')).to.equal('beginning');
+      expect(trace.getAttribute('level')).toBeUndefined();
+      expect(trace.getAttribute('stage')).toBe('beginning');
     });
   });
 

--- a/packages/performance/src/resources/trace.test.ts
+++ b/packages/performance/src/resources/trace.test.ts
@@ -25,6 +25,8 @@ import { FirebaseInstallations } from '@firebase/installations-types';
 import '../../test/setup';
 import { vi } from 'vitest';
 
+import { consoleLogger } from '../utils/console_logger';
+
 vi.mock('../services/perf_logger', { spy: true });
 
 describe('Firebase Performance > trace', () => {
@@ -56,6 +58,7 @@ describe('Firebase Performance > trace', () => {
 
   beforeEach(() => {
     vi.spyOn(Api.prototype, 'mark');
+    vi.spyOn(consoleLogger, 'info').mockImplementation(() => {});
     trace = createTrace();
   });
 

--- a/packages/performance/src/services/api_service.test.ts
+++ b/packages/performance/src/services/api_service.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2020 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,9 @@
  * limitations under the License.
  */
 
-import { stub } from 'sinon';
-import { expect } from 'chai';
 import { Api, setupApi } from './api_service';
 import '../../test/setup';
+import { vi } from 'vitest';
 
 describe('Firebase Performance > api_service', () => {
   const PAGE_URL = 'http://www.test.com/abcd?a=2';
@@ -37,12 +36,16 @@ describe('Firebase Performance > api_service', () => {
   let api: Api;
 
   beforeEach(() => {
-    stub(mockWindow.performance, 'mark');
-    stub(mockWindow.performance, 'measure');
-    stub(mockWindow.performance, 'getEntriesByType').returns([
+    vi.spyOn(mockWindow.performance, 'mark').mockImplementation(
+      () => undefined as any
+    );
+    vi.spyOn(mockWindow.performance, 'measure').mockImplementation(
+      () => undefined as any
+    );
+    vi.spyOn(mockWindow.performance, 'getEntriesByType').mockReturnValue([
       PERFORMANCE_ENTRY
     ]);
-    stub(mockWindow.performance, 'getEntriesByName').returns([
+    vi.spyOn(mockWindow.performance, 'getEntriesByName').mockReturnValue([
       PERFORMANCE_ENTRY
     ]);
     // This is to make sure the test page is not changed by changing the href of location object.
@@ -52,9 +55,14 @@ describe('Firebase Performance > api_service', () => {
     api = Api.getInstance();
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
   describe('getUrl', () => {
     it('removes the query params', () => {
-      expect(api.getUrl()).to.equal('http://www.test.com/abcd');
+      expect(api.getUrl()).toBe('http://www.test.com/abcd');
     });
   });
 
@@ -63,7 +71,8 @@ describe('Firebase Performance > api_service', () => {
       const MARK_NAME = 'mark1';
       api.mark(MARK_NAME);
 
-      expect(mockWindow.performance.mark).to.be.calledOnceWith(MARK_NAME);
+      expect(mockWindow.performance.mark).toHaveBeenCalledTimes(1);
+      expect(mockWindow.performance.mark).toHaveBeenCalledWith(MARK_NAME);
     });
   });
 
@@ -74,7 +83,8 @@ describe('Firebase Performance > api_service', () => {
       const MARK_2_NAME = 'mark2';
       api.measure(MEASURE_NAME, MARK_1_NAME, MARK_2_NAME);
 
-      expect(mockWindow.performance.measure).to.be.calledOnceWith(
+      expect(mockWindow.performance.measure).toHaveBeenCalledTimes(1);
+      expect(mockWindow.performance.measure).toHaveBeenCalledWith(
         MEASURE_NAME,
         MARK_1_NAME,
         MARK_2_NAME
@@ -84,7 +94,7 @@ describe('Firebase Performance > api_service', () => {
 
   describe('getEntriesByType', () => {
     it('calls the underlying performance api', () => {
-      expect(api.getEntriesByType('paint')).to.deep.equal([PERFORMANCE_ENTRY]);
+      expect(api.getEntriesByType('paint')).toEqual([PERFORMANCE_ENTRY]);
     });
 
     it('does not throw if the browser does not include underlying api', () => {
@@ -92,14 +102,14 @@ describe('Firebase Performance > api_service', () => {
 
       expect(() => {
         api.getEntriesByType('paint');
-      }).to.not.throw();
-      expect(api.getEntriesByType('paint')).to.deep.equal([]);
+      }).not.toThrow();
+      expect(api.getEntriesByType('paint')).toEqual([]);
     });
   });
 
   describe('getEntriesByName', () => {
     it('calls the underlying performance api', () => {
-      expect(api.getEntriesByName('paint')).to.deep.equal([PERFORMANCE_ENTRY]);
+      expect(api.getEntriesByName('paint')).toEqual([PERFORMANCE_ENTRY]);
     });
 
     it('does not throw if the browser does not include underlying api', () => {
@@ -107,8 +117,8 @@ describe('Firebase Performance > api_service', () => {
 
       expect(() => {
         api.getEntriesByName('paint');
-      }).to.not.throw();
-      expect(api.getEntriesByName('paint')).to.deep.equal([]);
+      }).not.toThrow();
+      expect(api.getEntriesByName('paint')).toEqual([]);
     });
   });
 });

--- a/packages/performance/src/services/iid_service.test.ts
+++ b/packages/performance/src/services/iid_service.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2019 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-import { stub } from 'sinon';
-import { expect } from 'chai';
 import {
   getIid,
   getIidPromise,
@@ -25,15 +23,16 @@ import {
 } from './iid_service';
 import '../../test/setup';
 import { _FirebaseInstallationsInternal } from '@firebase/installations';
+import { vi } from 'vitest';
 
 describe('Firebase Performance > iid_service', () => {
   const IID = 'fid';
   const AUTH_TOKEN = 'authToken';
 
   let fakeInstallations: _FirebaseInstallationsInternal;
-  before(() => {
-    const getId = stub().resolves(IID);
-    const getToken = stub().resolves(AUTH_TOKEN);
+  beforeAll(() => {
+    const getId = vi.fn().mockResolvedValue(IID);
+    const getToken = vi.fn().mockResolvedValue(AUTH_TOKEN);
     fakeInstallations = {
       getId,
       getToken
@@ -44,8 +43,8 @@ describe('Firebase Performance > iid_service', () => {
     it('provides iid', async () => {
       const iid = await getIidPromise(fakeInstallations);
 
-      expect(iid).to.be.equal(IID);
-      expect(getIid()).to.be.equal(IID);
+      expect(iid).toBe(IID);
+      expect(getIid()).toBe(IID);
     });
   });
 
@@ -53,8 +52,8 @@ describe('Firebase Performance > iid_service', () => {
     it('provides authentication token', async () => {
       const token = await getAuthTokenPromise(fakeInstallations);
 
-      expect(token).to.be.equal(AUTH_TOKEN);
-      expect(getAuthenticationToken()).to.be.equal(AUTH_TOKEN);
+      expect(token).toBe(AUTH_TOKEN);
+      expect(getAuthenticationToken()).toBe(AUTH_TOKEN);
     });
   });
 });

--- a/packages/performance/src/services/initialization_service.test.ts
+++ b/packages/performance/src/services/initialization_service.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2020 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-import { stub } from 'sinon';
-import { expect } from 'chai';
 import {
   getInitializationPromise,
   isPerfInitialized
@@ -26,12 +24,13 @@ import { FirebaseApp } from '@firebase/app';
 import '../../test/setup';
 import { FirebaseInstallations } from '@firebase/installations-types';
 import { PerformanceController } from '../controllers/perf';
+import { vi } from 'vitest';
 
 describe('Firebase Performance > initialization_service', () => {
   const IID = 'fid';
   const AUTH_TOKEN = 'authToken';
-  const getId = stub();
-  const getToken = stub();
+  const getId = vi.fn();
+  const getToken = vi.fn();
 
   const fakeFirebaseConfig = {
     apiKey: 'api-key',
@@ -60,26 +59,26 @@ describe('Firebase Performance > initialization_service', () => {
   mockWindow.document = { ...mockWindow.document, readyState: 'complete' };
 
   beforeEach(() => {
-    stub(self, 'fetch').resolves(new Response('{}'));
-    mockWindow.localStorage = { ...mockWindow.localStorage, setItem: stub() };
+    vi.spyOn(self, 'fetch').mockResolvedValue(new Response('{}'));
+    mockWindow.localStorage = { ...mockWindow.localStorage, setItem: vi.fn() };
 
     setupApi(mockWindow);
   });
 
   it('changes initialization status after initialization is done', async () => {
-    getId.resolves(IID);
-    getToken.resolves(AUTH_TOKEN);
+    getId.mockResolvedValue(IID);
+    getToken.mockResolvedValue(AUTH_TOKEN);
     await getInitializationPromise(performanceController);
 
-    expect(isPerfInitialized()).to.be.true;
+    expect(isPerfInitialized()).toBe(true);
   });
 
   it('returns initialization as not done before promise is resolved', async () => {
-    getId.resolves(IID);
-    getToken.resolves(AUTH_TOKEN);
+    getId.mockResolvedValue(IID);
+    getToken.mockResolvedValue(AUTH_TOKEN);
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     getInitializationPromise(performanceController);
 
-    expect(isPerfInitialized()).to.be.false;
+    expect(isPerfInitialized()).toBe(false);
   });
 });

--- a/packages/performance/src/services/oob_resources_service.test.ts
+++ b/packages/performance/src/services/oob_resources_service.test.ts
@@ -142,7 +142,9 @@ describe('Firebase Performance > oob_resources_service', () => {
         }
         return [PAINT_PERFORMANCE_ENTRY];
       });
-    setupObserverStub = vi.spyOn(Api.prototype, 'setupObserver');
+    setupObserverStub = vi
+      .spyOn(Api.prototype, 'setupObserver')
+      .mockImplementation(() => {});
     createOobTraceSpy = vi.spyOn(Trace, 'createOobTrace');
     const api = Api.getInstance();
     lcpSpy = vi.spyOn(api, 'onLCP');

--- a/packages/performance/src/services/oob_resources_service.test.ts
+++ b/packages/performance/src/services/oob_resources_service.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2020 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,6 @@
  * limitations under the License.
  */
 
-import {
-  spy,
-  stub,
-  restore as sinonRestore,
-  SinonSpy,
-  SinonStub,
-  useFakeTimers,
-  SinonFakeTimers
-} from 'sinon';
-import { expect } from 'chai';
 import { Api, setupApi, EntryType } from './api_service';
 import * as iidService from './iid_service';
 import { setupOobResources, resetForUnitTests } from './oob_resources_service';
@@ -42,6 +32,9 @@ import {
   LCPAttribution,
   LCPMetricWithAttribution
 } from 'web-vitals/attribution';
+import { vi, MockInstance } from 'vitest';
+
+vi.mock('./iid_service', { spy: true });
 
 // eslint-disable-next-line no-restricted-properties
 describe('Firebase Performance > oob_resources_service', () => {
@@ -91,35 +84,15 @@ describe('Firebase Performance > oob_resources_service', () => {
     toJSON: () => {}
   };
 
-  let getIidStub: SinonStub<[], string | undefined>;
-  let apiGetInstanceSpy: SinonSpy<[], Api>;
-  let eventListenerSpy: SinonSpy<
-    [
-      type: string,
-      listener: EventListenerOrEventListenerObject,
-      options?: boolean | AddEventListenerOptions | undefined
-    ],
-    void
-  >;
-  let getEntriesByTypeStub: SinonStub<[EntryType], PerformanceEntry[]>;
-  let setupObserverStub: SinonStub<
-    [EntryType, (entry: PerformanceEntry) => void],
-    void
-  >;
-  let createOobTraceSpy: SinonSpy<
-    [
-      PerformanceController,
-      PerformanceNavigationTiming[],
-      PerformanceEntry[],
-      WebVitalMetrics,
-      (number | undefined)?
-    ],
-    void
-  >;
-  let clock: SinonFakeTimers;
-  let lcpSpy: SinonSpy<[(m: LCPMetricWithAttribution) => void], void>;
-  let inpSpy: SinonSpy<[(m: INPMetricWithAttribution) => void], void>;
-  let clsSpy: SinonSpy<[(m: CLSMetricWithAttribution) => void], void>;
+  let getIidStub: MockInstance;
+  let apiGetInstanceSpy: MockInstance;
+  let eventListenerSpy: MockInstance;
+  let getEntriesByTypeStub: MockInstance;
+  let setupObserverStub: MockInstance;
+  let createOobTraceSpy: MockInstance;
+  let lcpSpy: MockInstance;
+  let inpSpy: MockInstance;
+  let clsSpy: MockInstance;
 
   const mockWindow = { ...self };
   setupApi(mockWindow);
@@ -145,8 +118,8 @@ describe('Firebase Performance > oob_resources_service', () => {
   );
 
   function callEventListener(name: string): void {
-    for (let i = eventListenerSpy.callCount; i > 0; i--) {
-      const [eventName, eventFn] = eventListenerSpy.getCall(i - 1).args;
+    for (let i = eventListenerSpy.mock.calls.length; i > 0; i--) {
+      const [eventName, eventFn] = eventListenerSpy.mock.calls[i - 1];
       if (eventName === name) {
         if (typeof eventFn === 'function') {
           eventFn(new CustomEvent(name));
@@ -157,30 +130,31 @@ describe('Firebase Performance > oob_resources_service', () => {
 
   beforeEach(() => {
     resetForUnitTests();
-    getIidStub = stub(iidService, 'getIid');
-    eventListenerSpy = spy(mockWindow.document, 'addEventListener');
+    getIidStub = vi.mocked(iidService.getIid);
+    eventListenerSpy = vi.spyOn(mockWindow.document, 'addEventListener');
 
-    clock = useFakeTimers();
-    getEntriesByTypeStub = stub(Api.prototype, 'getEntriesByType').callsFake(
-      entry => {
+    vi.useFakeTimers();
+    getEntriesByTypeStub = vi
+      .spyOn(Api.prototype, 'getEntriesByType')
+      .mockImplementation(entry => {
         if (entry === 'navigation') {
           return [NAVIGATION_PERFORMANCE_ENTRY];
         }
         return [PAINT_PERFORMANCE_ENTRY];
-      }
-    );
-    setupObserverStub = stub(Api.prototype, 'setupObserver');
-    createOobTraceSpy = spy(Trace, 'createOobTrace');
+      });
+    setupObserverStub = vi.spyOn(Api.prototype, 'setupObserver');
+    createOobTraceSpy = vi.spyOn(Trace, 'createOobTrace');
     const api = Api.getInstance();
-    lcpSpy = spy(api, 'onLCP');
-    inpSpy = spy(api, 'onINP');
-    clsSpy = spy(api, 'onCLS');
-    apiGetInstanceSpy = spy(Api, 'getInstance');
+    lcpSpy = vi.spyOn(api, 'onLCP');
+    inpSpy = vi.spyOn(api, 'onINP');
+    clsSpy = vi.spyOn(api, 'onCLS');
+    apiGetInstanceSpy = vi.spyOn(Api, 'getInstance');
   });
 
   afterEach(() => {
-    clock.restore();
-    sinonRestore();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
     const api = Api.getInstance();
     //@ts-ignore Assignment to read-only property.
     api.onFirstInputDelay = undefined;
@@ -188,43 +162,48 @@ describe('Firebase Performance > oob_resources_service', () => {
 
   describe('setupOobResources', () => {
     it('does not start if there is no iid', () => {
-      getIidStub.returns(undefined);
+      getIidStub.mockReturnValue(undefined);
       setupOobResources(performanceController);
 
-      expect(apiGetInstanceSpy).not.to.be.called;
+      expect(apiGetInstanceSpy).not.toHaveBeenCalled();
     });
 
     it('sets up network request collection', () => {
-      getIidStub.returns(MOCK_ID);
+      getIidStub.mockReturnValue(MOCK_ID);
       setupOobResources(performanceController);
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
 
-      expect(apiGetInstanceSpy).to.be.called;
-      expect(getEntriesByTypeStub).to.be.calledWith('resource');
-      expect(setupObserverStub).to.be.calledWith('resource');
+      expect(apiGetInstanceSpy).toHaveBeenCalled();
+      expect(getEntriesByTypeStub).toHaveBeenCalledWith('resource');
+      expect(setupObserverStub).toHaveBeenCalledWith(
+        'resource',
+        expect.any(Function)
+      );
     });
 
     it('does not create page load trace before hidden', () => {
-      getIidStub.returns(MOCK_ID);
+      getIidStub.mockReturnValue(MOCK_ID);
       setupOobResources(performanceController);
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
 
-      expect(apiGetInstanceSpy).to.be.called;
-      expect(createOobTraceSpy).not.to.be.called;
+      expect(apiGetInstanceSpy).toHaveBeenCalled();
+      expect(createOobTraceSpy).not.toHaveBeenCalled();
     });
 
     it('creates page load trace after hidden', () => {
-      getIidStub.returns(MOCK_ID);
+      getIidStub.mockReturnValue(MOCK_ID);
       setupOobResources(performanceController);
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
 
-      stub(mockWindow.document, 'visibilityState').value('hidden');
+      vi.spyOn(mockWindow.document, 'visibilityState', 'get').mockReturnValue(
+        'hidden'
+      );
       callEventListener('visibilitychange');
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
 
-      expect(getEntriesByTypeStub).to.be.calledWith('navigation');
-      expect(getEntriesByTypeStub).to.be.calledWith('paint');
-      expect(createOobTraceSpy).to.be.calledWithExactly(
+      expect(getEntriesByTypeStub).toHaveBeenCalledWith('navigation');
+      expect(getEntriesByTypeStub).toHaveBeenCalledWith('paint');
+      expect(createOobTraceSpy).toHaveBeenCalledWith(
         performanceController,
         [NAVIGATION_PERFORMANCE_ENTRY],
         [PAINT_PERFORMANCE_ENTRY],
@@ -234,16 +213,16 @@ describe('Firebase Performance > oob_resources_service', () => {
     });
 
     it('creates page load trace after pagehide', () => {
-      getIidStub.returns(MOCK_ID);
+      getIidStub.mockReturnValue(MOCK_ID);
       setupOobResources(performanceController);
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
 
       callEventListener('pagehide');
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
 
-      expect(getEntriesByTypeStub).to.be.calledWith('navigation');
-      expect(getEntriesByTypeStub).to.be.calledWith('paint');
-      expect(createOobTraceSpy).to.be.calledWithExactly(
+      expect(getEntriesByTypeStub).toHaveBeenCalledWith('navigation');
+      expect(getEntriesByTypeStub).toHaveBeenCalledWith('paint');
+      expect(createOobTraceSpy).toHaveBeenCalledWith(
         performanceController,
         [NAVIGATION_PERFORMANCE_ENTRY],
         [PAINT_PERFORMANCE_ENTRY],
@@ -253,7 +232,7 @@ describe('Firebase Performance > oob_resources_service', () => {
     });
 
     it('logs first input delay if polyfill is available and callback is called', () => {
-      getIidStub.returns(MOCK_ID);
+      getIidStub.mockReturnValue(MOCK_ID);
       const api = Api.getInstance();
       const FIRST_INPUT_DELAY = 123;
       // Underscore is to avoid compiler complaining about variable being declared but not used.
@@ -264,15 +243,17 @@ describe('Firebase Performance > oob_resources_service', () => {
         firstInputDelayCallback = cb;
       };
       setupOobResources(performanceController);
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
       firstInputDelayCallback(FIRST_INPUT_DELAY);
 
       // Force the page load event to be sent
-      stub(mockWindow.document, 'visibilityState').value('hidden');
+      vi.spyOn(mockWindow.document, 'visibilityState', 'get').mockReturnValue(
+        'hidden'
+      );
       callEventListener('visibilitychange');
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
 
-      expect(createOobTraceSpy).to.be.calledWithExactly(
+      expect(createOobTraceSpy).toHaveBeenCalledWith(
         performanceController,
         [NAVIGATION_PERFORMANCE_ENTRY],
         [PAINT_PERFORMANCE_ENTRY],
@@ -282,21 +263,24 @@ describe('Firebase Performance > oob_resources_service', () => {
     });
 
     it('sets up user timing traces', () => {
-      getIidStub.returns(MOCK_ID);
+      getIidStub.mockReturnValue(MOCK_ID);
       setupOobResources(performanceController);
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
 
-      expect(apiGetInstanceSpy).to.be.called;
-      expect(getEntriesByTypeStub).to.be.calledWith('measure');
-      expect(setupObserverStub).to.be.calledWith('measure');
+      expect(apiGetInstanceSpy).toHaveBeenCalled();
+      expect(getEntriesByTypeStub).toHaveBeenCalledWith('measure');
+      expect(setupObserverStub).toHaveBeenCalledWith(
+        'measure',
+        expect.any(Function)
+      );
     });
 
     it('sends LCP metrics with attribution', () => {
-      getIidStub.returns(MOCK_ID);
+      getIidStub.mockReturnValue(MOCK_ID);
       setupOobResources(performanceController);
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
 
-      lcpSpy.getCall(-1).args[0]({
+      lcpSpy.mock.lastCall![0]({
         value: 12.34,
         attribution: {
           element: 'some-element'
@@ -304,11 +288,13 @@ describe('Firebase Performance > oob_resources_service', () => {
       } as LCPMetricWithAttribution);
 
       // Force the page load event to be sent
-      stub(mockWindow.document, 'visibilityState').value('hidden');
+      vi.spyOn(mockWindow.document, 'visibilityState', 'get').mockReturnValue(
+        'hidden'
+      );
       callEventListener('visibilitychange');
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
 
-      expect(createOobTraceSpy).to.be.calledWithExactly(
+      expect(createOobTraceSpy).toHaveBeenCalledWith(
         performanceController,
         [NAVIGATION_PERFORMANCE_ENTRY],
         [PAINT_PERFORMANCE_ENTRY],
@@ -320,11 +306,11 @@ describe('Firebase Performance > oob_resources_service', () => {
     });
 
     it('sends INP metrics with attribution', () => {
-      getIidStub.returns(MOCK_ID);
+      getIidStub.mockReturnValue(MOCK_ID);
       setupOobResources(performanceController);
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
 
-      inpSpy.getCall(-1).args[0]({
+      inpSpy.mock.lastCall![0]({
         value: 0.198,
         attribution: {
           interactionTarget: 'another-element'
@@ -332,11 +318,13 @@ describe('Firebase Performance > oob_resources_service', () => {
       } as INPMetricWithAttribution);
 
       // Force the page load event to be sent
-      stub(mockWindow.document, 'visibilityState').value('hidden');
+      vi.spyOn(mockWindow.document, 'visibilityState', 'get').mockReturnValue(
+        'hidden'
+      );
       callEventListener('visibilitychange');
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
 
-      expect(createOobTraceSpy).to.be.calledWithExactly(
+      expect(createOobTraceSpy).toHaveBeenCalledWith(
         performanceController,
         [NAVIGATION_PERFORMANCE_ENTRY],
         [PAINT_PERFORMANCE_ENTRY],
@@ -348,11 +336,11 @@ describe('Firebase Performance > oob_resources_service', () => {
     });
 
     it('sends CLS metrics with attribution', () => {
-      getIidStub.returns(MOCK_ID);
+      getIidStub.mockReturnValue(MOCK_ID);
       setupOobResources(performanceController);
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
 
-      clsSpy.getCall(-1).args[0]({
+      clsSpy.mock.lastCall![0]({
         value: 0.3,
         // eslint-disable-next-line
         attribution: {
@@ -361,11 +349,13 @@ describe('Firebase Performance > oob_resources_service', () => {
       } as CLSMetricWithAttribution);
 
       // Force the page load event to be sent
-      stub(mockWindow.document, 'visibilityState').value('hidden');
+      vi.spyOn(mockWindow.document, 'visibilityState', 'get').mockReturnValue(
+        'hidden'
+      );
       callEventListener('visibilitychange');
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
 
-      expect(createOobTraceSpy).to.be.calledWithExactly(
+      expect(createOobTraceSpy).toHaveBeenCalledWith(
         performanceController,
         [NAVIGATION_PERFORMANCE_ENTRY],
         [PAINT_PERFORMANCE_ENTRY],
@@ -377,18 +367,18 @@ describe('Firebase Performance > oob_resources_service', () => {
     });
 
     it('sends all core web vitals metrics', () => {
-      getIidStub.returns(MOCK_ID);
+      getIidStub.mockReturnValue(MOCK_ID);
       setupOobResources(performanceController);
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
 
-      lcpSpy.getCall(-1).args[0]({
+      lcpSpy.mock.lastCall![0]({
         value: 5.91,
         attribution: { element: 'an-element' } as LCPAttribution
       } as LCPMetricWithAttribution);
-      inpSpy.getCall(-1).args[0]({
+      inpSpy.mock.lastCall![0]({
         value: 0.1
       } as INPMetricWithAttribution);
-      clsSpy.getCall(-1).args[0]({
+      clsSpy.mock.lastCall![0]({
         value: 0.3,
         attribution: {
           largestShiftTarget: 'large-shift-element'
@@ -396,11 +386,13 @@ describe('Firebase Performance > oob_resources_service', () => {
       } as CLSMetricWithAttribution);
 
       // Force the page load event to be sent
-      stub(mockWindow.document, 'visibilityState').value('hidden');
+      vi.spyOn(mockWindow.document, 'visibilityState', 'get').mockReturnValue(
+        'hidden'
+      );
       callEventListener('visibilitychange');
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
 
-      expect(createOobTraceSpy).to.be.calledWithExactly(
+      expect(createOobTraceSpy).toHaveBeenCalledWith(
         performanceController,
         [NAVIGATION_PERFORMANCE_ENTRY],
         [PAINT_PERFORMANCE_ENTRY],

--- a/packages/performance/src/services/perf_logger.test.ts
+++ b/packages/performance/src/services/perf_logger.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2020 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,9 @@
  * limitations under the License.
  */
 
-import { stub, SinonStub, useFakeTimers, SinonFakeTimers } from 'sinon';
 import { Trace } from '../resources/trace';
 import * as transportService from './transport_service';
 import * as iidService from './iid_service';
-import { expect } from 'chai';
 import { Api, setupApi } from './api_service';
 import { SettingsService } from './settings_service';
 import { FirebaseApp } from '@firebase/app';
@@ -31,6 +29,12 @@ import '../../test/setup';
 import { mergeStrings } from '../utils/string_merger';
 import { FirebaseInstallations } from '@firebase/installations-types';
 import { PerformanceController } from '../controllers/perf';
+import { vi, MockInstance } from 'vitest';
+
+vi.mock('./iid_service', { spy: true });
+vi.mock('./transport_service', { spy: true });
+vi.mock('./initialization_service', { spy: true });
+vi.mock('../utils/attributes_utils', { spy: true });
 
 // eslint-disable-next-line no-restricted-properties
 describe('Performance Monitoring > perf_logger', () => {
@@ -51,12 +55,8 @@ describe('Performance Monitoring > perf_logger', () => {
 "visibility_state":${VISIBILITY_STATE},"effective_connection_type":${EFFECTIVE_CONNECTION_TYPE}},\
 "application_process_state":0}`;
 
-  let addToQueueStub: SinonStub<
-    Array<{ message: string; eventTime: number }>,
-    void
-  >;
-  let getIidStub: SinonStub<[], string | undefined>;
-  let clock: SinonFakeTimers;
+  let addToQueueStub: MockInstance;
+  let getIidStub: MockInstance;
 
   function mockTransportHandler(
     serializer: (...args: any[]) => string
@@ -82,42 +82,46 @@ describe('Performance Monitoring > perf_logger', () => {
   );
 
   beforeEach(() => {
-    getIidStub = stub(iidService, 'getIid');
-    addToQueueStub = stub();
-    stub(transportService, 'transportHandler').callsFake(mockTransportHandler);
-    stub(Api.prototype, 'getUrl').returns(PAGE_URL);
-    stub(Api.prototype, 'getTimeOrigin').returns(TIME_ORIGIN);
-    stub(attributeUtils, 'getEffectiveConnectionType').returns(
+    getIidStub = vi.mocked(iidService.getIid);
+    addToQueueStub = vi.fn();
+    vi.mocked(transportService.transportHandler).mockImplementation(
+      mockTransportHandler
+    );
+    vi.spyOn(Api.prototype, 'getUrl').mockReturnValue(PAGE_URL);
+    vi.spyOn(Api.prototype, 'getTimeOrigin').mockReturnValue(TIME_ORIGIN);
+    vi.mocked(attributeUtils.getEffectiveConnectionType).mockReturnValue(
       EFFECTIVE_CONNECTION_TYPE
     );
-    stub(attributeUtils, 'getServiceWorkerStatus').returns(
+    vi.mocked(attributeUtils.getServiceWorkerStatus).mockReturnValue(
       SERVICE_WORKER_STATUS
     );
-    clock = useFakeTimers();
+    vi.useFakeTimers();
   });
 
   describe('logTrace', () => {
     it('will not drop custom events sent before initialization finishes', async () => {
-      getIidStub.returns(IID);
-      stub(attributeUtils, 'getVisibilityState').returns(VISIBILITY_STATE);
-      stub(initializationService, 'isPerfInitialized').returns(false);
+      getIidStub.mockReturnValue(IID);
+      vi.mocked(attributeUtils.getVisibilityState).mockReturnValue(
+        VISIBILITY_STATE
+      );
+      vi.mocked(initializationService.isPerfInitialized).mockReturnValue(false);
 
       // Simulates logging being enabled after initialization completes.
       const initializationPromise = Promise.resolve().then(() => {
         SettingsService.getInstance().loggingEnabled = true;
         SettingsService.getInstance().logTraceAfterSampling = true;
       });
-      stub(initializationService, 'getInitializationPromise').returns(
+      vi.mocked(initializationService.getInitializationPromise).mockReturnValue(
         initializationPromise
       );
 
       const trace = new Trace(performanceController, TRACE_NAME);
       trace.record(START_TIME, DURATION);
       await initializationPromise.then(() => {
-        clock.tick(1);
+        vi.advanceTimersByTime(1);
       });
 
-      expect(addToQueueStub).to.be.called;
+      expect(addToQueueStub).toHaveBeenCalled();
     });
 
     it('creates, serializes and sends a trace to transport service', () => {
@@ -127,32 +131,36 @@ describe('Performance Monitoring > perf_logger', () => {
         `,"trace_metric":{"name":"${TRACE_NAME}","is_auto":false,\
 "client_start_time_us":${START_TIME * 1000},"duration_us":${DURATION * 1000},\
 "counters":{"counter1":3},"custom_attributes":{"attr":"val"}}}`;
-      getIidStub.returns(IID);
-      stub(attributeUtils, 'getVisibilityState').returns(VISIBILITY_STATE);
-      stub(initializationService, 'isPerfInitialized').returns(true);
+      getIidStub.mockReturnValue(IID);
+      vi.mocked(attributeUtils.getVisibilityState).mockReturnValue(
+        VISIBILITY_STATE
+      );
+      vi.mocked(initializationService.isPerfInitialized).mockReturnValue(true);
       SettingsService.getInstance().loggingEnabled = true;
       SettingsService.getInstance().logTraceAfterSampling = true;
       const trace = new Trace(performanceController, TRACE_NAME);
       trace.putAttribute('attr', 'val');
       trace.putMetric('counter1', 3);
       trace.record(START_TIME, DURATION);
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
 
-      expect(addToQueueStub).to.be.called;
-      expect(addToQueueStub.getCall(0).args[0].message).to.be.equal(
+      expect(addToQueueStub).toHaveBeenCalled();
+      expect(addToQueueStub.mock.calls[0][0].message).toBe(
         EXPECTED_TRACE_MESSAGE
       );
     });
 
     it('does not log an event if cookies are disabled in the browser', () => {
-      stub(Api.prototype, 'requiredApisAvailable').returns(false);
-      stub(attributeUtils, 'getVisibilityState').returns(VISIBILITY_STATE);
-      stub(initializationService, 'isPerfInitialized').returns(true);
+      vi.spyOn(Api.prototype, 'requiredApisAvailable').mockReturnValue(false);
+      vi.mocked(attributeUtils.getVisibilityState).mockReturnValue(
+        VISIBILITY_STATE
+      );
+      vi.mocked(initializationService.isPerfInitialized).mockReturnValue(true);
       const trace = new Trace(performanceController, TRACE_NAME);
       trace.record(START_TIME, DURATION);
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
 
-      expect(addToQueueStub).not.to.be.called;
+      expect(addToQueueStub).not.toHaveBeenCalled();
     });
 
     it('ascertains that the max number of customMetric allowed is 32', () => {
@@ -167,9 +175,11 @@ describe('Performance Monitoring > perf_logger', () => {
 "counter19":19,"counter20":20,"counter21":21,"counter22":22,"counter23":23,"counter24":24,\
 "counter25":25,"counter26":26,"counter27":27,"counter28":28,"counter29":29,"counter30":30,\
 "counter31":31,"counter32":32}}}`;
-      getIidStub.returns(IID);
-      stub(attributeUtils, 'getVisibilityState').returns(VISIBILITY_STATE);
-      stub(initializationService, 'isPerfInitialized').returns(true);
+      getIidStub.mockReturnValue(IID);
+      vi.mocked(attributeUtils.getVisibilityState).mockReturnValue(
+        VISIBILITY_STATE
+      );
+      vi.mocked(initializationService.isPerfInitialized).mockReturnValue(true);
       SettingsService.getInstance().loggingEnabled = true;
       SettingsService.getInstance().logTraceAfterSampling = true;
       const trace = new Trace(performanceController, TRACE_NAME);
@@ -177,10 +187,10 @@ describe('Performance Monitoring > perf_logger', () => {
         trace.putMetric('counter' + i, i);
       }
       trace.record(START_TIME, DURATION);
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
 
-      expect(addToQueueStub).to.be.called;
-      expect(addToQueueStub.getCall(0).args[0].message).to.be.equal(
+      expect(addToQueueStub).toHaveBeenCalled();
+      expect(addToQueueStub.mock.calls[0][0].message).toBe(
         EXPECTED_TRACE_MESSAGE
       );
     });
@@ -192,9 +202,11 @@ describe('Performance Monitoring > perf_logger', () => {
         `,"trace_metric":{"name":"${TRACE_NAME}","is_auto":false,\
 "client_start_time_us":${START_TIME * 1000},"duration_us":${DURATION * 1000},\
 "custom_attributes":{"attr1":"val1","attr2":"val2","attr3":"val3","attr4":"val4","attr5":"val5"}}}`;
-      getIidStub.returns(IID);
-      stub(attributeUtils, 'getVisibilityState').returns(VISIBILITY_STATE);
-      stub(initializationService, 'isPerfInitialized').returns(true);
+      getIidStub.mockReturnValue(IID);
+      vi.mocked(attributeUtils.getVisibilityState).mockReturnValue(
+        VISIBILITY_STATE
+      );
+      vi.mocked(initializationService.isPerfInitialized).mockReturnValue(true);
       SettingsService.getInstance().loggingEnabled = true;
       SettingsService.getInstance().logTraceAfterSampling = true;
       const trace = new Trace(performanceController, TRACE_NAME);
@@ -202,10 +214,10 @@ describe('Performance Monitoring > perf_logger', () => {
         trace.putAttribute('attr' + i, 'val' + i);
       }
       trace.record(START_TIME, DURATION);
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
 
-      expect(addToQueueStub).to.be.called;
-      expect(addToQueueStub.getCall(0).args[0].message).to.be.equal(
+      expect(addToQueueStub).toHaveBeenCalled();
+      expect(addToQueueStub.mock.calls[0][0].message).toBe(
         EXPECTED_TRACE_MESSAGE
       );
     });
@@ -226,12 +238,12 @@ describe('Performance Monitoring > perf_logger', () => {
 "_fp":40000,"_fcp":50000,"_fid":90000,"_lcp":3999,"_cls":250,"_inp":100},\
 "custom_attributes":{"lcp_element":"lcp-element","cls_largestShiftTarget":"cls-element",\
 "inp_interactionTarget":"inp-element"}}}`;
-      stub(initializationService, 'isPerfInitialized').returns(true);
-      getIidStub.returns(IID);
+      vi.mocked(initializationService.isPerfInitialized).mockReturnValue(true);
+      getIidStub.mockReturnValue(IID);
       SettingsService.getInstance().loggingEnabled = true;
       SettingsService.getInstance().logTraceAfterSampling = true;
 
-      stub(attributeUtils, 'getVisibilityState').returns(
+      vi.mocked(attributeUtils.getVisibilityState).mockReturnValue(
         attributeUtils.VisibilityState.VISIBLE
       );
 
@@ -285,10 +297,10 @@ describe('Performance Monitoring > perf_logger', () => {
         },
         90
       );
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
 
-      expect(addToQueueStub).to.be.called;
-      expect(addToQueueStub.getCall(0).args[0].message).to.be.equal(
+      expect(addToQueueStub).toHaveBeenCalled();
+      expect(addToQueueStub.mock.calls[0][0].message).toBe(
         EXPECTED_TRACE_MESSAGE
       );
     });
@@ -338,9 +350,11 @@ describe('Performance Monitoring > perf_logger', () => {
 "response_payload_bytes":${RESOURCE_PERFORMANCE_ENTRY.transferSize},\
 "client_start_time_us":${START_TIME},\
 "time_to_response_completed_us":${TIME_TO_RESPONSE_COMPLETED}}}`;
-      stub(initializationService, 'isPerfInitialized').returns(true);
-      getIidStub.returns(IID);
-      stub(attributeUtils, 'getVisibilityState').returns(VISIBILITY_STATE);
+      vi.mocked(initializationService.isPerfInitialized).mockReturnValue(true);
+      getIidStub.mockReturnValue(IID);
+      vi.mocked(attributeUtils.getVisibilityState).mockReturnValue(
+        VISIBILITY_STATE
+      );
       SettingsService.getInstance().loggingEnabled = true;
       SettingsService.getInstance().logNetworkAfterSampling = true;
       // Calls logNetworkRequest under the hood.
@@ -348,10 +362,10 @@ describe('Performance Monitoring > perf_logger', () => {
         performanceController,
         RESOURCE_PERFORMANCE_ENTRY
       );
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
 
-      expect(addToQueueStub).to.be.called;
-      expect(addToQueueStub.getCall(0).args[0].message).to.be.equal(
+      expect(addToQueueStub).toHaveBeenCalled();
+      expect(addToQueueStub.mock.calls[0][0].message).toBe(
         EXPECTED_NETWORK_MESSAGE
       );
     });
@@ -384,8 +398,8 @@ describe('Performance Monitoring > perf_logger', () => {
         workerStart: 0,
         toJSON: () => {}
       };
-      stub(initializationService, 'isPerfInitialized').returns(true);
-      getIidStub.returns(IID);
+      vi.mocked(initializationService.isPerfInitialized).mockReturnValue(true);
+      getIidStub.mockReturnValue(IID);
       SettingsService.getInstance().loggingEnabled = true;
       SettingsService.getInstance().logNetworkAfterSampling = true;
       // Calls logNetworkRequest under the hood.
@@ -393,9 +407,9 @@ describe('Performance Monitoring > perf_logger', () => {
         performanceController,
         CC_NETWORK_PERFORMANCE_ENTRY
       );
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
 
-      expect(addToQueueStub).not.called;
+      expect(addToQueueStub).not.toHaveBeenCalled();
     });
 
     // Performance SDK doesn't instrument requests sent from SDK itself, therefore blacklist
@@ -429,8 +443,8 @@ describe('Performance Monitoring > perf_logger', () => {
         workerStart: 0,
         toJSON: () => {}
       };
-      stub(initializationService, 'isPerfInitialized').returns(true);
-      getIidStub.returns(IID);
+      vi.mocked(initializationService.isPerfInitialized).mockReturnValue(true);
+      getIidStub.mockReturnValue(IID);
       SettingsService.getInstance().loggingEnabled = true;
       SettingsService.getInstance().logNetworkAfterSampling = true;
       // Calls logNetworkRequest under the hood.
@@ -438,9 +452,9 @@ describe('Performance Monitoring > perf_logger', () => {
         performanceController,
         FL_NETWORK_PERFORMANCE_ENTRY
       );
-      clock.tick(1);
+      vi.advanceTimersByTime(1);
 
-      expect(addToQueueStub).not.called;
+      expect(addToQueueStub).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/performance/src/services/remote_config_service.test.ts
+++ b/packages/performance/src/services/remote_config_service.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2020 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-import { stub, useFakeTimers, SinonFakeTimers, SinonStub } from 'sinon';
-import { expect } from 'chai';
 import { SettingsService } from './settings_service';
 import { CONFIG_EXPIRY_LOCAL_STORAGE_KEY } from '../constants';
 import { setupApi, Api } from './api_service';
@@ -26,6 +24,9 @@ import { FirebaseApp } from '@firebase/app';
 import '../../test/setup';
 import { FirebaseInstallations } from '@firebase/installations-types';
 import { PerformanceController } from '../controllers/perf';
+import { vi, MockInstance } from 'vitest';
+
+vi.mock('./iid_service', { spy: true });
 
 describe('Performance Monitoring > remote_config_service', () => {
   const IID = 'asd123';
@@ -47,8 +48,6 @@ describe('Performance Monitoring > remote_config_service', () => {
   const APP_ID = '1:23r:web:fewq';
   const API_KEY = 'asdfghjk';
   const NOT_VALID_CONFIG = 'not a valid config and should not be used';
-
-  let clock: SinonFakeTimers;
 
   setupApi(self);
   const ApiInstance = Api.getInstance();
@@ -89,43 +88,34 @@ describe('Performance Monitoring > remote_config_service', () => {
     storageConfig: { expiry: string; config: string },
     fetchConfig?: { reject: boolean; value?: Response }
   ): {
-    storageGetItemStub: SinonStub<[string], string | null>;
-    fetchStub: SinonStub<[RequestInfo | URL, RequestInit?], Promise<Response>>;
+    storageGetItemStub: MockInstance;
+    fetchStub: MockInstance;
   } {
-    const fetchStub = stub(self, 'fetch');
+    const fetchStub = vi.spyOn(self, 'fetch');
 
     if (fetchConfig) {
       fetchConfig.reject
-        ? fetchStub.rejects()
-        : fetchStub.resolves(fetchConfig.value);
+        ? fetchStub.mockRejectedValue(new Error('Network error'))
+        : fetchStub.mockResolvedValue(fetchConfig.value);
     }
 
-    stub(iidService, 'getAuthTokenPromise').returns(
-      Promise.resolve(AUTH_TOKEN)
-    );
+    vi.mocked(iidService.getAuthTokenPromise).mockResolvedValue(AUTH_TOKEN);
 
-    clock = useFakeTimers(GLOBAL_CLOCK_NOW);
+    vi.useFakeTimers({ now: GLOBAL_CLOCK_NOW });
 
-    // we need to stub the entire localStorage, because storage can't be stubbed in Firefox and IE.
-    // stubbing on self(window) seems to only work the first time (at least in Firefox), the subsequent
-    // tests will have the same stub. stub.reset() in afterEach doesn't help either. As a result, we stub on ApiInstance.
-    // https://github.com/sinonjs/sinon/issues/662
-    const storageStub = stub(ApiInstance, 'localStorage');
-    const getItemStub: SinonStub<[string], string | null> = stub();
-
-    storageStub.value({
-      getItem: getItemStub.callsFake(
+    const getItemStub: MockInstance = vi.fn();
+    vi.spyOn(ApiInstance, 'localStorage', 'get').mockReturnValue({
+      getItem: getItemStub.mockImplementation(
         storageGetItemFakeFactory(storageConfig.expiry, storageConfig.config)
       ),
       setItem: () => {}
-    });
+    } as unknown as Storage);
 
     return { storageGetItemStub: getItemStub, fetchStub };
   }
 
   afterEach(() => {
     resetSettingsService();
-    clock.restore();
   });
 
   describe('getConfig', () => {
@@ -139,20 +129,18 @@ describe('Performance Monitoring > remote_config_service', () => {
 
       await getConfig(performanceController, IID);
 
-      expect(getItemStub).to.be.called;
-      expect(SettingsService.getInstance().loggingEnabled).to.be.true;
-      expect(SettingsService.getInstance().logEndPointUrl).to.equal(LOG_URL);
-      expect(SettingsService.getInstance().transportKey).to.equal(
-        TRANSPORT_KEY
+      expect(getItemStub).toHaveBeenCalled();
+      expect(SettingsService.getInstance().loggingEnabled).toBe(true);
+      expect(SettingsService.getInstance().logEndPointUrl).toBe(LOG_URL);
+      expect(SettingsService.getInstance().transportKey).toBe(TRANSPORT_KEY);
+      expect(SettingsService.getInstance().logSource).toBe(LOG_SOURCE);
+      expect(SettingsService.getInstance().networkRequestsSamplingRate).toBe(
+        NETWORK_SAMPLING_RATE
       );
-      expect(SettingsService.getInstance().logSource).to.equal(LOG_SOURCE);
-      expect(
-        SettingsService.getInstance().networkRequestsSamplingRate
-      ).to.equal(NETWORK_SAMPLING_RATE);
-      expect(SettingsService.getInstance().tracesSamplingRate).to.equal(
+      expect(SettingsService.getInstance().tracesSamplingRate).toBe(
         TRACE_SAMPLING_RATE
       );
-      expect(SettingsService.getInstance().logMaxFlushSize).to.equal(10);
+      expect(SettingsService.getInstance().logMaxFlushSize).toBe(10);
     });
 
     it('does not call remote config if a valid config is in local storage', async () => {
@@ -166,7 +154,7 @@ describe('Performance Monitoring > remote_config_service', () => {
 
       await getConfig(performanceController, IID);
 
-      expect(fetchStub).not.to.be.called;
+      expect(fetchStub).not.toHaveBeenCalled();
     });
 
     it('gets the config from RC if local version is not valid', async () => {
@@ -180,20 +168,18 @@ describe('Performance Monitoring > remote_config_service', () => {
 
       await getConfig(performanceController, IID);
 
-      expect(getItemStub).to.be.calledOnce;
-      expect(SettingsService.getInstance().loggingEnabled).to.be.true;
-      expect(SettingsService.getInstance().logEndPointUrl).to.equal(LOG_URL);
-      expect(SettingsService.getInstance().transportKey).to.equal(
-        TRANSPORT_KEY
+      expect(getItemStub).toHaveBeenCalledTimes(1);
+      expect(SettingsService.getInstance().loggingEnabled).toBe(true);
+      expect(SettingsService.getInstance().logEndPointUrl).toBe(LOG_URL);
+      expect(SettingsService.getInstance().transportKey).toBe(TRANSPORT_KEY);
+      expect(SettingsService.getInstance().logSource).toBe(LOG_SOURCE);
+      expect(SettingsService.getInstance().networkRequestsSamplingRate).toBe(
+        NETWORK_SAMPLING_RATE
       );
-      expect(SettingsService.getInstance().logSource).to.equal(LOG_SOURCE);
-      expect(
-        SettingsService.getInstance().networkRequestsSamplingRate
-      ).to.equal(NETWORK_SAMPLING_RATE);
-      expect(SettingsService.getInstance().tracesSamplingRate).to.equal(
+      expect(SettingsService.getInstance().tracesSamplingRate).toBe(
         TRACE_SAMPLING_RATE
       );
-      expect(SettingsService.getInstance().logMaxFlushSize).to.equal(10);
+      expect(SettingsService.getInstance().logMaxFlushSize).toBe(10);
     });
 
     it('does not change the default config if call to RC fails', async () => {
@@ -210,8 +196,8 @@ describe('Performance Monitoring > remote_config_service', () => {
 
       await getConfig(performanceController, IID);
 
-      expect(SettingsService.getInstance().loggingEnabled).to.equal(false);
-      expect(SettingsService.getInstance().logMaxFlushSize).to.equal(40);
+      expect(SettingsService.getInstance().loggingEnabled).toBe(false);
+      expect(SettingsService.getInstance().logMaxFlushSize).toBe(40);
     });
 
     it('uses secondary configs if the response does not have all the fields', async () => {
@@ -232,7 +218,7 @@ describe('Performance Monitoring > remote_config_service', () => {
 
       await getConfig(performanceController, IID);
 
-      expect(SettingsService.getInstance().loggingEnabled).to.be.true;
+      expect(SettingsService.getInstance().loggingEnabled).toBe(true);
     });
 
     it('uses secondary configs if the response does not have any fields', async () => {
@@ -249,7 +235,7 @@ describe('Performance Monitoring > remote_config_service', () => {
       );
       await getConfig(performanceController, IID);
 
-      expect(SettingsService.getInstance().loggingEnabled).to.be.true;
+      expect(SettingsService.getInstance().loggingEnabled).toBe(true);
     });
 
     it('gets the config from RC even with deprecated transport flag', async () => {
@@ -271,17 +257,15 @@ describe('Performance Monitoring > remote_config_service', () => {
 
       await getConfig(performanceController, IID);
 
-      expect(getItemStub).to.be.calledOnce;
-      expect(SettingsService.getInstance().loggingEnabled).to.be.true;
-      expect(SettingsService.getInstance().logEndPointUrl).to.equal(LOG_URL);
-      expect(SettingsService.getInstance().transportKey).to.equal(
-        TRANSPORT_KEY
+      expect(getItemStub).toHaveBeenCalledTimes(1);
+      expect(SettingsService.getInstance().loggingEnabled).toBe(true);
+      expect(SettingsService.getInstance().logEndPointUrl).toBe(LOG_URL);
+      expect(SettingsService.getInstance().transportKey).toBe(TRANSPORT_KEY);
+      expect(SettingsService.getInstance().logSource).toBe(LOG_SOURCE);
+      expect(SettingsService.getInstance().networkRequestsSamplingRate).toBe(
+        NETWORK_SAMPLING_RATE
       );
-      expect(SettingsService.getInstance().logSource).to.equal(LOG_SOURCE);
-      expect(
-        SettingsService.getInstance().networkRequestsSamplingRate
-      ).to.equal(NETWORK_SAMPLING_RATE);
-      expect(SettingsService.getInstance().tracesSamplingRate).to.equal(
+      expect(SettingsService.getInstance().tracesSamplingRate).toBe(
         TRACE_SAMPLING_RATE
       );
     });

--- a/packages/performance/src/services/remote_config_service.test.ts
+++ b/packages/performance/src/services/remote_config_service.test.ts
@@ -25,6 +25,7 @@ import '../../test/setup';
 import { FirebaseInstallations } from '@firebase/installations-types';
 import { PerformanceController } from '../controllers/perf';
 import { vi, MockInstance } from 'vitest';
+import { consoleLogger } from '../utils/console_logger';
 
 vi.mock('./iid_service', { spy: true });
 
@@ -91,13 +92,17 @@ describe('Performance Monitoring > remote_config_service', () => {
     storageGetItemStub: MockInstance;
     fetchStub: MockInstance;
   } {
-    const fetchStub = vi.spyOn(self, 'fetch');
+    const fetchStub = vi
+      .spyOn(self, 'fetch')
+      .mockResolvedValue(new Response('{}'));
 
     if (fetchConfig) {
       fetchConfig.reject
         ? fetchStub.mockRejectedValue(new Error('Network error'))
         : fetchStub.mockResolvedValue(fetchConfig.value);
     }
+
+    vi.spyOn(consoleLogger, 'info').mockImplementation(() => {});
 
     vi.mocked(iidService.getAuthTokenPromise).mockResolvedValue(AUTH_TOKEN);
 

--- a/packages/performance/src/services/transport_service.test.ts
+++ b/packages/performance/src/services/transport_service.test.ts
@@ -40,7 +40,7 @@ describe('Firebase Performance > transport_service', () => {
     setupTransportService();
     sendBeaconStub = vi.spyOn(navigator, 'sendBeacon');
     sendBeaconStub.mockReturnValue(true);
-    fetchStub = vi.spyOn(window, 'fetch');
+    fetchStub = vi.spyOn(window, 'fetch').mockResolvedValue(new Response('{}'));
   });
 
   afterEach(() => {

--- a/packages/performance/src/services/transport_service.test.ts
+++ b/packages/performance/src/services/transport_service.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2020 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,6 @@
  * limitations under the License.
  */
 
-import { stub, useFakeTimers, SinonFakeTimers, SinonStub } from 'sinon';
-import { use, expect } from 'chai';
-import sinonChai from 'sinon-chai';
 import {
   transportHandler,
   setupTransportService,
@@ -25,68 +22,60 @@ import {
   flushQueuedEvents
 } from './transport_service';
 import { SettingsService } from './settings_service';
-
-use(sinonChai);
+import { vi, MockInstance } from 'vitest';
 
 /* eslint-disable no-restricted-properties */
 describe('Firebase Performance > transport_service', () => {
-  let sendBeaconStub: SinonStub<
-    [url: string | URL, data?: BodyInit | null | undefined],
-    boolean
-  >;
-  let fetchStub: SinonStub<
-    [RequestInfo | URL, RequestInit?],
-    Promise<Response>
-  >;
+  let sendBeaconStub: MockInstance;
+  let fetchStub: MockInstance;
   const INITIAL_SEND_TIME_DELAY_MS = 5.5 * 1000;
   const DEFAULT_SEND_INTERVAL_MS = 10 * 1000;
   const MAX_EVENT_COUNT_PER_REQUEST = 1000;
-  // Starts date at timestamp 1 instead of 0, otherwise it causes validation errors.
-  let clock: SinonFakeTimers;
   const testTransportHandler = transportHandler((...args) => {
     return args[0];
   });
 
   beforeEach(() => {
-    clock = useFakeTimers(1);
+    vi.useFakeTimers({ now: 1 });
     setupTransportService();
-    sendBeaconStub = stub(navigator, 'sendBeacon');
-    sendBeaconStub.returns(true);
-    fetchStub = stub(window, 'fetch');
+    sendBeaconStub = vi.spyOn(navigator, 'sendBeacon');
+    sendBeaconStub.mockReturnValue(true);
+    fetchStub = vi.spyOn(window, 'fetch');
   });
 
   afterEach(() => {
-    clock.restore();
+    vi.useRealTimers();
     resetTransportService();
-    sendBeaconStub.restore();
-    fetchStub.restore();
+    sendBeaconStub.mockRestore();
+    fetchStub.mockRestore();
+    vi.clearAllMocks();
   });
 
   it('throws an error when logging an empty message', () => {
     expect(() => {
       testTransportHandler('');
-    }).to.throw;
+    }).toThrow();
   });
 
   it('does not attempt to log an event after INITIAL_SEND_TIME_DELAY_MS if queue is empty', () => {
-    clock.tick(INITIAL_SEND_TIME_DELAY_MS);
-    expect(sendBeaconStub).to.not.have.been.called;
-    expect(fetchStub).to.not.have.been.called;
+    vi.advanceTimersByTime(INITIAL_SEND_TIME_DELAY_MS);
+    expect(sendBeaconStub).not.toHaveBeenCalled();
+    expect(fetchStub).not.toHaveBeenCalled();
   });
 
   it('attempts to log an event after DEFAULT_SEND_INTERVAL_MS if queue not empty', async () => {
-    clock.tick(INITIAL_SEND_TIME_DELAY_MS);
+    vi.advanceTimersByTime(INITIAL_SEND_TIME_DELAY_MS);
     testTransportHandler('someEvent');
-    clock.tick(DEFAULT_SEND_INTERVAL_MS);
-    expect(sendBeaconStub).to.have.been.calledOnce;
-    expect(fetchStub).to.not.have.been.called;
+    vi.advanceTimersByTime(DEFAULT_SEND_INTERVAL_MS);
+    expect(sendBeaconStub).toHaveBeenCalledTimes(1);
+    expect(fetchStub).not.toHaveBeenCalled();
   });
 
   it('successful send a message to transport', () => {
     testTransportHandler('event1');
-    clock.tick(INITIAL_SEND_TIME_DELAY_MS);
-    expect(sendBeaconStub).to.have.been.calledOnce;
-    expect(fetchStub).to.not.have.been.called;
+    vi.advanceTimersByTime(INITIAL_SEND_TIME_DELAY_MS);
+    expect(sendBeaconStub).toHaveBeenCalledTimes(1);
+    expect(fetchStub).not.toHaveBeenCalled();
   });
 
   it('sends up to the maximum event limit in one request if payload is under 64 KB', async () => {
@@ -102,10 +91,10 @@ describe('Firebase Performance > transport_service', () => {
       testTransportHandler('event' + i);
     }
     // Wait for first and second event dispatch to happen.
-    clock.tick(INITIAL_SEND_TIME_DELAY_MS);
+    vi.advanceTimersByTime(INITIAL_SEND_TIME_DELAY_MS);
     // This is to resolve the floating promise chain in transport service.
     await Promise.resolve().then().then().then();
-    clock.tick(DEFAULT_SEND_INTERVAL_MS);
+    vi.advanceTimersByTime(DEFAULT_SEND_INTERVAL_MS);
 
     // Assert
     // Expects the first logRequest which contains first 1000 events.
@@ -116,7 +105,7 @@ describe('Firebase Performance > transport_service', () => {
         'event_time_ms': '1'
       });
     }
-    expect(sendBeaconStub).which.to.have.been.calledWith(
+    expect(sendBeaconStub).toHaveBeenCalledWith(
       flTransportFullUrl,
       JSON.stringify(firstLogRequest)
     );
@@ -129,11 +118,11 @@ describe('Firebase Performance > transport_service', () => {
         'event_time_ms': '1'
       });
     }
-    expect(sendBeaconStub).calledWith(
+    expect(sendBeaconStub).toHaveBeenCalledWith(
       flTransportFullUrl,
       JSON.stringify(secondLogRequest)
     );
-    expect(fetchStub).to.not.have.been.called;
+    expect(fetchStub).not.toHaveBeenCalled();
   });
 
   it('sends fetch if payload is above 64 KB', async () => {
@@ -141,7 +130,7 @@ describe('Firebase Performance > transport_service', () => {
     const setting = SettingsService.getInstance();
     const flTransportFullUrl =
       setting.flTransportEndpointUrl + '?key=' + setting.transportKey;
-    fetchStub.resolves(
+    fetchStub.mockResolvedValue(
       new Response('{}', {
         status: 200,
         headers: { 'Content-type': 'application/json' }
@@ -155,10 +144,10 @@ describe('Firebase Performance > transport_service', () => {
       testTransportHandler(payload + i);
     }
     // Wait for first and second event dispatch to happen.
-    clock.tick(INITIAL_SEND_TIME_DELAY_MS);
+    vi.advanceTimersByTime(INITIAL_SEND_TIME_DELAY_MS);
     // This is to resolve the floating promise chain in transport service.
     await Promise.resolve().then().then().then();
-    clock.tick(DEFAULT_SEND_INTERVAL_MS);
+    vi.advanceTimersByTime(DEFAULT_SEND_INTERVAL_MS);
 
     // Assert
     // Expects the first logRequest which contains first 1000 events.
@@ -169,7 +158,7 @@ describe('Firebase Performance > transport_service', () => {
         'event_time_ms': '1'
       });
     }
-    expect(fetchStub).calledWith(flTransportFullUrl, {
+    expect(fetchStub).toHaveBeenCalledWith(flTransportFullUrl, {
       method: 'POST',
       body: JSON.stringify(firstLogRequest)
     });
@@ -182,23 +171,23 @@ describe('Firebase Performance > transport_service', () => {
         'event_time_ms': '1'
       });
     }
-    expect(sendBeaconStub).calledWith(
+    expect(sendBeaconStub).toHaveBeenCalledWith(
       flTransportFullUrl,
       JSON.stringify(secondLogRequest)
     );
   });
 
   it('falls back to fetch if sendBeacon fails.', async () => {
-    sendBeaconStub.returns(false);
-    fetchStub.resolves(
+    sendBeaconStub.mockReturnValue(false);
+    fetchStub.mockResolvedValue(
       new Response('{}', {
         status: 200,
         headers: { 'Content-type': 'application/json' }
       })
     );
     testTransportHandler('event1');
-    clock.tick(INITIAL_SEND_TIME_DELAY_MS);
-    expect(fetchStub).to.have.been.calledOnce;
+    vi.advanceTimersByTime(INITIAL_SEND_TIME_DELAY_MS);
+    expect(fetchStub).toHaveBeenCalledTimes(1);
   });
 
   it('flushes the queue with multiple sendBeacons in batches of 40', async () => {
@@ -206,7 +195,7 @@ describe('Firebase Performance > transport_service', () => {
     const setting = SettingsService.getInstance();
     const flTransportFullUrl =
       setting.flTransportEndpointUrl + '?key=' + setting.transportKey;
-    fetchStub.resolves(
+    fetchStub.mockResolvedValue(
       new Response('{}', {
         status: 200,
         headers: { 'Content-type': 'application/json' }
@@ -235,15 +224,15 @@ describe('Firebase Performance > transport_service', () => {
         'event_time_ms': '1'
       });
     }
-    expect(sendBeaconStub).calledWith(
+    expect(sendBeaconStub).toHaveBeenCalledWith(
       flTransportFullUrl,
       JSON.stringify(firstLogRequest)
     );
-    expect(sendBeaconStub).calledWith(
+    expect(sendBeaconStub).toHaveBeenCalledWith(
       flTransportFullUrl,
       JSON.stringify(secondLogRequest)
     );
-    expect(fetchStub).to.not.have.been.called;
+    expect(fetchStub).not.toHaveBeenCalled();
   });
 
   it('flushes the queue with fetch for sendBeacons that failed', async () => {
@@ -251,7 +240,7 @@ describe('Firebase Performance > transport_service', () => {
     const setting = SettingsService.getInstance();
     const flTransportFullUrl =
       setting.flTransportEndpointUrl + '?key=' + setting.transportKey;
-    fetchStub.resolves(
+    fetchStub.mockResolvedValue(
       new Response('{}', {
         status: 200,
         headers: { 'Content-type': 'application/json' }
@@ -264,8 +253,7 @@ describe('Firebase Performance > transport_service', () => {
     for (let i = 0; i < 80; i++) {
       testTransportHandler(payload + i);
     }
-    sendBeaconStub.onCall(0).returns(true);
-    sendBeaconStub.onCall(1).returns(false);
+    sendBeaconStub.mockReturnValueOnce(true).mockReturnValueOnce(false);
     flushQueuedEvents();
 
     // Assert
@@ -283,11 +271,11 @@ describe('Firebase Performance > transport_service', () => {
         'event_time_ms': '1'
       });
     }
-    expect(sendBeaconStub).calledWith(
+    expect(sendBeaconStub).toHaveBeenCalledWith(
       flTransportFullUrl,
       JSON.stringify(firstLogRequest)
     );
-    expect(fetchStub).calledWith(flTransportFullUrl, {
+    expect(fetchStub).toHaveBeenCalledWith(flTransportFullUrl, {
       method: 'POST',
       body: JSON.stringify(secondLogRequest)
     });

--- a/packages/performance/src/utils/attribute_utils.test.ts
+++ b/packages/performance/src/utils/attribute_utils.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2020 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -10,13 +10,11 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF unknown KIND, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 
-import { restore, stub } from 'sinon';
-import { expect } from 'chai';
 import { Api } from '../services/api_service';
 
 import {
@@ -29,27 +27,28 @@ import {
 } from './attributes_utils';
 
 import '../../test/setup';
+import { vi } from 'vitest';
 
 describe('Firebase Performance > attribute_utils', () => {
   describe('#getServiceWorkerStatus', () => {
     it('returns unsupported when service workers is in navigator but has a falsy value', () => {
-      stub(Api, 'getInstance').returns({
+      vi.spyOn(Api, 'getInstance').mockReturnValue({
         navigator: { serviceWorker: undefined }
       } as unknown as Api);
 
-      expect(getServiceWorkerStatus()).to.be.eql(1 /** UNSUPPORTED */);
+      expect(getServiceWorkerStatus()).toEqual(1);
     });
 
     it('returns unsupported when service workers unsupported', () => {
-      stub(Api, 'getInstance').returns({
+      vi.spyOn(Api, 'getInstance').mockReturnValue({
         navigator: {}
       } as unknown as Api);
 
-      expect(getServiceWorkerStatus()).to.be.eql(1 /** UNSUPPORTED */);
+      expect(getServiceWorkerStatus()).toEqual(1);
     });
 
     it('returns controlled when service workers controlled', () => {
-      stub(Api, 'getInstance').returns({
+      vi.spyOn(Api, 'getInstance').mockReturnValue({
         navigator: {
           serviceWorker: {
             controller: {}
@@ -57,167 +56,169 @@ describe('Firebase Performance > attribute_utils', () => {
         }
       } as unknown as Api);
 
-      expect(getServiceWorkerStatus()).to.be.eql(2 /** CONTROLLED */);
+      expect(getServiceWorkerStatus()).toEqual(2);
     });
 
     it('returns uncontrolled when service workers uncontrolled', () => {
-      stub(Api, 'getInstance').returns({
+      vi.spyOn(Api, 'getInstance').mockReturnValue({
         navigator: {
           serviceWorker: {}
         }
       } as unknown as Api);
 
-      expect(getServiceWorkerStatus()).to.be.eql(3 /** UNCONTROLLED */);
+      expect(getServiceWorkerStatus()).toEqual(3);
     });
   });
 
   describe('#getVisibilityState', () => {
     afterEach(() => {
-      restore();
+      vi.restoreAllMocks();
     });
 
     it('returns visible when document is visible', () => {
-      stub(Api, 'getInstance').returns({
+      vi.spyOn(Api, 'getInstance').mockReturnValue({
         document: {
           visibilityState: 'visible'
         }
       } as unknown as Api);
-      expect(getVisibilityState()).to.be.eql(VisibilityState.VISIBLE);
+      expect(getVisibilityState()).toEqual(VisibilityState.VISIBLE);
     });
 
     it('returns hidden when document is hidden', () => {
-      stub(Api, 'getInstance').returns({
+      vi.spyOn(Api, 'getInstance').mockReturnValue({
         document: {
           visibilityState: 'hidden'
         }
       } as unknown as Api);
-      expect(getVisibilityState()).to.be.eql(VisibilityState.HIDDEN);
+      expect(getVisibilityState()).toEqual(VisibilityState.HIDDEN);
     });
 
     it('returns unknown when document is unknown', () => {
-      stub(Api, 'getInstance').returns({
+      vi.spyOn(Api, 'getInstance').mockReturnValue({
         document: {
           visibilityState: 'unknown'
         }
       } as unknown as Api);
-      expect(getVisibilityState()).to.be.eql(VisibilityState.UNKNOWN);
+      expect(getVisibilityState()).toEqual(VisibilityState.UNKNOWN);
     });
   });
 
   describe('#getEffectiveConnectionType', () => {
     afterEach(() => {
-      restore();
+      vi.restoreAllMocks();
     });
 
     it('returns EffectiveConnectionType.CONNECTION_SLOW_2G when slow-2g', () => {
-      stub(Api, 'getInstance').returns({
+      vi.spyOn(Api, 'getInstance').mockReturnValue({
         navigator: {
           connection: {
             effectiveType: 'slow-2g'
           }
         }
       } as unknown as Api);
-      expect(getEffectiveConnectionType()).to.be.eql(1);
+      expect(getEffectiveConnectionType()).toEqual(1);
     });
 
     it('returns EffectiveConnectionType.CONNECTION_2G when 2g', () => {
-      stub(Api, 'getInstance').returns({
+      vi.spyOn(Api, 'getInstance').mockReturnValue({
         navigator: {
           connection: {
             effectiveType: '2g'
           }
         }
       } as unknown as Api);
-      expect(getEffectiveConnectionType()).to.be.eql(2);
+      expect(getEffectiveConnectionType()).toEqual(2);
     });
 
     it('returns EffectiveConnectionType.CONNECTION_3G when 3g', () => {
-      stub(Api, 'getInstance').returns({
+      vi.spyOn(Api, 'getInstance').mockReturnValue({
         navigator: {
           connection: {
             effectiveType: '3g'
           }
         }
       } as unknown as Api);
-      expect(getEffectiveConnectionType()).to.be.eql(3);
+      expect(getEffectiveConnectionType()).toEqual(3);
     });
 
     it('returns EffectiveConnectionType.CONNECTION_4G when 4g', () => {
-      stub(Api, 'getInstance').returns({
+      vi.spyOn(Api, 'getInstance').mockReturnValue({
         navigator: {
           connection: {
             effectiveType: '4g'
           }
         }
       } as unknown as Api);
-      expect(getEffectiveConnectionType()).to.be.eql(4);
+      expect(getEffectiveConnectionType()).toEqual(4);
     });
 
     it('returns EffectiveConnectionType.UNKNOWN when unknown connection type', () => {
-      stub(Api, 'getInstance').returns({
+      vi.spyOn(Api, 'getInstance').mockReturnValue({
         navigator: {
           connection: {
             effectiveType: '5g'
           }
         }
       } as unknown as Api);
-      expect(getEffectiveConnectionType()).to.be.eql(0);
+      expect(getEffectiveConnectionType()).toEqual(0);
     });
 
     it('returns EffectiveConnectionType.UNKNOWN when no effective type', () => {
-      stub(Api, 'getInstance').returns({
+      vi.spyOn(Api, 'getInstance').mockReturnValue({
         navigator: {
           connection: {}
         }
       } as unknown as Api);
-      expect(getEffectiveConnectionType()).to.be.eql(0);
+      expect(getEffectiveConnectionType()).toEqual(0);
     });
   });
 
   describe('#isValidCustomAttributeName', () => {
     it('returns true when name is valid', () => {
-      expect(isValidCustomAttributeName('validCustom_Attribute_Name')).to.be
-        .true;
+      expect(isValidCustomAttributeName('validCustom_Attribute_Name')).toBe(
+        true
+      );
     });
 
     it('returns false when name is blank', () => {
-      expect(isValidCustomAttributeName('')).to.be.false;
+      expect(isValidCustomAttributeName('')).toBe(false);
     });
 
     it('returns false when name is too long', () => {
       expect(
         isValidCustomAttributeName('invalid_custom_name_over_forty_characters')
-      ).to.be.false;
+      ).toBe(false);
     });
 
     it('returns false when name starts with a reserved prefix', () => {
-      expect(isValidCustomAttributeName('firebase_invalidCustomName')).to.be
-        .false;
+      expect(isValidCustomAttributeName('firebase_invalidCustomName')).toBe(
+        false
+      );
     });
 
     it('returns false when name does not begin with a letter', () => {
-      expect(isValidCustomAttributeName('_invalidCustomName')).to.be.false;
+      expect(isValidCustomAttributeName('_invalidCustomName')).toBe(false);
     });
 
     it('returns false when name contains prohibited characters', () => {
-      expect(isValidCustomAttributeName('invalidCustomName&')).to.be.false;
+      expect(isValidCustomAttributeName('invalidCustomName&')).toBe(false);
     });
   });
 
   describe('#isValidCustomAttributeValue', () => {
     it('returns true when value is valid', () => {
-      expect(isValidCustomAttributeValue('valid_attribute_value')).to.be.true;
+      expect(isValidCustomAttributeValue('valid_attribute_value')).toBe(true);
     });
 
     it('returns false when value is blank', () => {
-      expect(isValidCustomAttributeValue('')).to.be.false;
+      expect(isValidCustomAttributeValue('')).toBe(false);
     });
 
     it('returns false when value is too long', () => {
       const longAttributeValue =
         'too_long_attribute_value_over_one_hundred_characters_too_long_attribute_value_over_one_' +
         'hundred_charac';
-      expect(isValidCustomAttributeValue(longAttributeValue)).to.be.false;
+      expect(isValidCustomAttributeValue(longAttributeValue)).toBe(false);
     });
   });
 });

--- a/packages/performance/src/utils/metric_utils.test.ts
+++ b/packages/performance/src/utils/metric_utils.test.ts
@@ -14,9 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import { expect } from 'chai';
-
 import { isValidMetricName } from './metric_utils';
 import {
   FIRST_PAINT_COUNTER_NAME,
@@ -28,28 +25,28 @@ import '../../test/setup';
 describe('Firebase Performance > metric_utils', () => {
   describe('#isValidMetricName', () => {
     it('returns true when name is valid', () => {
-      expect(isValidMetricName('validCustom_Metric_Name')).to.be.true;
+      expect(isValidMetricName('validCustom_Metric_Name')).toBe(true);
     });
 
     it('returns false when name is blank', () => {
-      expect(isValidMetricName('')).to.be.false;
+      expect(isValidMetricName('')).toBe(false);
     });
 
     it('returns false when name is too long', () => {
       const longMetricName =
         'too_long_metric_name_over_one_hundred_characters_too_long_metric_name_over_one_' +
         'hundred_characters_too';
-      expect(isValidMetricName(longMetricName)).to.be.false;
+      expect(isValidMetricName(longMetricName)).toBe(false);
     });
 
     it('returns false when name starts with a reserved prefix', () => {
-      expect(isValidMetricName('_invalidMetricName')).to.be.false;
+      expect(isValidMetricName('_invalidMetricName')).toBe(false);
     });
 
     it('returns true for first paint metric', () => {
       expect(
         isValidMetricName(FIRST_PAINT_COUNTER_NAME, '_wt_http://example.com')
-      ).to.be.true;
+      ).toBe(true);
     });
 
     it('returns true for first contentful paint metric', () => {
@@ -58,7 +55,7 @@ describe('Firebase Performance > metric_utils', () => {
           FIRST_CONTENTFUL_PAINT_COUNTER_NAME,
           '_wt_http://example.com'
         )
-      ).to.be.true;
+      ).toBe(true);
     });
 
     it('returns true for first input delay metric', () => {
@@ -67,12 +64,13 @@ describe('Firebase Performance > metric_utils', () => {
           FIRST_INPUT_DELAY_COUNTER_NAME,
           '_wt_http://example.com'
         )
-      ).to.be.true;
+      ).toBe(true);
     });
 
     it('returns false if first paint metric name is used outside of page load traces', () => {
-      expect(isValidMetricName(FIRST_PAINT_COUNTER_NAME, 'some_random_trace'))
-        .to.be.false;
+      expect(
+        isValidMetricName(FIRST_PAINT_COUNTER_NAME, 'some_random_trace')
+      ).toBe(false);
     });
 
     it('returns false if first contentful paint metric name is used outside of page load traces', () => {
@@ -81,13 +79,13 @@ describe('Firebase Performance > metric_utils', () => {
           FIRST_CONTENTFUL_PAINT_COUNTER_NAME,
           'some_random_trace'
         )
-      ).to.be.false;
+      ).toBe(false);
     });
 
     it('returns false if first input delay metric name is used outside of page load traces', () => {
       expect(
         isValidMetricName(FIRST_INPUT_DELAY_COUNTER_NAME, 'some_random_trace')
-      ).to.be.false;
+      ).toBe(false);
     });
   });
 });

--- a/packages/performance/src/utils/string_merger.test.ts
+++ b/packages/performance/src/utils/string_merger.test.ts
@@ -14,9 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import { expect } from 'chai';
-
 import { mergeStrings } from './string_merger';
 import { FirebaseError } from '@firebase/util';
 import '../../test/setup';
@@ -24,29 +21,29 @@ import '../../test/setup';
 describe('Firebase Performance > string_merger', () => {
   describe('#mergeStrings', () => {
     it('Throws exception when string length has | diff | > 1', () => {
-      expect(() => mergeStrings('', '123')).to.throw(
+      expect(() => mergeStrings('', '123')).toThrow(
         FirebaseError,
         'performance/invalid String merger input'
       );
     });
 
     it('returns empty string when both inputs are empty', () => {
-      expect(mergeStrings('', '')).equal('');
+      expect(mergeStrings('', '')).toBe('');
     });
 
     it('returns merge result string when both inputs have same length', () => {
-      expect(mergeStrings('12345', 'abcde')).equal('1a2b3c4d5e');
+      expect(mergeStrings('12345', 'abcde')).toBe('1a2b3c4d5e');
     });
 
     it('returns merge result string when input length diff == 1', () => {
-      expect(() => mergeStrings('1234', 'abcde')).to.throw(
+      expect(() => mergeStrings('1234', 'abcde')).toThrow(
         FirebaseError,
         'performance/invalid String merger input'
       );
     });
 
     it('returns merge result string when input length diff == -1', () => {
-      expect(mergeStrings('12345', 'abcd')).equal('1a2b3c4d5');
+      expect(mergeStrings('12345', 'abcd')).toBe('1a2b3c4d5');
     });
   });
 });

--- a/packages/performance/test/types/vitest-globals.d.ts
+++ b/packages/performance/test/types/vitest-globals.d.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2020 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,20 +15,4 @@
  * limitations under the License.
  */
 
-const karmaBase = require('../../config/karma.base');
-
-const files = [`test/**/*`, 'src/**/*.test.ts'];
-
-module.exports = function (config) {
-  config.set({
-    ...karmaBase,
-    // files to load into karma
-    files,
-    preprocessors: { '**/*.ts': ['webpack', 'sourcemap'] },
-    // frameworks to use
-    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['mocha']
-  });
-};
-
-module.exports.files = files;
+import 'vitest/globals';

--- a/packages/performance/vitest.config.mjs
+++ b/packages/performance/vitest.config.mjs
@@ -15,9 +15,13 @@
  * limitations under the License.
  */
 
-import { vi } from 'vitest';
-afterEach(() => {
-  vi.useRealTimers();
-  vi.restoreAllMocks();
-  vi.clearAllMocks();
-});
+import createBaseConfig from '../../config/vitest.base.mjs';
+
+const config = createBaseConfig(import.meta.url);
+
+// Browser-only SDK: filter test projects to browser runner
+config.test.projects = config.test.projects.filter(
+  project => project.test?.name === 'browser'
+);
+
+export default config;


### PR DESCRIPTION
### Summary
Migrates `@firebase/performance` unit tests from legacy Karma (Mocha / Chai / Sinon) to **Vitest** (Browser Chromium via Playwright).

### Description
- **Runner & Config**: Replaced `karma.conf.js` with `vitest.config.mjs` extending `config/vitest.base.mjs`. Added `test/setup.ts` for automatic post-test timer and mock cleanup, and `test/types/vitest-globals.d.ts`.
- **Target Environment**: `@firebase/performance` relies on browser primitives (`PerformanceObserver`, `PerformanceMark`, `PerformanceMeasure`, `navigator.sendBeacon`, `IndexedDB`). Tests run in the `browser` project via `@vitest/browser-playwright`.
- **Assertions & Lifecycle**: Converted legacy Chai assertions (`.to.equal`, `.to.deep.equal`, `.to.throw`) to native Vitest matchers (`.toBe()`, `.toEqual()`, `.toThrow()`).
- **Mocks & Spies**: Converted Sinon stubs/spies to native Vitest utilities (`vi.fn()`, `vi.spyOn()`). Added `vi.mock('./iid_service', { spy: true })` to support spying on sealed browser ESM module namespaces.
- **Type-only Exports**: Updated `src/index.ts` to use `import type` and `export type` for interface re-exports (`FirebasePerformance`, `PerformanceSettings`, `PerformanceTrace`) to support Vite/esbuild isolated modules compilation.

### Performance
- **Baseline (Karma + Webpack)**: ~15–20s total duration
- **Vitest**: **~3.3s** 