### PR TITLE
feat(lint): disallow eval and implied-eval across all packages

### DIFF
--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -45,6 +45,8 @@ module.exports = {
     }
   ],
   'rules': {
+    'no-eval': 'error',
+    '@typescript-eslint/no-implied-eval': 'error',
     'curly': ['error', 'all'],
     'guard-for-in': 'error',
     'no-extra-label': 'error',


### PR DESCRIPTION
Monorepo-wide ESLint enforcement to disallow eval() and implied eval (setTimeout/setInterval with strings). This ensures third-party bundles comply with strict CSP and Google3 Closure Compiler conformance checks without dynamic execution.