### PR TITLE
Crashlytics disable otel auto flush

### DIFF
--- a/packages/crashlytics/src/logging/logger-provider.test.ts
+++ b/packages/crashlytics/src/logging/logger-provider.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { FirebaseApp } from '@firebase/app';
+import {
+  LoggerProvider,
+  BatchLogRecordProcessor
+} from '@opentelemetry/sdk-logs';
+import { createLoggerProvider } from './logger-provider';
+import { AttributesStore } from '../attributes-store';
+import { FirebaseAttributesProcessor } from './attributes-processor';
+
+describe('createLoggerProvider', () => {
+  let app: FirebaseApp;
+  let attributesStore: AttributesStore;
+
+  beforeEach(() => {
+    app = {
+      name: '[DEFAULT]',
+      options: {
+        projectId: 'test-project',
+        appId: 'test-app',
+        apiKey: 'test-api-key'
+      }
+    } as FirebaseApp;
+    attributesStore = new AttributesStore(app.options);
+  });
+
+  it('should initialize LoggerProvider with FirebaseAttributesProcessor and BatchLogRecordProcessor', () => {
+    const provider = createLoggerProvider(app, {}, attributesStore, []);
+    expect(provider).to.be.an.instanceOf(LoggerProvider);
+
+    const sharedState = (
+      provider as unknown as {
+        _sharedState: { registeredLogRecordProcessors: unknown[] };
+      }
+    )._sharedState;
+    expect(sharedState.registeredLogRecordProcessors).to.have.lengthOf(2);
+    expect(
+      sharedState.registeredLogRecordProcessors[0]
+    ).to.be.an.instanceOf(FirebaseAttributesProcessor);
+    expect(
+      sharedState.registeredLogRecordProcessors[1]
+    ).to.be.an.instanceOf(BatchLogRecordProcessor);
+  });
+
+  describe('BatchLogRecordProcessor auto-flush on document hide', () => {
+    it('does not register document event listeners when disableAutoFlushOnDocumentHide is true', () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { BatchLogRecordProcessor: BrowserBatchLogRecordProcessor } = require('@opentelemetry/sdk-logs/build/src/platform/browser/export/BatchLogRecordProcessor');
+
+      const addEventListenerSpy = sinon.spy();
+      const originalDocument = (global as unknown as { document?: unknown })
+        .document;
+      (global as unknown as { document: unknown }).document = {
+        addEventListener: addEventListenerSpy,
+        removeEventListener: sinon.spy()
+      };
+
+      try {
+        new BrowserBatchLogRecordProcessor({
+          exporter: { export: sinon.spy(), shutdown: sinon.stub().resolves() },
+          disableAutoFlushOnDocumentHide: true
+        });
+        expect(addEventListenerSpy.called).to.be.false;
+
+        new BrowserBatchLogRecordProcessor({
+          exporter: { export: sinon.spy(), shutdown: sinon.stub().resolves() },
+          disableAutoFlushOnDocumentHide: false
+        });
+        expect(addEventListenerSpy.calledWith('visibilitychange')).to.be.true;
+        expect(addEventListenerSpy.calledWith('pagehide')).to.be.true;
+      } finally {
+        (global as unknown as { document: unknown }).document =
+          originalDocument;
+      }
+    });
+  });
+});

--- a/packages/crashlytics/src/logging/logger-provider.test.ts
+++ b/packages/crashlytics/src/logging/logger-provider.test.ts
@@ -18,6 +18,7 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { FirebaseApp } from '@firebase/app';
+import * as sdkLogs from '@opentelemetry/sdk-logs';
 import {
   LoggerProvider,
   BatchLogRecordProcessor
@@ -52,43 +53,36 @@ describe('createLoggerProvider', () => {
       }
     )._sharedState;
     expect(sharedState.registeredLogRecordProcessors).to.have.lengthOf(2);
-    expect(
-      sharedState.registeredLogRecordProcessors[0]
-    ).to.be.an.instanceOf(FirebaseAttributesProcessor);
-    expect(
-      sharedState.registeredLogRecordProcessors[1]
-    ).to.be.an.instanceOf(BatchLogRecordProcessor);
+    expect(sharedState.registeredLogRecordProcessors[0]).to.be.an.instanceOf(
+      FirebaseAttributesProcessor
+    );
+    expect(sharedState.registeredLogRecordProcessors[1]).to.be.an.instanceOf(
+      BatchLogRecordProcessor
+    );
   });
 
   describe('BatchLogRecordProcessor auto-flush on document hide', () => {
-    it('does not register document event listeners when disableAutoFlushOnDocumentHide is true', () => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { BatchLogRecordProcessor: BrowserBatchLogRecordProcessor } = require('@opentelemetry/sdk-logs/build/src/platform/browser/export/BatchLogRecordProcessor');
-
-      const addEventListenerSpy = sinon.spy();
-      const originalDocument = (global as unknown as { document?: unknown })
-        .document;
-      (global as unknown as { document: unknown }).document = {
-        addEventListener: addEventListenerSpy,
-        removeEventListener: sinon.spy()
-      };
-
+    it('should pass disableAutoFlushOnDocumentHide: true to BatchLogRecordProcessor', () => {
+      const origDesc = Object.getOwnPropertyDescriptor(
+        sdkLogs,
+        'BatchLogRecordProcessor'
+      );
+      Object.defineProperty(sdkLogs, 'BatchLogRecordProcessor', {
+        value: origDesc?.get ? origDesc.get() : sdkLogs.BatchLogRecordProcessor,
+        configurable: true,
+        writable: true
+      });
+      const batchProcessorSpy = sinon.spy(sdkLogs, 'BatchLogRecordProcessor');
       try {
-        new BrowserBatchLogRecordProcessor({
-          exporter: { export: sinon.spy(), shutdown: sinon.stub().resolves() },
-          disableAutoFlushOnDocumentHide: true
-        });
-        expect(addEventListenerSpy.called).to.be.false;
-
-        new BrowserBatchLogRecordProcessor({
-          exporter: { export: sinon.spy(), shutdown: sinon.stub().resolves() },
-          disableAutoFlushOnDocumentHide: false
-        });
-        expect(addEventListenerSpy.calledWith('visibilitychange')).to.be.true;
-        expect(addEventListenerSpy.calledWith('pagehide')).to.be.true;
+        createLoggerProvider(app, {}, attributesStore, []);
+        expect(batchProcessorSpy.calledOnce).to.be.true;
+        const args = batchProcessorSpy.firstCall.args[0];
+        expect(args).to.have.property('disableAutoFlushOnDocumentHide', true);
       } finally {
-        (global as unknown as { document: unknown }).document =
-          originalDocument;
+        batchProcessorSpy.restore();
+        if (origDesc) {
+          Object.defineProperty(sdkLogs, 'BatchLogRecordProcessor', origDesc);
+        }
       }
     });
   });

--- a/packages/crashlytics/src/logging/logger-provider.ts
+++ b/packages/crashlytics/src/logging/logger-provider.ts
@@ -18,6 +18,7 @@
 import {
   LoggerProvider,
   BatchLogRecordProcessor,
+  BatchLogRecordProcessorBrowserOptions,
   ReadableLogRecord,
   LogRecordExporter,
   LogRecordProcessor
@@ -85,7 +86,10 @@ export function createLoggerProvider(
 
   const processors: LogRecordProcessor[] = [
     new FirebaseAttributesProcessor(attributesStore, projectId),
-    new BatchLogRecordProcessor({ exporter: logExporter })
+    new BatchLogRecordProcessor({
+      exporter: logExporter,
+      disableAutoFlushOnDocumentHide: true
+    } as BatchLogRecordProcessorBrowserOptions)
   ];
 
   const provider = new LoggerProvider({


### PR DESCRIPTION
We already register listeners and flush in helpers.ts. Without this setting, the BatchLogRecordProcessor also registers listeners and flushes the logs, but if that flush fails it enqueues an error log to be exported again:  https://github.com/open-telemetry/opentelemetry-js/blob/3d1d427a445d6d1b76b94785c3d0f4048e38cc69/experimental/packages/sdk-logs/src/platform/browser/export/BatchLogRecordProcessor.ts#L40-L47